### PR TITLE
Remove dependencies on environment variables for tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ $(LOCAL_BINARY): $(SOURCES)
 
 .PHONY: test
 test:
-	. ./scripts/shared_env && AWS_REGION=us-east-1 AWS_SECRET_KEY=secret AWS_ACCESS_KEY=AKIDEXAMPLE go test -timeout=120s -v -cover ./ecs-cli/modules/...
+	. ./scripts/shared_env && env -i PATH=$$PATH GOPATH=$$GOPATH GOROOT=$$GOROOT go test -timeout=120s -v -cover ./ecs-cli/modules/...
 
 .PHONY: generate
 generate: $(SOURCES)

--- a/ecs-cli/modules/command/cluster_app_test.go
+++ b/ecs-cli/modules/command/cluster_app_test.go
@@ -53,6 +53,13 @@ func TestClusterUp(t *testing.T) {
 	mockEcs := mock_ecs.NewMockECSClient(ctrl)
 	mockCloudformation := mock_cloudformation.NewMockCloudformationClient(ctrl)
 
+	os.Setenv("AWS_ACCESS_KEY", "AKIDEXAMPLE")
+	os.Setenv("AWS_SECRET_KEY", "secret")
+	defer func() {
+		os.Unsetenv("AWS_ACCESS_KEY")
+		os.Unsetenv("AWS_SECRET_KEY")
+	}()
+
 	gomock.InOrder(
 		mockEcs.EXPECT().Initialize(gomock.Any()),
 		mockEcs.EXPECT().CreateCluster(gomock.Any()).Do(func(in interface{}) {
@@ -89,6 +96,14 @@ func TestClusterUpWithoutKeyPair(t *testing.T) {
 	defer ctrl.Finish()
 	mockEcs := mock_ecs.NewMockECSClient(ctrl)
 	mockCloudformation := mock_cloudformation.NewMockCloudformationClient(ctrl)
+
+	os.Setenv("AWS_ACCESS_KEY", "AKIDEXAMPLE")
+	os.Setenv("AWS_SECRET_KEY", "secret")
+	defer func() {
+		os.Unsetenv("AWS_ACCESS_KEY")
+		os.Unsetenv("AWS_SECRET_KEY")
+	}()
+
 	gomock.InOrder(
 		mockCloudformation.EXPECT().Initialize(gomock.Any()),
 		mockCloudformation.EXPECT().ValidateStackExists(gomock.Any()).Return(errors.New("error")),
@@ -143,6 +158,13 @@ func TestClusterUpForImageIdInput(t *testing.T) {
 	mockCloudformation := mock_cloudformation.NewMockCloudformationClient(ctrl)
 	imageId := "ami-12345"
 
+	os.Setenv("AWS_ACCESS_KEY", "AKIDEXAMPLE")
+	os.Setenv("AWS_SECRET_KEY", "secret")
+	defer func() {
+		os.Unsetenv("AWS_ACCESS_KEY")
+		os.Unsetenv("AWS_SECRET_KEY")
+	}()
+
 	gomock.InOrder(
 		mockEcs.EXPECT().Initialize(gomock.Any()),
 		mockEcs.EXPECT().CreateCluster(gomock.Any()).Do(func(in interface{}) {
@@ -189,8 +211,6 @@ func TestClusterUpWithoutRegion(t *testing.T) {
 	defer ctrl.Finish()
 	mockEcs := mock_ecs.NewMockECSClient(ctrl)
 	mockCloudformation := mock_cloudformation.NewMockCloudformationClient(ctrl)
-
-	os.Clearenv()
 
 	globalSet := flag.NewFlagSet("ecs-cli", 0)
 	globalContext := cli.NewContext(nil, globalSet, nil)
@@ -247,8 +267,6 @@ func TestClusterDownWithoutForce(t *testing.T) {
 	mockEcs := mock_ecs.NewMockECSClient(ctrl)
 	mockCloudformation := mock_cloudformation.NewMockCloudformationClient(ctrl)
 
-	os.Clearenv()
-
 	globalSet := flag.NewFlagSet("ecs-cli", 0)
 	globalSet.String("region", "us-west-1", "")
 	globalContext := cli.NewContext(nil, globalSet, nil)
@@ -302,8 +320,6 @@ func TestClusterScaleWithoutIamCapability(t *testing.T) {
 	mockEcs := mock_ecs.NewMockECSClient(ctrl)
 	mockCloudformation := mock_cloudformation.NewMockCloudformationClient(ctrl)
 
-	os.Clearenv()
-
 	globalSet := flag.NewFlagSet("ecs-cli", 0)
 	globalContext := cli.NewContext(nil, globalSet, nil)
 
@@ -322,8 +338,6 @@ func TestClusterScaleWithoutSize(t *testing.T) {
 	defer ctrl.Finish()
 	mockEcs := mock_ecs.NewMockECSClient(ctrl)
 	mockCloudformation := mock_cloudformation.NewMockCloudformationClient(ctrl)
-
-	os.Clearenv()
 
 	globalSet := flag.NewFlagSet("ecs-cli", 0)
 	globalContext := cli.NewContext(nil, globalSet, nil)

--- a/ecs-cli/modules/compose/cli/ecs/app/factory_test.go
+++ b/ecs-cli/modules/compose/cli/ecs/app/factory_test.go
@@ -15,6 +15,7 @@ package app
 
 import (
 	"flag"
+	"io/ioutil"
 	"os"
 	"testing"
 
@@ -31,10 +32,27 @@ func TestPopulateContext(t *testing.T) {
 	globalContext := cli.NewContext(nil, globalSet, nil)
 	cliContext := cli.NewContext(nil, nil, globalContext)
 	ecsContext := &ecscompose.Context{}
+
+	// Create a temprorary directory for the dummy ecs config
+	tempDirName, err := ioutil.TempDir("", "test")
+	if err != nil {
+		t.Fatal("Error while creating the dummy ecs config directory")
+	}
+	defer os.Remove(tempDirName)
+	os.Setenv("HOME", tempDirName)
+
 	os.Setenv("AWS_REGION", "us-east-1")
+	os.Setenv("AWS_ACCESS_KEY", "AKIDEXAMPLE")
+	os.Setenv("AWS_SECRET_KEY", "secret")
+	defer func() {
+		os.Unsetenv("AWS_REGION")
+		os.Unsetenv("AWS_ACCESS_KEY")
+		os.Unsetenv("AWS_SECRET_KEY")
+		os.Unsetenv("HOME")
+	}()
 
 	projectFactory := projectFactory{}
-	err := projectFactory.populateContext(ecsContext, cliContext)
+	err = projectFactory.populateContext(ecsContext, cliContext)
 
 	if err != nil {
 		t.Fatal("Error while populating the context")

--- a/ecs-cli/modules/config/destination_test.go
+++ b/ecs-cli/modules/config/destination_test.go
@@ -14,11 +14,23 @@
 package config
 
 import (
+	"io/ioutil"
+	"os"
 	"strings"
 	"testing"
 )
 
 func TestNewDefaultDestination(t *testing.T) {
+	// Create a temprorary directory for the dummy ecs config
+	tempDirName, err := ioutil.TempDir("", "test")
+	if err != nil {
+		t.Fatal("Error while creating the dummy ecs config directory")
+	}
+	defer os.Remove(tempDirName)
+
+	os.Setenv("HOME", tempDirName)
+	defer os.Unsetenv("HOME")
+
 	dest, err := newDefaultDestionation()
 	if err != nil {
 		t.Errorf("Error creating new config path: ", err)


### PR DESCRIPTION
Removing dependencies on environment variables which cause tests
to fail if environment variables are cleared(e.g via os.ClearEnv())
within the test cases.

@samuelkarp @euank @aaithal 