### PR TITLE
ECS-CLI Amazon ELB Support

### DIFF
--- a/ecs-cli/modules/aws/clients/cloudformation/params.go
+++ b/ecs-cli/modules/aws/clients/cloudformation/params.go
@@ -34,6 +34,7 @@ const (
 	ParameterKeyKeyPairName   = "KeyName"
 	ParameterKeyCluster       = "EcsCluster"
 	ParameterKeyAmiId         = "EcsAmiId"
+	ParameterKeyCertificate   = "Certificate"
 )
 
 var ParameterNotFoundError = errors.New("Parameter not found")

--- a/ecs-cli/modules/aws/clients/ecs/client.go
+++ b/ecs-cli/modules/aws/clients/ecs/client.go
@@ -134,11 +134,29 @@ func (client *ecsClient) DeleteService(serviceName string) error {
 }
 
 func (client *ecsClient) CreateService(serviceName, taskDefName string) error {
-	_, err := client.client.CreateService(&ecs.CreateServiceInput{
+	taskDef, err := client.DescribeTaskDefinition(taskDefName)
+	if err != nil {
+		log.WithFields(log.Fields{
+			"service": serviceName,
+			"error":   err,
+		}).Error("Error creating service - could not describe task definition")
+		return err
+	}
+	lbs := make([]*ecs.LoadBalancer, len(taskDef.ContainerDefinitions))
+	for i, containerDef := range taskDef.ContainerDefinitions {
+		lbs[i] = &ecs.LoadBalancer{
+			ContainerName:    aws.String(*containerDef.Name),
+			ContainerPort:    aws.Int64(*containerDef.PortMappings[0].ContainerPort),
+			LoadBalancerName: aws.String(client.params.Cluster),
+		}
+	}
+	_, err = client.client.CreateService(&ecs.CreateServiceInput{
 		DesiredCount:   aws.Int64(0),            // Required
 		ServiceName:    aws.String(serviceName), // Required
 		TaskDefinition: aws.String(taskDefName), // Required
 		Cluster:        aws.String(client.params.Cluster),
+		LoadBalancers:  lbs,
+		Role:           aws.String("ecsServiceRole"),
 	})
 	if err != nil {
 		log.WithFields(log.Fields{
@@ -148,7 +166,8 @@ func (client *ecsClient) CreateService(serviceName, taskDefName string) error {
 		return err
 	}
 	log.WithFields(log.Fields{
-		"service": serviceName,
+		"service":     serviceName,
+		"taskDefName": taskDefName,
 	}).Debug("Created ECS service")
 	return nil
 }

--- a/ecs-cli/modules/command/cluster.go
+++ b/ecs-cli/modules/command/cluster.go
@@ -31,6 +31,7 @@ const (
 	keypairNameFlag   = "keypair"
 	capabilityIAMFlag = "capability-iam"
 	forceFlag         = "force"
+	certificateFlag   = "certificate-arn"
 )
 
 func UpCommand() cli.Command {
@@ -86,6 +87,10 @@ func UpCommand() cli.Command {
 			cli.StringFlag{
 				Name:  imageIdFlag,
 				Usage: "[Optional] Specify the AMI ID for your container instances. Defaults to amazon-ecs-optimized AMI.",
+			},
+			cli.StringFlag{
+				Name:  certificateFlag,
+				Usage: "Specify the certificate-arn for the Amazon ELB.",
 			},
 		},
 	}

--- a/ecs-cli/modules/command/cluster_app.go
+++ b/ecs-cli/modules/command/cluster_app.go
@@ -44,6 +44,7 @@ func init() {
 		instanceTypeFlag:  cloudformation.ParameterKeyInstanceType,
 		keypairNameFlag:   cloudformation.ParameterKeyKeyPairName,
 		imageIdFlag:       cloudformation.ParameterKeyAmiId,
+		certificateFlag:   cloudformation.ParameterKeyCertificate,
 	}
 }
 
@@ -129,6 +130,14 @@ func createCluster(context *cli.Context, rdwr config.ReadWriter, ecsClient ecscl
 	// Populate cfn params
 	cfnParams := cliFlagsToCfnStackParams(context)
 	cfnParams.Add(cloudformation.ParameterKeyCluster, ecsParams.Cluster)
+
+	// Check if certificate exists
+	_, err = cfnParams.GetParameter(cloudformation.ParameterKeyCertificate)
+	if err == cloudformation.ParameterNotFoundError {
+		return fmt.Errorf("Please specify the certificate-arn name with '--%s' flag", certificateFlag)
+	} else if err != nil {
+		return err
+	}
 
 	// Check if key pair exists
 	_, err = cfnParams.GetParameter(cloudformation.ParameterKeyKeyPairName)

--- a/ecs-cli/modules/command/cluster_app_test.go
+++ b/ecs-cli/modules/command/cluster_app_test.go
@@ -83,6 +83,7 @@ func TestClusterUp(t *testing.T) {
 	flagSet := flag.NewFlagSet("ecs-cli-up", 0)
 	flagSet.Bool(capabilityIAMFlag, true, "")
 	flagSet.String(keypairNameFlag, "default", "")
+	flagSet.String(certificateFlag, "default", "")
 
 	context := cli.NewContext(nil, flagSet, globalContext)
 	err := createCluster(context, &mockReadWriter{}, mockEcs, mockCloudformation, ami.NewStaticAmiIds())
@@ -198,6 +199,7 @@ func TestClusterUpForImageIdInput(t *testing.T) {
 	flagSet.Bool(capabilityIAMFlag, true, "")
 	flagSet.String(keypairNameFlag, "default", "")
 	flagSet.String(imageIdFlag, imageId, "")
+	flagSet.String(certificateFlag, "default", "")
 
 	context := cli.NewContext(nil, flagSet, globalContext)
 	err := createCluster(context, &mockReadWriter{}, mockEcs, mockCloudformation, ami.NewStaticAmiIds())

--- a/ecs-cli/modules/config/config.go
+++ b/ecs-cli/modules/config/config.go
@@ -41,6 +41,7 @@ type CliConfig struct {
 // SectionKeys is the struct embedded in CliConfig. It groups all the keys in the 'ecs' section in the ini file.
 type SectionKeys struct {
 	Cluster      string `ini:"cluster"`
+	Certificate  string `ini:"certificate_arn"`
 	AwsProfile   string `ini:"aws_profile"`
 	Region       string `ini:"region"`
 	AwsAccessKey string `ini:"aws_access_key_id"`

--- a/ecs-cli/modules/config/params.go
+++ b/ecs-cli/modules/config/params.go
@@ -28,6 +28,7 @@ const cloudformationStackNamePrefix = "amazon-ecs-cli-setup"
 // CliParams saves config to create an aws service clients
 type CliParams struct {
 	Cluster string
+	Certificate string
 	Config  *aws.Config
 }
 
@@ -53,5 +54,5 @@ func NewCliParams(context *cli.Context, rdwr ReadWriter) (*CliParams, error) {
 		return nil, err
 	}
 
-	return &CliParams{Cluster: ecsConfig.Cluster, Config: svcConfig}, nil
+	return &CliParams{Cluster: ecsConfig.Cluster, Certificate: ecsConfig.Certificate, Config: svcConfig}, nil
 }


### PR DESCRIPTION
ECS-CLI Amazon ELB Support

Not sure why amazon ELB support is not provided by the amazon ecs-cli tool. Added a pull request to provide a simple configuration to get this started using the ecs-cli tool.
- Uses the cloud formation template to construct an ELB associated with your vpc
- Adds an extra parameter for the SSL certificate called certificate-arn.

```
certificate-arn = arn:aws:acm:us-east-1:000000000000:certificate/00000000-0000-0000-0000-000000000000
```
- Assumes the ECS instance uses port 80 and the ELB uses 443 and terminates SSL - this should ideally be optional and somehow configured but seems to be a good default.
- Opens Egress to everything for the ELB and only 443 and 80 for the ECS instance as it makes http calls - this again should be configurable.
- Added a cloudformation template that adds extra logging using the fluent logging driver - again should be configurable as not logging your docker container logs seems wrong.Assumes you have added a task called fluentd-task and image for getting docker logs to wherever you need using fluentd
- Assumes you have a role called ecsServiceRole that connects ELB and ECS.

The IAM policy for the ecsServiceRole looks like this

```
{
  "Version": "2012-10-17",
  "Statement": [
    {
      "Effect": "Allow",
      "Action": [
        "elasticloadbalancing:Describe*",
        "elasticloadbalancing:DeregisterInstancesFromLoadBalancer",
        "elasticloadbalancing:RegisterInstancesWithLoadBalancer",
        "ec2:Describe*",
        "ec2:AuthorizeSecurityGroupIngress"
      ],
      "Resource": [
        "*"
      ]
    }
  ]
}
```

This tries to provide an out of the box configuration for connecting amazon ELB and Amazon ECS but should be more configurable so that custom configurations can be easily altered.

This is something that I created in a short time frame that needs extra work to parameterize more, but the default should ideally work for simple configurations.
