### PR TITLE
ELB/ALB bug fix and add validations

### DIFF
--- a/ecs-cli/modules/aws/clients/ecs/client.go
+++ b/ecs-cli/modules/aws/clients/ecs/client.go
@@ -140,12 +140,8 @@ func (client *ecsClient) CreateService(serviceName, taskDefName string, loadBala
 		TaskDefinition:          aws.String(taskDefName), // Required
 		Cluster:                 aws.String(client.params.Cluster),
 		DeploymentConfiguration: deploymentConfig,
-	}
-
-	if loadBalancer != nil &&
-		(aws.StringValue(loadBalancer.TargetGroupArn) != "" || aws.StringValue(loadBalancer.LoadBalancerName) != "") {
-		createServiceInput.LoadBalancers = []*ecs.LoadBalancer{loadBalancer}
-		createServiceInput.Role = aws.String(role)
+		LoadBalancers:           []*ecs.LoadBalancer{loadBalancer},
+		Role:                    aws.String(role),
 	}
 
 	if _, err := client.client.CreateService(createServiceInput); err != nil {

--- a/ecs-cli/modules/compose/ecs/service.go
+++ b/ecs-cli/modules/compose/ecs/service.go
@@ -25,6 +25,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ecs"
 	"github.com/docker/libcompose/project"
+	"github.com/pkg/errors"
 )
 
 // Service type is placeholder for a single task definition and its cache
@@ -53,7 +54,7 @@ func NewService(context *Context) ProjectEntity {
 	}
 }
 
-// LoadContext reads the context set in NewService and loads DeploymentConfiguration
+// LoadContext reads the context set in NewService and loads DeploymentConfiguration and LoadBalnacer
 func (s *Service) LoadContext() error {
 	maxPercent, err := getInt64FromCLIContext(s.Context(), DeploymentMaxPercentFlag)
 	if err != nil {
@@ -68,24 +69,33 @@ func (s *Service) LoadContext() error {
 		MinimumHealthyPercent: minHealthyPercent,
 	}
 
+	// Load Balancer
+	role := s.Context().CLIContext.String(RoleFlag)
 	targetGroupArn := s.Context().CLIContext.String(TargetGroupArnFlag)
+	loadBalancerName := s.Context().CLIContext.String(LoadBalancerNameFlag)
 	containerName := s.Context().CLIContext.String(ContainerNameFlag)
 	containerPort, err := getInt64FromCLIContext(s.Context(), ContainerPortFlag)
 	if err != nil {
 		return err
 	}
-	loadBalancerName := s.Context().CLIContext.String(LoadBalancerNameFlag)
 
-	s.loadBalancer = &ecs.LoadBalancer{
-		ContainerName: aws.String(containerName),
-		ContainerPort: containerPort,
+	if role != "" || targetGroupArn != "" || loadBalancerName != "" || containerName != "" || containerPort != nil {
+		if targetGroupArn != "" && loadBalancerName != "" {
+			return errors.Errorf("[--%s] and [--%s] flags cannot both be specified", LoadBalancerNameFlag, TargetGroupArnFlag)
+		}
+
+		s.loadBalancer = &ecs.LoadBalancer{
+			ContainerName: aws.String(containerName),
+			ContainerPort: containerPort,
+		}
+		if targetGroupArn != "" {
+			s.loadBalancer.TargetGroupArn = aws.String(targetGroupArn)
+		}
+		if loadBalancerName != "" {
+			s.loadBalancer.LoadBalancerName = aws.String(loadBalancerName)
+		}
+		s.role = role
 	}
-
-	// AWS API server side validation will inform the user about not specifying both.
-	s.loadBalancer.TargetGroupArn = aws.String(targetGroupArn)
-	s.loadBalancer.LoadBalancerName = aws.String(loadBalancerName)
-
-	s.role = s.Context().CLIContext.String(RoleFlag)
 	return nil
 }
 
@@ -299,10 +309,9 @@ func (s *Service) Run(commandOverrides map[string]string) error {
 // createService calls the underlying ECS.CreateService
 func (s *Service) createService() error {
 	serviceName := s.getServiceName()
-	taskDefinitionId := getIdFromArn(s.TaskDefinition().TaskDefinitionArn)
-	loadBalancer := s.loadBalancer
-	role := s.role
-	err := s.Context().ECSClient.CreateService(serviceName, taskDefinitionId, loadBalancer, role, s.DeploymentConfig())
+	taskDefinitionID := getIdFromArn(s.TaskDefinition().TaskDefinitionArn)
+
+	err := s.Context().ECSClient.CreateService(serviceName, taskDefinitionID, s.loadBalancer, s.role, s.DeploymentConfig())
 	if err != nil {
 		return err
 	}

--- a/ecs-cli/modules/compose/ecs/service.go
+++ b/ecs-cli/modules/compose/ecs/service.go
@@ -79,6 +79,8 @@ func (s *Service) LoadContext() error {
 		return err
 	}
 
+	// Validates LoadBalancerName and TargetGroupArn cannot exist at the same time
+	// The rest will be taken care off by the API call
 	if role != "" || targetGroupArn != "" || loadBalancerName != "" || containerName != "" || containerPort != nil {
 		if targetGroupArn != "" && loadBalancerName != "" {
 			return errors.Errorf("[--%s] and [--%s] flags cannot both be specified", LoadBalancerNameFlag, TargetGroupArnFlag)


### PR DESCRIPTION
* Bug fix: prevent `LoadBalancerName` or `TargetGroupArn` to be specified as "" when it is not used.
* Validates `LoadBalancerName` and `TargetGroupArn` cannot exist at the same time, the rest will be taken care off by the API call.

## Testing
```
$ make build
$ make test
PASS
```
```
./bin/local/ecs-cli compose service up                                                                                                                          
WARN[0000] Skipping unsupported YAML option...           option name=networks
WARN[0000] Skipping unsupported YAML option for service...  option name=networks service name=mysql
WARN[0000] Skipping unsupported YAML option for service...  option name=networks service name=wordpress
INFO[0000] Using ECS task definition                     TaskDefinition="ecscompose-amazon-ecs-cli:5"
INFO[0000] Created an ECS service                        service=ecscompose-service-amazon-ecs-cli taskDefinition="ecscompose-amazon-ecs-cli:5"
INFO[0000] Updated ECS service successfully              desiredCount=1 serviceName=ecscompose-service-amazon-ecs-cli
INFO[0000] Describe ECS Service status                   desiredCount=1 runningCount=0 serviceName=ecscompose-service-amazon-ecs-cli
```
```
./bin/local/ecs-cli compose service up --load-balancer-name elb-v2-service wordpress --container-port 80 --role ecsServiceRole 
WARN[0000] Skipping unsupported YAML option...           option name=networks
WARN[0000] Skipping unsupported YAML option for service...  option name=networks service name=wordpress
WARN[0000] Skipping unsupported YAML option for service...  option name=networks service name=mysql
INFO[0000] Using ECS task definition                     TaskDefinition="ecscompose-amazon-ecs-cli:6"
INFO[0000] Created an ECS service                        service=ecscompose-service-amazon-ecs-cli taskDefinition="ecscompose-amazon-ecs-cli:6"
INFO[0000] Updated ECS service successfully              desiredCount=1 serviceName=ecscompose-service-amazon-ecs-cli
INFO[0001] Describe ECS Service status                   desiredCount=1 runningCount=0 serviceName=ecscompose-service-amazon-ecs-cli
...
```

```
$ ./bin/local/ecs-cli compose service up --target-group-arn arn:aws:elasticloadbalancing:us-east-1:****************:targetgroup/tg-alb/bc28e526d84d21f5 --container-name wordpress --container-port 80 --role ecsServiceRole
WARN[0000] Skipping unsupported YAML option...           option name=networks
WARN[0000] Skipping unsupported YAML option for service...  option name=networks service name=mysql
WARN[0000] Skipping unsupported YAML option for service...  option name=networks service name=wordpress
INFO[0000] Using ECS task definition                     TaskDefinition="ecscompose-amazon-ecs-cli:5"
INFO[0000] Created an ECS service                        service=ecscompose-service-amazon-ecs-cli taskDefinition="ecscompose-amazon-ecs-cli:5"
INFO[0000] Updated ECS service successfully              desiredCount=1 serviceName=ecscompose-service-amazon-ecs-cli
INFO[0001] Describe ECS Service status                   desiredCount=1 runningCount=0 serviceName=ecscompose-service-amazon-ecs-cli
INFO[0016] ECS Service has reached a stable state        desiredCount=1 runningCount=1 serviceName=ecscompose-service-amazon-ecs-cli
```

### Error case
```
$ ./bin/local/ecs-cli compose service up --target-group-arn arn:aws:elasticloadbalancing:us-east-1:*************:targetgroup/tg-alb/bc28e526d84d21f5 --container-name wordpress --container-port 80 --load-balancer-name elb-v2-service
ERRO[0000] Unable to open ECS Compose Project            error="[--load-balancer-name] and [--target-group-arn] flags cannot both be specified"
FATA[0000] Unable to create and read ECS Compose Project  error="[--load-balancer-name] and [--target-group-arn] flags cannot both be specified"
```

```
$  ./bin/local/ecs-cli compose service up --load-balancer-name elb-v2-service --container-name wordpress --container-port 80
WARN[0000] Skipping unsupported YAML option...           option name=networks
WARN[0000] Skipping unsupported YAML option for service...  option name=networks service name=mysql
WARN[0000] Skipping unsupported YAML option for service...  option name=networks service name=wordpress
INFO[0000] Using ECS task definition                     TaskDefinition="ecscompose-amazon-ecs-cli:5"
ERRO[0000] Error creating service                        error="ClientException: Role is required when configuring load-balancers for service\n\tstatus code: 400, request id:...
```
