### PR TITLE
AWS ELB-ALB support

### DIFF
--- a/ecs-cli/modules/aws/clients/ecs/client.go
+++ b/ecs-cli/modules/aws/clients/ecs/client.go
@@ -134,28 +134,19 @@ func (client *ecsClient) DeleteService(serviceName string) error {
 }
 
 func (client *ecsClient) CreateService(serviceName, taskDefName string, loadBalancer *ecs.LoadBalancer, role string, deploymentConfig *ecs.DeploymentConfiguration) error {
-	var err error
-
-	if *loadBalancer.TargetGroupArn != "" {
-		_, err = client.client.CreateService(&ecs.CreateServiceInput{
-			DesiredCount:            aws.Int64(0),            // Required
-			ServiceName:             aws.String(serviceName), // Required
-			TaskDefinition:          aws.String(taskDefName), // Required
-			Cluster:                 aws.String(client.params.Cluster),
-			DeploymentConfiguration: deploymentConfig,
-			LoadBalancers:           []*ecs.LoadBalancer{loadBalancer},
-			Role:                    aws.String(role),
-		})
-	} else {
-		_, err = client.client.CreateService(&ecs.CreateServiceInput{
-			DesiredCount:            aws.Int64(0),            // Required
-			ServiceName:             aws.String(serviceName), // Required
-			TaskDefinition:          aws.String(taskDefName), // Required
-			Cluster:                 aws.String(client.params.Cluster),
-			DeploymentConfiguration: deploymentConfig,
-		})
+	createServiceInput := &ecs.CreateServiceInput{
+		DesiredCount:            aws.Int64(0),            // Required
+		ServiceName:             aws.String(serviceName), // Required
+		TaskDefinition:          aws.String(taskDefName), // Required
+		Cluster:                 aws.String(client.params.Cluster),
+		DeploymentConfiguration: deploymentConfig,
 	}
-	if err != nil {
+	if *loadBalancer.TargetGroupArn != "" {
+		createServiceInput.LoadBalancers = []*ecs.LoadBalancer{loadBalancer}
+		createServiceInput.Role = aws.String(role)
+	}
+
+	if _, err := client.client.CreateService(createServiceInput); err != nil {
 		log.WithFields(log.Fields{
 			"service": serviceName,
 			"error":   err,

--- a/ecs-cli/modules/aws/clients/ecs/client.go
+++ b/ecs-cli/modules/aws/clients/ecs/client.go
@@ -141,7 +141,8 @@ func (client *ecsClient) CreateService(serviceName, taskDefName string, loadBala
 		Cluster:                 aws.String(client.params.Cluster),
 		DeploymentConfiguration: deploymentConfig,
 	}
-	if *loadBalancer.TargetGroupArn != "" {
+
+	if *loadBalancer.TargetGroupArn != "" || *loadBalancer.LoadBalancerName != "" {
 		createServiceInput.LoadBalancers = []*ecs.LoadBalancer{loadBalancer}
 		createServiceInput.Role = aws.String(role)
 	}

--- a/ecs-cli/modules/aws/clients/ecs/client.go
+++ b/ecs-cli/modules/aws/clients/ecs/client.go
@@ -142,7 +142,8 @@ func (client *ecsClient) CreateService(serviceName, taskDefName string, loadBala
 		DeploymentConfiguration: deploymentConfig,
 	}
 
-	if aws.StringValue(loadBalancer.TargetGroupArn) != "" || aws.StringValue(loadBalancer.LoadBalancerName) != "" {
+	if loadBalancer != nil &&
+		(aws.StringValue(loadBalancer.TargetGroupArn) != "" || aws.StringValue(loadBalancer.LoadBalancerName) != "") {
 		createServiceInput.LoadBalancers = []*ecs.LoadBalancer{loadBalancer}
 		createServiceInput.Role = aws.String(role)
 	}

--- a/ecs-cli/modules/aws/clients/ecs/client.go
+++ b/ecs-cli/modules/aws/clients/ecs/client.go
@@ -142,7 +142,7 @@ func (client *ecsClient) CreateService(serviceName, taskDefName string, loadBala
 		DeploymentConfiguration: deploymentConfig,
 	}
 
-	if *loadBalancer.TargetGroupArn != "" || *loadBalancer.LoadBalancerName != "" {
+	if aws.StringValue(loadBalancer.TargetGroupArn) != "" || aws.StringValue(loadBalancer.LoadBalancerName) != "" {
 		createServiceInput.LoadBalancers = []*ecs.LoadBalancer{loadBalancer}
 		createServiceInput.Role = aws.String(role)
 	}

--- a/ecs-cli/modules/aws/clients/ecs/mock/client.go
+++ b/ecs-cli/modules/aws/clients/ecs/mock/client.go
@@ -56,14 +56,14 @@ func (_mr *_MockECSClientRecorder) CreateCluster(arg0 interface{}) *gomock.Call 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateCluster", arg0)
 }
 
-func (_m *MockECSClient) CreateService(_param0 string, _param1 string, _param2 *ecs.DeploymentConfiguration) error {
-	ret := _m.ctrl.Call(_m, "CreateService", _param0, _param1, _param2)
+func (_m *MockECSClient) CreateService(_param0 string, _param1 string, _param2 *ecs.LoadBalancer, _param3 string, _param4 *ecs.DeploymentConfiguration) error {
+	ret := _m.ctrl.Call(_m, "CreateService", _param0, _param1, _param2, _param3, _param4)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-func (_mr *_MockECSClientRecorder) CreateService(arg0, arg1, arg2 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateService", arg0, arg1, arg2)
+func (_mr *_MockECSClientRecorder) CreateService(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateService", arg0, arg1, arg2, arg3, arg4)
 }
 
 func (_m *MockECSClient) DeleteCluster(_param0 string) (string, error) {

--- a/ecs-cli/modules/compose/cli/ecs/app/service_command.go
+++ b/ecs-cli/modules/compose/cli/ecs/app/service_command.go
@@ -138,10 +138,10 @@ func deploymentConfigFlags(specifyDefaults bool) []cli.Flag {
 }
 
 func loadBalancerFlags() []cli.Flag {
-	targetGroupArnUsageString := "[Optional] The full Amazon Resource Name (ARN) of the Elastic Load Balancing target group associated with a service. Defaults to none"
-	containerNameUsageString := "[Optional] Mandatory if target-group-arn is specified. The container name (as it appears in a container definition). Defaults to none"
-	containerPortUsageString := "[Optional] Mandatory if target-group-arn is specified. The container port to access from the load balancer. Defaults to none"
-	loadBalancerNameUsageString := "[Optional] The name of the load balancer. Defaults to none"
+	targetGroupArnUsageString := "[Optional] The full Amazon Resource Name (ARN) of the Elastic Load Balancing target group associated with a service."
+	containerNameUsageString := "[Optional] Mandatory if target-group-arn is specified. The container name (as it appears in a container definition)."
+	containerPortUsageString := "[Optional] Mandatory if target-group-arn is specified. The container port to access from the load balancer."
+	loadBalancerNameUsageString := "[Optional] The name of the load balancer."
 	roleUsageString := fmt.Sprintf("[Optional] The name or full Amazon Resource Name (ARN) of the IAM role that allows Amazon ECS to make calls to your load balancer on your behalf. This parameter is required if you are using a load balancer with your service. If you specify the role parameter, you must also specify a target-group-arn, container-name and container-port. Defaults to %s.", ecs.RoleDefaultValue)
 
 	return []cli.Flag{

--- a/ecs-cli/modules/compose/cli/ecs/app/service_command.go
+++ b/ecs-cli/modules/compose/cli/ecs/app/service_command.go
@@ -62,7 +62,7 @@ func createServiceCommand(factory ProjectFactory) cli.Command {
 		Name:   ecs.CreateServiceCommandName,
 		Usage:  "Creates an ECS service from your compose file. The service is created with a desired count of 0, so no containers are started by this command. Note that we do not recommend using plain text environment variables for sensitive information, such as credential data.",
 		Action: WithProject(factory, ProjectCreate, true),
-		Flags:  deploymentConfigFlags(true),
+		Flags:  append(deploymentConfigFlags(true), loadBalancerFlags(true)...),
 	}
 }
 
@@ -79,7 +79,7 @@ func upServiceCommand(factory ProjectFactory) cli.Command {
 		Name:   "up",
 		Usage:  "Creates an ECS service from your compose file (if it does not already exist) and runs one instance of that task on your cluster (a combination of create and start). This command updates the desired count of the service to 1.",
 		Action: WithProject(factory, ProjectUp, true),
-		Flags:  deploymentConfigFlags(true),
+		Flags:  append(deploymentConfigFlags(true), loadBalancerFlags(true)...),
 	}
 }
 
@@ -133,6 +133,39 @@ func deploymentConfigFlags(specifyDefaults bool) []cli.Flag {
 		cli.StringFlag{
 			Name:  ecs.DeploymentMinHealthyPercentFlag,
 			Usage: minHealthyPercentUsageString,
+		},
+	}
+}
+
+func loadBalancerFlags(specifyDefaults bool) []cli.Flag {
+	targetGroupArnUsageString := "[Optional] The full Amazon Resource Name (ARN) of the Elastic Load Balancing target group associated with a service."
+	containerNameUsageString := "[Optional] Mandatory if target-group-arn is specified. The container name (as it appears in a container definition)."
+	containerPortUsageString := "[Optional] Mandatory if target-group-arn is specified. The container port to access from the load balancer."
+	roleUsageString := "[Optional] The name or full Amazon Resource Name (ARN) of the IAM role that allows Amazon ECS to make calls to your load balancer on your behalf. This parameter is required if you are using a load balancer with your service. If you specify the role parameter, you must also specify a target-group-arn, container-name and container-port."
+
+	if specifyDefaults {
+		targetGroupArnUsageString += fmt.Sprintf(" Defaults to none")
+		containerNameUsageString += fmt.Sprintf(" Defaults to none")
+		containerPortUsageString += fmt.Sprintf(" Defaults to none")
+		roleUsageString += fmt.Sprintf(" Defaults to ecsServiceRole")
+	}
+	return []cli.Flag{
+		cli.StringFlag{
+			Name:  ecs.TargetGroupArnFlag,
+			Usage: targetGroupArnUsageString,
+		},
+		cli.StringFlag{
+			Name:  ecs.ContainerNameFlag,
+			Usage: containerPortUsageString,
+		},
+		cli.StringFlag{
+			Name:  ecs.ContainerPortFlag,
+			Usage: containerPortUsageString,
+		},
+		cli.StringFlag{
+			Name:  ecs.RoleFlag,
+			Value: "ecsServiceRole",
+			Usage: roleUsageString,
 		},
 	}
 }

--- a/ecs-cli/modules/compose/cli/ecs/app/service_command.go
+++ b/ecs-cli/modules/compose/cli/ecs/app/service_command.go
@@ -141,13 +141,15 @@ func loadBalancerFlags(specifyDefaults bool) []cli.Flag {
 	targetGroupArnUsageString := "[Optional] The full Amazon Resource Name (ARN) of the Elastic Load Balancing target group associated with a service."
 	containerNameUsageString := "[Optional] Mandatory if target-group-arn is specified. The container name (as it appears in a container definition)."
 	containerPortUsageString := "[Optional] Mandatory if target-group-arn is specified. The container port to access from the load balancer."
+	loadBalancerNameUsageString := "[Optional] The name of the load balancer."
 	roleUsageString := "[Optional] The name or full Amazon Resource Name (ARN) of the IAM role that allows Amazon ECS to make calls to your load balancer on your behalf. This parameter is required if you are using a load balancer with your service. If you specify the role parameter, you must also specify a target-group-arn, container-name and container-port."
 
 	if specifyDefaults {
-		targetGroupArnUsageString += fmt.Sprintf(" Defaults to none")
-		containerNameUsageString += fmt.Sprintf(" Defaults to none")
-		containerPortUsageString += fmt.Sprintf(" Defaults to none")
-		roleUsageString += fmt.Sprintf(" Defaults to ecsServiceRole")
+		targetGroupArnUsageString += " Defaults to none"
+		containerNameUsageString += " Defaults to none"
+		containerPortUsageString += " Defaults to none"
+		loadBalancerNameUsageString += " Defaults to none"
+		roleUsageString += " Defaults to ecsServiceRole"
 	}
 	return []cli.Flag{
 		cli.StringFlag{
@@ -161,6 +163,10 @@ func loadBalancerFlags(specifyDefaults bool) []cli.Flag {
 		cli.StringFlag{
 			Name:  ecs.ContainerPortFlag,
 			Usage: containerPortUsageString,
+		},
+		cli.StringFlag{
+			Name:  ecs.LoadBalancerNameFlag,
+			Usage: loadBalancerNameUsageString,
 		},
 		cli.StringFlag{
 			Name:  ecs.RoleFlag,

--- a/ecs-cli/modules/compose/cli/ecs/app/service_command.go
+++ b/ecs-cli/modules/compose/cli/ecs/app/service_command.go
@@ -138,11 +138,11 @@ func deploymentConfigFlags(specifyDefaults bool) []cli.Flag {
 }
 
 func loadBalancerFlags() []cli.Flag {
-	targetGroupArnUsageString := "[Optional] The full Amazon Resource Name (ARN) of the Elastic Load Balancing target group associated with a service."
-	containerNameUsageString := "[Optional] Mandatory if target-group-arn is specified. The container name (as it appears in a container definition)."
-	containerPortUsageString := "[Optional] Mandatory if target-group-arn is specified. The container port to access from the load balancer."
-	loadBalancerNameUsageString := "[Optional] The name of the load balancer."
-	roleUsageString := fmt.Sprintf("[Optional] The name or full Amazon Resource Name (ARN) of the IAM role that allows Amazon ECS to make calls to your load balancer on your behalf. This parameter is required if you are using a load balancer with your service. If you specify the role parameter, you must also specify a target-group-arn, container-name and container-port.")
+	targetGroupArnUsageString := "[Optional] Specifies the full Amazon Resource Name (ARN) of a previously configured Elastic Load Balancing target group to associate with your service."
+	containerNameUsageString := "[Optional] Specifies the container name (as it appears in a container definition). This parameter is required if a load balancer or target group is specified."
+	containerPortUsageString := "[Optional] Specifies the port on the container to associate with the load balancer. This port must correspond to a containerPort in the service's task definition. This parameter is required if a load balancer or target group is specified."
+	loadBalancerNameUsageString := "[Optional] Specifies the name of a previously configured Elastic Load Balancing load balancer to associate with your service."
+	roleUsageString := fmt.Sprintf("[Optional] Specifies the name or full Amazon Resource Name (ARN) of the IAM role that allows Amazon ECS to make calls to your load balancer or target group on your behalf. This parameter is required if you are using a load balancer or target group with your service. If you specify the role parameter, you must also specify a load balancer name or target group ARN, along with a container name and container port.")
 
 	return []cli.Flag{
 		cli.StringFlag{

--- a/ecs-cli/modules/compose/cli/ecs/app/service_command.go
+++ b/ecs-cli/modules/compose/cli/ecs/app/service_command.go
@@ -62,7 +62,7 @@ func createServiceCommand(factory ProjectFactory) cli.Command {
 		Name:   ecs.CreateServiceCommandName,
 		Usage:  "Creates an ECS service from your compose file. The service is created with a desired count of 0, so no containers are started by this command. Note that we do not recommend using plain text environment variables for sensitive information, such as credential data.",
 		Action: WithProject(factory, ProjectCreate, true),
-		Flags:  append(deploymentConfigFlags(true), loadBalancerFlags(true)...),
+		Flags:  append(deploymentConfigFlags(true), loadBalancerFlags()...),
 	}
 }
 
@@ -79,7 +79,7 @@ func upServiceCommand(factory ProjectFactory) cli.Command {
 		Name:   "up",
 		Usage:  "Creates an ECS service from your compose file (if it does not already exist) and runs one instance of that task on your cluster (a combination of create and start). This command updates the desired count of the service to 1.",
 		Action: WithProject(factory, ProjectUp, true),
-		Flags:  append(deploymentConfigFlags(true), loadBalancerFlags(true)...),
+		Flags:  append(deploymentConfigFlags(true), loadBalancerFlags()...),
 	}
 }
 
@@ -137,20 +137,13 @@ func deploymentConfigFlags(specifyDefaults bool) []cli.Flag {
 	}
 }
 
-func loadBalancerFlags(specifyDefaults bool) []cli.Flag {
-	targetGroupArnUsageString := "[Optional] The full Amazon Resource Name (ARN) of the Elastic Load Balancing target group associated with a service."
-	containerNameUsageString := "[Optional] Mandatory if target-group-arn is specified. The container name (as it appears in a container definition)."
-	containerPortUsageString := "[Optional] Mandatory if target-group-arn is specified. The container port to access from the load balancer."
-	loadBalancerNameUsageString := "[Optional] The name of the load balancer."
-	roleUsageString := "[Optional] The name or full Amazon Resource Name (ARN) of the IAM role that allows Amazon ECS to make calls to your load balancer on your behalf. This parameter is required if you are using a load balancer with your service. If you specify the role parameter, you must also specify a target-group-arn, container-name and container-port."
+func loadBalancerFlags() []cli.Flag {
+	targetGroupArnUsageString := "[Optional] The full Amazon Resource Name (ARN) of the Elastic Load Balancing target group associated with a service. Defaults to none"
+	containerNameUsageString := "[Optional] Mandatory if target-group-arn is specified. The container name (as it appears in a container definition). Defaults to none"
+	containerPortUsageString := "[Optional] Mandatory if target-group-arn is specified. The container port to access from the load balancer. Defaults to none"
+	loadBalancerNameUsageString := "[Optional] The name of the load balancer. Defaults to none"
+	roleUsageString := fmt.Sprintf("[Optional] The name or full Amazon Resource Name (ARN) of the IAM role that allows Amazon ECS to make calls to your load balancer on your behalf. This parameter is required if you are using a load balancer with your service. If you specify the role parameter, you must also specify a target-group-arn, container-name and container-port. Defaults to %s.", ecs.RoleDefaultValue)
 
-	if specifyDefaults {
-		targetGroupArnUsageString += " Defaults to none"
-		containerNameUsageString += " Defaults to none"
-		containerPortUsageString += " Defaults to none"
-		loadBalancerNameUsageString += " Defaults to none"
-		roleUsageString += fmt.Sprintf(" Defaults to %s.", ecs.RoleDefaultValue)
-	}
 	return []cli.Flag{
 		cli.StringFlag{
 			Name:  ecs.TargetGroupArnFlag,
@@ -158,7 +151,7 @@ func loadBalancerFlags(specifyDefaults bool) []cli.Flag {
 		},
 		cli.StringFlag{
 			Name:  ecs.ContainerNameFlag,
-			Usage: containerPortUsageString,
+			Usage: containerNameUsageString,
 		},
 		cli.StringFlag{
 			Name:  ecs.ContainerPortFlag,

--- a/ecs-cli/modules/compose/cli/ecs/app/service_command.go
+++ b/ecs-cli/modules/compose/cli/ecs/app/service_command.go
@@ -142,7 +142,7 @@ func loadBalancerFlags() []cli.Flag {
 	containerNameUsageString := "[Optional] Specifies the container name (as it appears in a container definition). This parameter is required if a load balancer or target group is specified."
 	containerPortUsageString := "[Optional] Specifies the port on the container to associate with the load balancer. This port must correspond to a containerPort in the service's task definition. This parameter is required if a load balancer or target group is specified."
 	loadBalancerNameUsageString := "[Optional] Specifies the name of a previously configured Elastic Load Balancing load balancer to associate with your service."
-	roleUsageString := fmt.Sprintf("[Optional] Specifies the name or full Amazon Resource Name (ARN) of the IAM role that allows Amazon ECS to make calls to your load balancer or target group on your behalf. This parameter is required if you are using a load balancer or target group with your service. If you specify the role parameter, you must also specify a load balancer name or target group ARN, along with a container name and container port.")
+	roleUsageString := "[Optional] Specifies the name or full Amazon Resource Name (ARN) of the IAM role that allows Amazon ECS to make calls to your load balancer or target group on your behalf. This parameter is required if you are using a load balancer or target group with your service. If you specify the role parameter, you must also specify a load balancer name or target group ARN, along with a container name and container port."
 
 	return []cli.Flag{
 		cli.StringFlag{

--- a/ecs-cli/modules/compose/cli/ecs/app/service_command.go
+++ b/ecs-cli/modules/compose/cli/ecs/app/service_command.go
@@ -142,7 +142,7 @@ func loadBalancerFlags() []cli.Flag {
 	containerNameUsageString := "[Optional] Mandatory if target-group-arn is specified. The container name (as it appears in a container definition)."
 	containerPortUsageString := "[Optional] Mandatory if target-group-arn is specified. The container port to access from the load balancer."
 	loadBalancerNameUsageString := "[Optional] The name of the load balancer."
-	roleUsageString := fmt.Sprintf("[Optional] The name or full Amazon Resource Name (ARN) of the IAM role that allows Amazon ECS to make calls to your load balancer on your behalf. This parameter is required if you are using a load balancer with your service. If you specify the role parameter, you must also specify a target-group-arn, container-name and container-port. Defaults to %s.", ecs.RoleDefaultValue)
+	roleUsageString := fmt.Sprintf("[Optional] The name or full Amazon Resource Name (ARN) of the IAM role that allows Amazon ECS to make calls to your load balancer on your behalf. This parameter is required if you are using a load balancer with your service. If you specify the role parameter, you must also specify a target-group-arn, container-name and container-port.")
 
 	return []cli.Flag{
 		cli.StringFlag{
@@ -163,7 +163,6 @@ func loadBalancerFlags() []cli.Flag {
 		},
 		cli.StringFlag{
 			Name:  ecs.RoleFlag,
-			Value: ecs.RoleDefaultValue,
 			Usage: roleUsageString,
 		},
 	}

--- a/ecs-cli/modules/compose/cli/ecs/app/service_command.go
+++ b/ecs-cli/modules/compose/cli/ecs/app/service_command.go
@@ -149,7 +149,7 @@ func loadBalancerFlags(specifyDefaults bool) []cli.Flag {
 		containerNameUsageString += " Defaults to none"
 		containerPortUsageString += " Defaults to none"
 		loadBalancerNameUsageString += " Defaults to none"
-		roleUsageString += " Defaults to ecsServiceRole"
+		roleUsageString += fmt.Sprintf(" Defaults to %s.", ecs.RoleDefaultValue)
 	}
 	return []cli.Flag{
 		cli.StringFlag{
@@ -170,7 +170,7 @@ func loadBalancerFlags(specifyDefaults bool) []cli.Flag {
 		},
 		cli.StringFlag{
 			Name:  ecs.RoleFlag,
-			Value: "ecsServiceRole",
+			Value: ecs.RoleDefaultValue,
 			Usage: roleUsageString,
 		},
 	}

--- a/ecs-cli/modules/compose/ecs/flags.go
+++ b/ecs-cli/modules/compose/ecs/flags.go
@@ -23,5 +23,6 @@ const (
 	ContainerNameFlag                       = "container-name"
 	ContainerPortFlag                       = "container-port"
 	LoadBalancerNameFlag                    = "load-balancer-name"
+	RoleDefaultValue                        = "ecsServiceRole"
 	RoleFlag                                = "role"
 )

--- a/ecs-cli/modules/compose/ecs/flags.go
+++ b/ecs-cli/modules/compose/ecs/flags.go
@@ -23,6 +23,5 @@ const (
 	ContainerNameFlag                       = "container-name"
 	ContainerPortFlag                       = "container-port"
 	LoadBalancerNameFlag                    = "load-balancer-name"
-	RoleDefaultValue                        = "ecsServiceRole"
 	RoleFlag                                = "role"
 )

--- a/ecs-cli/modules/compose/ecs/flags.go
+++ b/ecs-cli/modules/compose/ecs/flags.go
@@ -22,5 +22,6 @@ const (
 	TargetGroupArnFlag                      = "target-group-arn"
 	ContainerNameFlag                       = "container-name"
 	ContainerPortFlag                       = "container-port"
+	LoadBalancerNameFlag                    = "load-balancer-name"
 	RoleFlag                                = "role"
 )

--- a/ecs-cli/modules/compose/ecs/flags.go
+++ b/ecs-cli/modules/compose/ecs/flags.go
@@ -19,4 +19,8 @@ const (
 	DeploymentMaxPercentFlag                = "deployment-max-percent"
 	DeploymentMinHealthyPercentDefaultValue = 100
 	DeploymentMinHealthyPercentFlag         = "deployment-min-healthy-percent"
+	TargetGroupArnFlag                      = "target-group-arn"
+	ContainerNameFlag                       = "container-name"
+	ContainerPortFlag                       = "container-port"
+	RoleFlag                                = "role"
 )

--- a/ecs-cli/modules/compose/ecs/service.go
+++ b/ecs-cli/modules/compose/ecs/service.go
@@ -81,11 +81,9 @@ func (s *Service) LoadContext() error {
 		ContainerPort: containerPort,
 	}
 
-	if targetGroupArn != "" {
-		s.loadBalancer.TargetGroupArn = aws.String(targetGroupArn)
-	} else if loadBalancerName != "" {
-		s.loadBalancer.LoadBalancerName = aws.String(loadBalancerName)
-	}
+	// AWS API server side validation will inform the user about not specifying both.
+	s.loadBalancer.TargetGroupArn = aws.String(targetGroupArn)
+	s.loadBalancer.LoadBalancerName = aws.String(loadBalancerName)
 
 	s.role = s.Context().CLIContext.String(RoleFlag)
 	return nil

--- a/ecs-cli/modules/compose/ecs/service.go
+++ b/ecs-cli/modules/compose/ecs/service.go
@@ -74,11 +74,17 @@ func (s *Service) LoadContext() error {
 	if err != nil {
 		return err
 	}
+	loadBalancerName := s.Context().CLIContext.String(LoadBalancerNameFlag)
 
 	s.loadBalancer = &ecs.LoadBalancer{
-		TargetGroupArn: aws.String(targetGroupArn),
-		ContainerName:  aws.String(containerName),
-		ContainerPort:  containerPort,
+		ContainerName: aws.String(containerName),
+		ContainerPort: containerPort,
+	}
+
+	if targetGroupArn != "" {
+		s.loadBalancer.TargetGroupArn = aws.String(targetGroupArn)
+	} else if loadBalancerName != "" {
+		s.loadBalancer.LoadBalancerName = aws.String(loadBalancerName)
 	}
 
 	s.role = s.Context().CLIContext.String(RoleFlag)

--- a/ecs-cli/modules/compose/ecs/service.go
+++ b/ecs-cli/modules/compose/ecs/service.go
@@ -35,6 +35,8 @@ type Service struct {
 	projectContext   *Context
 	timeSleeper      *utils.TimeSleeper
 	deploymentConfig *ecs.DeploymentConfiguration
+	loadBalancer     *ecs.LoadBalancer
+	role             string
 }
 
 const (
@@ -65,6 +67,21 @@ func (s *Service) LoadContext() error {
 		MaximumPercent:        maxPercent,
 		MinimumHealthyPercent: minHealthyPercent,
 	}
+
+	targetGroupArn := s.Context().CLIContext.String(TargetGroupArnFlag)
+	containerName := s.Context().CLIContext.String(ContainerNameFlag)
+	containerPort, err := getInt64FromCLIContext(s.Context(), ContainerPortFlag)
+	if err != nil {
+		return err
+	}
+
+	s.loadBalancer = &ecs.LoadBalancer{
+		TargetGroupArn: aws.String(targetGroupArn),
+		ContainerName:  aws.String(containerName),
+		ContainerPort:  containerPort,
+	}
+
+	s.role = s.Context().CLIContext.String(RoleFlag)
 	return nil
 }
 
@@ -279,7 +296,9 @@ func (s *Service) Run(commandOverrides map[string]string) error {
 func (s *Service) createService() error {
 	serviceName := s.getServiceName()
 	taskDefinitionId := getIdFromArn(s.TaskDefinition().TaskDefinitionArn)
-	err := s.Context().ECSClient.CreateService(serviceName, taskDefinitionId, s.DeploymentConfig())
+	loadBalancer := s.loadBalancer
+	role := s.role
+	err := s.Context().ECSClient.CreateService(serviceName, taskDefinitionId, loadBalancer, role, s.DeploymentConfig())
 	if err != nil {
 		return err
 	}

--- a/ecs-cli/modules/compose/ecs/service_test.go
+++ b/ecs-cli/modules/compose/ecs/service_test.go
@@ -99,8 +99,8 @@ func createServiceTest(t *testing.T, cliContext *cli.Context, validateDeployment
 					aws.StringValue(taskDefinition.Family), aws.StringValue(req.Family))
 			}
 		}).Return(&respTaskDef, nil),
-		mockEcs.EXPECT().CreateService(gomock.Any(), gomock.Any(), gomock.Any()).Do(func(x, y, z interface{}) {
-			observedTaskDefId := y.(string)
+		mockEcs.EXPECT().CreateService(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Do(func(v, w, x, y, z interface{}) {
+			observedTaskDefId := w.(string)
 			if taskDefId != observedTaskDefId {
 				t.Errorf("Expected task definition name to be [%s] but got [%s]", taskDefId, observedTaskDefId)
 			}


### PR DESCRIPTION
We want to be able to create a new service and assign it an Application Load Balancer.

Add 5 new params that allows to specify the Load Balancer details in order for the service to be created with an associated ELB/ALB.

Specify the Target Group ARN, Load Balancer Name, Container Name, Container Port and Role to allow the service to register new instances in the ELB/ALB.

* `--target-group-arn`: The full Amazon Resource Name (ARN) of the Elastic Load Balancing target  group associated with a service.
* `--load-balancer-name`: The name of the classic load balancer.
* `--container-name`: The name of the container (as it appears in a container definition) to associate with the load balancer.
* `--container-port`: The port on the container to associate with the load balancer. This port must correspond to a containerPort in the service's task definition. Your container instances must allow ingress traffic on the hostPort of the port mapping.
* `--role`: The name or full Amazon Resource Name (ARN) of the IAM role that allows Amazon ECS to make calls to your load balancer on your behalf. This parameter is required if you are using a load balancer with your service. If you specify the role parameter, you must also specify a load balancer object with the loadBalancers parameter.

If `--target-group-arn` or `--load-balancer-name` is not passed then the current behaviour is maintained and it doesn't try to associate an ELB with the service.

Note: If both `target-goup-arn` and `load-balancer-name` present, `target-group-arn` param will take precedence.