### PR TITLE
Extend README.md - download specific version

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,12 +26,26 @@ Download the binary archive for your platform, decompress the archive, and
 install the binary on your `$PATH`. You can use the provided `md5` hash to 
 verify the integrity of your download.
 
+
+### Latest version
 * Linux: 
   * [https://s3.amazonaws.com/amazon-ecs-cli/ecs-cli-linux-amd64-latest](https://s3.amazonaws.com/amazon-ecs-cli/ecs-cli-linux-amd64-latest)
   * [https://s3.amazonaws.com/amazon-ecs-cli/ecs-cli-linux-amd64-latest.md5](https://s3.amazonaws.com/amazon-ecs-cli/ecs-cli-linux-amd64-latest.md5)
 * Macintosh:
   * [https://s3.amazonaws.com/amazon-ecs-cli/ecs-cli-darwin-amd64-latest](https://s3.amazonaws.com/amazon-ecs-cli/ecs-cli-darwin-amd64-latest)
   * [https://s3.amazonaws.com/amazon-ecs-cli/ecs-cli-darwin-amd64-latest.md5](https://s3.amazonaws.com/amazon-ecs-cli/ecs-cli-darwin-amd64-latest.md5)
+* Windows:
+  * (Not yet implemented)
+
+### Download specific version
+Using urls above, just replace `latest` with desired tag, for example `v0.4.1`. After download remember to rename binary to ecs-cli.
+
+* Linux: 
+  * [https://s3.amazonaws.com/amazon-ecs-cli/ecs-cli-linux-amd64-v0.4.1](https://s3.amazonaws.com/amazon-ecs-cli/ecs-cli-linux-amd64-v0.4.1)
+  * [https://s3.amazonaws.com/amazon-ecs-cli/ecs-cli-linux-amd64-v0.4.1.md5](https://s3.amazonaws.com/amazon-ecs-cli/ecs-cli-linux-amd64-v0.4.1.md5)
+* Macintosh:
+  * [https://s3.amazonaws.com/amazon-ecs-cli/ecs-cli-darwin-amd64-v0.4.1](https://s3.amazonaws.com/amazon-ecs-cli/ecs-cli-darwin-amd64-v0.4.1)
+  * [https://s3.amazonaws.com/amazon-ecs-cli/ecs-cli-darwin-amd64-v0.4.1.md5](https://s3.amazonaws.com/amazon-ecs-cli/ecs-cli-darwin-amd64-v0.4.1.md5)
 * Windows:
   * (Not yet implemented)
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ verify the integrity of your download.
   * (Not yet implemented)
 
 ### Download specific version
-Using urls above, just replace `latest` with desired tag, for example `v0.4.1`. After download remember to rename binary to ecs-cli.
+Using the URLs above, replace `latest` with the desired tag, for example `v0.4.1`. After downloading, remember to rename the binary file to `ecs-cli`.
 
 * Linux: 
   * [https://s3.amazonaws.com/amazon-ecs-cli/ecs-cli-linux-amd64-v0.4.1](https://s3.amazonaws.com/amazon-ecs-cli/ecs-cli-linux-amd64-v0.4.1)


### PR DESCRIPTION
Extend README with info how to download specific version from the S3, because sometimes you do not want to download the `latest` version.
