### PR TITLE
Partial support for multi-argument commands with compose run

### DIFF
--- a/ecs-cli/modules/aws/clients/ecs/client.go
+++ b/ecs-cli/modules/aws/clients/ecs/client.go
@@ -17,6 +17,7 @@ import (
 	"crypto/md5"
 	"errors"
 	"fmt"
+	"strings"
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/aws/clients"
@@ -402,7 +403,7 @@ func (client *ecsClient) RunTaskWithOverrides(taskDefinition, startedBy string, 
 	for cont, command := range overrides {
 		contOverride := &ecs.ContainerOverride{
 			Name:    aws.String(cont),
-			Command: aws.StringSlice([]string{command}),
+			Command: aws.StringSlice(strings.Split(command, ",")),
 		}
 		commandOverrides = append(commandOverrides, contOverride)
 	}


### PR DESCRIPTION
Addresses Issue #148 

Now, a user can pass commands with multiple arguments as a comma-delimited list into the ECS-CLI as:

`ecs-cli compose run <container> cmd0,cmd1,cmd2`

NOTE: subcommands with embedded commas are not yet supported, though this could be added in the future through the use of `encoding/csv` with an agreed-upon command-line delimiter escape sequence.
