### PR TITLE
Fix segmentation violation error when ec2InstanceId does not exist

### DIFF
--- a/ecs-cli/modules/aws/clients/ec2/client.go
+++ b/ecs-cli/modules/aws/clients/ec2/client.go
@@ -40,6 +40,10 @@ type ec2Client struct {
 func NewEC2Client(params *config.CliParams) EC2Client {
 	client := ec2.New(params.Session)
 	client.Handlers.Build.PushBackNamed(clients.CustomUserAgentHandler())
+	return newClient(params, client)
+}
+
+func newClient(params *config.CliParams, client ec2iface.EC2API) EC2Client {
 	return &ec2Client{
 		client: client,
 	}

--- a/ecs-cli/modules/aws/clients/ec2/client_test.go
+++ b/ecs-cli/modules/aws/clients/ec2/client_test.go
@@ -24,24 +24,13 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestDescribeInstances(t *testing.T) {
 	defer os.Clearenv()
-	ctrl := gomock.NewController(t)
-	mockEC2 := mock_ec2iface.NewMockEC2API(ctrl)
-	client := NewEC2Client(&config.CliParams{Session: newTestSession(t)})
-	client.(*ec2Client).client = mockEC2
+	mockEC2, client, ctrl := setupTest(t)
 	defer ctrl.Finish()
-
-	// empty list of input ids
-	output, err := client.DescribeInstances([]*string{})
-	if err != nil {
-		t.Errorf("Expected no error for empty input, but got [%v]", err)
-	}
-	if len(output) != 0 {
-		t.Errorf("Expected empty output map for empty input list, but got [%v]", output)
-	}
 
 	// 2 ids in the input list
 	expectedIds := []*string{aws.String("id1"), aws.String("id2")}
@@ -58,63 +47,77 @@ func TestDescribeInstances(t *testing.T) {
 
 	mockEC2.EXPECT().DescribeInstances(gomock.Any()).Do(func(input interface{}) {
 		observedIds := input.(*ec2.DescribeInstancesInput)
-		if len(expectedIds) != len(observedIds.InstanceIds) {
-			t.Fatalf("Expected request to have ids set to [%v] but got [%v]", expectedIds, observedIds.InstanceIds)
-		}
-		for idx, _ := range expectedIds {
-			if aws.StringValue(expectedIds[idx]) != aws.StringValue(observedIds.InstanceIds[idx]) {
-				t.Fatalf("Expected request to have ids set to [%s] but got [%s]",
-					aws.StringValue(expectedIds[idx]), aws.StringValue(observedIds.InstanceIds[idx]))
-			}
+		assert.Equal(t, len(expectedIds), len(observedIds.InstanceIds), "Expected request to have ids set")
+
+		for idx := range expectedIds {
+			assert.Equal(t, aws.StringValue(expectedIds[idx]), aws.StringValue(observedIds.InstanceIds[idx]), "Expected request instance ids to match")
 		}
 	}).Return(result, nil)
 
-	output, err = client.DescribeInstances(expectedIds)
-	if err != nil {
-		t.Fatalf("Expected no error while Describing EC2 Instances, but got [%v]", err)
-	}
-	if len(output) == 0 {
-		t.Fatalf("Expected output to be of length [%s] but got 0", len(reservation.Instances))
-	}
+	output, err := client.DescribeInstances(expectedIds)
+	assert.NoError(t, err, "Expected no error while Describing EC2 Instances")
+	assert.NotEmpty(t, output, "Expected output to be of length")
+
 	for _, id := range expectedIds {
-		if output[aws.StringValue(id)] == nil {
-			t.Errorf("Expected output to have an instance for [%s] but got 0", aws.StringValue(id))
-		}
+		assert.NotNil(t, output[aws.StringValue(id)], "Expected output to have an instance")
 	}
 }
 
-func TestDescribeInstancesErrorCases(t *testing.T) {
+func TestDescribeInstancesWithEmptyList(t *testing.T) {
 	defer os.Clearenv()
+	_, client, ctrl := setupTest(t)
+	defer ctrl.Finish()
 
-	ctrl := gomock.NewController(t)
-	mockEC2 := mock_ec2iface.NewMockEC2API(ctrl)
-	client := NewEC2Client(&config.CliParams{Session: newTestSession(t)})
-	client.(*ec2Client).client = mockEC2
+	// empty list of input ids
+	output, err := client.DescribeInstances([]*string{})
+	assert.NoError(t, err, "Expected no error for empty input")
+	assert.Empty(t, output, "Expected empty output map for empty input list")
+
+}
+
+func TestDescribeInstancesErrorCase(t *testing.T) {
+	defer os.Clearenv()
+	mockEC2, client, ctrl := setupTest(t)
 	defer ctrl.Finish()
 
 	expectedIds := []*string{aws.String("id1"), aws.String("id2")}
 
-	// Describe returned error
 	mockEC2.EXPECT().DescribeInstances(gomock.Any()).Return(nil, errors.New("something failed"))
+
 	_, err := client.DescribeInstances(expectedIds)
-	if err == nil {
-		t.Error("Expected error while Describing EC2 Instances, but got none")
-	}
+
+	assert.Error(t, err, "Expected error while Describing EC2 Instances")
+}
+
+func TestDescribeInstancesErrorCaseWithEmptyOutput(t *testing.T) {
+	defer os.Clearenv()
+	mockEC2, client, ctrl := setupTest(t)
+	defer ctrl.Finish()
+
+	expectedIds := []*string{aws.String("id1"), aws.String("id2")}
 
 	// Describe returned nil reservations in the response
 	mockEC2.EXPECT().DescribeInstances(gomock.Any()).Return(&ec2.DescribeInstancesOutput{}, nil)
-	_, err = client.DescribeInstances(expectedIds)
-	if err == nil {
-		t.Error("Expected error for nil reservations, but got none")
-	}
+
+	_, err := client.DescribeInstances(expectedIds)
+
+	assert.Error(t, err, "Expected error for nil reservations")
+}
+
+func TestDescribeInstancesErrorCaseWithEmptyReservation(t *testing.T) {
+	defer os.Clearenv()
+	mockEC2, client, ctrl := setupTest(t)
+	defer ctrl.Finish()
+
+	expectedIds := []*string{aws.String("id1"), aws.String("id2")}
 
 	// Describe returned empty reservations in the response
 	mockEC2.EXPECT().DescribeInstances(gomock.Any()).Return(
 		&ec2.DescribeInstancesOutput{Reservations: []*ec2.Reservation{}}, nil)
-	_, err = client.DescribeInstances(expectedIds)
-	if err == nil {
-		t.Error("Expected error for empty reservations, but got none")
-	}
+
+	_, err := client.DescribeInstances(expectedIds)
+
+	assert.Error(t, err, "Expected error for empty reservations")
 }
 
 func newTestSession(t *testing.T) *session.Session {
@@ -122,8 +125,15 @@ func newTestSession(t *testing.T) *session.Session {
 	os.Setenv("AWS_SECRET_KEY", "secret")
 
 	testSession, err := session.NewSession()
-	if err != nil {
-		t.Fatal("Unexpected error in creating session")
-	}
+	assert.NoError(t, err, "Unexpected error in creating session")
+
 	return testSession
+}
+
+func setupTest(t *testing.T) (*mock_ec2iface.MockEC2API, EC2Client, *gomock.Controller) {
+	ctrl := gomock.NewController(t)
+	mockEC2 := mock_ec2iface.NewMockEC2API(ctrl)
+	client := newClient(&config.CliParams{Session: newTestSession(t)}, mockEC2)
+
+	return mockEC2, client, ctrl
 }

--- a/ecs-cli/modules/aws/clients/ecs/client.go
+++ b/ecs-cli/modules/aws/clients/ecs/client.go
@@ -62,7 +62,7 @@ type ECSClient interface {
 	GetTasksPages(listTasksInput *ecs.ListTasksInput, fn ProcessTasksAction) error
 	RunTask(taskDefinition, startedBy string, count int) (*ecs.RunTaskOutput, error)
 	RunTaskWithOverrides(taskDefinition, startedBy string, count int, overrides map[string]string) (*ecs.RunTaskOutput, error)
-	StopTask(taskId string) error
+	StopTask(taskID string) error
 	DescribeTasks(taskIds []*string) ([]*ecs.Task, error)
 
 	// Container Instance related
@@ -75,6 +75,7 @@ type ecsClient struct {
 	params *config.CliParams
 }
 
+// NewECSClient creates a new ECS client
 func NewECSClient() ECSClient {
 	return &ecsClient{}
 }
@@ -117,10 +118,10 @@ func (c *ecsClient) DeleteCluster(clusterName string) (string, error) {
 	return *resp.Cluster.ClusterName, nil
 }
 
-func (client *ecsClient) DeleteService(serviceName string) error {
-	_, err := client.client.DeleteService(&ecs.DeleteServiceInput{
+func (c *ecsClient) DeleteService(serviceName string) error {
+	_, err := c.client.DeleteService(&ecs.DeleteServiceInput{
 		Service: aws.String(serviceName),
-		Cluster: aws.String(client.params.Cluster),
+		Cluster: aws.String(c.params.Cluster),
 	})
 	if err != nil {
 		log.WithFields(log.Fields{
@@ -133,18 +134,18 @@ func (client *ecsClient) DeleteService(serviceName string) error {
 	return nil
 }
 
-func (client *ecsClient) CreateService(serviceName, taskDefName string, loadBalancer *ecs.LoadBalancer, role string, deploymentConfig *ecs.DeploymentConfiguration) error {
+func (c *ecsClient) CreateService(serviceName, taskDefName string, loadBalancer *ecs.LoadBalancer, role string, deploymentConfig *ecs.DeploymentConfiguration) error {
 	createServiceInput := &ecs.CreateServiceInput{
 		DesiredCount:            aws.Int64(0),            // Required
 		ServiceName:             aws.String(serviceName), // Required
 		TaskDefinition:          aws.String(taskDefName), // Required
-		Cluster:                 aws.String(client.params.Cluster),
+		Cluster:                 aws.String(c.params.Cluster),
 		DeploymentConfiguration: deploymentConfig,
 		LoadBalancers:           []*ecs.LoadBalancer{loadBalancer},
 		Role:                    aws.String(role),
 	}
 
-	if _, err := client.client.CreateService(createServiceInput); err != nil {
+	if _, err := c.client.CreateService(createServiceInput); err != nil {
 		log.WithFields(log.Fields{
 			"service": serviceName,
 			"error":   err,
@@ -167,21 +168,21 @@ func (client *ecsClient) CreateService(serviceName, taskDefName string, loadBala
 	return nil
 }
 
-func (client *ecsClient) UpdateServiceCount(serviceName string, count int64, deploymentConfig *ecs.DeploymentConfiguration) error {
-	return client.UpdateService(serviceName, "", count, deploymentConfig)
+func (c *ecsClient) UpdateServiceCount(serviceName string, count int64, deploymentConfig *ecs.DeploymentConfiguration) error {
+	return c.UpdateService(serviceName, "", count, deploymentConfig)
 }
 
-func (client *ecsClient) UpdateService(serviceName, taskDefinition string, count int64, deploymentConfig *ecs.DeploymentConfiguration) error {
+func (c *ecsClient) UpdateService(serviceName, taskDefinition string, count int64, deploymentConfig *ecs.DeploymentConfiguration) error {
 	input := &ecs.UpdateServiceInput{
 		DesiredCount:            aws.Int64(count),
 		Service:                 aws.String(serviceName),
-		Cluster:                 aws.String(client.params.Cluster),
+		Cluster:                 aws.String(c.params.Cluster),
 		DeploymentConfiguration: deploymentConfig,
 	}
 	if taskDefinition != "" {
 		input.TaskDefinition = aws.String(taskDefinition)
 	}
-	_, err := client.client.UpdateService(input)
+	_, err := c.client.UpdateService(input)
 	if err != nil {
 		log.WithFields(log.Fields{
 			"service": serviceName,
@@ -206,10 +207,10 @@ func (client *ecsClient) UpdateService(serviceName, taskDefinition string, count
 	return nil
 }
 
-func (client *ecsClient) DescribeService(serviceName string) (*ecs.DescribeServicesOutput, error) {
-	output, err := client.client.DescribeServices(&ecs.DescribeServicesInput{
+func (c *ecsClient) DescribeService(serviceName string) (*ecs.DescribeServicesOutput, error) {
+	output, err := c.client.DescribeServices(&ecs.DescribeServicesInput{
 		Services: []*string{aws.String(serviceName)},
-		Cluster:  aws.String(client.params.Cluster),
+		Cluster:  aws.String(c.params.Cluster),
 	})
 	if err != nil {
 		log.WithFields(log.Fields{
@@ -221,8 +222,8 @@ func (client *ecsClient) DescribeService(serviceName string) (*ecs.DescribeServi
 	return output, err
 }
 
-func (client *ecsClient) RegisterTaskDefinition(request *ecs.RegisterTaskDefinitionInput) (*ecs.TaskDefinition, error) {
-	resp, err := client.client.RegisterTaskDefinition(request)
+func (c *ecsClient) RegisterTaskDefinition(request *ecs.RegisterTaskDefinitionInput) (*ecs.TaskDefinition, error) {
+	resp, err := c.client.RegisterTaskDefinition(request)
 	if err != nil {
 		log.WithFields(log.Fields{
 			"family": aws.StringValue(request.Family),
@@ -239,31 +240,31 @@ func (client *ecsClient) RegisterTaskDefinition(request *ecs.RegisterTaskDefinit
 //
 // This exists to avoid an explosion of task definitions for automatically
 // registered inputs.
-func (client *ecsClient) RegisterTaskDefinitionIfNeeded(
+func (c *ecsClient) RegisterTaskDefinitionIfNeeded(
 	request *ecs.RegisterTaskDefinitionInput,
 	taskDefinitionCache cache.Cache) (*ecs.TaskDefinition, error) {
 	if request.Family == nil {
 		return nil, errors.New("invalid task definitions: family is required")
 	}
 
-	taskDefResp, err := client.DescribeTaskDefinition(aws.StringValue(request.Family))
+	taskDefResp, err := c.DescribeTaskDefinition(aws.StringValue(request.Family))
 
 	// If there are no task definitions for this family OR the task definition exists and is marked as 'INACTIVE',
 	// register the task definition and create a cache entry
 	if err != nil || *taskDefResp.Status == ecs.TaskDefinitionStatusInactive {
-		return persistTaskDefinition(request, client, taskDefinitionCache)
+		return persistTaskDefinition(request, c, taskDefinitionCache)
 	}
 
-	tdHash := client.constructTaskDefinitionCacheHash(taskDefResp, request)
+	tdHash := c.constructTaskDefinitionCacheHash(taskDefResp, request)
 
 	td := &ecs.TaskDefinition{}
 	err = taskDefinitionCache.Get(tdHash, td)
-	if err != nil || !cachedTaskDefinitionRevisionIsActive(td, client) {
+	if err != nil || !cachedTaskDefinitionRevisionIsActive(td, c) {
 		log.WithFields(log.Fields{
 			"taskDefHash": tdHash,
 			"taskDef":     td,
 		}).Debug("cache miss")
-		return persistTaskDefinition(request, client, taskDefinitionCache)
+		return persistTaskDefinition(request, c, taskDefinitionCache)
 	}
 
 	log.WithFields(log.Fields{
@@ -289,11 +290,11 @@ func cachedTaskDefinitionRevisionIsActive(cachedTaskDefinition *ecs.TaskDefiniti
 // constructTaskDefinitionCacheHash computes md5sum of the region, awsAccountId and the requested task definition data
 // BUG(juanrhenals) The requested Task Definition data (taskDefinitionRequest) is not created in a deterministic fashion because there are maps within
 // the request ecs.RegisterTaskDefinitionInput structure, and map iteration in Go is not deterministic. We need to fix this.
-func (client *ecsClient) constructTaskDefinitionCacheHash(taskDefinition *ecs.TaskDefinition, request *ecs.RegisterTaskDefinitionInput) string {
+func (c *ecsClient) constructTaskDefinitionCacheHash(taskDefinition *ecs.TaskDefinition, request *ecs.RegisterTaskDefinitionInput) string {
 	// Get the region from the ecsClient configuration
-	region := aws.StringValue(client.params.Session.Config.Region)
-	awsUserAccountId := utils.GetAwsAccountIdFromArn(aws.StringValue(taskDefinition.TaskDefinitionArn))
-	tdHashInput := fmt.Sprintf("%s-%s-%s", region, awsUserAccountId, request.GoString())
+	region := aws.StringValue(c.params.Session.Config.Region)
+	awsUserAccountID := utils.GetAwsAccountIdFromArn(aws.StringValue(taskDefinition.TaskDefinitionArn))
+	tdHashInput := fmt.Sprintf("%s-%s-%s", region, awsUserAccountID, request.GoString())
 	return fmt.Sprintf("%x", md5.Sum([]byte(tdHashInput)))
 }
 
@@ -317,8 +318,8 @@ func persistTaskDefinition(request *ecs.RegisterTaskDefinitionInput, client *ecs
 
 }
 
-func (client *ecsClient) DescribeTaskDefinition(taskDefinitionName string) (*ecs.TaskDefinition, error) {
-	resp, err := client.client.DescribeTaskDefinition(&ecs.DescribeTaskDefinitionInput{
+func (c *ecsClient) DescribeTaskDefinition(taskDefinitionName string) (*ecs.TaskDefinition, error) {
+	resp, err := c.client.DescribeTaskDefinition(&ecs.DescribeTaskDefinitionInput{
 		TaskDefinition: aws.String(taskDefinitionName),
 	})
 	if err != nil {
@@ -330,15 +331,15 @@ func (client *ecsClient) DescribeTaskDefinition(taskDefinitionName string) (*ecs
 
 // GetTasksPages lists and describe tasks per page and executes the custom function supplied
 // any time any call returns error, the processing stops and appropriate error is returned
-func (client *ecsClient) GetTasksPages(listTasksInput *ecs.ListTasksInput, tasksFunc ProcessTasksAction) error {
-	listTasksInput.Cluster = aws.String(client.params.Cluster)
+func (c *ecsClient) GetTasksPages(listTasksInput *ecs.ListTasksInput, tasksFunc ProcessTasksAction) error {
+	listTasksInput.Cluster = aws.String(c.params.Cluster)
 	var outErr error
-	err := client.client.ListTasksPages(listTasksInput, func(page *ecs.ListTasksOutput, end bool) bool {
+	err := c.client.ListTasksPages(listTasksInput, func(page *ecs.ListTasksOutput, end bool) bool {
 		if len(page.TaskArns) == 0 {
 			return false
 		}
 		// describe this page of tasks
-		resp, err := client.DescribeTasks(page.TaskArns)
+		resp, err := c.DescribeTasks(page.TaskArns)
 		if err != nil {
 			outErr = err
 			return false
@@ -364,12 +365,12 @@ func (client *ecsClient) GetTasksPages(listTasksInput *ecs.ListTasksInput, tasks
 	return nil
 }
 
-func (client *ecsClient) DescribeTasks(taskArns []*string) ([]*ecs.Task, error) {
+func (c *ecsClient) DescribeTasks(taskArns []*string) ([]*ecs.Task, error) {
 	descTasksRequest := &ecs.DescribeTasksInput{
 		Tasks:   taskArns,
-		Cluster: aws.String(client.params.Cluster),
+		Cluster: aws.String(c.params.Cluster),
 	}
-	descTasksResp, err := client.client.DescribeTasks(descTasksRequest)
+	descTasksResp, err := c.client.DescribeTasks(descTasksRequest)
 	if descTasksResp == nil || err != nil {
 		log.WithFields(log.Fields{
 			"request": descTasksResp,
@@ -381,9 +382,9 @@ func (client *ecsClient) DescribeTasks(taskArns []*string) ([]*ecs.Task, error) 
 }
 
 // RunTask issues a run task request for the input task definition
-func (client *ecsClient) RunTask(taskDefinition, startedBy string, count int) (*ecs.RunTaskOutput, error) {
-	resp, err := client.client.RunTask(&ecs.RunTaskInput{
-		Cluster:        aws.String(client.params.Cluster),
+func (c *ecsClient) RunTask(taskDefinition, startedBy string, count int) (*ecs.RunTaskOutput, error) {
+	resp, err := c.client.RunTask(&ecs.RunTaskInput{
+		Cluster:        aws.String(c.params.Cluster),
 		TaskDefinition: aws.String(taskDefinition),
 		StartedBy:      aws.String(startedBy),
 		Count:          aws.Int64(int64(count)),
@@ -398,7 +399,7 @@ func (client *ecsClient) RunTask(taskDefinition, startedBy string, count int) (*
 }
 
 // RunTask issues a run task request for the input task definition
-func (client *ecsClient) RunTaskWithOverrides(taskDefinition, startedBy string, count int, overrides map[string]string) (*ecs.RunTaskOutput, error) {
+func (c *ecsClient) RunTaskWithOverrides(taskDefinition, startedBy string, count int, overrides map[string]string) (*ecs.RunTaskOutput, error) {
 
 	commandOverrides := []*ecs.ContainerOverride{}
 	for cont, command := range overrides {
@@ -412,8 +413,8 @@ func (client *ecsClient) RunTaskWithOverrides(taskDefinition, startedBy string, 
 		ContainerOverrides: commandOverrides,
 	}
 
-	resp, err := client.client.RunTask(&ecs.RunTaskInput{
-		Cluster:        aws.String(client.params.Cluster),
+	resp, err := c.client.RunTask(&ecs.RunTaskInput{
+		Cluster:        aws.String(c.params.Cluster),
 		TaskDefinition: aws.String(taskDefinition),
 		StartedBy:      aws.String(startedBy),
 		Count:          aws.Int64(int64(count)),
@@ -428,14 +429,14 @@ func (client *ecsClient) RunTaskWithOverrides(taskDefinition, startedBy string, 
 	return resp, err
 }
 
-func (client *ecsClient) StopTask(taskId string) error {
-	_, err := client.client.StopTask(&ecs.StopTaskInput{
-		Cluster: aws.String(client.params.Cluster),
-		Task:    aws.String(taskId),
+func (c *ecsClient) StopTask(taskID string) error {
+	_, err := c.client.StopTask(&ecs.StopTaskInput{
+		Cluster: aws.String(c.params.Cluster),
+		Task:    aws.String(taskID),
 	})
 	if err != nil {
 		log.WithFields(log.Fields{
-			"taskId": taskId,
+			"taskId": taskID,
 			"error":  err,
 		}).Error("Stop task failed")
 	}
@@ -443,7 +444,7 @@ func (client *ecsClient) StopTask(taskId string) error {
 }
 
 // GetEC2InstanceIds returns a map of container instance arn to ec2 instance id
-func (client *ecsClient) GetEC2InstanceIDs(containerInstanceArns []*string) (map[string]string, error) {
+func (c *ecsClient) GetEC2InstanceIDs(containerInstanceArns []*string) (map[string]string, error) {
 	containerToEC2InstanceMap := map[string]string{}
 	for i := 0; i < len(containerInstanceArns); i += ecsChunkSize {
 		var chunk []*string
@@ -452,8 +453,8 @@ func (client *ecsClient) GetEC2InstanceIDs(containerInstanceArns []*string) (map
 		} else {
 			chunk = containerInstanceArns[i : i+ecsChunkSize]
 		}
-		descrContainerInstances, err := client.client.DescribeContainerInstances(&ecs.DescribeContainerInstancesInput{
-			Cluster:            aws.String(client.params.Cluster),
+		descrContainerInstances, err := c.client.DescribeContainerInstances(&ecs.DescribeContainerInstancesInput{
+			Cluster:            aws.String(c.params.Cluster),
 			ContainerInstances: chunk,
 		})
 		if err != nil {
@@ -473,8 +474,8 @@ func (client *ecsClient) GetEC2InstanceIDs(containerInstanceArns []*string) (map
 }
 
 // IsActiveCluster returns true if the cluster exists and can be described.
-func (client *ecsClient) IsActiveCluster(clusterName string) (bool, error) {
-	output, err := client.client.DescribeClusters(&ecs.DescribeClustersInput{
+func (c *ecsClient) IsActiveCluster(clusterName string) (bool, error) {
+	output, err := c.client.DescribeClusters(&ecs.DescribeClustersInput{
 		Clusters: []*string{aws.String(clusterName)},
 	})
 

--- a/ecs-cli/modules/compose/ecs/entity.go
+++ b/ecs-cli/modules/compose/ecs/entity.go
@@ -183,7 +183,7 @@ func getContainersForTasks(entity ProjectEntity, ecsTasks []*ecs.Task) ([]Contai
 	}
 
 	ec2InstanceIds := listEC2Ids(containerToEC2InstanceIDs)
-	fmt.Println(ec2InstanceIds)
+
 	ec2Instances, err := entity.Context().EC2Client.DescribeInstances(ec2InstanceIds)
 	if err != nil {
 		return nil, err

--- a/ecs-cli/modules/compose/ecs/entity.go
+++ b/ecs-cli/modules/compose/ecs/entity.go
@@ -183,7 +183,7 @@ func getContainersForTasks(entity ProjectEntity, ecsTasks []*ecs.Task) ([]Contai
 	}
 
 	ec2InstanceIds := listEC2Ids(containerToEC2InstanceIDs)
-
+	fmt.Println(ec2InstanceIds)
 	ec2Instances, err := entity.Context().EC2Client.DescribeInstances(ec2InstanceIds)
 	if err != nil {
 		return nil, err

--- a/ecs-cli/modules/compose/ecs/entity.go
+++ b/ecs-cli/modules/compose/ecs/entity.go
@@ -183,6 +183,7 @@ func getContainersForTasks(entity ProjectEntity, ecsTasks []*ecs.Task) ([]Contai
 	}
 
 	ec2InstanceIds := listEC2Ids(containerToEC2InstanceIDs)
+
 	ec2Instances, err := entity.Context().EC2Client.DescribeInstances(ec2InstanceIds)
 	if err != nil {
 		return nil, err
@@ -190,8 +191,9 @@ func getContainersForTasks(entity ProjectEntity, ecsTasks []*ecs.Task) ([]Contai
 
 	for _, ecsTask := range ecsTasks {
 		ec2ID := containerToEC2InstanceIDs[aws.StringValue(ecsTask.ContainerInstanceArn)]
+
 		var ec2IPAddress string
-		if ec2ID != "" {
+		if ec2ID != "" && ec2Instances[ec2ID] != nil {
 			ec2IPAddress = aws.StringValue(ec2Instances[ec2ID].PublicIpAddress)
 		}
 		for _, container := range ecsTask.Containers {

--- a/ecs-cli/modules/compose/ecs/entity_test.go
+++ b/ecs-cli/modules/compose/ecs/entity_test.go
@@ -1,0 +1,106 @@
+// Copyright 2015-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package ecs
+
+import (
+	"testing"
+
+	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/aws/clients/ec2/mock"
+	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/aws/clients/ecs/mock"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/service/ecs"
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetContainersForTasks(t *testing.T) {
+	containerInstanceArn := "containerInstanceArn"
+	ec2InstanceID := "ec2InstanceId"
+	ec2Instance := &ec2.Instance{PublicIpAddress: aws.String("publicIpAddress")}
+
+	ecsTasks := []*ecs.Task{
+		&ecs.Task{
+			Containers: []*ecs.Container{
+				&ecs.Container{
+					Name: aws.String("containerName"),
+				},
+			},
+			ContainerInstanceArn: aws.String(containerInstanceArn),
+		},
+	}
+	containerInstancesMap := make(map[string]string)
+	containerInstancesMap[containerInstanceArn] = ec2InstanceID
+
+	ec2InstancesMap := make(map[string]*ec2.Instance)
+	ec2InstancesMap[ec2InstanceID] = ec2Instance
+
+	mockEc2, mockEcs, projectEntity := setupTest(t)
+
+	gomock.InOrder(
+		mockEcs.EXPECT().GetEC2InstanceIDs([]*string{&containerInstanceArn}).Return(containerInstancesMap, nil),
+		mockEc2.EXPECT().DescribeInstances([]*string{&ec2InstanceID}).Return(ec2InstancesMap, nil),
+	)
+
+	containers, err := getContainersForTasks(projectEntity, ecsTasks)
+	assert.NoError(t, err, "Unexpect error when calling getContainersForTasks")
+	assert.Len(t, containers, 1, "Expects to have 1 containers")
+	assert.Equal(t, containers[0].ec2IPAddress, aws.StringValue(ec2Instance.PublicIpAddress), "Expects PublicIpAddress to match")
+}
+
+func TestGetContainersForTasksWithMissingEc2InstanceID(t *testing.T) {
+	containerInstanceArn := "containerInstanceArn"
+	ec2InstanceID := "ec2InstanceId"
+
+	ecsTasks := []*ecs.Task{
+		&ecs.Task{
+			Containers: []*ecs.Container{
+				&ecs.Container{
+					Name: aws.String("containerName"),
+				},
+			},
+			ContainerInstanceArn: aws.String(containerInstanceArn),
+		},
+	}
+	containerInstancesMap := make(map[string]string)
+	containerInstancesMap[containerInstanceArn] = ec2InstanceID
+
+	// No ec2InstanceID is found
+	ec2InstancesMap := make(map[string]*ec2.Instance)
+
+	mockEc2, mockEcs, projectEntity := setupTest(t)
+
+	gomock.InOrder(
+		mockEcs.EXPECT().GetEC2InstanceIDs([]*string{&containerInstanceArn}).Return(containerInstancesMap, nil),
+		mockEc2.EXPECT().DescribeInstances([]*string{&ec2InstanceID}).Return(ec2InstancesMap, nil),
+	)
+
+	containers, err := getContainersForTasks(projectEntity, ecsTasks)
+	assert.NoError(t, err, "Unexpect error when calling getContainersForTasks")
+	assert.Len(t, containers, 1, "Expects to have 1 containers")
+	assert.Empty(t, containers[0].ec2IPAddress, "Expects ec2IpAddress to be empty")
+}
+
+func setupTest(t *testing.T) (*mock_ec2.MockEC2Client, *mock_ecs.MockECSClient, ProjectEntity) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockEcs := mock_ecs.NewMockECSClient(ctrl)
+	mockEc2 := mock_ec2.NewMockEC2Client(ctrl)
+	context := &Context{
+		ECSClient: mockEcs,
+		EC2Client: mockEc2,
+	}
+	projectEntity := NewTask(context)
+	return mockEc2, mockEcs, projectEntity
+}


### PR DESCRIPTION
closes aws/amazon-ecs-cli#231.

`ecs-cli ps` gives segmentation violation error because it is trying to get the `PublicIPAddress` using the `EC2InstanceID` provided by the container instance, but the EC2 instance no longer exist.

This can be reproduced by first **stop** then **terminate** the EC2 instance. This error should go away without the fix ECS container instance recognize that the EC2 instance has been terminated.