### PR TITLE
Fixes #10 to add prompt for deleting cluster

### DIFF
--- a/ecs-cli/modules/command/cluster_app_test.go
+++ b/ecs-cli/modules/command/cluster_app_test.go
@@ -14,6 +14,8 @@
 package command
 
 import (
+	"bufio"
+	"bytes"
 	"errors"
 	"flag"
 	"os"
@@ -687,6 +689,20 @@ func TestClusterDownWithoutForce(t *testing.T) {
 	err := deleteCluster(context, newMockReadWriter(), mockECS, mockCloudformation)
 	if err == nil {
 		t.Fatalf("Expected error deleting cluster when '--%s' is not specified", forceFlag)
+	}
+}
+
+func TestDeleteClusterPrompt(t *testing.T) {
+	readBuffer := bytes.NewBuffer([]byte("yes\ny\nno\n"))
+	reader := bufio.NewReader(readBuffer)
+	if err := deleteClusterPrompt(reader); err != nil {
+		t.Error("Expected no error with prompt to delete cluster")
+	}
+	if err := deleteClusterPrompt(reader); err != nil {
+		t.Error("Expected no error with prompt to delete cluster")
+	}
+	if err := deleteClusterPrompt(reader); err == nil {
+		t.Error("Expected error with prompt to delete cluster")
 	}
 }
 


### PR DESCRIPTION
Add ability to prompt user when trying to do `ecs-cli down` without `--force` based on feedback for #10
Added testing for new change