### PR TITLE
Allow empty environment variable.

### DIFF
--- a/ecs-cli/modules/compose/ecs/utils/convert_task_definition.go
+++ b/ecs-cli/modules/compose/ecs/utils/convert_task_definition.go
@@ -261,8 +261,11 @@ func convertToKeyValuePairs(context *project.Context, envVars yaml.MaporEqualSli
 		// format: key=
 		if context.EnvironmentLookup != nil {
 			resolvedEnvVars := context.EnvironmentLookup.Lookup(key, serviceName, nil)
+			// If the environment variable couldn't be resolved, set the value to an empty string
+			// Reference: https://github.com/docker/libcompose/blob/3c40e1001a2646ec6f7a6613873cf5a30122a417/config/interpolation.go#L148
 			if len(resolvedEnvVars) == 0 {
-				log.WithFields(log.Fields{"key name": key}).Warn("Skipping unresolved Environment variable...")
+				log.WithFields(log.Fields{"key name": key}).Warn("Environment variable is unresolved. Setting it to a blank value...")
+				environment = append(environment, createKeyValuePair(key, ""))
 				continue
 			}
 

--- a/ecs-cli/modules/compose/ecs/utils/convert_task_definition_test.go
+++ b/ecs-cli/modules/compose/ecs/utils/convert_task_definition_test.go
@@ -180,14 +180,19 @@ func TestConvertToTaskDefinitionWithEnvFromShell(t *testing.T) {
 	taskDefinition := convertToTaskDefinitionInTest(t, "name", serviceConfig)
 	containerDef := *taskDefinition.ContainerDefinitions[0]
 
-	// skips the second one if envKey2
-	if containerDef.Environment == nil || len(containerDef.Environment) != 1 {
+	if containerDef.Environment == nil || len(containerDef.Environment) != 2 {
 		t.Fatalf("Expected non empty Environment, but was [%v]", containerDef.Environment)
 	}
 
 	if envKey1 != aws.StringValue(containerDef.Environment[0].Name) ||
 		envValue1 != aws.StringValue(containerDef.Environment[0].Value) {
 		t.Errorf("Expected env [%s] But was [%v]", env, containerDef.Environment)
+	}
+
+	// since envKey2 couldn't be resolved, value should be set to an empty string
+	if envKey2 != aws.StringValue(containerDef.Environment[1].Name) ||
+		"" != aws.StringValue(containerDef.Environment[1].Value) {
+		t.Errorf("Expected env [%s] But was [%v]", envKey2, containerDef.Environment)
 	}
 }
 
@@ -345,7 +350,7 @@ func verifyPortMapping(t *testing.T, output *ecs.PortMapping, hostPort, containe
 
 func TestConvertToMountPoints(t *testing.T) {
 	onlyContainerPath := yaml.Volume{Destination: containerPath}
-	hostAndContainerPath := yaml.Volume{Source: hostPath, Destination: containerPath}                          // "./cache:/tmp/cache"
+	hostAndContainerPath := yaml.Volume{Source: hostPath, Destination: containerPath}                         // "./cache:/tmp/cache"
 	hostAndContainerPathWithRO := yaml.Volume{Source: hostPath, Destination: containerPath, AccessMode: "ro"} // "./cache:/tmp/cache:ro"
 	hostAndContainerPathWithRW := yaml.Volume{Source: hostPath, Destination: containerPath, AccessMode: "rw"}
 


### PR DESCRIPTION
closes aws/amazon-ecs-cli#156.

Previously, ecs-cli was skipping unresolved environment variables, but looking at the [Compose documentation for variable-substitution](https://docs.docker.com/compose/compose-file/#variable-substitution):
> If an environment variable is not set, Compose substitutes with an empty string

This pull request enforces the same behavior with ecs-cli.

---
$ make build
. ./scripts/shared_env && ./scripts/build_binary.sh ./bin/local
Built ecs-cli

$ make test
> PASS

$ cat docker-compose.yml 
```yml
version: '2'
services:
  test:
    image: busybox
    environment:
      A:
```
$ ./bin/local/ecs-cli compose up
WARN[0000] Skipping unsupported YAML option for service...  option name=networks service name=test
WARN[0000] Environment variable is unresolved. Setting it to a blank value...  key name=A
INFO[0000] Using ECS task definition                     TaskDefinition=ecscompose-amazon-ecs-cli:45
INFO[0000] Starting container...                         container=xxxxxx/test

$ aws ecs describe-task-definition --task-definition ecscompose-amazon-ecs-cli:45
```json
{
    "taskDefinition": {
        "status": "ACTIVE", 
        "family": "ecscompose-amazon-ecs-cli", 
        "taskDefinitionArn": "arn:aws:ecs:us-west-2:xxxxxxxx:task-definition/ecscompose-amazon-ecs-cli:45", 
        "containerDefinitions": [
            {
                "dnsSearchDomains": [], 
                "environment": [
                    {
                        "name": "A", 
                        "value": ""
                    }
                ], 
                "name": "test", 
                "image": "busybox", 
```
...
