### PR TITLE
Proposal: compose run supports docker-compose style arguments

### DIFF
--- a/ecs-cli/modules/aws/clients/ecs/client.go
+++ b/ecs-cli/modules/aws/clients/ecs/client.go
@@ -61,7 +61,7 @@ type ECSClient interface {
 	// Tasks related
 	GetTasksPages(listTasksInput *ecs.ListTasksInput, fn ProcessTasksAction) error
 	RunTask(taskDefinition, startedBy string, count int) (*ecs.RunTaskOutput, error)
-	RunTaskWithOverrides(taskDefinition, startedBy string, count int, overrides map[string]string) (*ecs.RunTaskOutput, error)
+	RunTaskWithOverrides(taskDefinition, startedBy string, count int, container string, commands []string) (*ecs.RunTaskOutput, error)
 	StopTask(taskId string) error
 	DescribeTasks(taskIds []*string) ([]*ecs.Task, error)
 
@@ -398,16 +398,13 @@ func (client *ecsClient) RunTask(taskDefinition, startedBy string, count int) (*
 }
 
 // RunTask issues a run task request for the input task definition
-func (client *ecsClient) RunTaskWithOverrides(taskDefinition, startedBy string, count int, overrides map[string]string) (*ecs.RunTaskOutput, error) {
+func (client *ecsClient) RunTaskWithOverrides(taskDefinition, startedBy string, count int, container string, commands []string) (*ecs.RunTaskOutput, error) {
 
-	commandOverrides := []*ecs.ContainerOverride{}
-	for cont, command := range overrides {
-		contOverride := &ecs.ContainerOverride{
-			Name:    aws.String(cont),
-			Command: aws.StringSlice([]string{command}),
-		}
-		commandOverrides = append(commandOverrides, contOverride)
-	}
+	commandOverrides := []*ecs.ContainerOverride{
+		{
+			Name:    aws.String(container),
+			Command: aws.StringSlice(commands),
+		}}
 	ecsOverrides := &ecs.TaskOverride{
 		ContainerOverrides: commandOverrides,
 	}

--- a/ecs-cli/modules/aws/clients/ecs/mock/client.go
+++ b/ecs-cli/modules/aws/clients/ecs/mock/client.go
@@ -193,15 +193,15 @@ func (_mr *_MockECSClientRecorder) RunTask(arg0, arg1, arg2 interface{}) *gomock
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "RunTask", arg0, arg1, arg2)
 }
 
-func (_m *MockECSClient) RunTaskWithOverrides(_param0 string, _param1 string, _param2 int, _param3 map[string]string) (*ecs.RunTaskOutput, error) {
-	ret := _m.ctrl.Call(_m, "RunTaskWithOverrides", _param0, _param1, _param2, _param3)
+func (_m *MockECSClient) RunTaskWithOverrides(_param0 string, _param1 string, _param2 int, _param3 string, _param4 []string) (*ecs.RunTaskOutput, error) {
+	ret := _m.ctrl.Call(_m, "RunTaskWithOverrides", _param0, _param1, _param2, _param3, _param4)
 	ret0, _ := ret[0].(*ecs.RunTaskOutput)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockECSClientRecorder) RunTaskWithOverrides(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "RunTaskWithOverrides", arg0, arg1, arg2, arg3)
+func (_mr *_MockECSClientRecorder) RunTaskWithOverrides(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "RunTaskWithOverrides", arg0, arg1, arg2, arg3, arg4)
 }
 
 func (_m *MockECSClient) StopTask(_param0 string) error {

--- a/ecs-cli/modules/compose/cli/ecs/app/app.go
+++ b/ecs-cli/modules/compose/cli/ecs/app/app.go
@@ -88,14 +88,10 @@ func ProjectPs(p ecscompose.Project, c *cli.Context) {
 // ProjectRun starts containers and executes one-time command against the container
 func ProjectRun(p ecscompose.Project, c *cli.Context) {
 	args := c.Args()
-	if len(args)%2 != 0 {
-		log.Fatal("Please pass arguments in the form: CONTAINER COMMAND [CONTAINER COMMAND]...")
+	if len(args)<1 {
+		log.Fatal("Please pass arguments in the form: CONTAINER [COMMAND...]")
 	}
-	commandOverrides := make(map[string]string)
-	for i := 0; i < len(args); i += 2 {
-		commandOverrides[args[i]] = args[i+1]
-	}
-	err := p.Run(commandOverrides)
+	err := p.Run(args[0], args[1:])
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/ecs-cli/modules/compose/cli/ecs/app/app_test.go
+++ b/ecs-cli/modules/compose/cli/ecs/app/app_test.go
@@ -64,18 +64,18 @@ func TestWithProject(t *testing.T) {
 }
 
 func TestRun(t *testing.T) {
-	containers := []string{"cont1", "cont2"}
-	commands := []string{"cmd1", "cmd2"}
+	container := "cont1"
+	commands := []string{"cmd1", "cmd2", "cmd3"}
 
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	mockProject := mock_ecs.NewMockProject(ctrl)
-	mockProject.EXPECT().Run(map[string]string{"cont1": "cmd1", "cont2": "cmd2"}).Return(nil)
+	mockProject.EXPECT().Run("cont1", []string{"cmd1", "cmd2", "cmd3"}).Return(nil)
 
 	flagSet := flag.NewFlagSet("ecs-cli", 0)
 	cliContext := cli.NewContext(nil, flagSet, nil)
 	// flag with 2 containers with 2 commands
-	flagSet.Parse([]string{containers[0], commands[0], containers[1], commands[1]})
+	flagSet.Parse([]string{container, commands[0], commands[1], commands[2]})
 
 	ProjectRun(mockProject, cliContext)
 }

--- a/ecs-cli/modules/compose/cli/ecs/app/command.go
+++ b/ecs-cli/modules/compose/cli/ecs/app/command.go
@@ -136,7 +136,7 @@ func startCommand(factory ProjectFactory) cli.Command {
 func runCommand(factory ProjectFactory) cli.Command {
 	return cli.Command{
 		Name: "run",
-		Usage: "ecs-cli compose run [containerName] [command] [containerName] [command] ..." +
+		Usage: "ecs-cli compose run [containerName] [command]..." +
 			"- starts all containers overriding commands with the supplied one-off commands for the containers.",
 		Action: WithProject(factory, ProjectRun, false),
 	}

--- a/ecs-cli/modules/compose/ecs/entity.go
+++ b/ecs-cli/modules/compose/ecs/entity.go
@@ -32,7 +32,7 @@ type ProjectEntity interface {
 	Start() error
 	Up() error
 	Info(filterComposeTasks bool) (project.InfoSet, error)
-	Run(commandOverrides map[string]string) error
+	Run(container string, commands []string) error
 	Scale(count int) error
 	Stop() error
 	Down() error

--- a/ecs-cli/modules/compose/ecs/mocks/project.go
+++ b/ecs-cli/modules/compose/ecs/mocks/project.go
@@ -115,14 +115,14 @@ func (_mr *_MockProjectRecorder) Parse() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Parse")
 }
 
-func (_m *MockProject) Run(_param0 map[string]string) error {
-	ret := _m.ctrl.Call(_m, "Run", _param0)
+func (_m *MockProject) Run(_param0 string, _param1 []string) error {
+	ret := _m.ctrl.Call(_m, "Run", _param0, _param1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-func (_mr *_MockProjectRecorder) Run(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "Run", arg0)
+func (_mr *_MockProjectRecorder) Run(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Run", arg0, arg1)
 }
 
 func (_m *MockProject) Scale(_param0 int) error {

--- a/ecs-cli/modules/compose/ecs/project.go
+++ b/ecs-cli/modules/compose/ecs/project.go
@@ -20,6 +20,8 @@ import (
 	"github.com/docker/libcompose/project"
 )
 
+//go:generate mockgen.sh github.com/aws/amazon-ecs-cli/ecs-cli/modules/compose/ecs Project mock/$GOFILE
+
 // Project is the starting point for the compose app to interact with and issue commands
 // It acts as a blanket for the context and entities created as a part of this compose project
 type Project interface {
@@ -35,7 +37,7 @@ type Project interface {
 	Start() error
 	Up() error
 	Info() (project.InfoSet, error)
-	Run(commandOverrides map[string]string) error
+	Run(container string, commands []string) error
 	Scale(count int) error
 	Stop() error
 	Down() error
@@ -155,8 +157,8 @@ func (p *ecsProject) Info() (project.InfoSet, error) {
 	return p.entity.Info(true)
 }
 
-func (p *ecsProject) Run(commandOverrides map[string]string) error {
-	return p.entity.Run(commandOverrides)
+func (p *ecsProject) Run(container string, commands []string) error {
+	return p.entity.Run(container, commands)
 }
 
 func (p *ecsProject) Scale(count int) error {

--- a/ecs-cli/modules/compose/ecs/service.go
+++ b/ecs-cli/modules/compose/ecs/service.go
@@ -302,7 +302,7 @@ func (s *Service) Down() error {
 }
 
 // Run expects to issue a command override and start containers. But that doesnt apply to the context of ECS Services
-func (s *Service) Run(commandOverrides map[string]string) error {
+func (s *Service) Run(container string, commands []string) error {
 	return composeutils.ErrUnsupported
 }
 

--- a/ecs-cli/modules/compose/ecs/service_test.go
+++ b/ecs-cli/modules/compose/ecs/service_test.go
@@ -255,6 +255,6 @@ func TestServiceInfo(t *testing.T) {
 
 func TestServiceRun(t *testing.T) {
 	service := NewService(&Context{})
-	err := service.Run(map[string]string{})
+	err := service.Run("cont1", []string{})
 	assert.Error(t, err, "Expected unsupported error")
 }

--- a/ecs-cli/modules/compose/ecs/task.go
+++ b/ecs-cli/modules/compose/ecs/task.go
@@ -157,13 +157,13 @@ func (t *Task) Scale(expectedCount int) error {
 
 // Run starts all containers defined in the task definition once regardless of if they were started before
 // It also overrides the commands for the specified containers
-func (t *Task) Run(commandOverrides map[string]string) error {
+func (t *Task) Run(container string, commands []string) error {
 	taskDef, err := getOrCreateTaskDefinition(t)
 	if err != nil {
 		return err
 	}
 	taskDefinitionId := aws.StringValue(taskDef.TaskDefinitionArn)
-	ecsTasks, err := t.Context().ECSClient.RunTaskWithOverrides(taskDefinitionId, getStartedBy(t), 1, commandOverrides)
+	ecsTasks, err := t.Context().ECSClient.RunTaskWithOverrides(taskDefinitionId, getStartedBy(t), 1, container, commands)
 	if err != nil {
 		return nil
 	}


### PR DESCRIPTION
Addresses Issue #148
reference #150

`compose run` supports multi-argument commands as:
`ecs-cli compose run <container> <cmd0> <cmd1> <cmd2>`

It's a breaking change.

