### PR TITLE
Proposal: compose run supports  quoted multi-argument commands

### DIFF
--- a/ecs-cli/modules/aws/clients/ecs/client.go
+++ b/ecs-cli/modules/aws/clients/ecs/client.go
@@ -28,8 +28,8 @@ import (
 	"github.com/aws/aws-sdk-go/service/ecs/ecsiface"
 )
 
-//go:generate mockgen.sh github.com/aws/amazon-ecs-cli/ecs-cli/modules/aws/clients/ecs ECSClient mock/$GOFILE
-//go:generate mockgen.sh github.com/aws/aws-sdk-go/service/ecs/ecsiface ECSAPI mock/sdk/ecsiface_mock.go
+//go:generate ../../../../../scripts/mockgen.sh github.com/aws/amazon-ecs-cli/ecs-cli/modules/aws/clients/ecs ECSClient mock/$GOFILE
+//go:generate ../../../../../scripts/mockgen.sh github.com/aws/aws-sdk-go/service/ecs/ecsiface ECSAPI mock/sdk/ecsiface_mock.go
 
 // ecsChunkSize is the maximum number of elements to pass into a describe api
 const ecsChunkSize = 100
@@ -61,7 +61,7 @@ type ECSClient interface {
 	// Tasks related
 	GetTasksPages(listTasksInput *ecs.ListTasksInput, fn ProcessTasksAction) error
 	RunTask(taskDefinition, startedBy string, count int) (*ecs.RunTaskOutput, error)
-	RunTaskWithOverrides(taskDefinition, startedBy string, count int, overrides map[string]string) (*ecs.RunTaskOutput, error)
+	RunTaskWithOverrides(taskDefinition, startedBy string, count int, overrides map[string][]string) (*ecs.RunTaskOutput, error)
 	StopTask(taskId string) error
 	DescribeTasks(taskIds []*string) ([]*ecs.Task, error)
 
@@ -398,13 +398,13 @@ func (client *ecsClient) RunTask(taskDefinition, startedBy string, count int) (*
 }
 
 // RunTask issues a run task request for the input task definition
-func (client *ecsClient) RunTaskWithOverrides(taskDefinition, startedBy string, count int, overrides map[string]string) (*ecs.RunTaskOutput, error) {
+func (client *ecsClient) RunTaskWithOverrides(taskDefinition, startedBy string, count int, overrides map[string][]string) (*ecs.RunTaskOutput, error) {
 
 	commandOverrides := []*ecs.ContainerOverride{}
 	for cont, command := range overrides {
 		contOverride := &ecs.ContainerOverride{
 			Name:    aws.String(cont),
-			Command: aws.StringSlice([]string{command}),
+			Command: aws.StringSlice(command),
 		}
 		commandOverrides = append(commandOverrides, contOverride)
 	}

--- a/ecs-cli/modules/aws/clients/ecs/client.go
+++ b/ecs-cli/modules/aws/clients/ecs/client.go
@@ -28,8 +28,8 @@ import (
 	"github.com/aws/aws-sdk-go/service/ecs/ecsiface"
 )
 
-//go:generate ../../../../../scripts/mockgen.sh github.com/aws/amazon-ecs-cli/ecs-cli/modules/aws/clients/ecs ECSClient mock/$GOFILE
-//go:generate ../../../../../scripts/mockgen.sh github.com/aws/aws-sdk-go/service/ecs/ecsiface ECSAPI mock/sdk/ecsiface_mock.go
+//go:generate mockgen.sh github.com/aws/amazon-ecs-cli/ecs-cli/modules/aws/clients/ecs ECSClient mock/$GOFILE
+//go:generate mockgen.sh github.com/aws/aws-sdk-go/service/ecs/ecsiface ECSAPI mock/sdk/ecsiface_mock.go
 
 // ecsChunkSize is the maximum number of elements to pass into a describe api
 const ecsChunkSize = 100

--- a/ecs-cli/modules/aws/clients/ecs/client.go
+++ b/ecs-cli/modules/aws/clients/ecs/client.go
@@ -399,8 +399,7 @@ func (c *ecsClient) RunTask(taskDefinition, startedBy string, count int) (*ecs.R
 }
 
 // RunTask issues a run task request for the input task definition
-func (client *ecsClient) RunTaskWithOverrides(taskDefinition, startedBy string, count int, overrides map[string][]string) (*ecs.RunTaskOutput, error) {
-
+func (c *ecsClient) RunTaskWithOverrides(taskDefinition, startedBy string, count int, overrides map[string][]string) (*ecs.RunTaskOutput, error) {
 	commandOverrides := []*ecs.ContainerOverride{}
 	for cont, command := range overrides {
 		contOverride := &ecs.ContainerOverride{

--- a/ecs-cli/modules/aws/clients/ecs/mock/client.go
+++ b/ecs-cli/modules/aws/clients/ecs/mock/client.go
@@ -193,7 +193,7 @@ func (_mr *_MockECSClientRecorder) RunTask(arg0, arg1, arg2 interface{}) *gomock
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "RunTask", arg0, arg1, arg2)
 }
 
-func (_m *MockECSClient) RunTaskWithOverrides(_param0 string, _param1 string, _param2 int, _param3 map[string]string) (*ecs.RunTaskOutput, error) {
+func (_m *MockECSClient) RunTaskWithOverrides(_param0 string, _param1 string, _param2 int, _param3 map[string][]string) (*ecs.RunTaskOutput, error) {
 	ret := _m.ctrl.Call(_m, "RunTaskWithOverrides", _param0, _param1, _param2, _param3)
 	ret0, _ := ret[0].(*ecs.RunTaskOutput)
 	ret1, _ := ret[1].(error)

--- a/ecs-cli/modules/compose/cli/ecs/app/app.go
+++ b/ecs-cli/modules/compose/cli/ecs/app/app.go
@@ -90,13 +90,15 @@ func ProjectPs(p ecscompose.Project, c *cli.Context) {
 func ProjectRun(p ecscompose.Project, c *cli.Context) {
 	args := c.Args()
 	if len(args) % 2 != 0 {
-		log.Fatal("Please pass arguments in the form: CONTAINER COMMAND [CONTAINER COMMAND]...")
+		log.Fatal("Please pass arguments in the form: CONTAINER \"COMMAND ...\" [CONTAINER \"COMMAND...\"] ...")
 	}
 	commandOverrides := make(map[string][]string)
 	for i := 0; i < len(args); i += 2 {
 		parts, err := shlex.Split(args[i + 1])
 		if err != nil {
-			log.Fatal(err)
+			log.WithFields(log.Fields{
+				"error": err,
+			}).Fatal("Unable to parse run commands")
 		}
 		commandOverrides[args[i]] = parts
 	}

--- a/ecs-cli/modules/compose/cli/ecs/app/app.go
+++ b/ecs-cli/modules/compose/cli/ecs/app/app.go
@@ -97,6 +97,7 @@ func ProjectRun(p ecscompose.Project, c *cli.Context) {
 		parts, err := shlex.Split(args[i + 1])
 		if err != nil {
 			log.WithFields(log.Fields{
+				"container-name": args[i],
 				"error": err,
 			}).Fatal("Unable to parse run commands")
 		}

--- a/ecs-cli/modules/compose/cli/ecs/app/app.go
+++ b/ecs-cli/modules/compose/cli/ecs/app/app.go
@@ -21,6 +21,7 @@ import (
 	ecscompose "github.com/aws/amazon-ecs-cli/ecs-cli/modules/compose/ecs"
 	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/compose/ecs/utils"
 	"github.com/urfave/cli"
+	"github.com/flynn/go-shlex"
 )
 
 // displayTitle flag is used to print the title for the fields
@@ -88,12 +89,16 @@ func ProjectPs(p ecscompose.Project, c *cli.Context) {
 // ProjectRun starts containers and executes one-time command against the container
 func ProjectRun(p ecscompose.Project, c *cli.Context) {
 	args := c.Args()
-	if len(args)%2 != 0 {
+	if len(args) % 2 != 0 {
 		log.Fatal("Please pass arguments in the form: CONTAINER COMMAND [CONTAINER COMMAND]...")
 	}
-	commandOverrides := make(map[string]string)
+	commandOverrides := make(map[string][]string)
 	for i := 0; i < len(args); i += 2 {
-		commandOverrides[args[i]] = args[i+1]
+		parts, err := shlex.Split(args[i + 1])
+		if err != nil {
+			log.Fatal(err)
+		}
+		commandOverrides[args[i]] = parts
 	}
 	err := p.Run(commandOverrides)
 	if err != nil {

--- a/ecs-cli/modules/compose/cli/ecs/app/app_test.go
+++ b/ecs-cli/modules/compose/cli/ecs/app/app_test.go
@@ -65,12 +65,12 @@ func TestWithProject(t *testing.T) {
 
 func TestRun(t *testing.T) {
 	containers := []string{"cont1", "cont2"}
-	commands := []string{"cmd1", "cmd2"}
+	commands := []string{"cmd1 cmd2", "cmd3"}
 
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	mockProject := mock_ecs.NewMockProject(ctrl)
-	mockProject.EXPECT().Run(map[string]string{"cont1": "cmd1", "cont2": "cmd2"}).Return(nil)
+	mockProject.EXPECT().Run(map[string][]string{"cont1": {"cmd1", "cmd2"}, "cont2": {"cmd3"}}).Return(nil)
 
 	flagSet := flag.NewFlagSet("ecs-cli", 0)
 	cliContext := cli.NewContext(nil, flagSet, nil)

--- a/ecs-cli/modules/compose/cli/ecs/app/command.go
+++ b/ecs-cli/modules/compose/cli/ecs/app/command.go
@@ -136,8 +136,8 @@ func startCommand(factory ProjectFactory) cli.Command {
 func runCommand(factory ProjectFactory) cli.Command {
 	return cli.Command{
 		Name: "run",
-		Usage: "ecs-cli compose run [containerName] [command] [containerName] [command] ..." +
-			"- starts all containers overriding commands with the supplied one-off commands for the containers.",
+		Usage: "Starts all containers overriding commands with the supplied one-off commands for the containers.",
+		ArgsUsage: "[CONTAINER_NAME] [\"COMMAND ...\"] [CONTAINER_NAME] [\"COMMAND ...\"] ...",
 		Action: WithProject(factory, ProjectRun, false),
 	}
 }

--- a/ecs-cli/modules/compose/ecs/entity.go
+++ b/ecs-cli/modules/compose/ecs/entity.go
@@ -32,7 +32,7 @@ type ProjectEntity interface {
 	Start() error
 	Up() error
 	Info(filterComposeTasks bool) (project.InfoSet, error)
-	Run(commandOverrides map[string]string) error
+	Run(commandOverrides map[string][]string) error
 	Scale(count int) error
 	Stop() error
 	Down() error

--- a/ecs-cli/modules/compose/ecs/mocks/project.go
+++ b/ecs-cli/modules/compose/ecs/mocks/project.go
@@ -115,7 +115,7 @@ func (_mr *_MockProjectRecorder) Parse() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Parse")
 }
 
-func (_m *MockProject) Run(_param0 map[string]string) error {
+func (_m *MockProject) Run(_param0 map[string][]string) error {
 	ret := _m.ctrl.Call(_m, "Run", _param0)
 	ret0, _ := ret[0].(error)
 	return ret0

--- a/ecs-cli/modules/compose/ecs/mocks/project_entity.go
+++ b/ecs-cli/modules/compose/ecs/mocks/project_entity.go
@@ -17,10 +17,10 @@
 package mock_ecs
 
 import (
-	ecs "github.com/aws/amazon-ecs-cli/ecs-cli/modules/compose/ecs"
+	ecs0 "github.com/aws/amazon-ecs-cli/ecs-cli/modules/compose/ecs"
 	utils "github.com/aws/amazon-ecs-cli/ecs-cli/utils"
 	cache "github.com/aws/amazon-ecs-cli/ecs-cli/utils/cache"
-	ecs0 "github.com/aws/aws-sdk-go/service/ecs"
+	ecs "github.com/aws/aws-sdk-go/service/ecs"
 	project "github.com/docker/libcompose/project"
 	gomock "github.com/golang/mock/gomock"
 )
@@ -46,9 +46,9 @@ func (_m *MockProjectEntity) EXPECT() *_MockProjectEntityRecorder {
 	return _m.recorder
 }
 
-func (_m *MockProjectEntity) Context() *ecs.Context {
+func (_m *MockProjectEntity) Context() *ecs0.Context {
 	ret := _m.ctrl.Call(_m, "Context")
-	ret0, _ := ret[0].(*ecs.Context)
+	ret0, _ := ret[0].(*ecs0.Context)
 	return ret0
 }
 
@@ -97,7 +97,7 @@ func (_mr *_MockProjectEntityRecorder) LoadContext() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "LoadContext")
 }
 
-func (_m *MockProjectEntity) Run(_param0 map[string]string) error {
+func (_m *MockProjectEntity) Run(_param0 map[string][]string) error {
 	ret := _m.ctrl.Call(_m, "Run", _param0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -117,7 +117,7 @@ func (_mr *_MockProjectEntityRecorder) Scale(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Scale", arg0)
 }
 
-func (_m *MockProjectEntity) SetTaskDefinition(_param0 *ecs0.TaskDefinition) {
+func (_m *MockProjectEntity) SetTaskDefinition(_param0 *ecs.TaskDefinition) {
 	_m.ctrl.Call(_m, "SetTaskDefinition", _param0)
 }
 
@@ -155,9 +155,9 @@ func (_mr *_MockProjectEntityRecorder) Stop() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Stop")
 }
 
-func (_m *MockProjectEntity) TaskDefinition() *ecs0.TaskDefinition {
+func (_m *MockProjectEntity) TaskDefinition() *ecs.TaskDefinition {
 	ret := _m.ctrl.Call(_m, "TaskDefinition")
-	ret0, _ := ret[0].(*ecs0.TaskDefinition)
+	ret0, _ := ret[0].(*ecs.TaskDefinition)
 	return ret0
 }
 

--- a/ecs-cli/modules/compose/ecs/project.go
+++ b/ecs-cli/modules/compose/ecs/project.go
@@ -20,8 +20,6 @@ import (
 	"github.com/docker/libcompose/project"
 )
 
-//go:generate mockgen.sh github.com/aws/amazon-ecs-cli/ecs-cli/modules/compose/ecs Project mocks/$GOFILE
-
 // Project is the starting point for the compose app to interact with and issue commands
 // It acts as a blanket for the context and entities created as a part of this compose project
 type Project interface {

--- a/ecs-cli/modules/compose/ecs/project.go
+++ b/ecs-cli/modules/compose/ecs/project.go
@@ -20,6 +20,8 @@ import (
 	"github.com/docker/libcompose/project"
 )
 
+//go:generate ../../../../scripts/mockgen.sh github.com/aws/amazon-ecs-cli/ecs-cli/modules/compose/ecs Project mocks/$GOFILE
+
 // Project is the starting point for the compose app to interact with and issue commands
 // It acts as a blanket for the context and entities created as a part of this compose project
 type Project interface {
@@ -35,7 +37,7 @@ type Project interface {
 	Start() error
 	Up() error
 	Info() (project.InfoSet, error)
-	Run(commandOverrides map[string]string) error
+	Run(commandOverrides map[string][]string) error
 	Scale(count int) error
 	Stop() error
 	Down() error
@@ -155,7 +157,7 @@ func (p *ecsProject) Info() (project.InfoSet, error) {
 	return p.entity.Info(true)
 }
 
-func (p *ecsProject) Run(commandOverrides map[string]string) error {
+func (p *ecsProject) Run(commandOverrides map[string][]string) error {
 	return p.entity.Run(commandOverrides)
 }
 

--- a/ecs-cli/modules/compose/ecs/project.go
+++ b/ecs-cli/modules/compose/ecs/project.go
@@ -20,7 +20,7 @@ import (
 	"github.com/docker/libcompose/project"
 )
 
-//go:generate ../../../../scripts/mockgen.sh github.com/aws/amazon-ecs-cli/ecs-cli/modules/compose/ecs Project mocks/$GOFILE
+//go:generate mockgen.sh github.com/aws/amazon-ecs-cli/ecs-cli/modules/compose/ecs Project mocks/$GOFILE
 
 // Project is the starting point for the compose app to interact with and issue commands
 // It acts as a blanket for the context and entities created as a part of this compose project

--- a/ecs-cli/modules/compose/ecs/service.go
+++ b/ecs-cli/modules/compose/ecs/service.go
@@ -302,7 +302,7 @@ func (s *Service) Down() error {
 }
 
 // Run expects to issue a command override and start containers. But that doesnt apply to the context of ECS Services
-func (s *Service) Run(commandOverrides map[string]string) error {
+func (s *Service) Run(commandOverrides map[string][]string) error {
 	return composeutils.ErrUnsupported
 }
 

--- a/ecs-cli/modules/compose/ecs/service_test.go
+++ b/ecs-cli/modules/compose/ecs/service_test.go
@@ -255,6 +255,6 @@ func TestServiceInfo(t *testing.T) {
 
 func TestServiceRun(t *testing.T) {
 	service := NewService(&Context{})
-	err := service.Run(map[string]string{})
+	err := service.Run(map[string][]string{})
 	assert.Error(t, err, "Expected unsupported error")
 }

--- a/ecs-cli/modules/compose/ecs/task.go
+++ b/ecs-cli/modules/compose/ecs/task.go
@@ -157,7 +157,7 @@ func (t *Task) Scale(expectedCount int) error {
 
 // Run starts all containers defined in the task definition once regardless of if they were started before
 // It also overrides the commands for the specified containers
-func (t *Task) Run(commandOverrides map[string]string) error {
+func (t *Task) Run(commandOverrides map[string][]string) error {
 	taskDef, err := getOrCreateTaskDefinition(t)
 	if err != nil {
 		return err


### PR DESCRIPTION
Addresses Issue #148
reference #229

`compose run` supports multi-argument commands as:
`<container1> “<cmd0> <cmd1> <cmd2>” <container2> “<cmd0> <cmd1> <cmd2>...”`
