### PR TITLE
Correcting credential logic.

### DIFF
--- a/ecs-cli/modules/aws/clients/cloudformation/client.go
+++ b/ecs-cli/modules/aws/clients/cloudformation/client.go
@@ -74,6 +74,7 @@ func init() {
 	// http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-describing-stacks.html
 	createStackFailures = map[string]bool{
 		cloudformation.StackStatusCreateFailed:         true,
+		cloudformation.StackStatusRollbackInProgress:   true,
 		cloudformation.StackStatusRollbackComplete:     true,
 		cloudformation.StackStatusUpdateRollbackFailed: true,
 	}

--- a/ecs-cli/modules/aws/clients/cloudformation/template.go
+++ b/ecs-cli/modules/aws/clients/cloudformation/template.go
@@ -465,51 +465,6 @@ var template = `
     "EcsInstanceAsg": {
       "Type": "AWS::AutoScaling::AutoScalingGroup",
       "Properties": {
-        "AvailabilityZones": {
-          "Fn::If": [
-            "UseSpecifiedVpcAvailabilityZones",
-            [
-              {
-                "Fn::Select": [
-                  "0",
-                  {
-                    "Ref": "VpcAvailabilityZones"
-                  }
-                ]
-              },
-              {
-                "Fn::Select": [
-                  "1",
-                  {
-                    "Ref": "VpcAvailabilityZones"
-                  }
-                ]
-              }
-            ],
-            [
-              {
-                "Fn::Select": [
-                  "0",
-                  {
-                    "Fn::GetAZs": {
-                      "Ref": "AWS::Region"
-                    }
-                  }
-                ]
-              },
-              {
-                "Fn::Select": [
-                  "1",
-                  {
-                    "Fn::GetAZs": {
-                      "Ref": "AWS::Region"
-                    }
-                  }
-                ]
-              }
-            ]
-          ]
-        },
         "VPCZoneIdentifier": {
           "Fn::If": [
             "CreateVpcResources",

--- a/ecs-cli/modules/aws/clients/cloudformation/template.go
+++ b/ecs-cli/modules/aws/clients/cloudformation/template.go
@@ -284,6 +284,7 @@ var template = `
     },
     "PublicRouteViaIgw": {
       "Condition": "CreateVpcResources",
+      "DependsOn": "AttachGateway",
       "Type": "AWS::EC2::Route",
       "Properties": {
         "RouteTableId": {

--- a/ecs-cli/modules/cli/app.go
+++ b/ecs-cli/modules/cli/app.go
@@ -13,13 +13,15 @@
 
 package cli
 
-// Flag names used by the cli.
-// TODO: These need a better home.
-const (
-	ClusterFlag   = "cluster"
-	ProfileFlag   = "profile"
-	RegionFlag    = "region"
-	AccessKeyFlag = "access-key"
-	SecretKeyFlag = "secret-key"
-	VerboseFlag   = "verbose"
+import (
+	log "github.com/Sirupsen/logrus"
+	"github.com/codegangsta/cli"
 )
+
+// BeforeApp is an action that is executed before any cli command.
+func BeforeApp(c *cli.Context) error {
+	if c.GlobalBool(VerboseFlag) || c.Bool(VerboseFlag) {
+		log.SetLevel(log.DebugLevel)
+	}
+	return nil
+}

--- a/ecs-cli/modules/command/cluster.go
+++ b/ecs-cli/modules/command/cluster.go
@@ -13,7 +13,10 @@
 
 package command
 
-import "github.com/codegangsta/cli"
+import (
+	ecscli "github.com/aws/amazon-ecs-cli/ecs-cli/modules/cli"
+	"github.com/codegangsta/cli"
+)
 
 const (
 	asgMaxSizeFlag    = "size"
@@ -24,6 +27,7 @@ const (
 	subnetIdsFlag     = "subnets"
 	vpcIdFlag         = "vpc"
 	instanceTypeFlag  = "instance-type"
+	imageIdFlag       = "image-id"
 	keypairNameFlag   = "keypair"
 	capabilityIAMFlag = "capability-iam"
 	forceFlag         = "force"
@@ -33,8 +37,12 @@ func UpCommand() cli.Command {
 	return cli.Command{
 		Name:   "up",
 		Usage:  "Create the ECS Cluster (if it does not already exist) and the AWS resources required to set up the cluster.",
+		Before: ecscli.BeforeApp,
 		Action: ClusterUp,
 		Flags: []cli.Flag{
+			cli.BoolFlag{
+				Name: ecscli.VerboseFlag + ",debug",
+			},
 			cli.StringFlag{
 				Name:  keypairNameFlag,
 				Usage: "Specify the name of an existing Amazon EC2 key pair to enable SSH access to the EC2 instances in your cluster.",
@@ -74,6 +82,10 @@ func UpCommand() cli.Command {
 			cli.StringFlag{
 				Name:  instanceTypeFlag,
 				Usage: "[Optional] Specify the EC2 instance type for your container instances.",
+			},
+			cli.StringFlag{
+				Name:  imageIdFlag,
+				Usage: "[Optional] Specify the ID of the AMI for your container Instances.",
 			},
 		},
 	}

--- a/ecs-cli/modules/command/configure.go
+++ b/ecs-cli/modules/command/configure.go
@@ -101,8 +101,8 @@ func createECSConfigFromCli(context *cli.Context) (*config.CliConfig, error) {
 		return nil, fmt.Errorf("Missing required argument '%s'", ecscli.ClusterFlag)
 	}
 
-	if profile != "" {
-		if accessKey != "" || secretKey != "" {
+	if profile == "" {
+		if accessKey == "" || secretKey == "" {
 			return nil, fmt.Errorf("Missing required credentials. Specify either '%s' with the name of an existing named profile in ~/.aws/credentials, or your AWS credentials with '%s' and '%s'", ecscli.ProfileFlag, ecscli.AccessKeyFlag, ecscli.SecretKeyFlag)
 		}
 	}

--- a/ecs-cli/modules/compose/cli/ecs/app/app.go
+++ b/ecs-cli/modules/compose/cli/ecs/app/app.go
@@ -33,14 +33,6 @@ import (
 //	}
 type ProjectAction func(project ecscompose.Project, c *cli.Context)
 
-// BeforeApp is an action that is executed before any cli command.
-func BeforeApp(c *cli.Context) error {
-	if c.GlobalBool(verboseFlag) || c.Bool(verboseFlag) {
-		log.SetLevel(log.DebugLevel)
-	}
-	return nil
-}
-
 // WithProject is an helper function to create a cli.Command action with a ProjectFactory.
 func WithProject(factory ProjectFactory, action ProjectAction, isService bool) func(context *cli.Context) {
 	return func(context *cli.Context) {

--- a/ecs-cli/modules/compose/cli/ecs/app/app_test.go
+++ b/ecs-cli/modules/compose/cli/ecs/app/app_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	log "github.com/Sirupsen/logrus"
+	ecscli "github.com/aws/amazon-ecs-cli/ecs-cli/modules/cli"
 	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/compose/cli/ecs/app/mocks"
 	ecscompose "github.com/aws/amazon-ecs-cli/ecs-cli/modules/compose/ecs"
 	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/compose/ecs/mocks"
@@ -28,10 +29,10 @@ import (
 
 func TestBeforeApp(t *testing.T) {
 	flagSet := flag.NewFlagSet("ecs-cli", 0)
-	flagSet.Bool(verboseFlag, true, "")
+	flagSet.Bool(ecscli.VerboseFlag, true, "")
 	cliContext := cli.NewContext(nil, flagSet, nil)
 
-	BeforeApp(cliContext)
+	ecscli.BeforeApp(cliContext)
 
 	observedLogLevel := log.GetLevel()
 	if log.DebugLevel != observedLogLevel {

--- a/ecs-cli/modules/compose/cli/ecs/app/command.go
+++ b/ecs-cli/modules/compose/cli/ecs/app/command.go
@@ -14,6 +14,7 @@
 package app
 
 import (
+	ecscli "github.com/aws/amazon-ecs-cli/ecs-cli/modules/cli"
 	ecscompose "github.com/aws/amazon-ecs-cli/ecs-cli/modules/compose/ecs"
 	"github.com/codegangsta/cli"
 )
@@ -24,7 +25,6 @@ const (
 	composeFileNameDefaultValue = "docker-compose.yml"
 	containerNameFlag           = "name"
 	projectNameFlag             = "project-name"
-	verboseFlag                 = "verbose"
 )
 
 //* ----------------- COMPOSE PROJECT ----------------- */
@@ -52,7 +52,7 @@ func ComposeCommand(factory ProjectFactory) cli.Command {
 	return cli.Command{
 		Name:   "compose",
 		Usage:  "Execute docker-compose style commands on an ECS cluster.",
-		Before: BeforeApp,
+		Before: ecscli.BeforeApp,
 		Subcommands: []cli.Command{
 			createCommand(factory),
 			psCommand(factory),
@@ -76,7 +76,7 @@ func ComposeCommand(factory ProjectFactory) cli.Command {
 func commonComposeFlags() []cli.Flag {
 	return []cli.Flag{
 		cli.BoolFlag{
-			Name: verboseFlag + ",debug",
+			Name: ecscli.VerboseFlag + ",debug",
 		},
 		cli.StringFlag{
 			Name:   composeFileNameFlag + ",f",

--- a/ecs-cli/modules/config/ami/ami.go
+++ b/ecs-cli/modules/config/ami/ami.go
@@ -28,13 +28,13 @@ type staticAmiIds struct {
 
 func NewStaticAmiIds() ECSAmiIds {
 	regionToId := make(map[string]string)
-	// amzn-ami-2015.03.g-amazon-ecs-optimized AMIs
-	regionToId["us-east-1"] = "ami-4fe4852a"
-	regionToId["us-west-1"] = "ami-2708f363"
-	regionToId["us-west-2"] = "ami-8bd4c7bb"
-	regionToId["eu-west-1"] = "ami-bd5572ca"
-	regionToId["ap-northeast-1"] = "ami-ce2ba4ce"
-	regionToId["ap-southeast-2"] = "ami-3f531f05"
+	// amzn-ami-2015.09.b-amazon-ecs-optimized AMIs
+	regionToId["us-east-1"] = "ami-ddc7b6b7"
+	regionToId["us-west-1"] = "ami-a39df1c3"
+	regionToId["us-west-2"] = "ami-d74357b6"
+	regionToId["eu-west-1"] = "ami-f1b46b82"
+	regionToId["ap-northeast-1"] = "ami-3077525e"
+	regionToId["ap-southeast-2"] = "ami-23b4eb40"
 
 	return &staticAmiIds{regionToId: regionToId}
 }


### PR DESCRIPTION
The current credential logic seems wrong for what it is trying to do. The logic should check for profile, and if profile is empty, then fail if one of access key or secret key is also empty.
With the current logic, my system had the env vars set for access key and secret key, and then the `ecs-cli configure` command failed with the `--profile` flag.