### PR TITLE
Don't create Host key in Volume if no hostPath is defined

### DIFF
--- a/ecs-cli/modules/compose/ecs/utils/convert_task_definition.go
+++ b/ecs-cli/modules/compose/ecs/utils/convert_task_definition.go
@@ -130,13 +130,20 @@ func convertToContainerDef(inputCfg *libcompose.ServiceConfig,
 func convertToECSVolumes(hostPaths map[string]string) []*ecs.Volume {
 	output := []*ecs.Volume{}
 	for hostPath, volName := range hostPaths {
-		ecsVolume := &ecs.Volume{
-			Name: aws.String(volName),
-			Host: &ecs.HostVolumeProperties{
-				SourcePath: aws.String(hostPath),
-			},
+		if hostPath == "" {
+			ecsVolume := &ecs.Volume{
+				Name: aws.String(volName),
+			}
+			output = append(output, ecsVolume)
+		} else {
+			ecsVolume := &ecs.Volume{
+				Name: aws.String(volName),
+				Host: &ecs.HostVolumeProperties{
+					SourcePath: aws.String(hostPath),
+				},
+			}
+			output = append(output, ecsVolume)
 		}
-		output = append(output, ecsVolume)
 	}
 	return output
 }


### PR DESCRIPTION
Fixes #11 

Please note that this is my very first go patch so it may have to be refactored.
I couldn't find a way to declare `ecsVolume` out of the `if else` block, and there is probably a better way to initialize the `ecs.Volume` structure without duplicating code.
Comments very welcome :-)
