### PR TITLE
Deterministic TaskDefinitionCacheHash for the local cache

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,14 @@ docker-build:
 		--env ECS_RELEASE=$(ECS_RELEASE) \
 		golang:1.8 make $(DARWIN_BINARY)
 
+.PHONY: docker-test
+docker-test:
+	docker run -v $(shell pwd):/usr/src/app/src/github.com/aws/amazon-ecs-cli \
+		--workdir=/usr/src/app/src/github.com/aws/amazon-ecs-cli \
+		--env GOPATH=/usr/src/app \
+		--env ECS_RELEASE=$(ECS_RELEASE) \
+		golang:1.8 make test
+
 .PHONY: supported-platforms
 supported-platforms: $(LINUX_BINARY) $(DARWIN_BINARY)
 

--- a/ecs-cli/modules/clients/aws/ecs/client.go
+++ b/ecs-cli/modules/clients/aws/ecs/client.go
@@ -297,8 +297,7 @@ func (c *ecsClient) constructTaskDefinitionCacheHash(taskDefinition *ecs.TaskDef
 		log.WithFields(log.Fields{
 			"error": err,
 		}).Warn("Error during json marshalling; fallback to non-deterministic task definition data used for cache hash")
-		tdHashInput := fmt.Sprintf("%s-%s-%s", region, awsUserAccountId, request.GoString())
-		return fmt.Sprintf("%x", md5.Sum([]byte(tdHashInput)))
+		sortedRequestString = request.GoString()
 	}
 	tdHashInput := fmt.Sprintf("%s-%s-%s", region, awsUserAccountId, sortedRequestString)
 	return fmt.Sprintf("%x", md5.Sum([]byte(tdHashInput)))

--- a/ecs-cli/modules/clients/aws/ecs/client.go
+++ b/ecs-cli/modules/clients/aws/ecs/client.go
@@ -287,11 +287,20 @@ func cachedTaskDefinitionRevisionIsActive(cachedTaskDefinition *ecs.TaskDefiniti
 // constructTaskDefinitionCacheHash computes md5sum of the region, awsAccountId and the requested task definition data
 // BUG(juanrhenals) The requested Task Definition data (taskDefinitionRequest) is not created in a deterministic fashion because there are maps within
 // the request ecs.RegisterTaskDefinitionInput structure, and map iteration in Go is not deterministic. We need to fix this.
+// FIXED(pzimmermann) using a marshalled json representation for the task definition data to be deterministic
 func (c *ecsClient) constructTaskDefinitionCacheHash(taskDefinition *ecs.TaskDefinition, request *ecs.RegisterTaskDefinitionInput) string {
 	// Get the region from the ecsClient configuration
 	region := aws.StringValue(c.params.Session.Config.Region)
-	awsUserAccountID := utils.GetAwsAccountIdFromArn(aws.StringValue(taskDefinition.TaskDefinitionArn))
-	tdHashInput := fmt.Sprintf("%s-%s-%s", region, awsUserAccountID, request.GoString())
+	awsUserAccountId := utils.GetAwsAccountIdFromArn(aws.StringValue(taskDefinition.TaskDefinitionArn))
+	sortedRequestString, err := utils.SortedGoString(request)
+	if err != nil {
+		log.WithFields(log.Fields{
+			"error": err,
+		}).Warn("Error during json marshalling; fallback to non-deterministic task definition data used for cache hash")
+		tdHashInput := fmt.Sprintf("%s-%s-%s", region, awsUserAccountId, request.GoString())
+		return fmt.Sprintf("%x", md5.Sum([]byte(tdHashInput)))
+	}
+	tdHashInput := fmt.Sprintf("%s-%s-%s", region, awsUserAccountId, sortedRequestString)
 	return fmt.Sprintf("%x", md5.Sum([]byte(tdHashInput)))
 }
 

--- a/ecs-cli/modules/utils/compose/convert_task_definition.go
+++ b/ecs-cli/modules/utils/compose/convert_task_definition.go
@@ -533,6 +533,7 @@ func convertToULimits(cfgUlimits yaml.Ulimits) ([]*ecs.Ulimit, error) {
 }
 
 // GoString returns deterministic string representation
+// json Marshal sorts map keys, making it deterministic
 func SortedGoString(v interface{}) (string, error) {
 	b, err := json.Marshal(v)
 	if err != nil {

--- a/ecs-cli/modules/utils/compose/convert_task_definition.go
+++ b/ecs-cli/modules/utils/compose/convert_task_definition.go
@@ -14,12 +14,12 @@
 package utils
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"reflect"
 	"strconv"
 	"strings"
-	"encoding/json"
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/aws/aws-sdk-go/aws"

--- a/ecs-cli/modules/utils/compose/convert_task_definition.go
+++ b/ecs-cli/modules/utils/compose/convert_task_definition.go
@@ -19,6 +19,7 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
+	"encoding/json"
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/aws/aws-sdk-go/aws"
@@ -529,4 +530,13 @@ func convertToULimits(cfgUlimits yaml.Ulimits) ([]*ecs.Ulimit, error) {
 	}
 
 	return ulimits, nil
+}
+
+// GoString returns deterministic string representation
+func SortedGoString(v interface{}) (string, error) {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
 }

--- a/ecs-cli/modules/utils/compose/convert_task_definition_test.go
+++ b/ecs-cli/modules/utils/compose/convert_task_definition_test.go
@@ -643,27 +643,33 @@ func TestMemReservationHigherThanMemLimit(t *testing.T) {
 }
 
 func TestSortedGoString(t *testing.T) {
+	family := aws.String("family1")
+	name := aws.String("foo")
+	command := aws.StringSlice([]string{"dark", "side", "of", "the", "moon"})
+
 	inputA := ecs.RegisterTaskDefinitionInput{
-		Family: aws.String("family1"),
+		Family: family,
 		ContainerDefinitions: []*ecs.ContainerDefinition{
 			{
-				Name: aws.String("foo"),
-				Command: aws.StringSlice([]string{"dark","side","of","the","moon"}),
+				Name:    name,
+				Command: command,
 			},
 		},
 	}
 	inputB := ecs.RegisterTaskDefinitionInput{
 		ContainerDefinitions: []*ecs.ContainerDefinition{
 			{
-				Command: aws.StringSlice([]string{"dark","side","of","the","moon"}),
-				Name: aws.String("foo"),
+				Command: command,
+				Name:    name,
 			},
 		},
-		Family: aws.String("family1"),
+		Family: family,
 	}
 
-	strA, _ := SortedGoString(inputA)
-	strB, _ := SortedGoString(inputB)
+	strA, err := SortedGoString(inputA)
+	assert.NoError(t, err, "Unexpected error generating sorted map string")
+	strB, err := SortedGoString(inputB)
+	assert.NoError(t, err, "Unexpected error generating sorted map string")
 
-	assert.Equal(t, strA, strB, "Same same, but different")
+	assert.Equal(t, strA, strB, "Sorted inputs should match")
 }

--- a/ecs-cli/modules/utils/compose/convert_task_definition_test.go
+++ b/ecs-cli/modules/utils/compose/convert_task_definition_test.go
@@ -646,6 +646,10 @@ func TestSortedGoString(t *testing.T) {
 	family := aws.String("family1")
 	name := aws.String("foo")
 	command := aws.StringSlice([]string{"dark", "side", "of", "the", "moon"})
+	dockerLabels := map[string]string{
+		"label1":         "",
+		"com.foo.label2": "value",
+	}
 
 	inputA := ecs.RegisterTaskDefinitionInput{
 		Family: family,
@@ -653,6 +657,7 @@ func TestSortedGoString(t *testing.T) {
 			{
 				Name:    name,
 				Command: command,
+				DockerLabels:aws.StringMap(dockerLabels),
 			},
 		},
 	}
@@ -661,6 +666,7 @@ func TestSortedGoString(t *testing.T) {
 			{
 				Command: command,
 				Name:    name,
+				DockerLabels:aws.StringMap(dockerLabels),
 			},
 		},
 		Family: family,

--- a/ecs-cli/modules/utils/compose/convert_task_definition_test.go
+++ b/ecs-cli/modules/utils/compose/convert_task_definition_test.go
@@ -641,3 +641,29 @@ func TestMemReservationHigherThanMemLimit(t *testing.T) {
 	_, err = ConvertToTaskDefinition(taskDefName, context, serviceConfigs)
 	assert.EqualError(t, err, "mem_limit should not be less than mem_reservation")
 }
+
+func TestSortedGoString(t *testing.T) {
+	inputA := ecs.RegisterTaskDefinitionInput{
+		Family: aws.String("family1"),
+		ContainerDefinitions: []*ecs.ContainerDefinition{
+			{
+				Name: aws.String("foo"),
+				Command: aws.StringSlice([]string{"dark","side","of","the","moon"}),
+			},
+		},
+	}
+	inputB := ecs.RegisterTaskDefinitionInput{
+		ContainerDefinitions: []*ecs.ContainerDefinition{
+			{
+				Command: aws.StringSlice([]string{"dark","side","of","the","moon"}),
+				Name: aws.String("foo"),
+			},
+		},
+		Family: aws.String("family1"),
+	}
+
+	strA, _ := SortedGoString(inputA)
+	strB, _ := SortedGoString(inputB)
+
+	assert.Equal(t, strA, strB, "Same same, but different")
+}

--- a/ecs-cli/modules/utils/compose/convert_task_definition_test.go
+++ b/ecs-cli/modules/utils/compose/convert_task_definition_test.go
@@ -655,18 +655,18 @@ func TestSortedGoString(t *testing.T) {
 		Family: family,
 		ContainerDefinitions: []*ecs.ContainerDefinition{
 			{
-				Name:    name,
-				Command: command,
-				DockerLabels:aws.StringMap(dockerLabels),
+				Name:         name,
+				Command:      command,
+				DockerLabels: aws.StringMap(dockerLabels),
 			},
 		},
 	}
 	inputB := ecs.RegisterTaskDefinitionInput{
 		ContainerDefinitions: []*ecs.ContainerDefinition{
 			{
-				Command: command,
-				Name:    name,
-				DockerLabels:aws.StringMap(dockerLabels),
+				Command:      command,
+				Name:         name,
+				DockerLabels: aws.StringMap(dockerLabels),
 			},
 		},
 		Family: family,


### PR DESCRIPTION
Using a marshalled json representation for the task definition data to be deterministic hash
Unit test to provide coverage of SortedGoString (the bugfix is fixing a non-deterministic irreproducible scenario)