### PR TITLE
Adds support for --task-role-arn with compose commands

### DIFF
--- a/ecs-cli/modules/cli/compose/entity/entity_helper.go
+++ b/ecs-cli/modules/cli/compose/entity/entity_helper.go
@@ -56,6 +56,7 @@ func GetOrCreateTaskDefinition(entity ProjectEntity) (*ecs.TaskDefinition, error
 		Family:               taskDefinition.Family,
 		ContainerDefinitions: taskDefinition.ContainerDefinitions,
 		Volumes:              taskDefinition.Volumes,
+		TaskRoleArn:          taskDefinition.TaskRoleArn,
 	}, entity.TaskDefinitionCache())
 
 	if err != nil {

--- a/ecs-cli/modules/cli/compose/project/project.go
+++ b/ecs-cli/modules/cli/compose/project/project.go
@@ -23,6 +23,7 @@ import (
 	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/utils/compose"
 	"github.com/docker/libcompose/config"
 	"github.com/docker/libcompose/project"
+	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/commands"
 )
 
 // Project is the starting point for the compose app to interact with and issue commands
@@ -134,7 +135,8 @@ func (p *ecsProject) transformTaskDefinition() error {
 	// convert to task definition
 	logrus.Debug("Transforming yaml to task definition...")
 	taskDefinitionName := utils.GetTaskDefinitionName(context.ECSParams.ComposeProjectNamePrefix, context.Context.ProjectName)
-	taskDefinition, err := utils.ConvertToTaskDefinition(taskDefinitionName, &context.Context, p.ServiceConfigs())
+	taskRoleArn := context.CLIContext.GlobalString(command.TaskRoleArnFlag)
+	taskDefinition, err := utils.ConvertToTaskDefinition(taskDefinitionName, &context.Context, p.ServiceConfigs(), taskRoleArn)
 	if err != nil {
 		return err
 	}

--- a/ecs-cli/modules/commands/compose/compose_command.go
+++ b/ecs-cli/modules/commands/compose/compose_command.go
@@ -90,6 +90,10 @@ func composeFlags() []cli.Flag {
 			Usage:  "Specifies the project name to use. Defaults to the current directory name.",
 			EnvVar: "COMPOSE_PROJECT_NAME",
 		},
+		cli.StringFlag{
+			Name:   command.TaskRoleArnFlag,
+			Usage:  "[Optional] Specifies the short name or full Amazon Resource Name (ARN) of the IAM role that containers in this task can assume. All containers in this task are granted the permissions that are specified in this role.",
+		},
 	}
 }
 

--- a/ecs-cli/modules/commands/flags.go
+++ b/ecs-cli/modules/commands/flags.go
@@ -55,6 +55,7 @@ const (
 	// Compose
 	ProjectNameFlag     = "project-name"
 	ComposeFileNameFlag = "file"
+	TaskRoleArnFlag     = "task-role-arn"
 
 	// Compose Service
 	CreateServiceCommandName                = "create"

--- a/ecs-cli/modules/utils/compose/convert_task_definition.go
+++ b/ecs-cli/modules/utils/compose/convert_task_definition.go
@@ -64,7 +64,7 @@ func getSupportedComposeYamlOptionsMap() map[string]bool {
 
 // ConvertToTaskDefinition transforms the yaml configs to its ecs equivalent (task definition)
 func ConvertToTaskDefinition(taskDefinitionName string, context *project.Context,
-	serviceConfigs *config.ServiceConfigs) (*ecs.TaskDefinition, error) {
+	serviceConfigs *config.ServiceConfigs, taskRoleArn string) (*ecs.TaskDefinition, error) {
 
 	if serviceConfigs.Len() == 0 {
 		return nil, errors.New("cannot create a task definition with no containers; invalid service config")
@@ -96,6 +96,7 @@ func ConvertToTaskDefinition(taskDefinitionName string, context *project.Context
 		Family:               aws.String(taskDefinitionName),
 		ContainerDefinitions: containerDefinitions,
 		Volumes:              convertToECSVolumes(volumes),
+		TaskRoleArn:          aws.String(taskRoleArn),
 	}
 	return taskDefinition, nil
 }


### PR DESCRIPTION
This addresses #188 by providing a `--task-role-arn` flag with the compose command. The TaskRoleArn is passed to the RegisterTaskDefinition API call. Storing it as an property in the yml file is not an option since it would require modifying libCompose, so I opted for the command line argument instead.

Let me know if you'd like me to make any adjustments before merging. 