### PR TITLE
List images from ECR

### DIFF
--- a/ecs-cli/main.go
+++ b/ecs-cli/main.go
@@ -46,6 +46,7 @@ func main() {
 		command.PsCommand(),
 		command.PushCommand(),
 		command.PullCommand(),
+		command.ImagesCommand(),
 		license.LicenseCommand(),
 		ecscompose.ComposeCommand(composeFactory),
 	}

--- a/ecs-cli/modules/aws/clients/ecr/mock/client.go
+++ b/ecs-cli/modules/aws/clients/ecr/mock/client.go
@@ -64,6 +64,16 @@ func (_mr *_MockClientRecorder) GetAuthorizationToken(arg0 interface{}) *gomock.
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetAuthorizationToken", arg0)
 }
 
+func (_m *MockClient) GetImages(_param0 []*string, _param1 string, _param2 string, _param3 ecr.ProcessImageDetails) error {
+	ret := _m.ctrl.Call(_m, "GetImages", _param0, _param1, _param2, _param3)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockClientRecorder) GetImages(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetImages", arg0, arg1, arg2, arg3)
+}
+
 func (_m *MockClient) RepositoryExists(_param0 string) bool {
 	ret := _m.ctrl.Call(_m, "RepositoryExists", _param0)
 	ret0, _ := ret[0].(bool)

--- a/ecs-cli/modules/cli/flags.go
+++ b/ecs-cli/modules/cli/flags.go
@@ -27,6 +27,8 @@ const (
 	RegistryIdFlag         = "registry-id"
 	FromFlag               = "from"
 	ToFlag                 = "to"
+	TaggedFlag             = "tagged"
+	UntaggedFlag           = "untagged"
 
 	ComposeProjectNamePrefixFlag         = "compose-project-name-prefix"
 	ComposeProjectNamePrefixDefaultValue = "ecscompose-"

--- a/ecs-cli/modules/command/image.go
+++ b/ecs-cli/modules/command/image.go
@@ -19,8 +19,9 @@ import (
 )
 
 const (
-	PUSH_IMAGE_FORMAT = "REPOSITORY[:TAG]"
-	PULL_IMAGE_FORMAT = "REPOSITORY_NAME[:TAG|@DIGEST]"
+	PUSH_IMAGE_FORMAT  = "REPOSITORY[:TAG]"
+	PULL_IMAGE_FORMAT  = "REPOSITORY_NAME[:TAG|@DIGEST]"
+	LIST_IMAGES_FORMAT = "[REPOSITORY_NAME]"
 )
 
 // PushCommand push ECR image
@@ -60,6 +61,31 @@ func PullCommand() cli.Command {
 			cli.StringFlag{
 				Name:  ecscli.RegistryIdFlag,
 				Usage: "[Optional] Specifies the the Amazon ECR registry ID to pull the image from. By default, images are pulled from the current AWS account.",
+			},
+		},
+	}
+}
+
+// ImagesCommand list images in ECR
+func ImagesCommand() cli.Command {
+	return cli.Command{
+		Name:      "images",
+		Usage:     "List images an Amazon ECR repository.",
+		ArgsUsage: LIST_IMAGES_FORMAT,
+		Before:    ecscli.BeforeApp,
+		Action:    ImageList,
+		Flags: []cli.Flag{
+			cli.StringFlag{
+				Name:  ecscli.RegistryIdFlag,
+				Usage: "[Optional] Specifies the the Amazon ECR registry ID to pull the image from. By default, images are pulled from the current AWS account.",
+			},
+			cli.BoolFlag{
+				Name:  ecscli.TaggedFlag,
+				Usage: "[Optional] Filters the result to show only tagged images",
+			},
+			cli.BoolFlag{
+				Name:  ecscli.UntaggedFlag,
+				Usage: "[Optional] Filters the result to show only untagged images",
 			},
 		},
 	}

--- a/ecs-cli/modules/command/image_app.go
+++ b/ecs-cli/modules/command/image_app.go
@@ -15,7 +15,11 @@ package command
 
 import (
 	"fmt"
+	"io"
+	"os"
 	"strings"
+	"text/tabwriter"
+	"time"
 
 	"github.com/Sirupsen/logrus"
 	ecrclient "github.com/aws/amazon-ecs-cli/ecs-cli/modules/aws/clients/ecr"
@@ -23,6 +27,9 @@ import (
 	ecscli "github.com/aws/amazon-ecs-cli/ecs-cli/modules/cli"
 	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/config"
 	dockerclient "github.com/aws/amazon-ecs-cli/ecs-cli/modules/docker"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ecr"
+	units "github.com/docker/go-units"
 	docker "github.com/fsouza/go-dockerclient"
 	"github.com/urfave/cli"
 )
@@ -84,6 +91,27 @@ func ImagePull(c *cli.Context) {
 
 	if err := pullImage(c, rdwr, dockerClient, ecrClient, stsClient); err != nil {
 		logrus.Error("Error executing 'pull': ", err)
+		return
+	}
+}
+
+// ImageList lists images up to 1000 items from ECR repository
+func ImageList(c *cli.Context) {
+	rdwr, err := config.NewReadWriter()
+	if err != nil {
+		logrus.Error("Error executing 'images': ", err)
+		return
+	}
+
+	ecsParams, err := config.NewCliParams(c, rdwr)
+	if err != nil {
+		logrus.Error("Error executing 'images': ", err)
+		return
+	}
+
+	ecrClient := ecrclient.NewClient(ecsParams)
+	if err := getImages(c, rdwr, ecrClient); err != nil {
+		logrus.Error("Error executing 'images': ", err)
 		return
 	}
 }
@@ -199,6 +227,91 @@ func pullImage(c *cli.Context, rdwr config.ReadWriter, dockerClient dockerclient
 	}
 
 	return nil
+}
+
+type imageInfo struct {
+	RepositoryName string
+	Tag            string
+	ImageDigest    string
+	PushedAt       string
+	Size           string
+}
+
+func getImages(c *cli.Context, rdwr config.ReadWriter, ecrClient ecrclient.Client) error {
+	registryID := c.String(ecscli.RegistryIdFlag)
+	args := c.Args() // repository names
+
+	totalCount := 0
+	w := tabwriter.NewWriter(os.Stdout, 20, 1, 3, ' ', 0)
+
+	err := ecrClient.GetImages(aws.StringSlice(args), getTagStatus(c), registryID, func(imageDetails []*ecr.ImageDetail) error {
+		// Prints all images in table
+		for _, image := range imageDetails {
+			info := imageInfo{
+				RepositoryName: aws.StringValue(image.RepositoryName),
+				ImageDigest:    aws.StringValue(image.ImageDigest),
+			}
+			info.PushedAt = units.HumanDuration(time.Now().UTC().Sub(time.Unix(image.ImagePushedAt.Unix(), 0))) + " ago"
+			info.Size = units.HumanSizeWithPrecision(float64(aws.Int64Value(image.ImageSizeInBytes)), 3)
+			if len(image.ImageTags) == 0 {
+				info.Tag = "<none>"
+				listImagesContent(w, info, totalCount)
+				totalCount++
+			}
+			for _, tag := range image.ImageTags {
+				info.Tag = aws.StringValue(tag)
+				listImagesContent(w, info, totalCount)
+				totalCount++
+			}
+		}
+		return nil
+	})
+	w.Flush()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func listImagesContent(w *tabwriter.Writer, info imageInfo, count int) {
+	if count%100 == 0 {
+		w.Flush()
+		fmt.Println()
+		printImageRow(w, imageInfo{
+			RepositoryName: "REPOSITORY NAME",
+			Tag:            "TAG",
+			ImageDigest:    "IMAGE DIGEST",
+			PushedAt:       "PUSHED AT",
+			Size:           "SIZE",
+		})
+	}
+	printImageRow(w, info)
+}
+
+func printImageRow(w io.Writer, info imageInfo) {
+	fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t\n",
+		info.RepositoryName,
+		info.Tag,
+		info.ImageDigest,
+		info.PushedAt,
+		info.Size,
+	)
+}
+
+func getTagStatus(c *cli.Context) string {
+	if c.Bool(ecscli.TaggedFlag) && c.Bool(ecscli.UntaggedFlag) {
+		return ""
+	}
+
+	if c.Bool(ecscli.TaggedFlag) {
+		return ecr.TagStatusTagged
+	}
+	if c.Bool(ecscli.UntaggedFlag) {
+		return ecr.TagStatusUntagged
+	}
+
+	return ""
 }
 
 func getRegistryID(registryID string, stsClient stsclient.Client) (string, error) {

--- a/ecs-cli/modules/command/image_app.go
+++ b/ecs-cli/modules/command/image_app.go
@@ -37,6 +37,12 @@ import (
 const (
 	SEPERATOR_AT    = "@"
 	SEPERATOR_COLON = ":"
+	MIN_WIDTH       = 20
+	TAB_WIDTH       = 1
+	PADDING         = 3
+	PADDING_CHAR    = ' '
+	FLAGS           = 0
+	PAGE_SIZE       = 100
 )
 
 // ImagePush does ecr login, tag image, and push image to ECR repository
@@ -242,7 +248,8 @@ func getImages(c *cli.Context, rdwr config.ReadWriter, ecrClient ecrclient.Clien
 	args := c.Args() // repository names
 
 	totalCount := 0
-	w := tabwriter.NewWriter(os.Stdout, 20, 1, 3, ' ', 0)
+
+	w := tabwriter.NewWriter(os.Stdout, MIN_WIDTH, TAB_WIDTH, PADDING, PADDING_CHAR, FLAGS)
 
 	err := ecrClient.GetImages(aws.StringSlice(args), getTagStatus(c), registryID, func(imageDetails []*ecr.ImageDetail) error {
 		// Prints all images in table
@@ -267,15 +274,11 @@ func getImages(c *cli.Context, rdwr config.ReadWriter, ecrClient ecrclient.Clien
 		return nil
 	})
 	w.Flush()
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return err
 }
 
 func listImagesContent(w *tabwriter.Writer, info imageInfo, count int) {
-	if count%100 == 0 {
+	if count%PAGE_SIZE == 0 {
 		w.Flush()
 		fmt.Println()
 		printImageRow(w, imageInfo{

--- a/ecs-cli/modules/command/image_app.go
+++ b/ecs-cli/modules/command/image_app.go
@@ -35,14 +35,14 @@ import (
 )
 
 const (
-	SEPERATOR_AT    = "@"
-	SEPERATOR_COLON = ":"
-	MIN_WIDTH       = 20
-	TAB_WIDTH       = 1
-	PADDING         = 3
-	PADDING_CHAR    = ' '
-	FLAGS           = 0
-	PAGE_SIZE       = 100
+	SeperatorAt    = "@"
+	SeperatorColon = ":"
+	MinWidth       = 20
+	TabWidth       = 1
+	Padding        = 3
+	PaddingChar    = ' '
+	NumOfFlags     = 0
+	PageSize       = 100
 )
 
 // ImagePush does ecr login, tag image, and push image to ECR repository
@@ -149,7 +149,7 @@ func pushImage(c *cli.Context, rdwr config.ReadWriter, dockerClient dockerclient
 		targetImage = args[0]
 	}
 
-	repository, tag, err := splitImageName(targetImage, SEPERATOR_COLON, PUSH_IMAGE_FORMAT)
+	repository, tag, err := splitImageName(targetImage, SeperatorColon, PUSH_IMAGE_FORMAT)
 	if err != nil {
 		return err
 	}
@@ -200,9 +200,9 @@ func pullImage(c *cli.Context, rdwr config.ReadWriter, dockerClient dockerclient
 	}
 	image := args[0]
 
-	seperator := SEPERATOR_COLON
-	if strings.Contains(image, SEPERATOR_AT) {
-		seperator = SEPERATOR_AT
+	seperator := SeperatorColon
+	if strings.Contains(image, SeperatorAt) {
+		seperator = SeperatorAt
 	}
 	repository, tag, err := splitImageName(image, seperator, PULL_IMAGE_FORMAT)
 	if err != nil {
@@ -249,7 +249,7 @@ func getImages(c *cli.Context, rdwr config.ReadWriter, ecrClient ecrclient.Clien
 
 	totalCount := 0
 
-	w := tabwriter.NewWriter(os.Stdout, MIN_WIDTH, TAB_WIDTH, PADDING, PADDING_CHAR, FLAGS)
+	w := tabwriter.NewWriter(os.Stdout, MinWidth, TabWidth, Padding, PaddingChar, NumOfFlags)
 
 	err := ecrClient.GetImages(aws.StringSlice(args), getTagStatus(c), registryID, func(imageDetails []*ecr.ImageDetail) error {
 		// Prints all images in table
@@ -278,7 +278,7 @@ func getImages(c *cli.Context, rdwr config.ReadWriter, ecrClient ecrclient.Clien
 }
 
 func listImagesContent(w *tabwriter.Writer, info imageInfo, count int) {
-	if count%PAGE_SIZE == 0 {
+	if count%PageSize == 0 {
 		w.Flush()
 		fmt.Println()
 		printImageRow(w, imageInfo{


### PR DESCRIPTION
```
$ make build
$ make generate
$ make test
PASS
```

```
$ ./bin/local/ecs-cli images

REPOSITORY NAME     TAG                 IMAGE DIGEST                                                              PUSHED AT           SIZE                
busybox             image               sha256:2efce9f5b0cb8815d192ae634b4c87943d0f0b873d98487ee98f8ed0504bd572   4 weeks ago         703 kB              
busybox             latest              sha256:2efce9f5b0cb8815d192ae634b4c87943d0f0b873d98487ee98f8ed0504bd572   4 weeks ago         703 kB              
busybox             docker-whale        sha256:a7594f1fc305ef3bfb51987f4ac813c9c4faf9bf2116858c8a7b4e3eca7d94b5   4 weeks ago         130 MB              
hello-world         latest              sha256:5dd8d30453581321243bfc7fa472eb3f80048e8ea6d4ef6d24c89238ae68a62a   4 weeks ago         2.08 kB      
```

When results are more than 100, new header will be populated:
```
$ ./bin/local/ecs-cli images

REPOSITORY NAME     TAG                 IMAGE DIGEST                                                              PUSHED AT           SIZE                
busybox             image               sha256:2efce9f5b0cb8815d192ae634b4c87943d0f0b873d98487ee98f8ed0504bd572   4 weeks ago         703 kB              
busybox             latest              sha256:2efce9f5b0cb8815d192ae634b4c87943d0f0b873d98487ee98f8ed0504bd572   4 weeks ago         703 kB              
busybox             docker-whale        sha256:a7594f1fc305ef3bfb51987f4ac813c9c4faf9bf2116858c8a7b4e3eca7d94b5   4 weeks ago         130 MB              
hello-world         latest              sha256:5dd8d30453581321243bfc7fa472eb3f80048e8ea6d4ef6d24c89238ae68a62a   4 weeks ago         2.08 kB             
yinshiua            latest              sha256:2efce9f5b0cb8815d192ae634b4c87943d0f0b873d98487ee98f8ed0504bd572   8 days ago          703 kB              

REPOSITORY NAME                          TAG                 IMAGE DIGEST                                                              PUSHED AT           SIZE                
redis                                    latest              sha256:d912ae3ea67b0042cba4d5a129e9e842367ac3c5da32d04ea39eabdb55955dbb   4 weeks ago         76.1 MB             
repository-name-that-is-very-very-long   latest              sha256:68effe31a4ae8312e47f54bec52d1fc925908009ce7e6f734e1b54a4169081c5   27 hours ago        703 kB              
cli3                                     latest              sha256:e6b408c48eab395fd473be496923eb7d6a5088a447cae23a4e621cee103bb047   5 weeks ago         703 kB              
cli                                      jess                sha256:281c8681dd14d79a5cc9634eba29f59c6db6bad43f7cd1f3a301c39c6cffa19d   8 weeks ago         678 kB              
cli                                      latest              sha256:78b82e09204c7b712b666ce6fd4ad5c79505eef1def9daf7d16ad6a69653a5b8   3 days ago          143 MB  
```

When one repo name is specified:
```
$ ./bin/local/ecs-cli images busybox

REPOSITORY NAME     TAG                 IMAGE DIGEST                                                              PUSHED AT           SIZE                
busybox             image               sha256:2efce9f5b0cb8815d192ae634b4c87943d0f0b873d98487ee98f8ed0504bd572   4 weeks ago         703 kB              
busybox             latest              sha256:2efce9f5b0cb8815d192ae634b4c87943d0f0b873d98487ee98f8ed0504bd572   4 weeks ago         703 kB              
busybox             docker-whale        sha256:a7594f1fc305ef3bfb51987f4ac813c9c4faf9bf2116858c8a7b4e3eca7d94b5   4 weeks ago         130 MB  
```

Error occurs when a repo does not exist:
```
$ ./bin/local/ecs-cli images busybox blah

REPOSITORY NAME     TAG                 IMAGE DIGEST                                                              PUSHED AT           SIZE                
busybox             image               sha256:2efce9f5b0cb8815d192ae634b4c87943d0f0b873d98487ee98f8ed0504bd572   4 weeks ago         703 kB              
busybox             latest              sha256:2efce9f5b0cb8815d192ae634b4c87943d0f0b873d98487ee98f8ed0504bd572   4 weeks ago         703 kB              
busybox             docker-whale        sha256:a7594f1fc305ef3bfb51987f4ac813c9c4faf9bf2116858c8a7b4e3eca7d94b5   4 weeks ago         130 MB              
ERRO[0001] Error executing 'images': RepositoryNotFoundException: The repository with name 'blah' does not exist in the registry with id '**********'
	status code: 400, request id: *******-*****-****-****-************ 
```

Error occurs when more than 50 describeImages calls were made:
```
$ ./bin/local/ecs-cli images

REPOSITORY NAME     TAG                 IMAGE DIGEST                                                              PUSHED AT           SIZE                
busybox             image               sha256:2efce9f5b0cb8815d192ae634b4c87943d0f0b873d98487ee98f8ed0504bd572   4 weeks ago         703 kB              
busybox             latest              sha256:2efce9f5b0cb8815d192ae634b4c87943d0f0b873d98487ee98f8ed0504bd572   4 weeks ago         703 kB              
busybox             docker-whale        sha256:a7594f1fc305ef3bfb51987f4ac813c9c4faf9bf2116858c8a7b4e3eca7d94b5   4 weeks ago         130 MB              
hello-world         latest              sha256:5dd8d30453581321243bfc7fa472eb3f80048e8ea6d4ef6d24c89238ae68a62a   4 weeks ago         2.08 kB             
yinshiua            latest              sha256:2efce9f5b0cb8815d192ae634b4c87943d0f0b873d98487ee98f8ed0504bd572   8 days ago          703 kB              
redis               latest              sha256:d912ae3ea67b0042cba4d5a129e9e842367ac3c5da32d04ea39eabdb55955dbb   4 weeks ago         76.1 MB             
ERRO[0002] Error executing 'images': please specify the repository name if you wish to see more 
```