### PR TITLE
Allow ECR push/pull with URI

### DIFF
--- a/ecs-cli/modules/aws/clients/ecr/mock/client.go
+++ b/ecs-cli/modules/aws/clients/ecr/mock/client.go
@@ -64,6 +64,17 @@ func (_mr *_MockClientRecorder) GetAuthorizationToken(arg0 interface{}) *gomock.
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetAuthorizationToken", arg0)
 }
 
+func (_m *MockClient) GetAuthorizationTokenByID(_param0 string) (*ecr.Auth, error) {
+	ret := _m.ctrl.Call(_m, "GetAuthorizationTokenByID", _param0)
+	ret0, _ := ret[0].(*ecr.Auth)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockClientRecorder) GetAuthorizationTokenByID(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetAuthorizationTokenByID", arg0)
+}
+
 func (_m *MockClient) GetImages(_param0 []*string, _param1 string, _param2 string, _param3 ecr.ProcessImageDetails) error {
 	ret := _m.ctrl.Call(_m, "GetImages", _param0, _param1, _param2, _param3)
 	ret0, _ := ret[0].(error)

--- a/ecs-cli/modules/cli/flags.go
+++ b/ecs-cli/modules/cli/flags.go
@@ -25,8 +25,6 @@ const (
 	ClusterFlag            = "cluster"
 	VerboseFlag            = "verbose"
 	RegistryIdFlag         = "registry-id"
-	FromFlag               = "from"
-	ToFlag                 = "to"
 	TaggedFlag             = "tagged"
 	UntaggedFlag           = "untagged"
 

--- a/ecs-cli/modules/command/image.go
+++ b/ecs-cli/modules/command/image.go
@@ -38,14 +38,6 @@ func PushCommand() cli.Command {
 				Name:  ecscli.RegistryIdFlag,
 				Usage: "[Optional] Specifies the Amazon ECR registry ID to push the image to. By default, images are pushed to the current AWS account.",
 			},
-			cli.StringFlag{
-				Name:  ecscli.FromFlag,
-				Usage: "[Optional] Specifies the image to push.",
-			},
-			cli.StringFlag{
-				Name:  ecscli.ToFlag,
-				Usage: "[Optional] Specifies the ECR repository and tag to push your image to.",
-			},
 		},
 	}
 }

--- a/ecs-cli/modules/command/image.go
+++ b/ecs-cli/modules/command/image.go
@@ -18,10 +18,11 @@ import (
 	"github.com/urfave/cli"
 )
 
+// const formats
 const (
-	PUSH_IMAGE_FORMAT  = "REPOSITORY[:TAG]"
-	PULL_IMAGE_FORMAT  = "REPOSITORY_NAME[:TAG|@DIGEST]"
-	LIST_IMAGES_FORMAT = "[REPOSITORY_NAME]"
+	PushImageFormat = "ECR_REPOSITORY[:TAG]"
+	PullImageFormat = "ECR_REPOSITORY[:TAG|@DIGEST]"
+	ListImageFormat = "[ECR_REPOSITORY]"
 )
 
 // PushCommand push ECR image
@@ -29,7 +30,7 @@ func PushCommand() cli.Command {
 	return cli.Command{
 		Name:      "push",
 		Usage:     "Push an image to an Amazon ECR repository.",
-		ArgsUsage: "[" + PUSH_IMAGE_FORMAT + "]",
+		ArgsUsage: "[" + PushImageFormat + "]",
 		Before:    ecscli.BeforeApp,
 		Action:    ImagePush,
 		Flags: []cli.Flag{
@@ -54,7 +55,7 @@ func PullCommand() cli.Command {
 	return cli.Command{
 		Name:      "pull",
 		Usage:     "Pull an image from an Amazon ECR repository.",
-		ArgsUsage: PULL_IMAGE_FORMAT,
+		ArgsUsage: PullImageFormat,
 		Before:    ecscli.BeforeApp,
 		Action:    ImagePull,
 		Flags: []cli.Flag{
@@ -71,7 +72,7 @@ func ImagesCommand() cli.Command {
 	return cli.Command{
 		Name:      "images",
 		Usage:     "List images an Amazon ECR repository.",
-		ArgsUsage: LIST_IMAGES_FORMAT,
+		ArgsUsage: ListImageFormat,
 		Before:    ecscli.BeforeApp,
 		Action:    ImageList,
 		Flags: []cli.Flag{

--- a/ecs-cli/modules/command/image_app.go
+++ b/ecs-cli/modules/command/image_app.go
@@ -34,6 +34,7 @@ import (
 	"github.com/urfave/cli"
 )
 
+// const symbols and widths
 const (
 	SeperatorAt    = "@"
 	SeperatorColon = ":"
@@ -149,7 +150,7 @@ func pushImage(c *cli.Context, rdwr config.ReadWriter, dockerClient dockerclient
 		targetImage = args[0]
 	}
 
-	repository, tag, err := splitImageName(targetImage, SeperatorColon, PUSH_IMAGE_FORMAT)
+	repository, tag, err := splitImageName(targetImage, SeperatorColon, PushImageFormat)
 	if err != nil {
 		return err
 	}
@@ -204,7 +205,7 @@ func pullImage(c *cli.Context, rdwr config.ReadWriter, dockerClient dockerclient
 	if strings.Contains(image, SeperatorAt) {
 		seperator = SeperatorAt
 	}
-	repository, tag, err := splitImageName(image, seperator, PULL_IMAGE_FORMAT)
+	repository, tag, err := splitImageName(image, seperator, PullImageFormat)
 	if err != nil {
 		return err
 	}

--- a/ecs-cli/modules/command/image_app.go
+++ b/ecs-cli/modules/command/image_app.go
@@ -123,32 +123,15 @@ func ImageList(c *cli.Context) {
 
 func pushImage(c *cli.Context, rdwr config.ReadWriter, dockerClient dockerclient.Client, ecrClient ecrclient.Client, stsClient stsclient.Client) error {
 	registryID := c.String(ecscli.RegistryIdFlag)
-	targetImage := c.String(ecscli.ToFlag)
-	sourceImage := c.String(ecscli.FromFlag)
 	args := c.Args()
 
-	if len(args) == 0 && (sourceImage == "" || targetImage == "") {
-		return fmt.Errorf("ecs-cli push requires exactly 1 argument or [--%s] and [--%s] flags", ecscli.FromFlag, ecscli.ToFlag)
-	}
-
-	if len(args) == 1 && (sourceImage != "" || targetImage != "") {
-		return fmt.Errorf("ecs-cli push does not allow [--%s] and [--%s] flags to be used with arguments", ecscli.FromFlag, ecscli.ToFlag)
-	}
-
-	if len(args) > 1 {
+	if len(args) != 1 {
 		return fmt.Errorf("ecs-cli push requires exactly 1 argument")
 	}
 
-	if (sourceImage == "" && targetImage != "") || (sourceImage != "" && targetImage == "") {
-		return fmt.Errorf("ecs-cli push requires [--%s] and [--%s] flags", ecscli.FromFlag, ecscli.ToFlag)
-	}
+	image := args[0]
 
-	if len(args) == 1 {
-		sourceImage = args[0]
-		targetImage = args[0]
-	}
-
-	registryURI, repository, tag, err := splitImageName(targetImage, "[:]", PushImageFormat)
+	registryURI, repository, tag, err := splitImageName(image, "[:]", PushImageFormat)
 	if err != nil {
 		return err
 	}
@@ -162,7 +145,7 @@ func pushImage(c *cli.Context, rdwr config.ReadWriter, dockerClient dockerclient
 
 	// Tag image to ECR uri
 	if registryURI == "" {
-		if err := dockerClient.TagImage(sourceImage, repositoryURI, tag); err != nil {
+		if err := dockerClient.TagImage(image, repositoryURI, tag); err != nil {
 			return err
 		}
 	}

--- a/ecs-cli/modules/command/image_app_test.go
+++ b/ecs-cli/modules/command/image_app_test.go
@@ -49,7 +49,7 @@ func TestImagePush(t *testing.T) {
 
 	gomock.InOrder(
 		mockSTS.EXPECT().GetAWSAccountID().Return(registryID, nil),
-		mockECR.EXPECT().GetAuthorizationToken(gomock.Any()).Return(&ecr.Auth{
+		mockECR.EXPECT().GetAuthorizationTokenByID(gomock.Any()).Return(&ecr.Auth{
 			Registry: registry,
 		}, nil),
 		mockDocker.EXPECT().TagImage(image, repositoryURI, tag).Return(nil),
@@ -66,15 +66,15 @@ func TestImagePush(t *testing.T) {
 }
 
 func TestImagePushWithArgument(t *testing.T) {
+	repositoryWithURI := "012345678912.dkr.ecr.us-east-1.amazonaws.com/" + repositoryWithTag
+
 	mockECR, mockDocker, mockSTS := setupTestController(t)
 	setupEnvironmentVar()
 
 	gomock.InOrder(
-		mockSTS.EXPECT().GetAWSAccountID().Return(registryID, nil),
 		mockECR.EXPECT().GetAuthorizationToken(gomock.Any()).Return(&ecr.Auth{
 			Registry: registry,
 		}, nil),
-		mockDocker.EXPECT().TagImage(repositoryWithTag, repositoryURI, tag).Return(nil),
 		mockECR.EXPECT().RepositoryExists(repository).Return(false),
 		mockECR.EXPECT().CreateRepository(repository).Return(repository, nil),
 		mockDocker.EXPECT().PushImage(repositoryURI, tag, registry,
@@ -83,7 +83,7 @@ func TestImagePushWithArgument(t *testing.T) {
 
 	globalContext := setGlobalFlags()
 	flagSet := flag.NewFlagSet("ecs-cli-push", 0)
-	flagSet.Parse([]string{repositoryWithTag})
+	flagSet.Parse([]string{repositoryWithURI})
 	context := cli.NewContext(nil, flagSet, globalContext)
 	err := pushImage(context, newMockReadWriter(), mockDocker, mockECR, mockSTS)
 	assert.NoError(t, err, "Error pushing image")
@@ -95,7 +95,7 @@ func TestImagePushWhenRepositoryExists(t *testing.T) {
 
 	gomock.InOrder(
 		mockSTS.EXPECT().GetAWSAccountID().Return(registryID, nil),
-		mockECR.EXPECT().GetAuthorizationToken(gomock.Any()).Return(&ecr.Auth{
+		mockECR.EXPECT().GetAuthorizationTokenByID(gomock.Any()).Return(&ecr.Auth{
 			Registry: registry,
 		}, nil),
 		mockDocker.EXPECT().TagImage(image, repositoryURI, tag).Return(nil),
@@ -180,7 +180,7 @@ func TestImagePushWhenGethAuthorizationTokenFail(t *testing.T) {
 
 	gomock.InOrder(
 		mockSTS.EXPECT().GetAWSAccountID().Return(registryID, nil),
-		mockECR.EXPECT().GetAuthorizationToken(gomock.Any()).Return(nil, errors.New("something failed")),
+		mockECR.EXPECT().GetAuthorizationTokenByID(gomock.Any()).Return(nil, errors.New("something failed")),
 	)
 
 	globalContext := setGlobalFlags()
@@ -195,7 +195,7 @@ func TestImagePushWhenTagImageFail(t *testing.T) {
 
 	gomock.InOrder(
 		mockSTS.EXPECT().GetAWSAccountID().Return(registryID, nil),
-		mockECR.EXPECT().GetAuthorizationToken(gomock.Any()).Return(&ecr.Auth{
+		mockECR.EXPECT().GetAuthorizationTokenByID(gomock.Any()).Return(&ecr.Auth{
 			Registry: registry,
 		}, nil),
 		mockDocker.EXPECT().TagImage(image, repositoryURI, tag).Return(errors.New("something failed")),
@@ -213,7 +213,7 @@ func TestImagePushWhenCreateRepositoryFail(t *testing.T) {
 
 	gomock.InOrder(
 		mockSTS.EXPECT().GetAWSAccountID().Return(registryID, nil),
-		mockECR.EXPECT().GetAuthorizationToken(gomock.Any()).Return(&ecr.Auth{
+		mockECR.EXPECT().GetAuthorizationTokenByID(gomock.Any()).Return(&ecr.Auth{
 			Registry: registry,
 		}, nil),
 		mockDocker.EXPECT().TagImage(image, repositoryURI, tag).Return(nil),
@@ -233,7 +233,7 @@ func TestImagePushFail(t *testing.T) {
 
 	gomock.InOrder(
 		mockSTS.EXPECT().GetAWSAccountID().Return(registryID, nil),
-		mockECR.EXPECT().GetAuthorizationToken(gomock.Any()).Return(&ecr.Auth{
+		mockECR.EXPECT().GetAuthorizationTokenByID(gomock.Any()).Return(&ecr.Auth{
 			Registry: registry,
 		}, nil),
 		mockDocker.EXPECT().TagImage(image, repositoryURI, tag).Return(nil),
@@ -255,7 +255,7 @@ func TestImagePull(t *testing.T) {
 
 	gomock.InOrder(
 		mockSTS.EXPECT().GetAWSAccountID().Return(registryID, nil),
-		mockECR.EXPECT().GetAuthorizationToken(gomock.Any()).Return(&ecr.Auth{
+		mockECR.EXPECT().GetAuthorizationTokenByID(gomock.Any()).Return(&ecr.Auth{
 			Registry: registry,
 		}, nil),
 		mockDocker.EXPECT().PullImage(repositoryURI, tag,
@@ -285,7 +285,7 @@ func TestImagePullWhenGetAuthorizationTokenFail(t *testing.T) {
 
 	gomock.InOrder(
 		mockSTS.EXPECT().GetAWSAccountID().Return(registryID, nil),
-		mockECR.EXPECT().GetAuthorizationToken(gomock.Any()).Return(nil, errors.New("something failed")),
+		mockECR.EXPECT().GetAuthorizationTokenByID(gomock.Any()).Return(nil, errors.New("something failed")),
 	)
 
 	globalContext := setGlobalFlags()
@@ -300,7 +300,7 @@ func TestImagePullFail(t *testing.T) {
 
 	gomock.InOrder(
 		mockSTS.EXPECT().GetAWSAccountID().Return(registryID, nil),
-		mockECR.EXPECT().GetAuthorizationToken(gomock.Any()).Return(&ecr.Auth{
+		mockECR.EXPECT().GetAuthorizationTokenByID(gomock.Any()).Return(&ecr.Auth{
 			Registry: registry,
 		}, nil),
 		mockDocker.EXPECT().PullImage(repositoryURI, tag,

--- a/ecs-cli/modules/compose/ecs/mocks/project_entity.go
+++ b/ecs-cli/modules/compose/ecs/mocks/project_entity.go
@@ -17,10 +17,10 @@
 package mock_ecs
 
 import (
-	ecs0 "github.com/aws/amazon-ecs-cli/ecs-cli/modules/compose/ecs"
+	ecs "github.com/aws/amazon-ecs-cli/ecs-cli/modules/compose/ecs"
 	utils "github.com/aws/amazon-ecs-cli/ecs-cli/utils"
 	cache "github.com/aws/amazon-ecs-cli/ecs-cli/utils/cache"
-	ecs "github.com/aws/aws-sdk-go/service/ecs"
+	ecs0 "github.com/aws/aws-sdk-go/service/ecs"
 	project "github.com/docker/libcompose/project"
 	gomock "github.com/golang/mock/gomock"
 )
@@ -46,9 +46,9 @@ func (_m *MockProjectEntity) EXPECT() *_MockProjectEntityRecorder {
 	return _m.recorder
 }
 
-func (_m *MockProjectEntity) Context() *ecs0.Context {
+func (_m *MockProjectEntity) Context() *ecs.Context {
 	ret := _m.ctrl.Call(_m, "Context")
-	ret0, _ := ret[0].(*ecs0.Context)
+	ret0, _ := ret[0].(*ecs.Context)
 	return ret0
 }
 
@@ -117,7 +117,7 @@ func (_mr *_MockProjectEntityRecorder) Scale(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Scale", arg0)
 }
 
-func (_m *MockProjectEntity) SetTaskDefinition(_param0 *ecs.TaskDefinition) {
+func (_m *MockProjectEntity) SetTaskDefinition(_param0 *ecs0.TaskDefinition) {
 	_m.ctrl.Call(_m, "SetTaskDefinition", _param0)
 }
 
@@ -155,9 +155,9 @@ func (_mr *_MockProjectEntityRecorder) Stop() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Stop")
 }
 
-func (_m *MockProjectEntity) TaskDefinition() *ecs.TaskDefinition {
+func (_m *MockProjectEntity) TaskDefinition() *ecs0.TaskDefinition {
 	ret := _m.ctrl.Call(_m, "TaskDefinition")
-	ret0, _ := ret[0].(*ecs.TaskDefinition)
+	ret0, _ := ret[0].(*ecs0.TaskDefinition)
 	return ret0
 }
 

--- a/ecs-cli/modules/docker/client.go
+++ b/ecs-cli/modules/docker/client.go
@@ -75,11 +75,11 @@ func (c *dockerClient) PushImage(repository, tag, registry string, auth docker.A
 }
 
 // Tags repository[:tag] to local docker image
-func (c *dockerClient) TagImage(sourceImage, repository, tag string) error {
+func (c *dockerClient) TagImage(image, repository, tag string) error {
 	log.WithFields(log.Fields{
-		"source-image": sourceImage,
-		"repository":   repository,
-		"tag":          tag,
+		"image":      image,
+		"repository": repository,
+		"tag":        tag,
 	}).Info("Tagging image")
 
 	opts := docker.TagImageOptions{
@@ -87,7 +87,7 @@ func (c *dockerClient) TagImage(sourceImage, repository, tag string) error {
 		Tag:  tag,
 	}
 
-	if err := c.client.TagImage(sourceImage, opts); err != nil {
+	if err := c.client.TagImage(image, opts); err != nil {
 		return errors.Wrap(err, "unable to tag image")
 	}
 	log.Info("Image tagged")
@@ -108,6 +108,6 @@ func (c *dockerClient) PullImage(repository, tag string, auth docker.AuthConfigu
 	if err := c.client.PullImage(opts, auth); err != nil {
 		return errors.Wrap(err, "unable to pull image")
 	}
-	log.Infof("Image pulled")
+	log.Info("Image pulled")
 	return nil
 }


### PR DESCRIPTION
```
$ make build
$ make generate
$ make test
PASS
```

```
$ ./bin/local/ecs-cli pull ********.dkr.ecr.us-east-1.amazonaws.com/busybox
INFO[0000] Pulling image                                 repository="**********.dkr.ecr.us-east-1.amazonaws.com/busybox" tag=
INFO[0002] Image pulled                                 

$ ./bin/local/ecs-cli push ***********.dkr.ecr.us-east-1.amazonaws.com/busybox  
INFO[0000] Pushing image                                 repository="******.dkr.ecr.us-east-1.amazonaws.com/busybox" tag=
INFO[0005] Image pushed

$  ./bin/local/ecs-cli push busybox
INFO[0000] Getting AWS account ID...                    
INFO[0000] Tagging image                                 image=busybox repository="********.dkr.ecr.us-east-1.amazonaws.com/busybox" tag=
INFO[0000] Image tagged                                 
INFO[0000] Pushing image                                 repository="********.dkr.ecr.us-east-1.amazonaws.com/busybox" tag=
INFO[0007] Image pushed 

                                
$ ./bin/local/ecs-cli push busybox:latest
INFO[0000] Getting AWS account ID...                    
INFO[0000] Tagging image                                 image="busybox:latest" repository="********.dkr.ecr.us-east-1.amazonaws.com/busybox" tag=latest
INFO[0000] Image tagged                                 
INFO[0000] Pushing image                                 repository="********.dkr.ecr.us-east-1.amazonaws.com/busybox" tag=latest
INFO[0002] Image pushed  
```