### PR TITLE
Fixes #11: Error attempting to ecs-cli compose up

### DIFF
--- a/ecs-cli/modules/compose/ecs/utils/convert_task_definition.go
+++ b/ecs-cli/modules/compose/ecs/utils/convert_task_definition.go
@@ -291,13 +291,20 @@ func createKeyValuePair(key, value string) *ecs.KeyValuePair {
 func convertToECSVolumes(hostPaths map[string]string) []*ecs.Volume {
 	output := []*ecs.Volume{}
 	for hostPath, volName := range hostPaths {
-		ecsVolume := &ecs.Volume{
-			Name: aws.String(volName),
-			Host: &ecs.HostVolumeProperties{
-				SourcePath: aws.String(hostPath),
-			},
+		if hostPath == "" {
+			ecsVolume := &ecs.Volume{
+				Name: aws.String(volName),
+			}
+			output = append(output, ecsVolume)
+		} else {
+			ecsVolume := &ecs.Volume{
+				Name: aws.String(volName),
+				Host: &ecs.HostVolumeProperties{
+					SourcePath: aws.String(hostPath),
+				},
+			}
+			output = append(output, ecsVolume)
 		}
-		output = append(output, ecsVolume)
 	}
 	return output
 }

--- a/ecs-cli/modules/compose/ecs/utils/convert_task_definition_test.go
+++ b/ecs-cli/modules/compose/ecs/utils/convert_task_definition_test.go
@@ -28,10 +28,11 @@ import (
 )
 
 const (
-	portNumber    = 8000
-	portMapping   = "8000:8000"
-	containerPath = "/tmp/cache"
-	hostPath      = "./cache"
+	portNumber     = 8000
+	portMapping    = "8000:8000"
+	containerPath  = "/tmp/cache"
+	containerPath2 = "/tmp/cache2"
+	hostPath       = "./cache"
 )
 
 func TestConvertToTaskDefinition(t *testing.T) {
@@ -262,7 +263,7 @@ func TestConvertToTaskDefinitionWithLogConfiguration(t *testing.T) {
 	taskDefinition = convertToTaskDefinitionInTest(t, "name", serviceConfig)
 	containerDef = *taskDefinition.ContainerDefinitions[0]
 	if logDriver != aws.StringValue(containerDef.LogConfiguration.LogDriver) {
-		t.Errorf("Expected Log driver [%s]. But was [%s]", containerDef.LogConfiguration)
+		t.Errorf("Expected Log driver [%s]. But was [%s]", logDriver, aws.StringValue(containerDef.LogConfiguration.LogDriver))
 	}
 	if !reflect.DeepEqual(logOpts, aws.StringValueMap(containerDef.LogConfiguration.Options)) {
 		t.Errorf("Expected Log options [%v]. But was [%v]", logOpts, aws.StringValueMap(containerDef.LogConfiguration.Options))
@@ -350,14 +351,19 @@ func verifyPortMapping(t *testing.T, output *ecs.PortMapping, hostPort, containe
 
 func TestConvertToMountPoints(t *testing.T) {
 	onlyContainerPath := yaml.Volume{Destination: containerPath}
-	hostAndContainerPath := yaml.Volume{Source: hostPath, Destination: containerPath}                         // "./cache:/tmp/cache"
+	onlyContainerPath2 := yaml.Volume{Destination: containerPath2}
+	hostAndContainerPath := yaml.Volume{Source: hostPath, Destination: containerPath} // "./cache:/tmp/cache"
+	onlyContainerPathWithRO := yaml.Volume{Destination: containerPath, AccessMode: "ro"}
 	hostAndContainerPathWithRO := yaml.Volume{Source: hostPath, Destination: containerPath, AccessMode: "ro"} // "./cache:/tmp/cache:ro"
 	hostAndContainerPathWithRW := yaml.Volume{Source: hostPath, Destination: containerPath, AccessMode: "rw"}
 
-	volumes := make(map[string]string)
+	volumes := &volumes{
+		volumeWithHost: make(map[string]string), // map with key:=hostSourcePath value:=VolumeName
+	}
 
-	mountPointsIn := yaml.Volumes{Volumes: []*yaml.Volume{&onlyContainerPath, &hostAndContainerPath,
-		&hostAndContainerPathWithRO, &hostAndContainerPathWithRW}}
+	// Valid inputs with host and container paths set
+	mountPointsIn := yaml.Volumes{Volumes: []*yaml.Volume{&onlyContainerPath, &onlyContainerPath2, &hostAndContainerPath,
+		&onlyContainerPathWithRO, &hostAndContainerPathWithRO, &hostAndContainerPathWithRW}}
 
 	mountPointsOut, err := convertToMountPoints(&mountPointsIn, volumes)
 	if err != nil {
@@ -366,11 +372,23 @@ func TestConvertToMountPoints(t *testing.T) {
 	if len(mountPointsIn.Volumes) != len(mountPointsOut) {
 		t.Errorf("Incorrect conversion. Input [%v] Output [%v]", mountPointsIn, mountPointsOut)
 	}
-	verifyMountPoint(t, mountPointsOut[0], volumes, "", containerPath, false)
-	verifyMountPoint(t, mountPointsOut[1], volumes, hostPath, containerPath, false)
-	verifyMountPoint(t, mountPointsOut[2], volumes, hostPath, containerPath, true)
-	verifyMountPoint(t, mountPointsOut[3], volumes, hostPath, containerPath, false)
 
+	verifyMountPoint(t, mountPointsOut[0], volumes, "", containerPath, false, 0)  // 0 is the counter for the first volume with an empty host path
+	verifyMountPoint(t, mountPointsOut[1], volumes, "", containerPath2, false, 1) // 1 is the counter for the second volume with an empty host path
+	verifyMountPoint(t, mountPointsOut[2], volumes, hostPath, containerPath, false, 1)
+	verifyMountPoint(t, mountPointsOut[3], volumes, "", containerPath, true, 2) // 2 is the counter for the third volume with an empty host path
+	verifyMountPoint(t, mountPointsOut[4], volumes, hostPath, containerPath, true, 2)
+	verifyMountPoint(t, mountPointsOut[5], volumes, hostPath, containerPath, false, 2)
+
+	if mountPointsOut[0].SourceVolume == mountPointsOut[1].SourceVolume {
+		t.Errorf("Expected volume %v (onlyContainerPath) and %v (onlyContainerPath2) to be different", mountPointsOut[0].SourceVolume, mountPointsOut[1].SourceVolume)
+	}
+
+	if mountPointsOut[1].SourceVolume == mountPointsOut[3].SourceVolume {
+		t.Errorf("Expected volume %v (onlyContainerPath2) and %v (onlyContainerPathWithRO) to be different", mountPointsOut[0].SourceVolume, mountPointsOut[1].SourceVolume)
+	}
+
+	// Invalid access mode input
 	hostAndContainerPathWithIncorrectAccess := yaml.Volume{Source: hostPath, Destination: containerPath, AccessMode: "readonly"}
 	mountPointsIn = yaml.Volumes{Volumes: []*yaml.Volume{&hostAndContainerPathWithIncorrectAccess}}
 	mountPointsOut, err = convertToMountPoints(&mountPointsIn, volumes)
@@ -387,18 +405,22 @@ func TestConvertToMountPoints(t *testing.T) {
 	}
 }
 
-func verifyMountPoint(t *testing.T, output *ecs.MountPoint, volumes map[string]string,
-	hostPath, containerPath string, readonly bool) {
-
+func verifyMountPoint(t *testing.T, output *ecs.MountPoint, volumes *volumes,
+	hostPath, containerPath string, readonly bool, EmptyHostCtr int) {
+	sourceVolume := ""
 	if containerPath != *output.ContainerPath {
 		t.Errorf("Expected containerPath [%s] But was [%s]", containerPath, *output.ContainerPath)
 	}
-	sourceVolume := volumes[hostPath]
+	if hostPath != "" {
+		sourceVolume = volumes.volumeWithHost[hostPath]
+	} else {
+		sourceVolume = volumes.volumeEmptyHost[EmptyHostCtr]
+	}
 	if sourceVolume != *output.SourceVolume {
 		t.Errorf("Expected sourceVolume [%s] But was [%s]", sourceVolume, *output.SourceVolume)
 	}
 	if readonly != *output.ReadOnly {
-		t.Errorf("Expected readonly [%s] But was [%s]", readonly, *output.ReadOnly)
+		t.Errorf("Expected readonly [%v] But was [%v]", readonly, *output.ReadOnly)
 	}
 }
 


### PR DESCRIPTION
Fixes #11 

-Cherry-picked PR #23 (thanks @mcanevet)
-The above PR made it so it wouldn't fail, but the same volume was shared amongst all container paths without a host path, so I added this
-Updated test
-Tested it with `ecs-cli compose up` on random compose file I mushed together:

```
data-container:
  image: redis:latest
  volumes:
    - /tmp/stuff 
    - /tmp/bar:/foo/baz
    - /tmp/ponies
    - /tmp/foo:/tmp/bar
    - /tmp/foo:/tmp/baz
  mem_limit: 100M

data-container2:
  image: redis:latest
  volumes:
    - /tmp/hi:/tmp/hello
    - /tmp/foo:/tmp/foo
    - /tmp/unicorns
  mem_limit: 100M
```