### PR TITLE
Update AMIs from 2015.09.c to 2015.09.d

### DIFF
--- a/ecs-cli/modules/config/ami/ami.go
+++ b/ecs-cli/modules/config/ami/ami.go
@@ -28,15 +28,15 @@ type staticAmiIds struct {
 
 func NewStaticAmiIds() ECSAmiIds {
 	regionToId := make(map[string]string)
-	// amzn-ami-2015.09.c-amazon-ecs-optimized AMIs
-	regionToId["us-east-1"] = "ami-6ff4bd05"
-	regionToId["us-west-1"] = "ami-46cda526"
-	regionToId["us-west-2"] = "ami-313d2150"
-	regionToId["eu-west-1"] = "ami-8073d3f3"
-	regionToId["eu-central-1"] = "ami-60627e0c"
-	regionToId["ap-northeast-1"] = "ami-6ca38b02"
-	regionToId["ap-southeast-1"] = "ami-a6ba79c5"
-	regionToId["ap-southeast-2"] = "ami-00e7bf63"
+	// amzn-ami-2015.09.d-amazon-ecs-optimized AMIs
+	regionToId["us-east-1"] = "ami-2b3b6041"
+	regionToId["us-west-1"] = "ami-bfe095df"
+	regionToId["us-west-2"] = "ami-ac6872cd"
+	regionToId["eu-west-1"] = "ami-03238b70"
+	regionToId["eu-central-1"] = "ami-e1e6f88d"
+	regionToId["ap-northeast-1"] = "ami-fb2f1295"
+	regionToId["ap-southeast-1"] = "ami-c78f43a4"
+	regionToId["ap-southeast-2"] = "ami-43547120"
 
 	return &staticAmiIds{regionToId: regionToId}
 }


### PR DESCRIPTION
Sourced from http://docs.aws.amazon.com/AmazonECS/latest/developerguide/launch_container_instance.html