### PR TITLE
Add support for compose option env_file. Also, support session environment variables.

### DIFF
--- a/ecs-cli/modules/compose/cli/ecs/app/command.go
+++ b/ecs-cli/modules/compose/cli/ecs/app/command.go
@@ -102,7 +102,7 @@ func populate(ecsContext *ecscompose.Context, cliContext *cli.Context) {
 func createCommand(factory ProjectFactory) cli.Command {
 	return cli.Command{
 		Name:   "create",
-		Usage:  "Creates an ECS task definition from your compose file.",
+		Usage:  "Creates an ECS task definition from your compose file. Note that we do not recommend using plain text environment variables for sensitive information, such as credential data.",
 		Action: WithProject(factory, ProjectCreate, false),
 	}
 }

--- a/ecs-cli/modules/compose/cli/ecs/app/service_command.go
+++ b/ecs-cli/modules/compose/cli/ecs/app/service_command.go
@@ -60,7 +60,7 @@ func serviceCommand(factory ProjectFactory) cli.Command {
 func createServiceCommand(factory ProjectFactory) cli.Command {
 	return cli.Command{
 		Name:   ecs.CreateServiceCommandName,
-		Usage:  "Creates an ECS service from your compose file. The service is created with a desired count of 0, so no containers are started by this command.",
+		Usage:  "Creates an ECS service from your compose file. The service is created with a desired count of 0, so no containers are started by this command. Note that we do not recommend using plain text environment variables for sensitive information, such as credential data.",
 		Action: WithProject(factory, ProjectCreate, true),
 		Flags:  deploymentConfigFlags(true),
 	}

--- a/ecs-cli/modules/compose/ecs/context.go
+++ b/ecs-cli/modules/compose/ecs/context.go
@@ -51,6 +51,9 @@ func (context *Context) open() error {
 	context.ECSClient.Initialize(context.ECSParams)
 
 	context.EC2Client = ec2client.NewEC2Client(context.ECSParams)
+
+	context.Context.EnvironmentLookup = &libcompose.OsEnvLookup{}
+	context.Context.ConfigLookup = &libcompose.FileConfigLookup{}
 	return nil
 }
 

--- a/ecs-cli/modules/compose/ecs/utils/convert_compose_yml.go
+++ b/ecs-cli/modules/compose/ecs/utils/convert_compose_yml.go
@@ -32,6 +32,7 @@ func composeOptionsInit() {
 		"dns":          true,
 		"dns_search":   true,
 		"entrypoint":   true,
+		"env_file":     true,
 		"environment":  true,
 		"extra_hosts":  true,
 		"hostname":     true,

--- a/ecs-cli/modules/compose/ecs/utils/convert_compose_yml_test.go
+++ b/ecs-cli/modules/compose/ecs/utils/convert_compose_yml_test.go
@@ -28,7 +28,8 @@ func TestUnmarshalComposeConfig(t *testing.T) {
 	dnsServers := []string{"1.2.3.4"}
 	dnsSearchDomains := []string{"search.example.com"}
 	entryPoint := "/code/entrypoint.sh"
-	env := []string{"RACK_ENV=development", "SESSION_SECRET=session_secret"}
+	envFiles := []string{"./common.env", "/opt/prod.env"}
+	env := []string{"RACK_ENV=development", "SESSION_PORT=session_port"}
 	extraHosts := []string{"test.local:127.10.10.10"}
 	hostname := "foobarbaz"
 	labels := map[string]string{
@@ -59,9 +60,12 @@ func TestUnmarshalComposeConfig(t *testing.T) {
    - 1.2.3.4
   dns_search: search.example.com
   entrypoint: /code/entrypoint.sh
+  env_file:
+   - ./common.env
+   - /opt/prod.env
   environment:
     RACK_ENV: development
-    SESSION_SECRET: session_secret
+    SESSION_PORT: session_port
   extra_hosts:
    - test.local:127.10.10.10
   hostname: "foobarbaz"
@@ -135,6 +139,9 @@ redis:
 	sort.Strings(webEnv)
 	if !reflect.DeepEqual(env, webEnv) {
 		t.Errorf("Expected Environment to be [%v] but got [%v]", env, webEnv)
+	}
+	if !reflect.DeepEqual(envFiles, web.EnvFile.Slice()) {
+		t.Errorf("Expected env_file to be [%v] but got [%v]", envFiles, web.EnvFile.Slice())
 	}
 
 	if !reflect.DeepEqual(extraHosts, web.ExtraHosts) {

--- a/ecs-cli/modules/compose/libcompose/merge.go
+++ b/ecs-cli/modules/compose/libcompose/merge.go
@@ -1,0 +1,77 @@
+// This file is derived from Docker's Libcompose project, Copyright 2015 Docker, Inc.
+// The original code may be found :
+// https://github.com/docker/libcompose/blob/master/project/merge.go
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Modifications are Copyright 2015-2016 Amazon.com, Inc. or its affiliates. Licensed under the Apache License 2.0
+// - Extracted local variables
+// - Continued to use "ConfigLookup" instead of the new "ResourceLookup"
+// - Instead of introducing a new struct RawService, passed the necessary config
+
+package libcompose
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"strings"
+)
+
+// GetEnvVarsFromConfig reads the environment variables from the compose file keys : environment and env_file
+func GetEnvVarsFromConfig(context Context, inputCfg *ServiceConfig) ([]string, error) {
+
+	envVars := inputCfg.Environment.Slice()
+	envFiles := inputCfg.EnvFile.Slice()
+	if len(envFiles) == 0 {
+		return envVars, nil
+	}
+
+	composeFile := context.ComposeFile
+	if context.ConfigLookup == nil {
+		return nil, fmt.Errorf("Can not use env_file in file %s no mechanism provided to load files", composeFile)
+	}
+
+	for i := len(envFiles) - 1; i >= 0; i-- {
+		envFile := envFiles[i]
+		// Lookup envFile relative to the compose file path
+		content, _, err := context.ConfigLookup.Lookup(envFile, composeFile)
+		if err != nil {
+			return nil, err
+		}
+
+		scanner := bufio.NewScanner(bytes.NewBuffer(content))
+		for scanner.Scan() {
+			line := strings.TrimSpace(scanner.Text())
+			key := strings.SplitAfter(line, "=")[0]
+
+			found := false
+			for _, v := range envVars {
+				if strings.HasPrefix(v, key) {
+					found = true
+					break
+				}
+			}
+
+			if !found {
+				envVars = append(envVars, line)
+			}
+		}
+
+		if scanner.Err() != nil {
+			return nil, scanner.Err()
+		}
+	}
+
+	return envVars, nil
+}

--- a/ecs-cli/modules/compose/libcompose/merge_test.go
+++ b/ecs-cli/modules/compose/libcompose/merge_test.go
@@ -1,0 +1,143 @@
+// Copyright 2015-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package libcompose
+
+import (
+	"io/ioutil"
+	"os"
+	"sort"
+	"testing"
+)
+
+func TestGetEnvVarsFromConfigWhenNoEnvVars(t *testing.T) {
+	observedEnvVars, err := GetEnvVarsFromConfig(Context{}, &ServiceConfig{})
+	if err != nil {
+		t.Fatal("Unexpected error while GetEnvVarsFromConfig when no env vars exist")
+	}
+	if len(observedEnvVars) != 0 {
+		t.Errorf("Expected GetEnvVarsFromConfig to return empty env vars but got [%v]", observedEnvVars)
+	}
+}
+
+func TestGetEnvVarsFromConfigWhenNoEnvFiles(t *testing.T) {
+	envKey := "rails_env"
+	envValue := "development"
+	env := envKey + "=" + envValue
+	serviceConfig := &ServiceConfig{
+		Environment: NewMaporEqualSlice([]string{env}),
+	}
+	observedEnvVars, err := GetEnvVarsFromConfig(Context{}, serviceConfig)
+	if err != nil {
+		t.Fatal("Unexpected error while GetEnvVarsFromConfig when no env files exist")
+	}
+	if len(observedEnvVars) != 1 || observedEnvVars[0] != env {
+		t.Errorf("Expected GetEnvVarsFromConfig to return env vars [%s] but got [%v]", env, observedEnvVars)
+	}
+}
+
+func TestGetEnvVarsFromConfigWhenEnvFilesButNoLookup(t *testing.T) {
+	envKey := "rails_env"
+	envValue := "development"
+	env := envKey + "=" + envValue
+	envFileName := "envFile"
+	serviceConfig := &ServiceConfig{
+		Environment: NewMaporEqualSlice([]string{env}),
+		EnvFile:     NewStringorslice(envFileName),
+	}
+	_, err := GetEnvVarsFromConfig(Context{}, serviceConfig)
+	if err == nil {
+		t.Fatal("Expected error while GetEnvVarsFromConfig when no config was supplied")
+	}
+}
+
+func TestGetEnvVarsFromConfigWhenEnvFilesButNoEnvVars(t *testing.T) {
+	envKey := "rails_env"
+	envValue := "development"
+	env := envKey + "=" + envValue
+	envContents := []byte(env)
+
+	envFile := writeToTmpFile(t, envContents)
+	defer os.Remove(envFile.Name()) // clean up
+
+	serviceConfig := &ServiceConfig{
+		EnvFile: NewStringorslice(envFile.Name()),
+	}
+	context := Context{
+		ConfigLookup: &FileConfigLookup{},
+	}
+	observedEnvVars, err := GetEnvVarsFromConfig(context, serviceConfig)
+
+	if err != nil {
+		t.Fatal("Unexpected error while GetEnvVarsFromConfig when env file is supplied")
+	}
+	if len(observedEnvVars) != 1 || observedEnvVars[0] != env {
+		t.Errorf("Expected GetEnvVarsFromConfig to return env vars [%s] but got [%v]", env, observedEnvVars)
+	}
+}
+
+func TestGetEnvVarsFromConfigWhenEnvVarsAndFiles(t *testing.T) {
+	envVar := "envKey1=envValue1"
+
+	envFile1var1 := "envKey2=envValue2"
+	envFile1var2 := "envKey1=envValue3" // repeat the same key as env var. Should not be selected.
+	envFile1var3 := "envKey4=envKey4"   // 2nd file has the same variable. Should not be selected.
+
+	envFile2var1 := "envKey3=envValue3"
+	envFile2var2 := "envKey4=envValue4first" // repeat the same key as previous file
+
+	envFile1 := writeToTmpFile(t, []byte(envFile1var1+"\n"+envFile1var2+"\n"+envFile1var3))
+	defer os.Remove(envFile1.Name())
+
+	envFile2 := writeToTmpFile(t, []byte(envFile2var1+"\n"+envFile2var2))
+	defer os.Remove(envFile2.Name())
+
+	serviceConfig := &ServiceConfig{
+		Environment: NewMaporEqualSlice([]string{envVar}),
+		EnvFile:     NewStringorslice(envFile1.Name(), envFile2.Name()),
+	}
+	context := Context{
+		ConfigLookup: &FileConfigLookup{},
+	}
+	observedEnvVars, err := GetEnvVarsFromConfig(context, serviceConfig)
+
+	if err != nil {
+		t.Fatal("Unexpected error while GetEnvVarsFromConfig when env file is supplied")
+	}
+	if len(observedEnvVars) != 4 {
+		t.Errorf("Expected GetEnvVarsFromConfig to return env vars count=[%d] but got=[%d]", 4, len(observedEnvVars))
+	}
+
+	sort.Strings(observedEnvVars)
+	verifyEnvVar(t, "envKey1=envValue1", observedEnvVars[0])
+	verifyEnvVar(t, "envKey2=envValue2", observedEnvVars[1])
+	verifyEnvVar(t, "envKey3=envValue3", observedEnvVars[2])
+	verifyEnvVar(t, "envKey4=envValue4first", observedEnvVars[3])
+}
+
+func verifyEnvVar(t *testing.T, expected, observed string) {
+	if expected != observed {
+		t.Errorf("Expected GetEnvVarsFromConfig to return env var [%s] but got [%s]", expected, observed)
+	}
+}
+
+func writeToTmpFile(t *testing.T, contents []byte) *os.File {
+	envFile, err := ioutil.TempFile("", "envfile")
+	if err != nil {
+		t.Fatal("Error creating tmp file:", err)
+	}
+	if _, err := envFile.Write(contents); err != nil {
+		t.Fatal("Error writing to tmp file:", err)
+	}
+	return envFile
+}


### PR DESCRIPTION
Closes aws/amazon-ecs-cli#48.

# TESTING
## ENV VARIABLE FROM SHELL
$ cat docker-compose.yml 
rails:
 ...
  environment:
    - STAGE
***
$ export STAGE="development"
$ ./bin/local/ecs-cli compose service create
INFO[0000] Using ECS task definition                     TaskDefinition=ecscompose-amazon-ecs-cli:16
INFO[0000] Created an ECS Service                       serviceName=ecscompose-service-amazon-ecs-cli taskDefinition=ecscompose-amazon-ecs-cli:16

$ aws ecs --region us-west-2 describe-task-definition --task-definition ecscompose-amazon-ecs-cli:16
                "environment": [
                    {
                        "name": "STAGE", 
                        "value": "development"
                    }
                ], 
***
UPDATED variable

$ export STAGE="testing"
$ ./bin/local/ecs-cli compose service up
INFO[0000] Using ECS task definition                     TaskDefinition=ecscompose-amazon-ecs-cli:17
INFO[0000] Updated the ECS service with a new task definition. Old containers will be stopped automatically, and replaced with new ones  desiredCount=1 serviceName=ecscompose-service-amazon-ecs-cli taskDefinition=ecscompose-amazon-ecs-cli:17
INFO[0000] Describe ECS Service status                   desiredCount=1 runningCount=0 serviceName=ecscompose-service-amazon-ecs-cli
INFO[0015] ECS Service has reached a stable state        desiredCount=1 runningCount=1 serviceName=ecscompose-service-amazon-ecs-cli
$ aws ecs --region us-west-2 describe-task-definition --task-definition ecscompose-amazon-ecs-cli:17
                "environment": [
                    {
                        "name": "STAGE", 
                        "value": "testing"
                    }
                ], 

***
UNSET variable

INFO[0005] Using ECS task definition                     TaskDefinition=ecscompose-amazon-ecs-cli:18
INFO[0005] Updated the ECS service with a new task definition. Old containers will be stopped automatically, and replaced with new ones  desiredCount=1 serviceName=ecscompose-service-amazon-ecs-cli taskDefinition=ecscompose-amazon-ecs-cli:18
INFO[0005] Describe ECS Service status                   desiredCount=1 runningCount=1 serviceName=ecscompose-service-amazon-ecs-cli
INFO[0035] Describe ECS Service status                   desiredCount=1 runningCount=1 serviceName=ecscompose-service-amazon-ecs-cli

$ aws ecs --region us-west-2 describe-task-definition --task-definition ecscompose-amazon-ecs-cli:18
                "environment": [], 

## ENV VARIABLES FROM FILE
$ cat docker-compose.yml 
rails:
...
  env_file:
    - ./envfile.env

$ cat envfile.env 
STAGE=

$ export STAGE="production"

$ ./bin/local/ecs-cli compose --project-name test service create
INFO[0000] Using ECS task definition                     TaskDefinition=ecscompose-test:5
INFO[0000] Created an ECS Service                        serviceName=ecscompose-service-test taskDefinition=ecscompose-test:5

$ aws ecs --region us-west-2 describe-task-definition --task-definition ecscompose-test:5
                "environment": [
                    {
                        "name": "STAGE", 
                        "value": "production"
                    }
                ], 

***
$ cat envfile.env 
STAGE=testing

$ ./bin/local/ecs-cli compose --project-name test service up
INFO[0000] Using ECS task definition                     TaskDefinition=ecscompose-test:6
INFO[0000] Updated the ECS service with a new task definition. Old containers will be stopped automatically, and replaced with new ones  desiredCount=1 serviceName=ecscompose-service-test taskDefinition=ecscompose-test:6
INFO[0000] Describe ECS Service status                   desiredCount=1 runningCount=0 serviceName=ecscompose-service-test

$ aws ecs --region us-west-2 describe-task-definition --task-definition ecscompose-test:6
                "environment": [
                    {
                        "name": "STAGE", 
                        "value": "testing"
                    }
                ], 
