### PR TITLE
Update the order of resolution for aws region and credentials.

### DIFF
--- a/ecs-cli/modules/aws/clients/cloudformation/client.go
+++ b/ecs-cli/modules/aws/clients/cloudformation/client.go
@@ -24,7 +24,6 @@ import (
 	"github.com/aws/amazon-ecs-cli/ecs-cli/utils"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
-	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
 	"github.com/aws/aws-sdk-go/service/cloudformation/cloudformationiface"
 )
@@ -117,7 +116,7 @@ func NewCloudformationClient() CloudformationClient {
 
 // Initialize initializes all the fields of the cloudFormationClient object.
 func (c *cloudformationClient) Initialize(params *config.CliParams) {
-	cfnClient := cloudformation.New(session.New(params.Config))
+	cfnClient := cloudformation.New(params.Session)
 	cfnClient.Handlers.Build.PushBackNamed(clients.CustomUserAgentHandler())
 	c.client = cfnClient
 	c.cliParams = params

--- a/ecs-cli/modules/aws/clients/ec2/client.go
+++ b/ecs-cli/modules/aws/clients/ec2/client.go
@@ -19,7 +19,6 @@ import (
 	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/aws/clients"
 	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/config"
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
 )
@@ -39,7 +38,7 @@ type ec2Client struct {
 
 // NewEC2Client creates an instance of ec2Client object.
 func NewEC2Client(params *config.CliParams) EC2Client {
-	client := ec2.New(session.New(params.Config))
+	client := ec2.New(params.Session)
 	client.Handlers.Build.PushBackNamed(clients.CustomUserAgentHandler())
 	return &ec2Client{
 		client: client,

--- a/ecs-cli/modules/aws/clients/ecs/client.go
+++ b/ecs-cli/modules/aws/clients/ecs/client.go
@@ -24,7 +24,6 @@ import (
 	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/config"
 	"github.com/aws/amazon-ecs-cli/ecs-cli/utils/cache"
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ecs"
 	"github.com/aws/aws-sdk-go/service/ecs/ecsiface"
 )
@@ -81,7 +80,7 @@ func NewECSClient() ECSClient {
 }
 
 func (c *ecsClient) Initialize(params *config.CliParams) {
-	client := ecs.New(session.New(params.Config))
+	client := ecs.New(params.Session)
 	client.Handlers.Build.PushBackNamed(clients.CustomUserAgentHandler())
 	c.client = client
 	c.params = params
@@ -289,7 +288,7 @@ func cachedTaskDefinitionRevisionIsActive(cachedTaskDefinition *ecs.TaskDefiniti
 // the request ecs.RegisterTaskDefinitionInput structure, and map iteration in Go is not deterministic. We need to fix this.
 func (client *ecsClient) constructTaskDefinitionCacheHash(taskDefinition *ecs.TaskDefinition, request *ecs.RegisterTaskDefinitionInput) string {
 	// Get the region from the ecsClient configuration
-	region := aws.StringValue(client.params.Config.Region)
+	region := aws.StringValue(client.params.Session.Config.Region)
 	awsUserAccountId := utils.GetAwsAccountIdFromArn(aws.StringValue(taskDefinition.TaskDefinitionArn))
 	tdHashInput := fmt.Sprintf("%s-%s-%s", region, awsUserAccountId, request.GoString())
 	return fmt.Sprintf("%x", md5.Sum([]byte(tdHashInput)))

--- a/ecs-cli/modules/command/cluster_app.go
+++ b/ecs-cli/modules/command/cluster_app.go
@@ -222,7 +222,7 @@ func createCluster(context *cli.Context, rdwr config.ReadWriter, ecsClient ecscl
 	// Check if image id was supplied, else populate
 	_, err = cfnParams.GetParameter(cloudformation.ParameterKeyAmiId)
 	if err == cloudformation.ParameterNotFoundError {
-		amiId, err := amiIds.Get(aws.StringValue(ecsParams.Config.Region))
+		amiId, err := amiIds.Get(aws.StringValue(ecsParams.Session.Config.Region))
 		if err != nil {
 			return err
 		}

--- a/ecs-cli/modules/config/aws_config_example.ini
+++ b/ecs-cli/modules/config/aws_config_example.ini
@@ -1,0 +1,11 @@
+[default]
+region = us-west-2
+
+[customProfile]
+region = us-west-1
+
+[assumeRoleWithCreds]
+region = us-east-2
+
+[ec2InstanceRole]
+region = ap-northeast-1

--- a/ecs-cli/modules/config/aws_credentials_example.ini
+++ b/ecs-cli/modules/config/aws_credentials_example.ini
@@ -3,5 +3,13 @@ aws_access_key_id = defaultAwsAccessKey
 aws_secret_access_key = defaultAwsSecretKey
 
 [customProfile]
-aws_access_key_id = AKID
-aws_secret_access_key = SKID
+aws_access_key_id = customAKID
+aws_secret_access_key = customSKID
+
+[assumeRoleWithCreds]
+role_arn = assumeRoleWithCredsRoleArn
+source_profile = assumeRoleWithCreds
+external_id = 1234
+role_session_name = assumeRoleWithCredsSessionName
+aws_access_key_id = assumeRoleWithCredsAKID
+aws_secret_access_key = assumeRoleWithCredsSKID

--- a/ecs-cli/modules/config/config.go
+++ b/ecs-cli/modules/config/config.go
@@ -16,20 +16,14 @@ package config
 import (
 	"fmt"
 	"os"
-	"time"
 
 	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/cli"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
-	"github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds"
-	"github.com/aws/aws-sdk-go/aws/defaults"
-	"github.com/aws/aws-sdk-go/aws/ec2metadata"
-	"github.com/aws/aws-sdk-go/aws/endpoints"
+	"github.com/aws/aws-sdk-go/aws/session"
 )
 
-// This time.Minute value comes from the SDK defaults package
 const (
-	ec2RoleProviderExpiryWindow = 5 * time.Minute
 	ecsSectionKey               = "ecs"
 	composeProjectNamePrefixKey = "compose-project-name-prefix"
 	composeServiceNamePrefixKey = "compose-service-name-prefix"
@@ -59,42 +53,65 @@ func NewCliConfig(cluster string) *CliConfig {
 	return &CliConfig{&SectionKeys{Cluster: cluster}}
 }
 
-// ToServiceConfig creates an aws Config object from the CliConfig object.
-func (cfg *CliConfig) ToServiceConfig() (*aws.Config, error) {
-	region := cfg.getRegion()
-	if region == "" {
-		return nil, fmt.Errorf("Set a region with the --%s flag or %s environment variable", cli.RegionFlag, cli.AwsRegionEnvVar)
+// ToAWSSession creates a new Session object from the CliConfig object.
+//
+// Region: Order of resolution
+//  1) Environment Variable - attempts to fetch the region from environment variables:
+//    a) AWS_REGION (OR)
+//    b) AWS_DEFAULT_REGION
+//  2) ECS Config - attempts to fetch the region from the ECS config file
+//  3) AWS Profile - attempts to use region from AWS profile name
+//    a) profile name from ECS config file (OR)
+//    b) AWS_PROFILE environment variable (OR)
+//    c) AWS_DEFAULT_PROFILE environment variable (defaults to 'default')
+//
+// Credentials: Order of resolution
+//  1) Environment Variable - attempts to fetch the credentials from environment variables:
+//   a) AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY (OR)
+//   b) AWS_ACCESS_KEY and AWS_SECRET_KEY
+//  2) ECS Config - attempts to fetch the credentials from the ECS config file
+//  3) AWS Profile - attempts to use credentials (aws_access_key_id, aws_secret_access_key) or assume_role (role_arn, source_profile) from AWS profile name
+//    a) profile name from ECS config file (OR)
+//    b) AWS_PROFILE environment variable (OR)
+//    c) AWS_DEFAULT_PROFILE environment variable (defaults to 'default')
+//  4) EC2 Instance role
+func (cfg *CliConfig) ToAWSSession() (*session.Session, error) {
+	svcConfig := aws.Config{}
+	return cfg.toAWSSessionWithConfig(svcConfig)
+}
+
+func (cfg *CliConfig) toAWSSessionWithConfig(svcConfig aws.Config) (*session.Session, error) {
+	credentialProviders := cfg.getInitialCredentialProviders()
+	chainCredentials := credentials.NewChainCredentials(credentialProviders)
+	if _, err := chainCredentials.Get(); err == nil {
+		svcConfig.Credentials = chainCredentials
 	}
 
-	awsDefaults := defaults.Get()
-	credentialProviders := cfg.getCredentialProviders(cfg.getEC2MetadataClient(&awsDefaults))
-	chainCredentials := credentials.NewChainCredentials(credentialProviders)
-	creds, err := chainCredentials.Get()
+	svcConfig.Region = aws.String(cfg.getRegion())
+
+	svcSession, err := session.NewSessionWithOptions(session.Options{
+		Config:            svcConfig,
+		Profile:           cfg.AwsProfile,
+		SharedConfigState: session.SharedConfigEnable,
+	})
 	if err != nil {
 		return nil, err
 	}
-
-	// This is just a fail-fast check to ensure that valid credentials are available before returning to the caller.
-	if creds.AccessKeyID == "" {
-		return nil, fmt.Errorf("Error getting valid credentials")
+	region := *svcSession.Config.Region
+	if region == "" {
+		return nil, fmt.Errorf("Set a region using ecs-cli configure command with the --%s flag or %s environment variable or --%s flag", cli.RegionFlag, cli.AwsRegionEnvVar, cli.ProfileFlag)
 	}
 
-	svcConfig := awsDefaults.Config
-	svcConfig.Region = aws.String(region)
-	svcConfig.Credentials = chainCredentials
-
-	return svcConfig, nil
+	return svcSession, nil
 }
 
-// getCredentialProviders gets the chain of credentail provides to use when creating service clients.
-func (cfg *CliConfig) getCredentialProviders(ec2MetadataClient *ec2metadata.EC2Metadata) []credentials.Provider {
+// getInitialCredentialProviders gets the starting chain of credential providers to use when creating service clients.
+func (cfg *CliConfig) getInitialCredentialProviders() []credentials.Provider {
 	// Append providers in the default credential providers chain to the chain.
 	// Order of credential resolution
-	// 1) Environment Variable provider
-	// 2) ECS Profile provider - attempts to fetch the credentials from the ECS config file
-	// 3) AWS profile - attempts to use the AWS profile specified in the ECS config file;
-	// If the AWS profile has not been specified, provider will attempt to use the 'default' profile
-	// 4) EC2 Instance role
+	//  1) Environment Variable
+	//  2) ECS Config
+	// the rest are handled by session.NewSessionWithOptions invoked in ToAWSSession()
 	credentialProviders := []credentials.Provider{
 		&credentials.EnvProvider{},
 		&credentials.StaticProvider{
@@ -103,41 +120,27 @@ func (cfg *CliConfig) getCredentialProviders(ec2MetadataClient *ec2metadata.EC2M
 				SecretAccessKey: cfg.AwsSecretKey,
 			},
 		},
-		&credentials.SharedCredentialsProvider{
-			Filename: "",
-			Profile:  cfg.AwsProfile,
-		},
-		&ec2rolecreds.EC2RoleProvider{
-			Client:       ec2MetadataClient,
-			ExpiryWindow: ec2RoleProviderExpiryWindow,
-		},
 	}
 
 	return credentialProviders
 }
 
-// getEC2MetadataClient creates a new instance of the EC2Metadata client
-func (cfg *CliConfig) getEC2MetadataClient(awsDefaults *defaults.Defaults) *ec2metadata.EC2Metadata {
-	opts := func(opts *endpoints.Options) {
-		opts.DisableSSL = true
-		opts.UseDualStack = false
-	}
-	endpoint, _ := endpoints.DefaultResolver().EndpointFor(ec2metadata.ServiceName, cfg.getRegion(), opts)
-	return ec2metadata.NewClient(*awsDefaults.Config, awsDefaults.Handlers, endpoint.URL, endpoint.SigningRegion)
-}
-
-// getRegion gets the region to use from ecs-cli's config file..
+// getRegion gets the region to use from environment variables or ecs-cli's config file..
 func (cfg *CliConfig) getRegion() string {
-	region := cfg.Region
-	if region == "" {
-		// Search the chain of environment variables for region.
-		for _, envVar := range []string{cli.AwsRegionEnvVar, cli.AwsDefaultRegionEnvVar} {
-			region = os.Getenv(envVar)
-			if region != "" {
-				break
-			}
+	// Order of credential resolution
+	//  1) Environment Variable
+	//  2) ECS Config
+	// the rest are handled by session.NewSessionWithOptions invoked in ToAWSSession()
+	region := ""
+	// Search the chain of environment variables for region.
+	for _, envVar := range []string{cli.AwsRegionEnvVar, cli.AwsDefaultRegionEnvVar} {
+		region = os.Getenv(envVar)
+		if region != "" {
+			break
 		}
 	}
-
+	if region == "" {
+		region = cfg.Region
+	}
 	return region
 }

--- a/ecs-cli/modules/config/config_test.go
+++ b/ecs-cli/modules/config/config_test.go
@@ -19,225 +19,460 @@ import (
 	"net/http/httptest"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/credentials"
-	"github.com/aws/aws-sdk-go/aws/ec2metadata"
+	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/aws/session"
 )
 
 const (
 	clusterName             = "defaultCluster"
-	profileName             = "customProfile"
-	region                  = "us-west-1"
+	region                  = "us-east-1"
 	awsAccessKey            = "AKID"
 	awsSecretKey            = "SKID"
-	defaultAwsAccessKey     = "defaultAwsAccessKey"
-	defaultAwsSecretKey     = "defaultAwsSecretKey"
-	envAwsAccessKey         = "envAKID"
-	envAwsSecretKey         = "envSKID"
-	credentialProviderCount = 4
+	credentialProviderCount = 2
+
+	customProfileName  = "customProfile"
+	customAwsAccessKey = "customAKID"
+	customAwsRegion    = "us-west-1"
+	customAwsSecretKey = "customSKID"
+
+	defaultProfileName  = "default"
+	defaultAwsAccessKey = "defaultAwsAccessKey"
+	defaultAwsRegion    = "us-west-2"
+	defaultAwsSecretKey = "defaultAwsSecretKey"
+
+	envAwsAccessKey = "envAKID"
+	envAwsRegion    = "eu-west-1"
+	envAwsSecretKey = "envSKID"
+
+	assumeRoleName      = "assumeRoleWithCreds"
+	assumeRoleAccessKey = "assumeRoleAKID"
+	assumeRoleRegion    = "us-east-2"
+	assumeRoleSecretKey = "assumeRoleSKID"
+
+	ec2InstanceRoleName      = "ec2InstanceRole"
+	ec2InstanceRoleAccessKey = "ec2InstanceRoleAKID"
+	ec2InstanceRoleRegion    = "ap-northeast-1"
+	ec2InstanceRoleSecretKey = "ec2InstanceRoleSKID"
 )
 
-func TestGetCredentialProvidersVerifyProviderCountHasNotChanged(t *testing.T) {
+//------------------------------------------------------------------------------
+// ToAWSSession() --> REGION TESTS
+// Order of resolution:
+// 1a) Use AWS_REGION env variable
+// 1b) Use AWS_DEFAULT_REGION env variable
+// 2) Use Region in ECS Config
+// 3a) Use Region from profile in ECS Config
+// 3b) Use Region from AWS_PROFILE
+// 3c) Use Region from AWS_DEFAULT_PROFILE
+//------------------------------------------------------------------------------
+
+// 1a) Use AWS_REGION env variable
+func TestRegionWhenUsingEnvVariable(t *testing.T) {
+	// defaults
+	ecsConfig := NewCliConfig(clusterName)
+	ecsConfig.AwsAccessKey = awsAccessKey
+	ecsConfig.AwsSecretKey = awsSecretKey
+
+	// set variable for test
+	os.Setenv("AWS_REGION", envAwsRegion)
+	// Clear env variables as they persist past the individual test boundary
+	defer func() {
+		os.Unsetenv("AWS_REGION")
+	}()
+
+	// invoke test and verify
+	testRegionInSession(t, ecsConfig, envAwsRegion)
+}
+
+// 1b) Use AWS_DEFAULT_REGION env variable
+func TestRegionWhenUsingDefaultEnvVariable(t *testing.T) {
+	// defaults
+	ecsConfig := NewCliConfig(clusterName)
+	ecsConfig.AwsAccessKey = awsAccessKey
+	ecsConfig.AwsSecretKey = awsSecretKey
+
+	// set variable for test
+	os.Setenv("AWS_DEFAULT_REGION", envAwsRegion)
+	defer func() {
+		os.Unsetenv("AWS_DEFAULT_REGION")
+	}()
+
+	// invoke test and verify
+	testRegionInSession(t, ecsConfig, envAwsRegion)
+}
+
+// 2) Use Region in ECS Config
+func TestRegionWhenUsingECSConfigRegion(t *testing.T) {
+	// defaults
+	ecsConfig := NewCliConfig(clusterName)
+	ecsConfig.AwsAccessKey = awsAccessKey
+	ecsConfig.AwsSecretKey = awsSecretKey
+
+	// set variable for test
+	ecsConfig.Region = region
+
+	// invoke test and verify
+	testRegionInSession(t, ecsConfig, region)
+}
+
+// 3a) Use Region from profile in ECS Config
+func TestRegionWhenUsingECSConfigProfile(t *testing.T) {
+	// defaults
+	ecsConfig := NewCliConfig(clusterName)
+
+	// set variables for test
+	ecsConfig.AwsProfile = customProfileName
+	os.Setenv("AWS_CONFIG_FILE", "aws_config_example.ini")
+	os.Setenv("AWS_SHARED_CREDENTIALS_FILE", "aws_credentials_example.ini")
+	defer func() {
+		os.Unsetenv("AWS_CONFIG_FILE")
+		os.Unsetenv("AWS_SHARED_CREDENTIALS_FILE")
+	}()
+
+	// invoke test and verify
+	testRegionInSession(t, ecsConfig, customAwsRegion)
+}
+
+// 3b) Use Region from AWS_PROFILE
+func TestRegionWhenUsingAWSProfileEnvVariable(t *testing.T) {
+	// defaults
+	ecsConfig := NewCliConfig(clusterName)
+
+	// set variables for test
+	os.Setenv("AWS_PROFILE", customProfileName)
+	os.Setenv("AWS_CONFIG_FILE", "aws_config_example.ini")
+	os.Setenv("AWS_SHARED_CREDENTIALS_FILE", "aws_credentials_example.ini")
+	defer func() {
+		os.Unsetenv("AWS_PROFILE")
+		os.Unsetenv("AWS_CONFIG_FILE")
+		os.Unsetenv("AWS_SHARED_CREDENTIALS_FILE")
+	}()
+
+	// invoke test and verify
+	testRegionInSession(t, ecsConfig, customAwsRegion)
+}
+
+// 3c) Use Region from AWS_DEFAULT_PROFILE
+func TestRegionWhenUsingDefaultAWSProfileEnvVariable(t *testing.T) {
+	// defaults
+	ecsConfig := NewCliConfig(clusterName)
+
+	// set variables for test
+	os.Setenv("AWS_DEFAULT_PROFILE", defaultProfileName)
+	os.Setenv("AWS_CONFIG_FILE", "aws_config_example.ini")
+	os.Setenv("AWS_SHARED_CREDENTIALS_FILE", "aws_credentials_example.ini")
+	defer func() {
+		os.Unsetenv("AWS_DEFAULT_PROFILE")
+		os.Unsetenv("AWS_CONFIG_FILE")
+		os.Unsetenv("AWS_SHARED_CREDENTIALS_FILE")
+	}()
+
+	// invoke test and verify
+	testRegionInSession(t, ecsConfig, defaultAwsRegion)
+}
+
+func TestRegionWhenNoneSpecified(t *testing.T) {
+	// defaults
+	os.Clearenv()
+	ecsConfig := NewCliConfig(clusterName)
+	ecsConfig.AwsAccessKey = awsAccessKey
+	ecsConfig.AwsSecretKey = awsSecretKey
+
+	// NOTE: no region set
+
+	// invoke test and verify
+	if _, err := ecsConfig.ToAWSSession(); err == nil {
+		t.Error("There should always be an error when region is not specified or resolved.")
+	}
+}
+
+func testRegionInSession(t *testing.T, inputConfig *CliConfig, expectedRegion string) {
+	awsSession, err := inputConfig.ToAWSSession()
+	if err != nil {
+		t.Fatal("Error generating a new session")
+	}
+	awsConfig := awsSession.Config
+
+	if expectedRegion != *awsConfig.Region {
+		t.Errorf("Invalid region. Expected [%s]. Got [%s]", expectedRegion, *awsConfig.Region)
+	}
+}
+
+//-------------------------------END OF REGION TESTS----------------------------
+
+//------------------------------------------------------------------------------
+// ToAWSSession() --> CREDENTIALS TESTS
+// Order of resolution:
+// 1a) Use AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY env variables
+// 1b) Use AWS_ACCESS_KEY and AWS_SECRET_KEY env variables
+// 2) Use access and secrets keys from ECS Config
+// 3a) Use credentials from profile in ECS Config
+// 3b) Use credentials from AWS_PROFILE
+// 3c) Use credentials from AWS_DEFAULT_PROFILE
+// 3d) Use credentials from assume role profile
+// 4) EC2 Instance role
+//------------------------------------------------------------------------------
+
+func TestGetInitialCredentialProvidersVerifyProviderCountHasNotChanged(t *testing.T) {
 	ecsConfig := NewCliConfig(clusterName)
 	ecsConfig.Region = region
-	credentialProviders := ecsConfig.getCredentialProviders(&ec2metadata.EC2Metadata{})
+	credentialProviders := ecsConfig.getInitialCredentialProviders()
 	if len(credentialProviders) != credentialProviderCount {
 		t.Fatal("Unexpected number of credential providers in the chain: ", len(credentialProviders))
 	}
-
 }
 
-func TestToServiceConfigWhenUsingEnvVariables(t *testing.T) {
+// 1a) Use AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY env variables
+func TestCredentialsWhenUsingEnvVariable(t *testing.T) {
+	// defaults
 	ecsConfig := NewCliConfig(clusterName)
 	ecsConfig.Region = region
 
+	// set variables for test
 	os.Setenv("AWS_ACCESS_KEY_ID", envAwsAccessKey)
 	os.Setenv("AWS_SECRET_ACCESS_KEY", envAwsSecretKey)
-
-	// Clear env variables as they persist past the individual test boundary
 	defer func() {
 		os.Unsetenv("AWS_ACCESS_KEY_ID")
 		os.Unsetenv("AWS_SECRET_ACCESS_KEY")
+	}()
+
+	// invoke test and verify
+	testCredentialsInSession(t, ecsConfig, envAwsAccessKey, envAwsSecretKey)
+}
+
+// 1b) Use AWS_ACCESS_KEY and AWS_SECRET_KEY env variables
+func TestCredentialsWhenUsingDefaultEnvVariable(t *testing.T) {
+	// defaults
+	ecsConfig := NewCliConfig(clusterName)
+	ecsConfig.Region = region
+
+	// set variables for test
+	os.Setenv("AWS_ACCESS_KEY", envAwsAccessKey)
+	os.Setenv("AWS_SECRET_KEY", envAwsSecretKey)
+	defer func() {
 		os.Unsetenv("AWS_ACCESS_KEY")
 		os.Unsetenv("AWS_SECRET_KEY")
 	}()
 
-	awsConfig, _ := ecsConfig.ToServiceConfig()
-	resolvedCredentials, err := awsConfig.Credentials.Get()
-	if err != nil {
-		t.Error("Error fetching credentials from the chain provider")
-	}
-
-	if envAwsAccessKey != resolvedCredentials.AccessKeyID {
-		t.Errorf("Invalid access key set. Expected [%s]. Got [%s]", envAwsAccessKey, resolvedCredentials.AccessKeyID)
-	}
-	if envAwsSecretKey != resolvedCredentials.SecretAccessKey {
-		t.Errorf("Invalid secret key set. Expected [%s]. Got [%s]", envAwsSecretKey, resolvedCredentials.SecretAccessKey)
-	}
+	// invoke test and verify
+	testCredentialsInSession(t, ecsConfig, envAwsAccessKey, envAwsSecretKey)
 }
 
-func TestToServiceConfigWhenUsingECSProfileCredentials(t *testing.T) {
+// 2) Use access and secrets keys from ECS Config
+func TestCredentialsWhenUsingECSConfigRegion(t *testing.T) {
+	// defaults
 	ecsConfig := NewCliConfig(clusterName)
 	ecsConfig.Region = region
 
+	// set variables for test
 	ecsConfig.AwsAccessKey = awsAccessKey
 	ecsConfig.AwsSecretKey = awsSecretKey
 
-	awsConfig, _ := ecsConfig.ToServiceConfig()
-	resolvedCredentials, err := awsConfig.Credentials.Get()
-	if err != nil {
-		t.Error("Error fetching credentials from the chain provider")
-	}
-
-	if awsAccessKey != resolvedCredentials.AccessKeyID {
-		t.Errorf("Invalid access key set. Expected [%s]. Got [%s]", awsAccessKey, resolvedCredentials.AccessKeyID)
-	}
-	if awsSecretKey != resolvedCredentials.SecretAccessKey {
-		t.Errorf("Invalid secret key set. Expected [%s]. Got [%s]", awsSecretKey, resolvedCredentials.SecretAccessKey)
-	}
+	// invoke test and verify
+	testCredentialsInSession(t, ecsConfig, awsAccessKey, awsSecretKey)
 }
 
-func TestToServiceConfigWhenAWSProfileSpecified(t *testing.T) {
+// 3a) Use credentials from profile in ECS Config
+func TestCredentialsWhenUsingECSConfigProfile(t *testing.T) {
+	// defaults
+	ecsConfig := NewCliConfig(clusterName)
+	ecsConfig.AwsProfile = customProfileName
+
+	// set variables for test
+	os.Setenv("AWS_CONFIG_FILE", "aws_config_example.ini")
 	os.Setenv("AWS_SHARED_CREDENTIALS_FILE", "aws_credentials_example.ini")
 	defer func() {
+		os.Unsetenv("AWS_CONFIG_FILE")
 		os.Unsetenv("AWS_SHARED_CREDENTIALS_FILE")
 	}()
 
-	ecsConfig := NewCliConfig(clusterName)
-	ecsConfig.Region = region
-
-	ecsConfig.AwsProfile = profileName
-
-	awsConfig, _ := ecsConfig.ToServiceConfig()
-	resolvedCredentials, err := awsConfig.Credentials.Get()
-	if err != nil {
-		t.Error("Error fetching credentials from the chain provider")
-	}
-
-	if awsAccessKey != resolvedCredentials.AccessKeyID {
-		t.Errorf("Invalid access key set. Expected [%s]. Got [%s]", awsAccessKey, resolvedCredentials.AccessKeyID)
-	}
-	if awsSecretKey != resolvedCredentials.SecretAccessKey {
-		t.Errorf("Invalid secret key set. Expected [%s]. Got [%s]", awsSecretKey, resolvedCredentials.SecretAccessKey)
-	}
+	// invoke test and verify
+	testCredentialsInSession(t, ecsConfig, customAwsAccessKey, customAwsSecretKey)
 }
-func TestToServiceConfigWhenAWSProfileIsNotSpecified(t *testing.T) {
+
+// 3b) Use credentials from AWS_PROFILE
+func TestCredentialsWhenUsingAWSProfileEnvVariable(t *testing.T) {
+	// defaults
+	ecsConfig := NewCliConfig(clusterName)
+
+	// set variables for test
+	os.Setenv("AWS_PROFILE", customProfileName)
+	os.Setenv("AWS_CONFIG_FILE", "aws_config_example.ini")
 	os.Setenv("AWS_SHARED_CREDENTIALS_FILE", "aws_credentials_example.ini")
 	defer func() {
+		os.Unsetenv("AWS_PROFILE")
+		os.Unsetenv("AWS_CONFIG_FILE")
 		os.Unsetenv("AWS_SHARED_CREDENTIALS_FILE")
 	}()
 
-	ecsConfig := NewCliConfig(clusterName)
-	ecsConfig.Region = region
-	// not setting the profileName: it should use the "default" profile
-
-	awsConfig, _ := ecsConfig.ToServiceConfig()
-	resolvedCredentials, err := awsConfig.Credentials.Get()
-	if err != nil {
-		t.Error("Error fetching credentials from the chain provider")
-	}
-
-	if defaultAwsAccessKey != resolvedCredentials.AccessKeyID {
-		t.Errorf("Invalid access key set. Expected [%s]. Got [%s]", defaultAwsAccessKey, resolvedCredentials.AccessKeyID)
-	}
-	if defaultAwsSecretKey != resolvedCredentials.SecretAccessKey {
-		t.Errorf("Invalid secret key set. Expected [%s]. Got [%s]", defaultAwsSecretKey, resolvedCredentials.SecretAccessKey)
-	}
-
+	// invoke test and verify
+	testCredentialsInSession(t, ecsConfig, customAwsAccessKey, customAwsSecretKey)
 }
 
-func TestToServiceConfigWhenRegionIsNotSpecified(t *testing.T) {
+// 3c) Use Region from AWS_DEFAULT_PROFILE
+func TestCredentialsWhenUsingDefaultAWSProfileEnvVariable(t *testing.T) {
+	// defaults
 	ecsConfig := NewCliConfig(clusterName)
 
-	_, err := ecsConfig.ToServiceConfig()
-	if err == nil {
-		t.Error("There should always be an error when region is not specified in the ecsConfig.")
-	}
+	// set variables for test
+	os.Setenv("AWS_DEFAULT_PROFILE", defaultProfileName)
+	os.Setenv("AWS_CONFIG_FILE", "aws_config_example.ini")
+	os.Setenv("AWS_SHARED_CREDENTIALS_FILE", "aws_credentials_example.ini")
+	defer func() {
+		os.Unsetenv("AWS_DEFAULT_PROFILE")
+		os.Unsetenv("AWS_CONFIG_FILE")
+		os.Unsetenv("AWS_SHARED_CREDENTIALS_FILE")
+	}()
+
+	// invoke test and verify
+	testCredentialsInSession(t, ecsConfig, defaultAwsAccessKey, defaultAwsSecretKey)
 }
 
-// Code excerpt to start a test server for ec2MetadataClient is taken from
-// github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds/ec2_role_provider_test.go
-const credsRespTmpl = `{
-  "Code": "Success",
-  "Type": "AWS-HMAC",
-  "AccessKeyId" : "AKID",
-  "SecretAccessKey" : "SKID",
-  "Token" : "token",
-  "Expiration" : "%s",
-  "LastUpdated" : "2009-11-23T0:00:00Z"
-}`
+// 3d) Use credentials from assume role profile
+func TestCredentialsWhenUsingAssumeRoleProfile(t *testing.T) {
+	// defaults
+	ecsConfig := NewCliConfig(clusterName)
 
-const credsFailRespTmpl = `{
-  "Code": "ErrorCode",
-  "Message": "ErrorMsg",
-  "LastUpdated": "2009-11-23T0:00:00Z"
-}`
+	// set variables for test
+	os.Setenv("AWS_DEFAULT_PROFILE", assumeRoleName)
+	os.Setenv("AWS_CONFIG_FILE", "aws_config_example.ini")
+	os.Setenv("AWS_SHARED_CREDENTIALS_FILE", "aws_credentials_example.ini")
+	defer func() {
+		os.Unsetenv("AWS_DEFAULT_PROFILE")
+		os.Unsetenv("AWS_CONFIG_FILE")
+		os.Unsetenv("AWS_SHARED_CREDENTIALS_FILE")
+	}()
 
-func initTestServer(expireOn string, failAssume bool) *httptest.Server {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		const respMsg = `
+	<AssumeRoleResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">
+	  <AssumeRoleResult>
+	    <AssumedRoleUser>
+	      <Arn>arn:aws:sts::account_id:assumed-role/role/session_name</Arn>
+	      <AssumedRoleId>AKID:session_name</AssumedRoleId>
+	    </AssumedRoleUser>
+	    <Credentials>
+	      <AccessKeyId>` + assumeRoleAccessKey + `</AccessKeyId>
+	      <SecretAccessKey>` + assumeRoleSecretKey + `</SecretAccessKey>
+	      <SessionToken>SESSION_TOKEN</SessionToken>
+	      <Expiration>%s</Expiration>
+	    </Credentials>
+	  </AssumeRoleResult>
+	  <ResponseMetadata>
+	    <RequestId>request-id</RequestId>
+	  </ResponseMetadata>
+	</AssumeRoleResponse>
+	`
+		w.Write([]byte(fmt.Sprintf(respMsg, time.Now().Add(15*time.Minute).Format("2006-01-02T15:04:05Z"))))
+	}))
+
+	startingConfig := aws.Config{}
+	startingConfig.Endpoint = aws.String(server.URL)
+	startingConfig.DisableSSL = aws.Bool(true)
+
+	// invoke test and verify
+	testCredentialsInSessionWithConfig(t, ecsConfig, &startingConfig, assumeRoleAccessKey, assumeRoleSecretKey)
+}
+
+// 4) Use credentials from EC2 Instance Role
+func TestCredentialsWhenUsingEC2InstanceRole(t *testing.T) {
+	// defaults
+	ecsConfig := NewCliConfig(clusterName)
+
+	// set variables for test
+	os.Setenv("AWS_DEFAULT_PROFILE", ec2InstanceRoleName)
+	os.Setenv("AWS_CONFIG_FILE", "aws_config_example.ini")
+	os.Setenv("AWS_SHARED_CREDENTIALS_FILE", "aws_credentials_example.ini")
+	defer func() {
+		os.Unsetenv("AWS_DEFAULT_PROFILE")
+		os.Unsetenv("AWS_CONFIG_FILE")
+		os.Unsetenv("AWS_SHARED_CREDENTIALS_FILE")
+	}()
+
+	ec2Creds := `{
+	  "Code": "Success",
+	  "Type": "AWS-HMAC",
+	  "AccessKeyId" : "` + ec2InstanceRoleAccessKey + `",
+	  "SecretAccessKey" : "` + ec2InstanceRoleSecretKey + `",
+	  "Token" : "token",
+	  "Expiration" : "%s",
+	  "LastUpdated" : "2009-11-23T0:00:00Z"
+	}`
+
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/latest/meta-data/iam/security-credentials" {
-			fmt.Fprintln(w, "RoleName")
-		} else if r.URL.Path == "/latest/meta-data/iam/security-credentials/RoleName" {
-			if failAssume {
-				fmt.Fprintf(w, credsFailRespTmpl)
-			} else {
-				fmt.Fprintf(w, credsRespTmpl, expireOn)
-			}
+			fmt.Fprintln(w, ec2InstanceRoleName)
+		} else if r.URL.Path == "/latest/meta-data/iam/security-credentials/"+ec2InstanceRoleName {
+			fmt.Fprintf(w, ec2Creds, "2014-12-16T01:51:37Z")
 		} else {
 			http.Error(w, "bad request", http.StatusBadRequest)
 		}
 	}))
 
-	return server
+	myCustomResolver := func(service, region string, optFns ...func(*endpoints.Options)) (endpoints.ResolvedEndpoint, error) {
+		return endpoints.ResolvedEndpoint{
+			URL:           server.URL + "/latest",
+			SigningRegion: ec2InstanceRoleRegion,
+		}, nil
+	}
+	startingConfig := aws.Config{}
+	startingConfig.EndpointResolver = endpoints.ResolverFunc(myCustomResolver)
+
+	// invoke test and verify
+	testCredentialsInSessionWithConfig(t, ecsConfig, &startingConfig, ec2InstanceRoleAccessKey, ec2InstanceRoleSecretKey)
 }
 
-func TestGetCredentialProvidersWhenUsingEC2InstanceRole(t *testing.T) {
-	server := initTestServer("2016-06-19T00:00:00Z", false)
-	defer server.Close()
-
-	metadataClient := ec2metadata.New(session.New(), &aws.Config{Endpoint: aws.String(server.URL + "/latest")})
-
+// Error if Session.Credentials are nil
+func TestCredentialsWhenNoneSpecified(t *testing.T) {
+	// defaults
+	os.Clearenv()
 	ecsConfig := NewCliConfig(clusterName)
 	ecsConfig.Region = region
-	credentialProviders := ecsConfig.getCredentialProviders(metadataClient)
-	chainCredentials := credentials.NewChainCredentials(credentialProviders)
-	creds, err := chainCredentials.Get()
+
+	// NOTE: no credentials set
+
+	// invoke test and verify
+	awsSession, err := ecsConfig.ToAWSSession()
 	if err != nil {
-		t.Error("Unexpected error occured when retrieving credentials from EC2 metadata service")
+		t.Fatal("Error generating a new session")
 	}
-
-	if awsAccessKey != creds.AccessKeyID {
-		t.Errorf("Invalid access key set. Expected [%s]. Got [%s]", awsAccessKey, creds.AccessKeyID)
-	}
-	if awsSecretKey != creds.SecretAccessKey {
-		t.Errorf("Invalid secret key set. Expected [%s]. Got [%s]", awsSecretKey, creds.SecretAccessKey)
+	awsConfig := awsSession.Config
+	if _, err = awsConfig.Credentials.Get(); err == nil {
+		t.Fatal("Should have error getting credentials")
 	}
 }
 
-func TestGetCredentialProvidersWhenEC2MetadataServiceReturnsFailure(t *testing.T) {
-	server := initTestServer("2016-06-19T00:00:00Z", true)
-	defer server.Close()
-
-	metadataClient := ec2metadata.New(session.New(), &aws.Config{Endpoint: aws.String(server.URL + "/latest")})
-
-	ecsConfig := NewCliConfig(clusterName)
-	ecsConfig.Region = region
-	credentialProviders := ecsConfig.getCredentialProviders(metadataClient)
-	chainCredentials := credentials.NewChainCredentials(credentialProviders)
-	_, err := chainCredentials.Get()
-	if err == nil {
-		t.Error("Expected an error while retrieving credentials from EC2 metadata service")
+func testCredentialsInSession(t *testing.T, inputConfig *CliConfig, expectedAccessKey, expectedSecretKey string) {
+	awsSession, err := inputConfig.ToAWSSession()
+	if err != nil {
+		t.Fatal("Error generating a new session")
 	}
+	verifyCredentialsInSession(t, awsSession, expectedAccessKey, expectedSecretKey)
 }
 
-func TestToServiceConfigWhenNoCredentialsAreAvailable(t *testing.T) {
-	ecsConfig := NewCliConfig(clusterName)
-	ecsConfig.Region = region
+func testCredentialsInSessionWithConfig(t *testing.T, inputConfig *CliConfig, ecsConfig *aws.Config,
+	expectedAccessKey, expectedSecretKey string) {
+	awsSession, err := inputConfig.toAWSSessionWithConfig(*ecsConfig)
+	if err != nil {
+		t.Fatalf("Error generating a new session", err)
+	}
+	verifyCredentialsInSession(t, awsSession, expectedAccessKey, expectedSecretKey)
+}
 
-	_, err := ecsConfig.ToServiceConfig()
-	if err == nil {
-		t.Error("Should get an error for no credentials available")
+func verifyCredentialsInSession(t *testing.T, awsSession *session.Session, expectedAccessKey, expectedSecretKey string) {
+	awsConfig := awsSession.Config
+	resolvedCredentials, err := awsConfig.Credentials.Get()
+	if err != nil {
+		t.Fatal("Error fetching credentials from the chain provider")
+	}
+
+	if expectedAccessKey != resolvedCredentials.AccessKeyID {
+		t.Errorf("Invalid access key set. Expected [%s]. Got [%s]", expectedAccessKey, resolvedCredentials.AccessKeyID)
+	}
+	if expectedSecretKey != resolvedCredentials.SecretAccessKey {
+		t.Errorf("Invalid secret key set. Expected [%s]. Got [%s]", expectedSecretKey, resolvedCredentials.SecretAccessKey)
 	}
 }

--- a/ecs-cli/modules/config/params.go
+++ b/ecs-cli/modules/config/params.go
@@ -18,14 +18,14 @@ import (
 
 	"github.com/Sirupsen/logrus"
 	ecscli "github.com/aws/amazon-ecs-cli/ecs-cli/modules/cli"
-	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/codegangsta/cli"
 )
 
 // CliParams saves config to create an aws service clients
 type CliParams struct {
 	Cluster                  string
-	Config                   *aws.Config
+	Session                  *session.Session
 	ComposeProjectNamePrefix string
 	ComposeServiceNamePrefix string
 	CFNStackNamePrefix       string
@@ -60,14 +60,14 @@ func NewCliParams(context *cli.Context, rdwr ReadWriter) (*CliParams, error) {
 		ecsConfig.Region = regionFromFlag
 	}
 
-	svcConfig, err := ecsConfig.ToServiceConfig()
+	svcSession, err := ecsConfig.ToAWSSession()
 	if err != nil {
 		return nil, err
 	}
 
 	return &CliParams{
-		Cluster: ecsConfig.Cluster,
-		Config:  svcConfig,
+		Cluster:                  ecsConfig.Cluster,
+		Session:                  svcSession,
 		ComposeProjectNamePrefix: ecsConfig.ComposeProjectNamePrefix,
 		ComposeServiceNamePrefix: ecsConfig.ComposeServiceNamePrefix,
 		CFNStackNamePrefix:       ecsConfig.CFNStackNamePrefix,

--- a/ecs-cli/modules/config/params_test.go
+++ b/ecs-cli/modules/config/params_test.go
@@ -80,7 +80,7 @@ func TestNewCliParamsFromEnvVarsWithRegionSpecifiedAsEnvVariable(t *testing.T) {
 		t.Errorf("Unexpected error when region is specified using environment variable AWS_REGION: ", err)
 	}
 
-	paramsRegion := aws.StringValue(params.Config.Region)
+	paramsRegion := aws.StringValue(params.Session.Config.Region)
 	if "us-west-1" != paramsRegion {
 		t.Errorf("Unexpected region set, expected: us-west-1, got: %s", paramsRegion)
 	}
@@ -105,7 +105,7 @@ func TestNewCliParamsFromEnvVarsWithRegionSpecifiedinAwsDefaultEnvVariable(t *te
 	if err != nil {
 		t.Errorf("Unexpected error when region is specified using environment variable AWS_DEFAULT_REGION: ", err)
 	}
-	paramsRegion := aws.StringValue(params.Config.Region)
+	paramsRegion := aws.StringValue(params.Session.Config.Region)
 	if "us-west-2" != paramsRegion {
 		t.Errorf("Unexpected region set, expected: us-west-2, got: %s", paramsRegion)
 	}
@@ -131,7 +131,7 @@ func TestNewCliParamsFromConfig(t *testing.T) {
 	if err != nil {
 		t.Errorf("Unexpected error when region is specified using environment variable AWS_DEFAULT_REGION: ", err)
 	}
-	paramsRegion := aws.StringValue(params.Config.Region)
+	paramsRegion := aws.StringValue(params.Session.Config.Region)
 	if "us-east-1" != paramsRegion {
 		t.Errorf("Unexpected region set, expected: us-east-1, got: %s", paramsRegion)
 	}


### PR DESCRIPTION
- Add support for reading regions from aws profile
- Add support for assume role from aws profile

closes aws/amazon-ecs-cli#53.
closes aws/amazon-ecs-cli#55.
closes aws/amazon-ecs-cli#77.
closes aws/amazon-ecs-cli#92.

----
$ make test

coverage: 76.6% of statements
ok  	github.com/aws/amazon-ecs-cli/ecs-cli/modules/config	5.031s	coverage: 76.6% of statements

-----
## SETUP
Did a compose up: so that the task definition would print the region and account id in the ARN (so we can extract which region and aws account it talked to)
2 AWS profiles:
- default: AccountA (region us-west-2)
- test-cli: AccountA (region eu-west-1)
- another-test-cli: AccountB (region us-east-1)

---
## NO PROFILE/REGION/CREDENTIALS
```
$ ./bin/local/ecs-cli configure --cluster uttara
$ ./bin/local/ecs-cli compose up
FATA[0000] Unable to create an instance of ECSParams given the cli context  error="Set a region using ecs-cli configure command with the --region flag or AWS_REGION environment variable or --profile flag"
$ aws configure --profile default --region us-west-2
$ ./bin/local/ecs-cli compose up
FATA[0005] NoCredentialProviders: no valid providers in chain. Deprecated. 
	For verbose messaging see aws.Config.CredentialsChainVerboseErrors 
```
## 3a) Using AWS_PROFILE in ECS Config
```
$ ./bin/local/ecs-cli configure --cluster uttara --profile another-test-cli
$ ./bin/local/ecs-cli compose up
...task definition="arn:aws:ecs:us-east-1:AccountB:task-definition/ecscompose-amazon-ecs-cli:1"
```
Picked from aws-profile "another-test-cli"
- Region: us-east-1
- Account: AccountB

## 3b) AWS_PROFILE env var
```
$ export AWS_PROFILE="default"
$ ./bin/local/ecs-cli configure --cluster uttara
$ ./bin/local/ecs-cli compose up
.....task definition="arn:aws:ecs:us-west-2:AccountA:task-definition/ecscompose-amazon-ecs-cli:50"
```
Picked from aws-profile "default"
- Region: us-west-2
- Account: AccountA

## 3c) AWS_DEFAULT_PROFILE env var
```
$ export AWS_DEFAULT_PROFILE="test-cli"
$ ./bin/local/ecs-cli compose up
......task definition="arn:aws:ecs:eu-west-1:AccountA:task-definition/ecscompose-amazon-ecs-cli:1"
```
Picked from aws-profile "test-cli"
- Region: eu-west-1
- Account: AccountA

## 2) Use ECS Config
```
$ ./bin/local/ecs-cli configure --cluster uttara --region us-east-1 --access-key "XXXX" --secret-key "XXXX"
$ ./bin/local/ecs-cli compose up
....task definition="arn:aws:ecs:us-east-1:AccountB:task-definition/ecscompose-amazon-ecs-cli:1"
```
Picked from ecs config, overrode the AWS_PROFILE env var
- Region: us-east-1
- Account: AccountB

## 1) Use env variables
```
$ export AWS_DEFAULT_REGION="us-west-2"
$ export AWS_ACCESS_KEY="YYYY"
$ export AWS_SECRET_KEY="YYYY"
$ ./bin/local/ecs-cli compose up
....task definition="arn:aws:ecs:us-west-2:AccountA:task-definition/ecscompose-amazon-ecs-cli:50"
```
Picked from env var, overrode the ECS Config
- Region: us-west-2
- Account: AccountA
```
$ export AWS_REGION="eu-west-1"
$ export AWS_ACCESS_KEY_ID="XXXX"
$ export AWS_SECRET_ACCESS_KEY="XXXX"
$ ./bin/local/ecs-cli compose up
....task definition="arn:aws:ecs:eu-west-1:AccountA:task-definition/ecscompose-amazon-ecs-cli:1"
```
Picked from env var, overrode the above env var
- Region: eu-west-1
- Account: AccountA

## 4) EC2 Instance Role
```
$ ./ecs-cli configure --cluster uttara --region us-west-2
$ ./bin/local/ecs-cli compose up
FATA[0000] NoCredentialProviders: no valid providers in chain. Deprecated. 
	For verbose messaging see aws.Config.CredentialsChainVerboseErrors 
```
// Upon debugging found out that the error was:
EC2RoleRequestError: no EC2 instance role found
caused by: EC2MetadataError: failed to make EC2Metadata request

Next step: launched an instance with ec2 instance role
```
$ ./bin/local/ecs-cli compose up
FATA[0000] AccessDeniedException: User: arn:aws:sts::AccountA:assumed-role/ecsInstanceRole/i-08c578ddaf872bc4f is not authorized to perform: ecs:ListTasks on resource: *
```
Next step: attached the policy AmazonEC2ContainerServiceFullAccess to the role
```
$ ./bin/local/ecs-cli compose up
...task definition="arn:aws:ecs:us-west-2:AccountA:task-definition/ecscompose-tmp:1"
```
Picked 
- Region: us-west-2 // from ecs-cli configure command
- Account: AccountA // credentials from EC2

## 5) Assume_role
From ~/.aws/config
```
[profile some-role]
role_arn = arn:aws:iam::AccountA:role/test-cli-role
source_profile = default
```
```
$ ./bin/local/ecs-cli configure --cluster uttara --profile some-role --region us-west-2
$ ./bin/local/ecs-cli compose ps
$ FATA[0000] AccessDeniedException: User: arn:aws:sts::AccountA:assumed-role/test-cli-role/xxxx is not authorized to perform: ecs:ListTasks on resource: *
```
Next step: added the trust relationship
```
$ ./bin/local/ecs-cli compose up
.....task definition="arn:aws:ecs:us-west-2:AccountA:task-definition/ecscompose-amazon-ecs-cli:50"
```
Picked 
- Region: us-west-2 // from ecs-cli configure command
- Account: AccountA // credentials from assume_role
