### PR TITLE
Allow creation of non-essential containers by setting 'restart' parameter to 'no'

### DIFF
--- a/ecs-cli/modules/compose/ecs/utils/convert_compose_yml.go
+++ b/ecs-cli/modules/compose/ecs/utils/convert_compose_yml.go
@@ -44,6 +44,7 @@ func composeOptionsInit() {
 		"ports":        true,
 		"privileged":   true,
 		"read_only":    true,
+		"restart":      true,
 		"security_opt": true,
 		"ulimits":      true,
 		"user":         true,

--- a/ecs-cli/modules/compose/ecs/utils/convert_compose_yml_test.go
+++ b/ecs-cli/modules/compose/ecs/utils/convert_compose_yml_test.go
@@ -45,6 +45,7 @@ func TestUnmarshalComposeConfig(t *testing.T) {
 	ports := []string{"5000:5000", "127.0.0.1:8001:8001"}
 	privileged := true
 	readonly := true
+	restart := "no"
 	securityOpts := []string{"label:type:test_virt"}
 	ulimits := []string{"nofile=1024"}
 	user := "user"
@@ -80,6 +81,7 @@ func TestUnmarshalComposeConfig(t *testing.T) {
    - "127.0.0.1:8001:8001"
   privileged: true
   read_only: true
+  restart: no
   security_opt:
    - label:type:test_virt
   ulimits:
@@ -166,6 +168,9 @@ redis:
 	}
 	if readonly != web.ReadOnly {
 		t.Errorf("Expected readonly to be [%s] but got [%s]", readonly, web.ReadOnly)
+	}
+	if restart != web.Restart {
+		t.Errorf("Expected restart to be [%s] but got [%s]", restart, web.Restart)
 	}
 	if !reflect.DeepEqual(securityOpts, web.SecurityOpt) {
 		t.Errorf("Expected securityOpts to be [%v] but got [%v]", securityOpts, web.SecurityOpt)

--- a/ecs-cli/modules/compose/ecs/utils/convert_task_definition.go
+++ b/ecs-cli/modules/compose/ecs/utils/convert_task_definition.go
@@ -144,7 +144,7 @@ func convertToContainerDef(inputCfg *libcompose.ServiceConfig,
 	outputContDef.EntryPoint = aws.StringSlice(inputCfg.Entrypoint.Slice())
 	outputContDef.Environment = environment
 	if inputCfg.Restart == "no" {
-		outputContDef.Essential = aws.Bool(true)
+		outputContDef.Essential = aws.Bool(false)
 	}
 	outputContDef.ExtraHosts = extraHosts
 	if inputCfg.Hostname != "" {

--- a/ecs-cli/modules/compose/ecs/utils/convert_task_definition.go
+++ b/ecs-cli/modules/compose/ecs/utils/convert_task_definition.go
@@ -143,7 +143,7 @@ func convertToContainerDef(inputCfg *libcompose.ServiceConfig,
 	outputContDef.DockerSecurityOptions = aws.StringSlice(inputCfg.SecurityOpt)
 	outputContDef.EntryPoint = aws.StringSlice(inputCfg.Entrypoint.Slice())
 	outputContDef.Environment = environment
-	if inputCfg.restart == "no" {
+	if inputCfg.Restart == "no" {
 		outputContDef.Essential = false
 	}
 	outputContDef.ExtraHosts = extraHosts

--- a/ecs-cli/modules/compose/ecs/utils/convert_task_definition.go
+++ b/ecs-cli/modules/compose/ecs/utils/convert_task_definition.go
@@ -143,6 +143,9 @@ func convertToContainerDef(inputCfg *libcompose.ServiceConfig,
 	outputContDef.DockerSecurityOptions = aws.StringSlice(inputCfg.SecurityOpt)
 	outputContDef.EntryPoint = aws.StringSlice(inputCfg.Entrypoint.Slice())
 	outputContDef.Environment = environment
+	if inputCfg.restart == "no" {
+		outputContDef.Essential = false
+	}
 	outputContDef.ExtraHosts = extraHosts
 	if inputCfg.Hostname != "" {
 		outputContDef.Hostname = aws.String(inputCfg.Hostname)

--- a/ecs-cli/modules/compose/ecs/utils/convert_task_definition.go
+++ b/ecs-cli/modules/compose/ecs/utils/convert_task_definition.go
@@ -144,7 +144,7 @@ func convertToContainerDef(inputCfg *libcompose.ServiceConfig,
 	outputContDef.EntryPoint = aws.StringSlice(inputCfg.Entrypoint.Slice())
 	outputContDef.Environment = environment
 	if inputCfg.Restart == "no" {
-		outputContDef.Essential = false
+		outputContDef.Essential = aws.Bool(true)
 	}
 	outputContDef.ExtraHosts = extraHosts
 	if inputCfg.Hostname != "" {

--- a/ecs-cli/modules/compose/ecs/utils/convert_task_definition_test.go
+++ b/ecs-cli/modules/compose/ecs/utils/convert_task_definition_test.go
@@ -35,6 +35,7 @@ func TestConvertToTaskDefinition(t *testing.T) {
 	name := "mysql"
 	cpu := int64(10)
 	command := "cmd"
+	essential := false
 	hostname := "foobarbaz"
 	image := "testimage"
 	links := []string{"container1"}
@@ -48,6 +49,7 @@ func TestConvertToTaskDefinition(t *testing.T) {
 	serviceConfig := &libcompose.ServiceConfig{
 		CpuShares:   cpu,
 		Command:     libcompose.NewCommand(command),
+		Essential:   essential,
 		Hostname:    hostname,
 		Image:       image,
 		Links:       libcompose.NewMaporColonSlice(links),
@@ -72,6 +74,9 @@ func TestConvertToTaskDefinition(t *testing.T) {
 	}
 	if len(containerDef.Command) != 1 || command != aws.StringValue(containerDef.Command[0]) {
 		t.Errorf("Expected command [%s] But was [%v]", command, containerDef.Command)
+	}
+	if essential != aws.BoolValue(containerDef.Essential) {
+		t.Errorf("Expected essential [%s] But was [%s]", essential, aws.BoolValue(containerDef.Essential))
 	}
 	if !reflect.DeepEqual(securityOpts, aws.StringValueSlice(containerDef.DockerSecurityOptions)) {
 		t.Errorf("Expected securityOpt [%v] But was [%v]", securityOpts, aws.StringValueSlice(containerDef.DockerSecurityOptions))

--- a/ecs-cli/modules/compose/ecs/utils/convert_task_definition_test.go
+++ b/ecs-cli/modules/compose/ecs/utils/convert_task_definition_test.go
@@ -42,6 +42,7 @@ func TestConvertToTaskDefinition(t *testing.T) {
 	memory := int64(100) // 1 MiB = 1048576B
 	privileged := true
 	readOnly := true
+	restart := "no"
 	securityOpts := []string{"label:type:test_virt"}
 	user := "user"
 	workingDir := "/var"
@@ -49,13 +50,13 @@ func TestConvertToTaskDefinition(t *testing.T) {
 	serviceConfig := &libcompose.ServiceConfig{
 		CpuShares:   cpu,
 		Command:     libcompose.NewCommand(command),
-		Essential:   essential,
 		Hostname:    hostname,
 		Image:       image,
 		Links:       libcompose.NewMaporColonSlice(links),
 		MemLimit:    int64(1048576) * memory,
 		Privileged:  privileged,
 		ReadOnly:    readOnly,
+		Restart:     restart,
 		SecurityOpt: securityOpts,
 		User:        user,
 		WorkingDir:  workingDir,


### PR DESCRIPTION
At the moment it is impossible to create an ECS task definition from a compose file that uses data-only containers. This is because all containers are created as 'Essential', so when the data containers exit (as they should), the whole task is stopped.

Using the `restart` field fits within the compose.yml spec, does not affect existing behaviour, and also makes sense semantically:
- With `restart` set to `'no'` (thus `Essential` being `false`) the Task will not be killed, so an ECS service _won't_ reschedule a new instance of the Task as the existing one will continue to run.
- With `restart` set to any other value (thus `Essential` defaulting to `true`) the Task will be killed, so an ECS service _will_ reschedule a new instance of the Task as the existing one will not continue to run.

P.S. I don't write Go, apologies for any mistakes.

Thanks,

Alex
