### PR TITLE
Validate cluster name before running Cloudformation Stack

### DIFF
--- a/ecs-cli/modules/command/cluster_app.go
+++ b/ecs-cli/modules/command/cluster_app.go
@@ -122,6 +122,11 @@ func createCluster(context *cli.Context, rdwr config.ReadWriter, ecsClient ecscl
 		return err
 	}
 
+	// Check if cluster is specified
+	if ecsParams.Cluster == "" {
+		return fmt.Errorf("Please configure a cluster using the configure command.")
+	}
+
 	// Check if cfn stack already exists
 	cfnClient.Initialize(ecsParams)
 	stackName := ecsParams.GetCfnStackName()


### PR DESCRIPTION
Better validation message when running ecs-cli up without configuring a cluster name. 
https://github.com/aws/amazon-ecs-cli/issues/63