### PR TITLE
Include region, account id in key for local Task Definition cache

### DIFF
--- a/ecs-cli/modules/compose/ecs/utils/name.go
+++ b/ecs-cli/modules/compose/ecs/utils/name.go
@@ -55,11 +55,20 @@ func GetFormattedContainerName(ecsTaskId, ecsContainerName string) string {
 	return fmt.Sprintf("%s/%s", ecsTaskId, ecsContainerName)
 }
 
-// GetIdFromArn extracts the id from arn
+// GetIdFromArn parses an ARN and returns only the family name and revision
 func GetIdFromArn(arn string) string {
 	parts := strings.SplitN(arn, "/", 2)
 	if len(parts) != 2 {
 		return ""
 	}
 	return parts[1]
+}
+
+// GetAwsAccountIdFromArn parses an ARN and returns only the accountId portion
+func GetAwsAccountIdFromArn(arn string) string {
+	parts := strings.SplitN(arn, ":", 7)
+	if len(parts) != 7 {
+		return ""
+	}
+	return parts[4]
 }


### PR DESCRIPTION
The hash for the task definition local cache now utilizes the region,
AWS account id and compose file. The CLI now checks to see if a task
definition is ACTIVE prior to using it, i.e. when pulling the definition
from the either the cache or from ECS.

Fixes #38 

@samuelkarp @euank @uttarasridhar 