### PR TITLE
Update commands' help to match the text in ecs cli documentation.

### DIFF
--- a/ecs-cli/modules/aws/clients/ecs/client_test.go
+++ b/ecs-cli/modules/aws/clients/ecs/client_test.go
@@ -283,7 +283,7 @@ func TestRegisterTaskDefinitionIfNeededTDBecomesInactive(t *testing.T) {
 		mockCache.EXPECT().Put(gomock.Any(), gomock.Any()).Do(func(x, y interface{}) {
 			cache[x.(string)] = y.(*ecs.TaskDefinition)
 			if len(cache) != 1 {
-				t.Fatal("There should only be one entry in the cache since teh previous INACTIVE task should have the same hash")
+				t.Fatal("There should only be one entry in the cache, since the previous INACTIVE task should have the same hash")
 			}
 		}).Return(nil),
 	)

--- a/ecs-cli/modules/command/cluster.go
+++ b/ecs-cli/modules/command/cluster.go
@@ -65,7 +65,7 @@ func UpCommand() cli.Command {
 			},
 			cli.StringFlag{
 				Name:  sourceCidrFlag,
-				Usage: "[Optional] Specifies a CIDR/IP range for the security group to use for container instances in your cluster. This parameter is ignored if an existing security group is specified with the --security-group option. Defaults to 0.0.0.0/0 .",
+				Usage: "[Optional] Specifies a CIDR/IP range for the security group to use for container instances in your cluster. This parameter is ignored if an existing security group is specified with the --security-group option. Defaults to 0.0.0.0/0.",
 			},
 			cli.StringFlag{
 				Name:  ecsPortFlag,

--- a/ecs-cli/modules/command/cluster.go
+++ b/ecs-cli/modules/command/cluster.go
@@ -36,7 +36,7 @@ const (
 func UpCommand() cli.Command {
 	return cli.Command{
 		Name:   "up",
-		Usage:  "Create the ECS Cluster (if it does not already exist) and the AWS resources required to set up the cluster.",
+		Usage:  "Creates the ECS cluster (if it does not already exist) and the AWS resources required to set up the cluster.",
 		Before: ecscli.BeforeApp,
 		Action: ClusterUp,
 		Flags: []cli.Flag{
@@ -45,47 +45,47 @@ func UpCommand() cli.Command {
 			},
 			cli.StringFlag{
 				Name:  keypairNameFlag,
-				Usage: "Specify the name of an existing Amazon EC2 key pair to enable SSH access to the EC2 instances in your cluster.",
+				Usage: "Specifies the name of an existing Amazon EC2 key pair to enable SSH access to the EC2 instances in your cluster.",
 			},
 			cli.BoolFlag{
 				Name:  capabilityIAMFlag,
-				Usage: "Acknowledge that this command may create IAM resources.",
+				Usage: "Acknowledges that this command may create IAM resources.",
 			},
 			cli.StringFlag{
 				Name:  asgMaxSizeFlag,
-				Usage: "[Optional] Specify the number of instances to register to the cluster. The default is 1.",
+				Usage: "[Optional] Specifies the number of instances to launch and register to the cluster. Defaults to 1.",
 			},
 			cli.StringFlag{
 				Name:  vpcAzFlag,
-				Usage: "[Optional] Specify a comma-separated list of 2 VPC availability zones in which to create subnets (these AZs must be in the 'available' status). This option is recommended if you do not specify a VPC ID with the --vpc option. WARNING: Leaving this option blank can result in failure to launch container instances if an unavailable AZ is chosen at random.",
+				Usage: "[Optional] Specifies a comma-separated list of 2 VPC Availability Zones in which to create subnets (these zones must have the available status). This option is recommended if you do not specify a VPC ID with the --vpc option. WARNING: Leaving this option blank can result in failure to launch container instances if an unavailable zone is chosen at random.",
 			},
 			cli.StringFlag{
 				Name:  securityGroupFlag,
-				Usage: "[Optional] Specify an existing security group to associate it with container instances. Defaults to creating a new one.",
+				Usage: "[Optional] Specifies an existing security group to associate with your container instances. If you do not specify a security group here, then a new one is created.",
 			},
 			cli.StringFlag{
 				Name:  sourceCidrFlag,
-				Usage: "[Optional] Specify a CIDR/IP range for the security group to use for container instances in your cluster. Defaults to 0.0.0.0/0 if --security-group is not specified",
+				Usage: "[Optional] Specifies a CIDR/IP range for the security group to use for container instances in your cluster. This parameter is ignored if an existing security group is specified with the --security-group option. Defaults to 0.0.0.0/0 .",
 			},
 			cli.StringFlag{
 				Name:  ecsPortFlag,
-				Usage: "[Optional] Specify a port to open on a new security group that is created for your container instances if an existing security group is not specified with the --security-group option. Defaults to port 80.",
+				Usage: "[Optional] Specifies a port to open on the security group to use for container instances in your cluster. This parameter is ignored if an existing security group is specified with the --security-group option. Defaults to port 80.",
 			},
 			cli.StringFlag{
 				Name:  subnetIdsFlag,
-				Usage: "[Optional] Specify a comma-separated list of existing VPC Subnet IDs in which to launch your container instances. This option is required if you specify a VPC with the --vpc option.",
+				Usage: "[Optional] Specifies a comma-separated list of existing VPC Subnet IDs in which to launch your container instances. This option is required if you specify a VPC with the --vpc option.",
 			},
 			cli.StringFlag{
 				Name:  vpcIdFlag,
-				Usage: "[Optional] Specify the ID of an existing VPC in which to launch your container instances. If you specify a VPC ID, you must specify a list of existing subnets in that VPC with the --subnets option. If you do not specify a VPC ID, a new VPC is created with two subnets.",
+				Usage: "[Optional] Specifies the ID of an existing VPC in which to launch your container instances. If you specify a VPC ID, you must specify a list of existing subnets in that VPC with the --subnets option. If you do not specify a VPC ID, a new VPC is created with two subnets.",
 			},
 			cli.StringFlag{
 				Name:  instanceTypeFlag,
-				Usage: "[Optional] Specify the EC2 instance type for your container instances.",
+				Usage: "[Optional] Specifies the EC2 instance type for your container instances. Defaults to t2.micro.",
 			},
 			cli.StringFlag{
 				Name:  imageIdFlag,
-				Usage: "[Optional] Specify the ID of the AMI for your container Instances.",
+				Usage: "[Optional] Specify the AMI ID for your container instances. Defaults to amazon-ecs-optimized AMI.",
 			},
 		},
 	}
@@ -94,12 +94,12 @@ func UpCommand() cli.Command {
 func DownCommand() cli.Command {
 	return cli.Command{
 		Name:   "down",
-		Usage:  "Delete the ECS Cluster and associated resources in the CloudFormation stack.",
+		Usage:  "Deletes the CloudFormation stack that was created by ecs-cli up and the associated resources. The --force option is required.",
 		Action: ClusterDown,
 		Flags: []cli.Flag{
 			cli.BoolFlag{
 				Name:  forceFlag + ", f",
-				Usage: "Overrides cofirmation prompt before deleting resources",
+				Usage: "Acknowledges that this command permanently deletes resources.",
 			},
 		},
 	}
@@ -108,16 +108,16 @@ func DownCommand() cli.Command {
 func ScaleCommand() cli.Command {
 	return cli.Command{
 		Name:   "scale",
-		Usage:  "Modify the number of container instances in your cluster.",
+		Usage:  "Modifies the number of container instances in your cluster. This command changes the desired and maximum instance count in the Auto Scaling group created by the ecs-cli up command. You can use this command to scale up (increase the number of instances) or scale down (decrease the number of instances) your cluster.",
 		Action: ClusterScale,
 		Flags: []cli.Flag{
 			cli.BoolFlag{
 				Name:  capabilityIAMFlag,
-				Usage: "Acknowledge that this command may create IAM resources.",
+				Usage: "Acknowledges that this command may create IAM resources.",
 			},
 			cli.StringFlag{
 				Name:  asgMaxSizeFlag,
-				Usage: "Specify the number of instances to maintain in your cluster.",
+				Usage: "Specifies the number of instances to maintain in your cluster.",
 			},
 		},
 	}
@@ -126,7 +126,7 @@ func ScaleCommand() cli.Command {
 func PsCommand() cli.Command {
 	return cli.Command{
 		Name:   "ps",
-		Usage:  "List all of the running containers in your ECS Cluster.",
+		Usage:  "Lists all of the running containers in your ECS cluster",
 		Action: ClusterPS,
 	}
 }

--- a/ecs-cli/modules/command/configure.go
+++ b/ecs-cli/modules/command/configure.go
@@ -26,41 +26,41 @@ import (
 func ConfigureCommand() cli.Command {
 	return cli.Command{
 		Name:   "configure",
-		Usage:  "Configures your AWS credentials, the AWS region to use, and the EC2 Container Service cluster name to use with the ECS CLI.",
+		Usage:  "Configures your AWS credentials, the AWS region to use, and the ECS cluster name to use with the Amazon ECS CLI. The resulting configuration is stored in the ~/.ecs/config file.",
 		Action: configure,
 		Flags: []cli.Flag{
 			cli.StringFlag{
 				Name: ecscli.RegionFlag + ", r",
 				Usage: fmt.Sprintf(
-					"Specify the AWS Region to use.",
+					"Specifies the AWS region to use. If the AWS_REGION environment variable is set when ecs-cli configure is run, then the AWS region is set to the value of that environment variable.",
 				),
 				EnvVar: "AWS_REGION",
 			},
 			cli.StringFlag{
 				Name: ecscli.AccessKeyFlag,
 				Usage: fmt.Sprintf(
-					"Specify the AWS access key to use.",
+					"Specifies the AWS access key to use. If the AWS_ACCESS_KEY_ID environment variable is set when ecs-cli configure is run, then the AWS access key ID is set to the value of that environment variable.",
 				),
 				EnvVar: "AWS_ACCESS_KEY_ID",
 			},
 			cli.StringFlag{
 				Name: ecscli.SecretKeyFlag,
 				Usage: fmt.Sprintf(
-					"Specify the AWS secret key to use.",
+					"Specifies the AWS secret key to use. If the AWS_SECRET_ACCESS_KEY environment variable is set when ecs-cli configure is run, then the AWS secret access key is set to the value of that environment variable.",
 				),
 				EnvVar: "AWS_SECRET_ACCESS_KEY",
 			},
 			cli.StringFlag{
 				Name: ecscli.ProfileFlag + ", p",
 				Usage: fmt.Sprintf(
-					"Specify your AWS credentials with an existing named profile from ~/.aws/credentials.",
+					"Specifies your AWS credentials with an existing named profile from ~/.aws/credentials. If the AWS_PROFILE environment variable is set when ecs-cli configure is run, then the AWS named profile is set to the value of that environment variable.",
 				),
 				EnvVar: "AWS_PROFILE",
 			},
 			cli.StringFlag{
 				Name: ecscli.ClusterFlag + ", c",
 				Usage: fmt.Sprintf(
-					"Specify the ECS cluster name to use. If the cluster does not exist, it will be created.",
+					"Specifies the ECS cluster name to use. If the cluster does not exist, it is created when you try to add resources to it with the ecs-cli up command.",
 				),
 				// TODO: Override behavior for all ecs-cli commands : CommandLineFlags > EnvVar > ConfigFile > Defaults
 				// Commenting it now to avoid user misunderstanding the behavior of this env var with other ecs-cli commands

--- a/ecs-cli/modules/compose/cli/ecs/app/command.go
+++ b/ecs-cli/modules/compose/cli/ecs/app/command.go
@@ -51,7 +51,7 @@ const (
 func ComposeCommand(factory ProjectFactory) cli.Command {
 	return cli.Command{
 		Name:   "compose",
-		Usage:  "Executes docker-compose–style commands on an ECS cluster.",
+		Usage:  "Executes docker-compose-style commands on an ECS cluster.",
 		Before: ecscli.BeforeApp,
 		Subcommands: []cli.Command{
 			createCommand(factory),

--- a/ecs-cli/modules/compose/cli/ecs/app/command.go
+++ b/ecs-cli/modules/compose/cli/ecs/app/command.go
@@ -51,7 +51,7 @@ const (
 func ComposeCommand(factory ProjectFactory) cli.Command {
 	return cli.Command{
 		Name:   "compose",
-		Usage:  "Execute docker-compose style commands on an ECS cluster.",
+		Usage:  "Executes docker-compose–style commands on an ECS cluster.",
 		Before: ecscli.BeforeApp,
 		Subcommands: []cli.Command{
 			createCommand(factory),
@@ -76,17 +76,18 @@ func ComposeCommand(factory ProjectFactory) cli.Command {
 func commonComposeFlags() []cli.Flag {
 	return []cli.Flag{
 		cli.BoolFlag{
-			Name: ecscli.VerboseFlag + ",debug",
+			Name:  ecscli.VerboseFlag + ",debug",
+			Usage: "Increase the verbosity of command output to aid in diagnostics.",
 		},
 		cli.StringFlag{
 			Name:   composeFileNameFlag + ",f",
-			Usage:  "Specify an alternate compose file to use (default: " + composeFileNameDefaultValue + " ).",
+			Usage:  "Specifies the Docker compose file to use. Defaults to " + composeFileNameDefaultValue + " file.",
 			Value:  composeFileNameDefaultValue,
 			EnvVar: "COMPOSE_FILE",
 		},
 		cli.StringFlag{
 			Name:   projectNameFlag + ",p",
-			Usage:  "Specify an alternate project name to use (default: directory name).",
+			Usage:  "Specifies the project name to use. Defaults to the current directory name.",
 			EnvVar: "COMPOSE_PROJECT_NAME",
 		},
 	}
@@ -101,7 +102,7 @@ func populate(ecsContext *ecscompose.Context, cliContext *cli.Context) {
 func createCommand(factory ProjectFactory) cli.Command {
 	return cli.Command{
 		Name:   "create",
-		Usage:  "Create an ECS task definition from your compose file.",
+		Usage:  "Creates an ECS task definition from your compose file.",
 		Action: WithProject(factory, ProjectCreate, false),
 	}
 }
@@ -110,7 +111,7 @@ func psCommand(factory ProjectFactory) cli.Command {
 	return cli.Command{
 		Name:    "ps",
 		Aliases: []string{"list"},
-		Usage:   "List all the containers in your cluster.",
+		Usage:   "Lists all the containers in your cluster that were started by the compose project.",
 		Action:  WithProject(factory, ProjectPs, false),
 	}
 }
@@ -118,7 +119,7 @@ func psCommand(factory ProjectFactory) cli.Command {
 func upCommand(factory ProjectFactory) cli.Command {
 	return cli.Command{
 		Name:   "up",
-		Usage:  "Create an ECS task definition from your compose file (if it does not already exist) and run one instance of that task on your cluster.",
+		Usage:  "Creates an ECS task definition from your compose file (if it does not already exist) and runs one instance of that task on your cluster (a combination of create and start).",
 		Action: WithProject(factory, ProjectUp, false),
 	}
 }
@@ -126,7 +127,7 @@ func upCommand(factory ProjectFactory) cli.Command {
 func startCommand(factory ProjectFactory) cli.Command {
 	return cli.Command{
 		Name:   "start",
-		Usage:  "Starts the containers from your compose file.",
+		Usage:  "Starts a single task from the task definition created from your compose file.",
 		Action: WithProject(factory, ProjectStart, false),
 	}
 }
@@ -135,7 +136,7 @@ func runCommand(factory ProjectFactory) cli.Command {
 	return cli.Command{
 		Name: "run",
 		Usage: "ecs-cli compose run [containerName] [command] [containerName] [command] ..." +
-			"- starts all containers overriding commands with the supplied one-off commands for the containers",
+			"- starts all containers overriding commands with the supplied one-off commands for the containers.",
 		Action: WithProject(factory, ProjectRun, false),
 	}
 }
@@ -144,7 +145,7 @@ func stopCommand(factory ProjectFactory) cli.Command {
 	return cli.Command{
 		Name:    "stop",
 		Aliases: []string{"down"},
-		Usage:   "stops all the containers and ECS automatically deletes them after a while",
+		Usage:   "Stops all the running tasks created by the compose project.",
 		Action:  WithProject(factory, ProjectStop, false),
 	}
 }
@@ -152,7 +153,7 @@ func stopCommand(factory ProjectFactory) cli.Command {
 func scaleCommand(factory ProjectFactory) cli.Command {
 	return cli.Command{
 		Name:   "scale",
-		Usage:  "ecs-cli compose scale [count] - scales each container to the specified count",
+		Usage:  "ecs-cli compose scale [count] - scales the number of running tasks to the specified count.",
 		Action: WithProject(factory, ProjectScale, false),
 	}
 }

--- a/ecs-cli/modules/compose/cli/ecs/app/service_command.go
+++ b/ecs-cli/modules/compose/cli/ecs/app/service_command.go
@@ -41,7 +41,7 @@ const CreateServiceCommandName = "create"
 func serviceCommand(factory ProjectFactory) cli.Command {
 	return cli.Command{
 		Name:   "service",
-		Usage:  "Create an ECS Service from your compose file.",
+		Usage:  "Manage Amazon ECS services with docker-compose-style commands on an ECS cluster.",
 		Subcommands: []cli.Command{
 			createServiceCommand(factory),
 			startServiceCommand(factory),
@@ -57,7 +57,7 @@ func serviceCommand(factory ProjectFactory) cli.Command {
 func createServiceCommand(factory ProjectFactory) cli.Command {
 	return cli.Command{
 		Name:   CreateServiceCommandName,
-		Usage:  "Create an ECS service from your compose file. The service is created with a desired count of 0, so no containers are started by this command.",
+		Usage:  "Creates an ECS service from your compose file. The service is created with a desired count of 0, so no containers are started by this command.",
 		Action: WithProject(factory, ProjectCreate, true),
 	}
 }
@@ -65,7 +65,7 @@ func createServiceCommand(factory ProjectFactory) cli.Command {
 func startServiceCommand(factory ProjectFactory) cli.Command {
 	return cli.Command{
 		Name:   "start",
-		Usage:  "Start one copy of each of the containers on the created ECS service. This command updates the desired count of the service to 1.",
+		Usage:  "Starts one copy of each of the containers on the created ECS service. This command updates the desired count of the service to 1.",
 		Action: WithProject(factory, ProjectStart, true),
 	}
 }
@@ -73,7 +73,7 @@ func startServiceCommand(factory ProjectFactory) cli.Command {
 func upServiceCommand(factory ProjectFactory) cli.Command {
 	return cli.Command{
 		Name:   "up",
-		Usage:  "Create an ECS service from your compose file. If no tasks from this compose file are currently running in your cluster, the service is started with a desired count of 1. If tasks from this compose file are currently running, the desired count of the service is set to the number of running tasks.",
+		Usage:  "Creates an ECS service from your compose file (if it does not already exist) and runs one instance of that task on your cluster (a combination of create and start). This command updates the desired count of the service to 1.",
 		Action: WithProject(factory, ProjectUp, true),
 	}
 }
@@ -82,7 +82,7 @@ func psServiceCommand(factory ProjectFactory) cli.Command {
 	return cli.Command{
 		Name:    "ps",
 		Aliases: []string{"list"},
-		Usage:   "List all the containers in this service.",
+		Usage:   "Lists all the containers in your cluster that belong to the service created with the compose project.",
 		Action:  WithProject(factory, ProjectPs, true),
 	}
 }
@@ -90,7 +90,7 @@ func psServiceCommand(factory ProjectFactory) cli.Command {
 func scaleServiceCommand(factory ProjectFactory) cli.Command {
 	return cli.Command{
 		Name:   "scale",
-		Usage:  "ecs-cli compose service scale [count] - updates the count",
+		Usage:  "ecs-cli compose service scale [count] - scales the desired count of the service to the specified count",
 		Action: WithProject(factory, ProjectScale, true),
 	}
 }
@@ -98,7 +98,7 @@ func scaleServiceCommand(factory ProjectFactory) cli.Command {
 func stopServiceCommand(factory ProjectFactory) cli.Command {
 	return cli.Command{
 		Name:    "stop",
-		Usage:   "Stop the containers in this service. This command updates the desired count of the service to 0.",
+		Usage:   "Stops the running tasks that belong to the service created with the compose project. This command updates the desired count of the service to 0.",
 		Action:  WithProject(factory, ProjectStop, true),
 	}
 }
@@ -107,7 +107,7 @@ func rmServiceCommand(factory ProjectFactory) cli.Command {
 	return cli.Command{
 		Name:    "rm",
 		Aliases: []string{"delete", "down"},
-		Usage:   "deletes the service",
+		Usage:   "Updates the desired count of the service to 0 and then deletes the service.",
 		Action:  WithProject(factory, ProjectDown, true),
 	}
 }


### PR DESCRIPTION
Reference URL : http://docs.aws.amazon.com/AmazonECS/latest/developerguide/ECS_CLI_reference.html 