### PR TITLE
Preserve compose project name as user has defined it.

### DIFF
--- a/ecs-cli/modules/compose/cli/ecs/app/command.go
+++ b/ecs-cli/modules/compose/cli/ecs/app/command.go
@@ -86,7 +86,7 @@ func commonComposeFlags() []cli.Flag {
 			EnvVar: "COMPOSE_FILE",
 		},
 		cli.StringFlag{
-			Name:   projectNameFlag + ",p",
+			Name:   ecscompose.ProjectNameFlag + ",p",
 			Usage:  "Specifies the project name to use. Defaults to the current directory name.",
 			EnvVar: "COMPOSE_PROJECT_NAME",
 		},
@@ -97,7 +97,7 @@ func commonComposeFlags() []cli.Flag {
 func populate(ecsContext *ecscompose.Context, cliContext *cli.Context) {
 	// TODO: Support multiple compose files
 	ecsContext.ComposeFiles = []string{cliContext.GlobalString(composeFileNameFlag)}
-	ecsContext.ProjectName = cliContext.GlobalString(projectNameFlag)
+	ecsContext.ProjectName = cliContext.GlobalString(ecscompose.ProjectNameFlag)
 }
 
 func createCommand(factory ProjectFactory) cli.Command {

--- a/ecs-cli/modules/compose/ecs/project.go
+++ b/ecs-cli/modules/compose/ecs/project.go
@@ -111,9 +111,15 @@ func (p *ecsProject) Parse() error {
 
 // parseCompose loads and parses the compose yml files
 func (p *ecsProject) parseCompose() error {
-	// load the compose files
+	// load the compose files using libcompose
 	logrus.Debug("Parsing the compose yaml...")
-	return p.Project.Parse()
+	if err := p.Project.Parse(); err != nil {
+		return err
+	}
+
+	// libcompose sanitizes the project name and removes any non alpha-numeric character.
+	// The following undo-es that and sets the project name as user defined it.
+	return p.context.SetProjectName()
 }
 
 // transformTaskDefinition converts the compose yml into task definition


### PR DESCRIPTION
closes aws/amazon-ecs-cli#125.

CONTEXT
---
Recently, ecs-cli was migrated to use libcompose for parsing the compose project (including project name and compose yml files). 
Libcompose normalizes the project name by removing '-' and other non alpha-numeric values from the name as seen in the commit https://github.com/docker/libcompose/commit/ca237071578647c6fef35f6d5a9e424bb6deca03, libcompose. This behavior is not documented anywhere in [Docker Compose project_name doc](https://docs.docker.com/compose/reference/envvars/#compose-project-name).
As a result, the project name parsing wasn't backward compatible with ecs-cli. This commit addresses that concern and resets the project name to what the user set (after libcompose parses it).

TEST
---
$ make generate

$ make test
PASS

$ make docker-build
Built ecs-cli for linux
Built ecs-cli for darwin

$ make build
. ./scripts/shared_env && ./scripts/build_binary.sh ./bin/local
Built ecs-cli

$ ./bin/local/ecs-cli compose --project-name proj-name up
INFO[0000] Using ECS task definition                     TaskDefinition=ecscompose-proj-name:1

---