### PR TITLE
passing memory reservation to ecs via compose

### DIFF
--- a/ecs-cli/modules/compose/ecs/project_test.go
+++ b/ecs-cli/modules/compose/ecs/project_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/compose/ecs/utils"
 	"github.com/docker/libcompose/project"
 	"github.com/docker/libcompose/yaml"
+	"github.com/stretchr/testify/assert"
 	"github.com/urfave/cli"
 )
 
@@ -236,9 +237,8 @@ services:
 	if !reflect.DeepEqual(ports, wordpress.Ports) {
 		t.Errorf("Expected ports to be [%v] but got [%v]", ports, wordpress.Ports)
 	}
-	if memoryReservation != int64(wordpress.MemReservation) {
-		t.Errorf("Expected memoryReservation to be [%s] but got [%s]", memoryReservation, wordpress.MemReservation)
-	}
+
+	assert.Equal(t, memoryReservation, int64(wordpress.MemReservation), "Expected memoryReservation to match")
 
 	// verify mysql ServiceConfig
 	mysql, ok := configs.Get("mysql")

--- a/ecs-cli/modules/compose/ecs/project_test.go
+++ b/ecs-cli/modules/compose/ecs/project_test.go
@@ -205,12 +205,14 @@ func TestParseComposeForVersion2Files(t *testing.T) {
 	wordpressImage := "wordpress"
 	mysqlImage := "mysql"
 	ports := []string{"80:80"}
+	memoryReservation := int64(500000000)
 
 	composeFileString := `version: '2'
 services:
   wordpress:
     image: wordpress
     ports: ["80:80"]
+    mem_reservation: 500000000
   mysql:
     image: mysql`
 
@@ -233,6 +235,9 @@ services:
 	}
 	if !reflect.DeepEqual(ports, wordpress.Ports) {
 		t.Errorf("Expected ports to be [%v] but got [%v]", ports, wordpress.Ports)
+	}
+	if memoryReservation != int64(wordpress.MemReservation) {
+		t.Errorf("Expected memoryReservation to be [%s] but got [%s]", memoryReservation, wordpress.MemReservation)
 	}
 
 	// verify mysql ServiceConfig

--- a/ecs-cli/modules/compose/ecs/utils/convert_task_definition.go
+++ b/ecs-cli/modules/compose/ecs/utils/convert_task_definition.go
@@ -168,17 +168,18 @@ func convertToContainerDef(context *project.Context, inputCfg *config.ServiceCon
 	// setting memory
 	var mem int64
 	var memoryReservation int64
-	// mem_limit should be > mem_reservation, if it is specified
 	if inputCfg.MemReservation != 0 {
 		memoryReservation = int64(inputCfg.MemReservation) / kiB / kiB // convert bytes to MiB
-		if inputCfg.MemLimit != 0 && inputCfg.MemLimit < inputCfg.MemReservation {
-			return errors.New("mem_limit should not be less than mem_reservation")
-		}
 	}
 
 	if inputCfg.MemLimit != 0 {
 		mem = int64(inputCfg.MemLimit) / kiB / kiB // convert bytes to MiB
 	}
+	// mem_limit should be > mem_reservation, if it is specified
+	if mem != 0 && memoryReservation != 0 && mem < memoryReservation {
+		return errors.New("mem_limit should not be less than mem_reservation")
+	}
+
 	if mem == 0 && memoryReservation == 0 {
 		mem = defaultMemLimit
 	}

--- a/ecs-cli/modules/compose/ecs/utils/convert_task_definition_test.go
+++ b/ecs-cli/modules/compose/ecs/utils/convert_task_definition_test.go
@@ -630,13 +630,9 @@ func TestMemReservationHigherThanMemLimit(t *testing.T) {
 
 	taskDefName := "ProjectName"
 	envLookup, err := GetDefaultEnvironmentLookup()
-	if err != nil {
-		t.Fatal("Unexpected error setting up environment lookup")
-	}
+	assert.NoError(t, err, "Unexpected error setting up environment lookup")
 	resourceLookup, err := GetDefaultResourceLookup()
-	if err != nil {
-		t.Fatal("Unexpected error setting up resource lookup")
-	}
+	assert.NoError(t, err, "Unexpected error setting up resource lookup")
 	context := &project.Context{
 		Project:           &project.Project{},
 		EnvironmentLookup: envLookup,

--- a/ecs-cli/modules/compose/ecs/utils/convert_task_definition_test.go
+++ b/ecs-cli/modules/compose/ecs/utils/convert_task_definition_test.go
@@ -50,17 +50,18 @@ func TestConvertToTaskDefinition(t *testing.T) {
 	workingDir := "/var"
 
 	serviceConfig := &config.ServiceConfig{
-		CPUShares:   yaml.StringorInt(cpu),
-		Command:     []string{command},
-		Hostname:    hostname,
-		Image:       image,
-		Links:       links,
-		MemLimit:    yaml.MemStringorInt(int64(1048576) * memory), //1 MiB = 1048576B
-		Privileged:  privileged,
-		ReadOnly:    readOnly,
-		SecurityOpt: securityOpts,
-		User:        user,
-		WorkingDir:  workingDir,
+		CPUShares:      yaml.StringorInt(cpu),
+		Command:        []string{command},
+		Hostname:       hostname,
+		Image:          image,
+		Links:          links,
+		MemLimit:       yaml.MemStringorInt(int64(1048576) * memory), //1 MiB = 1048576B
+		MemReservation: yaml.MemStringorInt(int64(1048576) * memory),
+		Privileged:     privileged,
+		ReadOnly:       readOnly,
+		SecurityOpt:    securityOpts,
+		User:           user,
+		WorkingDir:     workingDir,
 	}
 
 	// convert
@@ -548,31 +549,33 @@ func TestIsZeroForEmptyConfig(t *testing.T) {
 
 func TestIsZeroWhenConfigHasValues(t *testing.T) {
 	hasValues := map[string]bool{
-		"CPUShares":   true,
-		"Command":     true,
-		"Hostname":    true,
-		"Image":       true,
-		"Links":       true,
-		"MemLimit":    true,
-		"Privileged":  true,
-		"ReadOnly":    true,
-		"SecurityOpt": true,
-		"User":        true,
-		"WorkingDir":  true,
+		"CPUShares":      true,
+		"Command":        true,
+		"Hostname":       true,
+		"Image":          true,
+		"Links":          true,
+		"MemLimit":       true,
+		"MemReservation": true,
+		"Privileged":     true,
+		"ReadOnly":       true,
+		"SecurityOpt":    true,
+		"User":           true,
+		"WorkingDir":     true,
 	}
 
 	serviceConfig := &config.ServiceConfig{
-		CPUShares:   yaml.StringorInt(int64(10)),
-		Command:     []string{"cmd"},
-		Hostname:    "foobarbaz",
-		Image:       "testimage",
-		Links:       []string{"container1"},
-		MemLimit:    yaml.MemStringorInt(int64(104857600)),
-		Privileged:  true,
-		ReadOnly:    true,
-		SecurityOpt: []string{"label:type:test_virt"},
-		User:        "user",
-		WorkingDir:  "/var",
+		CPUShares:      yaml.StringorInt(int64(10)),
+		Command:        []string{"cmd"},
+		Hostname:       "foobarbaz",
+		Image:          "testimage",
+		Links:          []string{"container1"},
+		MemLimit:       yaml.MemStringorInt(int64(104857600)),
+		MemReservation: yaml.MemStringorInt(int64(52428800)),
+		Privileged:     true,
+		ReadOnly:       true,
+		SecurityOpt:    []string{"label:type:test_virt"},
+		User:           "user",
+		WorkingDir:     "/var",
 	}
 
 	configValue := reflect.ValueOf(serviceConfig).Elem()

--- a/ecs-cli/modules/compose/ecs/utils/convert_task_definition_test.go
+++ b/ecs-cli/modules/compose/ecs/utils/convert_task_definition_test.go
@@ -43,6 +43,7 @@ func TestConvertToTaskDefinition(t *testing.T) {
 	image := "testimage"
 	links := []string{"container1"}
 	memory := int64(131072) // 128 GiB = 131072 MiB
+	memoryReservation := int64(65536)
 	privileged := true
 	readOnly := true
 	securityOpts := []string{"label:type:test_virt"}
@@ -56,7 +57,7 @@ func TestConvertToTaskDefinition(t *testing.T) {
 		Image:          image,
 		Links:          links,
 		MemLimit:       yaml.MemStringorInt(int64(1048576) * memory), //1 MiB = 1048576B
-		MemReservation: yaml.MemStringorInt(int64(1048576) * memory),
+		MemReservation: yaml.MemStringorInt(int64(524288) * memory),
 		Privileged:     privileged,
 		ReadOnly:       readOnly,
 		SecurityOpt:    securityOpts,
@@ -92,6 +93,9 @@ func TestConvertToTaskDefinition(t *testing.T) {
 	}
 	if memory != aws.Int64Value(containerDef.Memory) {
 		t.Errorf("Expected memory [%s] But was [%s]", memory, aws.Int64Value(containerDef.Memory))
+	}
+	if memoryReservation != aws.Int64Value(containerDef.MemoryReservation) {
+		t.Errorf("Expected memoryReservation [%s] But was [%s]", memoryReservation, aws.Int64Value(containerDef.MemoryReservation))
 	}
 	if privileged != aws.BoolValue(containerDef.Privileged) {
 		t.Errorf("Expected privileged [%s] But was [%s]", privileged, aws.BoolValue(containerDef.Privileged))


### PR DESCRIPTION
closes aws/amazon-ecs-cli#145
Adding the ability to specify `mem_reservation` in a docker-compose file, as per the [aws spec](http://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html), since it is now supported by [libcompse](https://github.com/docker/libcompose/pull/431/files)