### PR TITLE
Cluster up --force tag to delete CloudFormation stack if it exists

### DIFF
--- a/ecs-cli/modules/command/cluster.go
+++ b/ecs-cli/modules/command/cluster.go
@@ -87,6 +87,10 @@ func UpCommand() cli.Command {
 				Name:  imageIdFlag,
 				Usage: "[Optional] Specify the AMI ID for your container instances. Defaults to amazon-ecs-optimized AMI.",
 			},
+			cli.BoolFlag{
+				Name:  forceFlag + ", f",
+				Usage: "[Optional] Forces the recreation of any existing resources that match your current configuration. This option is useful for cleaning up stale resources from previous failed attempts.",
+			},
 		},
 	}
 }

--- a/ecs-cli/modules/command/configure_test.go
+++ b/ecs-cli/modules/command/configure_test.go
@@ -23,6 +23,7 @@ import (
 
 const (
 	clusterName  = "defaultCluster"
+	stackName    = "defaultCluster"
 	profileName  = "defaultProfile"
 	region       = "us-west-1"
 	awsAccessKey = "AKID"


### PR DESCRIPTION
closes https://github.com/aws/amazon-ecs-cli/issues/44

$ make build
. ./scripts/shared_env && ./scripts/build_binary.sh ./bin/local
Built ecs-cli

$ make test
PASS

$ ./bin/local/ecs-cli up --keypair *** --capability-iam 
ERRO[0000] Error executing 'up': A CloudFormation stack already exists for the cluster 'cli-demo'. Please specify '--force' to clean up your existing resources. 

$ ./bin/local/ecs-cli up --keypair *** --capability-iam --force
INFO[0000] Created cluster                               cluster=cli-demo
INFO[0001] Waiting for your CloudFormation stack resources to be deleted... 
INFO[0001] Cloudformation stack status                   stackStatus=DELETE_IN_PROGRESS
INFO[0037] Waiting for your cluster resources to be created... 
INFO[0037] Cloudformation stack status                   stackStatus=CREATE_IN_PROGRESS
....