### PR TITLE
Add support for t2.nano, g2 and d2 instance types

### DIFF
--- a/ecs-cli/modules/aws/clients/cloudformation/template.go
+++ b/ecs-cli/modules/aws/clients/cloudformation/template.go
@@ -44,6 +44,7 @@ var template = `
       "Description": "ECS EC2 instance type",
       "Default": "t2.micro",
       "AllowedValues": [
+        "t2.nano",
         "t2.micro",
         "t2.small",
         "t2.medium",
@@ -75,7 +76,13 @@ var template = `
         "i2.xlarge",
         "i2.2xlarge",
         "i2.4xlarge",
-        "i2.8xlarge"
+        "i2.8xlarge",
+        "g2.2xlarge",
+        "g2.8xlarge",
+        "d2.xlarge",
+        "d2.2xlarge",
+        "d2.4xlarge",
+        "d2.8xlarge"
       ],
       "ConstraintDescription": "must be a valid EC2 instance type."
     },


### PR DESCRIPTION
Addresses issue #64. Got the updated instance types list from https://aws.amazon.com/ec2/instance-types/ 