### PR TITLE
Add travis-ci testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: go
+sudo: false
+os:
+    - linux
+    - osx
+go:
+    - 1.4
+    - 1.5
+before_install: ./scripts/hack/symlink-gopath-travisci
+script:
+    - make test
+    - make
+    - ./bin/local/ecs-cli --version

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ $(LOCAL_BINARY): $(SOURCES)
 
 .PHONY: test
 test:
-	. ./scripts/shared_env && go test -timeout=120s -v -cover ./ecs-cli/modules/...
+	. ./scripts/shared_env && AWS_REGION=us-east-1 AWS_SECRET_KEY=secret AWS_ACCESS_KEY=AKIDEXAMPLE go test -timeout=120s -v -cover ./ecs-cli/modules/...
 
 .PHONY: generate
 generate: $(SOURCES)

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@
 
 ROOT := $(shell pwd)
 
-all: generate build
+all: build
 
 SOURCEDIR=./ecs-cli
 SOURCES := $(shell find $(SOURCEDIR) -name '*.go')
@@ -29,12 +29,18 @@ $(LOCAL_BINARY): $(SOURCES)
 	@echo "Built ecs-cli"
 
 .PHONY: test
-test: generate
-	. ./scripts/shared_env && go test -timeout=120s -v -cover github.com/aws/amazon-ecs-cli/ecs-cli/modules/...
+test:
+	. ./scripts/shared_env && go test -timeout=120s -v -cover ./ecs-cli/modules/...
 
 .PHONY: generate
 generate: $(SOURCES)
-	. ./scripts/shared_env && go install github.com/golang/mock/mockgen && go generate github.com/aws/amazon-ecs-cli/ecs-cli/modules/...
+	. ./scripts/shared_env && go generate ./ecs-cli/modules/...
+
+.PHONY: generate-deps
+generate-deps:
+	go install github.com/golang/mock/mockgen
+	go get golang.org/x/tools/cmd/goimports
+
 
 .PHONY: docker-build
 docker-build:

--- a/ecs-cli/modules/command/cluster_app_test.go
+++ b/ecs-cli/modules/command/cluster_app_test.go
@@ -52,17 +52,21 @@ func TestClusterUp(t *testing.T) {
 	mockEcs := mock_ecs.NewMockECSClient(ctrl)
 	mockCloudformation := mock_cloudformation.NewMockCloudformationClient(ctrl)
 
-	mockEcs.EXPECT().Initialize(gomock.Any())
-	mockEcs.EXPECT().CreateCluster(gomock.Any()).Do(func(in interface{}) {
-		if in.(string) != clusterName {
-			t.Fatal("Expected to be called with " + clusterName + " not " + in.(string))
-		}
-	}).Return(clusterName, nil)
+	gomock.InOrder(
+		mockEcs.EXPECT().Initialize(gomock.Any()),
+		mockEcs.EXPECT().CreateCluster(gomock.Any()).Do(func(in interface{}) {
+			if in.(string) != clusterName {
+				t.Fatal("Expected to be called with " + clusterName + " not " + in.(string))
+			}
+		}).Return(clusterName, nil),
+	)
 
-	mockCloudformation.EXPECT().Initialize(gomock.Any())
-	mockCloudformation.EXPECT().ValidateStackExists(gomock.Any()).Return(errors.New("error"))
-	mockCloudformation.EXPECT().CreateStack(gomock.Any(), gomock.Any(), gomock.Any()).Return("", nil)
-	mockCloudformation.EXPECT().WaitUntilCreateComplete(gomock.Any()).Return(nil)
+	gomock.InOrder(
+		mockCloudformation.EXPECT().Initialize(gomock.Any()),
+		mockCloudformation.EXPECT().ValidateStackExists(gomock.Any()).Return(errors.New("error")),
+		mockCloudformation.EXPECT().CreateStack(gomock.Any(), gomock.Any(), gomock.Any()).Return("", nil),
+		mockCloudformation.EXPECT().WaitUntilCreateComplete(gomock.Any()).Return(nil),
+	)
 
 	globalSet := flag.NewFlagSet("ecs-cli", 0)
 	globalSet.String("region", "us-west-1", "")

--- a/ecs-cli/modules/config/params_test.go
+++ b/ecs-cli/modules/config/params_test.go
@@ -43,18 +43,20 @@ func (rdwr *mockReadWriter) Save(dest *Destination) error {
 }
 
 func TestNewCliParamsFromEnvVars(t *testing.T) {
+	os.Clearenv()
+
 	globalSet := flag.NewFlagSet("ecs-cli", 0)
 	globalContext := cli.NewContext(nil, globalSet, nil)
 	context := cli.NewContext(nil, nil, globalContext)
 	rdwr := &mockReadWriter{}
-	os.Unsetenv("AWS_REGION")
-	os.Unsetenv("AWS_DEFAULT_REGION")
 	_, err := NewCliParams(context, rdwr)
 	if err == nil {
 		t.Errorf("Expected error when region not specified")
 	}
 
 	os.Setenv("AWS_REGION", "us-west-1")
+	os.Setenv("AWS_ACCESS_KEY", "AKIDEXAMPLE")
+	os.Setenv("AWS_SECRET_KEY", "SECRET")
 	params, err := NewCliParams(context, rdwr)
 	if err != nil {
 		t.Errorf("Unexpected error when region is specified using environment variable AWS_REGION: ", err)

--- a/scripts/hack/symlink-gopath-travisci
+++ b/scripts/hack/symlink-gopath-travisci
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Copyright 2014-2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the
+# License is located at
+#
+#	http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+set -ex
+
+# Because of how gopaths work, you want a canonicalized import path even when
+# developing on a fork of the repository.
+# This creates a usable symlink at the canonical gopath so that go imports work
+if [[ ! -d "$HOME/gopath/src/github.com/aws/amazon-ecs-cli" ]]; then
+	mkdir -p "$HOME/gopath/src/github.com/aws"
+	ln -s "$(pwd)" "$HOME/gopath/src/github.com/aws/amazon-ecs-cli"
+fi

--- a/scripts/shared_env
+++ b/scripts/shared_env
@@ -14,13 +14,6 @@
 
 # This script should be sourced by bash or zsh prior to doing basically
 # anything
-
-for godepPath in "$(find ecs-cli/vendor -path "*/Godeps/_workspace")"; do
-  export GOPATH="$(pwd)/${godepPath}:${GOPATH}"
-done
-
 vendor="$(pwd)/ecs-cli/vendor"
 export GOPATH="${vendor}:${GOPATH}"
-echo GOPATH="${GOPATH}"
-
 export PATH="${vendor}/bin:$(pwd)/scripts:${PATH}"


### PR DESCRIPTION
This adds a `.travis.yml` file and some misc things needed for it to work there.

One thing this added which shouldn't necessarily be there forever is the environment variables in the `make test` target. It would be better to not have such a dependency at all.

This also splits `generate` into a target which is not run every time in the interest of reducing dependencies when running tests and also in making the code-test-build cycle quicker.

Tested on my fork https://travis-ci.org/euank/amazon-ecs-cli

r? @samuelkarp @uttarasridhar 