### PR TITLE
Adding better error messaging for RegisterTaskDefinition API

### DIFF
--- a/ecs-cli/modules/aws/clients/ecs/client.go
+++ b/ecs-cli/modules/aws/clients/ecs/client.go
@@ -204,7 +204,7 @@ func (client *ecsClient) RegisterTaskDefinition(request *ecs.RegisterTaskDefinit
 	resp, err := client.client.RegisterTaskDefinition(request)
 	if err != nil {
 		log.WithFields(log.Fields{
-			"family": request.Family,
+			"family": aws.StringValue(request.Family),
 			"error":  err,
 		}).Error("Error registering task definition")
 		return nil, err


### PR DESCRIPTION
Fixed the logging of the Family name by dereferencing a pointer
correctly when calling RegisterTaskDefinition API.

Fixes #37 