### PR TITLE
Fix release builds appearing dirty

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,10 +47,12 @@ docker-build:
 	docker run -v $(shell pwd):/usr/src/app/src/github.com/aws/amazon-ecs-cli \
 		--workdir=/usr/src/app/src/github.com/aws/amazon-ecs-cli \
 		--env GOPATH=/usr/src/app \
+		--env ECS_RELEASE=$(ECS_RELEASE) \
 		golang:1.4-cross make $(LINUX_BINARY)
 	docker run -v $(shell pwd):/usr/src/app/src/github.com/aws/amazon-ecs-cli \
 		--workdir=/usr/src/app/src/github.com/aws/amazon-ecs-cli \
 		--env GOPATH=/usr/src/app \
+		--env ECS_RELEASE=$(ECS_RELEASE) \
 		golang:1.4-cross make $(DARWIN_BINARY)
 
 .PHONY: supported-platforms

--- a/scripts/stage.sh
+++ b/scripts/stage.sh
@@ -99,6 +99,7 @@ if ! ${ALLOW_DIRTY}; then
 	echo "Cloning to a clean directory ${clean_directory}"
 	git clone --quiet "${CWD}" "${clean_directory}"
 	cd "${clean_directory}"
+	export ECS_RELEASE="cleanbuild"
 fi
 
 make docker-build


### PR DESCRIPTION
With this change, release builds (using the release script) no longer appear dirty:

```
$ ./ecs-cli -v
ecs-cli version 0.1.0 (1bff41b)
```

r? @uttarasridhar @euank 