### PR TITLE
Add missing EC2MetadataClient to EC2RoleProvider

### DIFF
--- a/ecs-cli/modules/config/aws_credentials_example.ini
+++ b/ecs-cli/modules/config/aws_credentials_example.ini
@@ -1,0 +1,7 @@
+[default]
+aws_access_key_id = defaultAwsAccessKey
+aws_secret_access_key = defaultAwsSecretKey
+
+[customProfile]
+aws_access_key_id = AKID
+aws_secret_access_key = SKID

--- a/ecs-cli/modules/config/config_test.go
+++ b/ecs-cli/modules/config/config_test.go
@@ -14,16 +14,26 @@
 package config
 
 import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/ec2metadata"
+	"github.com/aws/aws-sdk-go/aws/session"
 )
 
 const (
 	clusterName             = "defaultCluster"
-	profileName             = "defaultProfile"
+	profileName             = "customProfile"
 	region                  = "us-west-1"
 	awsAccessKey            = "AKID"
 	awsSecretKey            = "SKID"
+	defaultAwsAccessKey     = "defaultAwsAccessKey"
+	defaultAwsSecretKey     = "defaultAwsSecretKey"
 	envAwsAccessKey         = "envAKID"
 	envAwsSecretKey         = "envSKID"
 	credentialProviderCount = 4
@@ -32,7 +42,7 @@ const (
 func TestGetCredentialProvidersVerifyProviderCountHasNotChanged(t *testing.T) {
 	ecsConfig := NewCliConfig(clusterName)
 	ecsConfig.Region = region
-	credentialProviders := ecsConfig.getCredentialProviders()
+	credentialProviders := ecsConfig.getCredentialProviders(&ec2metadata.EC2Metadata{})
 	if len(credentialProviders) != credentialProviderCount {
 		t.Fatal("Unexpected number of credential providers in the chain: ", len(credentialProviders))
 	}
@@ -89,15 +99,53 @@ func TestToServiceConfigWhenUsingECSProfileCredentials(t *testing.T) {
 	}
 }
 
-// TODO Add proper tests for the shared credential provider resolution
 func TestToServiceConfigWhenAWSProfileSpecified(t *testing.T) {
-	t.Skip("Implement me")
+	os.Setenv("AWS_SHARED_CREDENTIALS_FILE", "aws_credentials_example.ini")
+	defer func() {
+		os.Unsetenv("AWS_SHARED_CREDENTIALS_FILE")
+	}()
+
+	ecsConfig := NewCliConfig(clusterName)
+	ecsConfig.Region = region
+
+	ecsConfig.AwsProfile = profileName
+
+	awsConfig, _ := ecsConfig.ToServiceConfig()
+	resolvedCredentials, err := awsConfig.Credentials.Get()
+	if err != nil {
+		t.Error("Error fetching credentials from the chain provider")
+	}
+
+	if awsAccessKey != resolvedCredentials.AccessKeyID {
+		t.Errorf("Invalid access key set. Expected [%s]. Got [%s]", awsAccessKey, resolvedCredentials.AccessKeyID)
+	}
+	if awsSecretKey != resolvedCredentials.SecretAccessKey {
+		t.Errorf("Invalid secret key set. Expected [%s]. Got [%s]", awsSecretKey, resolvedCredentials.SecretAccessKey)
+	}
 }
-func TestToServiceConfigWhenNoAWSProfileSpecified(t *testing.T) {
-	t.Skip("Implement me")
-}
-func TestToServiceConfigWhenUsingEC2InstanceRole(t *testing.T) {
-	t.Skip("Implement me")
+func TestToServiceConfigWhenAWSProfileIsNotSpecified(t *testing.T) {
+	os.Setenv("AWS_SHARED_CREDENTIALS_FILE", "aws_credentials_example.ini")
+	defer func() {
+		os.Unsetenv("AWS_SHARED_CREDENTIALS_FILE")
+	}()
+
+	ecsConfig := NewCliConfig(clusterName)
+	ecsConfig.Region = region
+	// not setting the profileName: it should use the "default" profile
+
+	awsConfig, _ := ecsConfig.ToServiceConfig()
+	resolvedCredentials, err := awsConfig.Credentials.Get()
+	if err != nil {
+		t.Error("Error fetching credentials from the chain provider")
+	}
+
+	if defaultAwsAccessKey != resolvedCredentials.AccessKeyID {
+		t.Errorf("Invalid access key set. Expected [%s]. Got [%s]", defaultAwsAccessKey, resolvedCredentials.AccessKeyID)
+	}
+	if defaultAwsSecretKey != resolvedCredentials.SecretAccessKey {
+		t.Errorf("Invalid secret key set. Expected [%s]. Got [%s]", defaultAwsSecretKey, resolvedCredentials.SecretAccessKey)
+	}
+
 }
 
 func TestToServiceConfigWhenRegionIsNotSpecified(t *testing.T) {
@@ -108,6 +156,88 @@ func TestToServiceConfigWhenRegionIsNotSpecified(t *testing.T) {
 		t.Error("There should always be an error when region is not specified in the ecsConfig.")
 	}
 }
+
+// Code excerpt to start a test server for ec2MetadataClient is taken from
+// github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds/ec2_role_provider_test.go
+const credsRespTmpl = `{
+  "Code": "Success",
+  "Type": "AWS-HMAC",
+  "AccessKeyId" : "AKID",
+  "SecretAccessKey" : "SKID",
+  "Token" : "token",
+  "Expiration" : "%s",
+  "LastUpdated" : "2009-11-23T0:00:00Z"
+}`
+
+const credsFailRespTmpl = `{
+  "Code": "ErrorCode",
+  "Message": "ErrorMsg",
+  "LastUpdated": "2009-11-23T0:00:00Z"
+}`
+
+func initTestServer(expireOn string, failAssume bool) *httptest.Server {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/latest/meta-data/iam/security-credentials" {
+			fmt.Fprintln(w, "RoleName")
+		} else if r.URL.Path == "/latest/meta-data/iam/security-credentials/RoleName" {
+			if failAssume {
+				fmt.Fprintf(w, credsFailRespTmpl)
+			} else {
+				fmt.Fprintf(w, credsRespTmpl, expireOn)
+			}
+		} else {
+			http.Error(w, "bad request", http.StatusBadRequest)
+		}
+	}))
+
+	return server
+}
+
+func TestGetCredentialProvidersWhenUsingEC2InstanceRole(t *testing.T) {
+	server := initTestServer("2016-06-19T00:00:00Z", false)
+	defer server.Close()
+
+	metadataClient := ec2metadata.New(session.New(), &aws.Config{Endpoint: aws.String(server.URL + "/latest")})
+
+	ecsConfig := NewCliConfig(clusterName)
+	ecsConfig.Region = region
+	credentialProviders := ecsConfig.getCredentialProviders(metadataClient)
+	chainCredentials := credentials.NewChainCredentials(credentialProviders)
+	creds, err := chainCredentials.Get()
+	if err != nil {
+		t.Error("Unexpected error occured when retrieving credentials from EC2 metadata service")
+	}
+
+	if awsAccessKey != creds.AccessKeyID {
+		t.Errorf("Invalid access key set. Expected [%s]. Got [%s]", awsAccessKey, creds.AccessKeyID)
+	}
+	if awsSecretKey != creds.SecretAccessKey {
+		t.Errorf("Invalid secret key set. Expected [%s]. Got [%s]", awsSecretKey, creds.SecretAccessKey)
+	}
+}
+
+func TestGetCredentialProvidersWhenEC2MetadataServiceReturnsFailure(t *testing.T) {
+	server := initTestServer("2016-06-19T00:00:00Z", true)
+	defer server.Close()
+
+	metadataClient := ec2metadata.New(session.New(), &aws.Config{Endpoint: aws.String(server.URL + "/latest")})
+
+	ecsConfig := NewCliConfig(clusterName)
+	ecsConfig.Region = region
+	credentialProviders := ecsConfig.getCredentialProviders(metadataClient)
+	chainCredentials := credentials.NewChainCredentials(credentialProviders)
+	_, err := chainCredentials.Get()
+	if err == nil {
+		t.Error("Expected an error while retrieving credentials from EC2 metadata service")
+	}
+}
+
 func TestToServiceConfigWhenNoCredentialsAreAvailable(t *testing.T) {
-	t.Skip("Implement me")
+	ecsConfig := NewCliConfig(clusterName)
+	ecsConfig.Region = region
+
+	_, err := ecsConfig.ToServiceConfig()
+	if err == nil {
+		t.Error("Should get an error for no credentials available")
+	}
 }


### PR DESCRIPTION
Fixes aws/amazon-ecs-cli#105

# Unit tests
$ make test
PASS

# Integration Tests
## On Local machine
$ make build
. ./scripts/shared_env && ./scripts/build_binary.sh ./bin/local
Built ecs-cli
$ ./bin/local/ecs-cli configure -r us-west-2 -c local-test
INFO[0000] Saved ECS CLI configuration for cluster (local-test) 
$ ./bin/local/ecs-cli up --capability-iam --keypair test_key_pair
INFO[0000] Created cluster cluster=local-test
INFO[0000] Waiting for your cluster resources to be created 
INFO[0000] Cloudformation stack status                   stackStatus=CREATE_IN_PROGRESS

## On EC2 instance
### BEFORE change
[ec2-user@ip-xx-x-x-xxx ~]$ sudo /usr/local/bin/ecs-cli up --capability-iam
panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xb code=0x1 addr=0x0 pc=0x6e9b05]

goroutine 1 [running]:
github.com/aws/aws-sdk-go/aws/ec2metadata.(*EC2Metadata).GetMetadata(0x0, 0xad3770, 0x19, 0x0, 0x0, 0x0, 0x0)
	/usr/src/app/src/github.com/aws/amazon-ecs-cli/ecs-cli/vendor/src/github.com/aws/aws-sdk-go/aws/ec2metadata/api.go:24 +0x1b5
github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds.requestCredList(0x0, 0x0, 0x0, 0x0, 0x0, 0x0)
	/usr/src/app/src/github.com/aws/amazon-ecs-cli/ecs-cli/vendor/src/github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds/ec2_role_provider.go:133 +0x85
github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds.(*EC2RoleProvider).Retrieve(0xc20800bb00, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
	/usr/src/app/src/github.com/aws/amazon-ecs-cli/ecs-cli/vendor/src/github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds/ec2_role_provider.go:89 +0x61
github.com/aws/aws-sdk-go/aws/credentials.(*ChainProvider).Retrieve(0xc20800bb30, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
	/usr/src/app/src/github.com/aws/amazon-ecs-cli/ecs-cli/vendor/src/github.com/aws/aws-sdk-go/aws/credentials/chain_provider.go:75 +0xfc

### AFTER change
[ec2-user@ip-xx-x-x-xxx ~]$ ./ecs-cli up --capability-iam --keypair test_key_pair
INFO[0000] Created cluster                               cluster=test
INFO[0000] Waiting for your cluster resources to be created 
INFO[0000] Cloudformation stack status                   stackStatus=CREATE_IN_PROGRESS

