### PR TITLE
Truncate the file to avoid messing up the config file

### DIFF
--- a/ecs-cli/modules/config/readwriter.go
+++ b/ecs-cli/modules/config/readwriter.go
@@ -126,6 +126,11 @@ func (rdwr *IniReadWriter) Save(dest *Destination) error {
 	// Open the file, optionally creating it with our desired permissions.
 	// This will let us pass it (as io.Writer) to go-ini but let us control the file.
 	configFile, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE, configFileMode)
+
+	// Truncate the file in case the earlier contents are longer than the new
+	// contents, so there will not be any trash at the end of the file
+	configFile.Truncate(0)
+
 	if err != nil {
 		logrus.Errorf("Unable to open/create %s with mode %s", path, configFileMode)
 		return err


### PR DESCRIPTION
closes https://github.com/aws/amazon-ecs-cli/issues/177
cherry-picked PR https://github.com/aws/amazon-ecs-cli/pull/214, thanks @markriggins

Commands ran: 
`$ make build`
`$ make test`

Testing:
`$ ecs-cli configure --profile *** --cluster ecs-cli-demo`
`$ ecs-cli configure --profile *** --cluster ecs-cli` // set config with shorter cluster name
`$ vim ~/.ecs/config` // verify that the config file is not messed up