### PR TITLE
Change ordering of AWS Credential resolution for the ecs-cli

### DIFF
--- a/ecs-cli/modules/command/configure.go
+++ b/ecs-cli/modules/command/configure.go
@@ -101,10 +101,11 @@ func createECSConfigFromCli(context *cli.Context) (*config.CliConfig, error) {
 		return nil, fmt.Errorf("Missing required argument '%s'", ecscli.ClusterFlag)
 	}
 
-	if profile != "" {
-		if accessKey != "" || secretKey != "" {
-			return nil, fmt.Errorf("Missing required credentials. Specify either '%s' with the name of an existing named profile in ~/.aws/credentials, or your AWS credentials with '%s' and '%s'", ecscli.ProfileFlag, ecscli.AccessKeyFlag, ecscli.SecretKeyFlag)
-		}
+	// ONLY allow for profile OR access keys to be specified
+	isProfileSpecified := profile != ""
+	isAccessKeySpecified := accessKey != "" || secretKey != ""
+	if isProfileSpecified && isAccessKeySpecified {
+		return nil, fmt.Errorf("Both AWS Access/Secret Keys and Profile were provided; only one of the two can be specified")
 	}
 
 	ecsConfig := config.NewCliConfig(cluster)

--- a/ecs-cli/modules/command/configure_test.go
+++ b/ecs-cli/modules/command/configure_test.go
@@ -17,8 +17,8 @@ import (
 	"flag"
 	"testing"
 
-	"github.com/codegangsta/cli"
 	ecscli "github.com/aws/amazon-ecs-cli/ecs-cli/modules/cli"
+	"github.com/codegangsta/cli"
 )
 
 const (
@@ -123,11 +123,10 @@ func TestConfigInitWithoutCluster(t *testing.T) {
 	if err == nil {
 		t.Errorf("Expected error when cluster is not specified")
 	}
-
 }
 
 func TestConfigInitWithProfileAndKeys(t *testing.T) {
-	// Config init with all params should fail.
+	// Config init with all params will attempt to use the credentials keys specified in the ecs profile
 	setEverything := flag.NewFlagSet("ecs-cli", 0)
 	setEverything.String(ecscli.ProfileFlag, profileName, "")
 	setEverything.String(ecscli.ClusterFlag, clusterName, "")
@@ -137,6 +136,6 @@ func TestConfigInitWithProfileAndKeys(t *testing.T) {
 	context := cli.NewContext(nil, setEverything, nil)
 	_, err := createECSConfigFromCli(context)
 	if err == nil {
-		t.Errorf("Expected error when both profile and keys are specified")
+		t.Errorf("Expected error when both AWS Profile and access keys are specified")
 	}
 }


### PR DESCRIPTION
This commit streamlines the logic for resolving AWS credentials.
The ecs-cli now attempts to resolve AWS credentials in the following
order: ENV variables, ECS Profile, AWS Profile and EC2 Instance role.
This commit also removes some unneccessary logic in the ecs-cli
configure command.

Fixes #35 

@samuelkarp @aaithal @euank @uttarasridhar 