### PR TITLE
Update ami to amzn-ami-2016.09.c-amazon-ecs-optimized and add new reg…

### DIFF
--- a/ecs-cli/modules/config/ami/ami.go
+++ b/ecs-cli/modules/config/ami/ami.go
@@ -29,15 +29,17 @@ type staticAmiIds struct {
 func NewStaticAmiIds() ECSAmiIds {
 	regionToId := make(map[string]string)
 	// amzn-ami-2016.09.a-amazon-ecs-optimized AMIs
-	regionToId["us-east-1"] = "ami-1924770e"
-	regionToId["us-east-2"] = "ami-bd3e64d8"
-	regionToId["us-west-1"] = "ami-7f004b1f"
-	regionToId["us-west-2"] = "ami-56ed4936"
-	regionToId["eu-west-1"] = "ami-c8337dbb"
-	regionToId["eu-central-1"] = "ami-dd12ebb2"
-	regionToId["ap-northeast-1"] = "ami-c8b016a9"
-	regionToId["ap-southeast-1"] = "ami-6d22840e"
-	regionToId["ap-southeast-2"] = "ami-73407d10"
+	regionToId["us-east-1"] = "ami-6df8fe7a"
+	regionToId["us-east-2"] = "ami-c6b5efa3"
+	regionToId["us-west-1"] = "ami-1eda8d7e"
+	regionToId["us-west-2"] = "ami-a2ca61c2"
+	regionToId["ca-central-1"] = "ami-be45f7da"
+	regionToId["eu-central-1"] = "ami-e012d48f"
+	regionToId["eu-west-1"] = "ami-ba346ec9"
+	regionToId["eu-west-2"] = "ami-42c5cf26"
+	regionToId["ap-northeast-1"] = "ami-08f7956f"
+	regionToId["ap-southeast-1"] = "ami-f4832f97"
+	regionToId["ap-southeast-2"] = "ami-774b7314"
 
 	return &staticAmiIds{regionToId: regionToId}
 }


### PR DESCRIPTION
1. Update ami ids for amzn-ami-2016.09.c-amazon-ecs-optimized
2. Add new aws regions ca-central-1 and eu-west-2