### PR TITLE
Inline region and cluster flags for all commands

### DIFF
--- a/ecs-cli/modules/cli/cluster/cluster_app.go
+++ b/ecs-cli/modules/cli/cluster/cluster_app.go
@@ -162,16 +162,16 @@ func createCluster(context *cli.Context, rdwr config.ReadWriter, ecsClient ecscl
 
 	// Check if cluster is specified
 	if ecsParams.Cluster == "" {
-		return fmt.Errorf("Please configure a cluster using the configure command.")
+		return fmt.Errorf("Please configure a cluster using the configure command or with '--%s' flag", command.ClusterFlag)
 	}
 
 	// Check if cfn stack already exists
 	cfnClient.Initialize(ecsParams)
 	stackName := ecsParams.GetCfnStackName()
 	var deleteStack bool
-	if err := cfnClient.ValidateStackExists(stackName); err == nil {
+	if err = cfnClient.ValidateStackExists(stackName); err == nil {
 		if !isForceSet(context) {
-			return fmt.Errorf("A CloudFormation stack already exists for the cluster '%s'. Please specify '--%s' to clean up your existing resources.", ecsParams.Cluster, command.ForceFlag)
+			return fmt.Errorf("A CloudFormation stack already exists for the cluster '%s'. Please specify '--%s' to clean up your existing resources", ecsParams.Cluster, command.ForceFlag)
 		}
 		deleteStack = true
 	}

--- a/ecs-cli/modules/cli/cluster/cluster_app.go
+++ b/ecs-cli/modules/cli/cluster/cluster_app.go
@@ -162,7 +162,7 @@ func createCluster(context *cli.Context, rdwr config.ReadWriter, ecsClient ecscl
 
 	// Check if cluster is specified
 	if ecsParams.Cluster == "" {
-		return fmt.Errorf("Please configure a cluster using the configure command or with '--%s' flag", command.ClusterFlag)
+		return fmt.Errorf("Please configure a cluster using the configure command or the '--%s' flag", command.ClusterFlag)
 	}
 
 	// Check if cfn stack already exists

--- a/ecs-cli/modules/cli/cluster/cluster_app_test.go
+++ b/ecs-cli/modules/cli/cluster/cluster_app_test.go
@@ -75,6 +75,7 @@ func setupTest(t *testing.T) (*mock_ecs.MockECSClient, *mock_cloudformation.Mock
 
 	os.Setenv("AWS_ACCESS_KEY", "AKIDEXAMPLE")
 	os.Setenv("AWS_SECRET_KEY", "secret")
+	os.Setenv("AWS_REGION", "us-west-1")
 	return mockECS, mockCloudformation
 }
 
@@ -94,15 +95,11 @@ func TestClusterUp(t *testing.T) {
 		mockCloudformation.EXPECT().WaitUntilCreateComplete(stackName).Return(nil),
 	)
 
-	globalSet := flag.NewFlagSet("ecs-cli", 0)
-	globalSet.String("region", "us-west-1", "")
-	globalContext := cli.NewContext(nil, globalSet, nil)
-
 	flagSet := flag.NewFlagSet("ecs-cli-up", 0)
 	flagSet.Bool(command.CapabilityIAMFlag, true, "")
 	flagSet.String(command.KeypairNameFlag, "default", "")
 
-	context := cli.NewContext(nil, flagSet, globalContext)
+	context := cli.NewContext(nil, flagSet, nil)
 	err := createCluster(context, newMockReadWriter(), mockECS, mockCloudformation, ami.NewStaticAmiIds())
 	assert.NoError(t, err, "Unexpected error bringing up cluster")
 }
@@ -125,16 +122,12 @@ func TestClusterUpWithForce(t *testing.T) {
 		mockCloudformation.EXPECT().WaitUntilCreateComplete(stackName).Return(nil),
 	)
 
-	globalSet := flag.NewFlagSet("ecs-cli", 0)
-	globalSet.String("region", "us-west-1", "")
-	globalContext := cli.NewContext(nil, globalSet, nil)
-
 	flagSet := flag.NewFlagSet("ecs-cli-up", 0)
 	flagSet.Bool(command.CapabilityIAMFlag, true, "")
 	flagSet.String(command.KeypairNameFlag, "default", "")
 	flagSet.Bool(command.ForceFlag, true, "")
 
-	context := cli.NewContext(nil, flagSet, globalContext)
+	context := cli.NewContext(nil, flagSet, nil)
 	err := createCluster(context, newMockReadWriter(), mockECS, mockCloudformation, ami.NewStaticAmiIds())
 	assert.NoError(t, err, "Unexpected error bringing up cluster")
 }
@@ -193,17 +186,13 @@ func TestClusterUpWithVPC(t *testing.T) {
 		mockCloudformation.EXPECT().WaitUntilCreateComplete(stackName).Return(nil),
 	)
 
-	globalSet := flag.NewFlagSet("ecs-cli", 0)
-	globalSet.String("region", "us-west-1", "")
-	globalContext := cli.NewContext(nil, globalSet, nil)
-
 	flagSet := flag.NewFlagSet("ecs-cli-up", 0)
 	flagSet.Bool(command.CapabilityIAMFlag, true, "")
 	flagSet.String(command.KeypairNameFlag, "default", "")
 	flagSet.String(command.VpcIdFlag, vpcID, "")
 	flagSet.String(command.SubnetIdsFlag, subnetIds, "")
 
-	context := cli.NewContext(nil, flagSet, globalContext)
+	context := cli.NewContext(nil, flagSet, nil)
 	err := createCluster(context, newMockReadWriter(), mockECS, mockCloudformation, ami.NewStaticAmiIds())
 	assert.NoError(t, err, "Unexpected error bringing up cluster")
 }
@@ -226,16 +215,12 @@ func TestClusterUpWithAvailabilityZones(t *testing.T) {
 		mockCloudformation.EXPECT().WaitUntilCreateComplete(stackName).Return(nil),
 	)
 
-	globalSet := flag.NewFlagSet("ecs-cli", 0)
-	globalSet.String("region", "us-west-1", "")
-	globalContext := cli.NewContext(nil, globalSet, nil)
-
 	flagSet := flag.NewFlagSet("ecs-cli-up", 0)
 	flagSet.Bool(command.CapabilityIAMFlag, true, "")
 	flagSet.String(command.KeypairNameFlag, "default", "")
 	flagSet.String(command.VpcAzFlag, vpcAZs, "")
 
-	context := cli.NewContext(nil, flagSet, globalContext)
+	context := cli.NewContext(nil, flagSet, nil)
 	err := createCluster(context, newMockReadWriter(), mockECS, mockCloudformation, ami.NewStaticAmiIds())
 	assert.NoError(t, err, "Unexpected error bringing up cluster")
 }
@@ -248,15 +233,12 @@ func TestClusterUpWithoutKeyPair(t *testing.T) {
 		mockCloudformation.EXPECT().Initialize(gomock.Any()),
 		mockCloudformation.EXPECT().ValidateStackExists(stackName).Return(errors.New("error")),
 	)
-	globalSet := flag.NewFlagSet("ecs-cli", 0)
-	globalSet.String("region", "us-west-1", "")
-	globalContext := cli.NewContext(nil, globalSet, nil)
 
 	flagSet := flag.NewFlagSet("ecs-cli-up", 0)
 	flagSet.Bool(command.CapabilityIAMFlag, true, "")
 	flagSet.Bool(command.ForceFlag, true, "")
 
-	context := cli.NewContext(nil, flagSet, globalContext)
+	context := cli.NewContext(nil, flagSet, nil)
 	err := createCluster(context, newMockReadWriter(), mockECS, mockCloudformation, ami.NewStaticAmiIds())
 	assert.Error(t, err, "Expected error for key pair name")
 }
@@ -271,9 +253,6 @@ func TestClusterUpWithSecurityGroupWithoutVPC(t *testing.T) {
 		mockCloudformation.EXPECT().Initialize(gomock.Any()),
 		mockCloudformation.EXPECT().ValidateStackExists(stackName).Return(errors.New("error")),
 	)
-	globalSet := flag.NewFlagSet("ecs-cli", 0)
-	globalSet.String("region", "us-west-1", "")
-	globalContext := cli.NewContext(nil, globalSet, nil)
 
 	flagSet := flag.NewFlagSet("ecs-cli-up", 0)
 	flagSet.Bool(command.CapabilityIAMFlag, true, "")
@@ -281,7 +260,7 @@ func TestClusterUpWithSecurityGroupWithoutVPC(t *testing.T) {
 	flagSet.Bool(command.ForceFlag, true, "")
 	flagSet.String(command.SecurityGroupFlag, securityGroupID, "")
 
-	context := cli.NewContext(nil, flagSet, globalContext)
+	context := cli.NewContext(nil, flagSet, nil)
 	err := createCluster(context, newMockReadWriter(), mockECS, mockCloudformation, ami.NewStaticAmiIds())
 	assert.Error(t, err, "Expected error for security group without VPC")
 }
@@ -298,9 +277,6 @@ func TestClusterUpWith2SecurityGroups(t *testing.T) {
 		mockCloudformation.EXPECT().Initialize(gomock.Any()),
 		mockCloudformation.EXPECT().ValidateStackExists(stackName).Return(errors.New("error")),
 	)
-	globalSet := flag.NewFlagSet("ecs-cli", 0)
-	globalSet.String("region", "us-west-1", "")
-	globalContext := cli.NewContext(nil, globalSet, nil)
 
 	flagSet := flag.NewFlagSet("ecs-cli-up", 0)
 	flagSet.Bool(command.CapabilityIAMFlag, true, "")
@@ -310,7 +286,7 @@ func TestClusterUpWith2SecurityGroups(t *testing.T) {
 	flagSet.String(command.VpcIdFlag, vpcId, "")
 	flagSet.String(command.SubnetIdsFlag, subnetIds, "")
 
-	context := cli.NewContext(nil, flagSet, globalContext)
+	context := cli.NewContext(nil, flagSet, nil)
 	err := createCluster(context, newMockReadWriter(), mockECS, mockCloudformation, ami.NewStaticAmiIds())
 	assert.Error(t, err, "Expected error for too many security groups")
 }
@@ -325,9 +301,6 @@ func TestClusterUpWithSubnetsWithoutVPC(t *testing.T) {
 		mockCloudformation.EXPECT().Initialize(gomock.Any()),
 		mockCloudformation.EXPECT().ValidateStackExists(stackName).Return(errors.New("error")),
 	)
-	globalSet := flag.NewFlagSet("ecs-cli", 0)
-	globalSet.String("region", "us-west-1", "")
-	globalContext := cli.NewContext(nil, globalSet, nil)
 
 	flagSet := flag.NewFlagSet("ecs-cli-up", 0)
 	flagSet.Bool(command.CapabilityIAMFlag, true, "")
@@ -335,7 +308,7 @@ func TestClusterUpWithSubnetsWithoutVPC(t *testing.T) {
 	flagSet.Bool(command.ForceFlag, true, "")
 	flagSet.String(command.SubnetIdsFlag, subnetID, "")
 
-	context := cli.NewContext(nil, flagSet, globalContext)
+	context := cli.NewContext(nil, flagSet, nil)
 	err := createCluster(context, newMockReadWriter(), mockECS, mockCloudformation, ami.NewStaticAmiIds())
 	assert.Error(t, err, "Expected error for subnets without VPC")
 }
@@ -350,9 +323,6 @@ func TestClusterUpWithVPCWithoutSubnets(t *testing.T) {
 		mockCloudformation.EXPECT().Initialize(gomock.Any()),
 		mockCloudformation.EXPECT().ValidateStackExists(stackName).Return(errors.New("error")),
 	)
-	globalSet := flag.NewFlagSet("ecs-cli", 0)
-	globalSet.String("region", "us-west-1", "")
-	globalContext := cli.NewContext(nil, globalSet, nil)
 
 	flagSet := flag.NewFlagSet("ecs-cli-up", 0)
 	flagSet.Bool(command.CapabilityIAMFlag, true, "")
@@ -360,7 +330,7 @@ func TestClusterUpWithVPCWithoutSubnets(t *testing.T) {
 	flagSet.Bool(command.ForceFlag, true, "")
 	flagSet.String(command.VpcIdFlag, vpcID, "")
 
-	context := cli.NewContext(nil, flagSet, globalContext)
+	context := cli.NewContext(nil, flagSet, nil)
 	err := createCluster(context, newMockReadWriter(), mockECS, mockCloudformation, ami.NewStaticAmiIds())
 	assert.Error(t, err, "Expected error for VPC without subnets")
 }
@@ -376,9 +346,6 @@ func TestClusterUpWithAvailabilityZonesWithVPC(t *testing.T) {
 		mockCloudformation.EXPECT().Initialize(gomock.Any()),
 		mockCloudformation.EXPECT().ValidateStackExists(stackName).Return(errors.New("error")),
 	)
-	globalSet := flag.NewFlagSet("ecs-cli", 0)
-	globalSet.String("region", "us-west-1", "")
-	globalContext := cli.NewContext(nil, globalSet, nil)
 
 	flagSet := flag.NewFlagSet("ecs-cli-up", 0)
 	flagSet.Bool(command.CapabilityIAMFlag, true, "")
@@ -387,7 +354,7 @@ func TestClusterUpWithAvailabilityZonesWithVPC(t *testing.T) {
 	flagSet.String(command.VpcIdFlag, vpcID, "")
 	flagSet.String(command.VpcAzFlag, vpcAZs, "")
 
-	context := cli.NewContext(nil, flagSet, globalContext)
+	context := cli.NewContext(nil, flagSet, nil)
 	err := createCluster(context, newMockReadWriter(), mockECS, mockCloudformation, ami.NewStaticAmiIds())
 	assert.Error(t, err, "Expected error for VPC with AZs")
 }
@@ -402,9 +369,6 @@ func TestClusterUpWithout2AvailabilityZones(t *testing.T) {
 		mockCloudformation.EXPECT().Initialize(gomock.Any()),
 		mockCloudformation.EXPECT().ValidateStackExists(stackName).Return(errors.New("error")),
 	)
-	globalSet := flag.NewFlagSet("ecs-cli", 0)
-	globalSet.String("region", "us-west-1", "")
-	globalContext := cli.NewContext(nil, globalSet, nil)
 
 	flagSet := flag.NewFlagSet("ecs-cli-up", 0)
 	flagSet.Bool(command.CapabilityIAMFlag, true, "")
@@ -412,21 +376,18 @@ func TestClusterUpWithout2AvailabilityZones(t *testing.T) {
 	flagSet.Bool(command.ForceFlag, true, "")
 	flagSet.String(command.VpcAzFlag, vpcAZs, "")
 
-	context := cli.NewContext(nil, flagSet, globalContext)
+	context := cli.NewContext(nil, flagSet, nil)
 	err := createCluster(context, newMockReadWriter(), mockECS, mockCloudformation, ami.NewStaticAmiIds())
 	assert.Error(t, err, "Expected error for 2 AZs")
 }
 
 func TestCliFlagsToCfnStackParams(t *testing.T) {
-	globalSet := flag.NewFlagSet("ecs-cli", 0)
-	globalSet.String("region", "us-west-1", "")
-	globalContext := cli.NewContext(nil, globalSet, nil)
 
 	flagSet := flag.NewFlagSet("ecs-cli-up", 0)
 	flagSet.Bool(command.CapabilityIAMFlag, true, "")
 	flagSet.String(command.KeypairNameFlag, "default", "")
 
-	context := cli.NewContext(nil, flagSet, globalContext)
+	context := cli.NewContext(nil, flagSet, nil)
 	params := cliFlagsToCfnStackParams(context)
 
 	_, err := params.GetParameter(cloudformation.ParameterKeyAsgMaxSize)
@@ -434,7 +395,7 @@ func TestCliFlagsToCfnStackParams(t *testing.T) {
 	assert.Equal(t, cloudformation.ParameterNotFoundError, err, "Expect error to be ParameterNotFoundError")
 
 	flagSet.String(command.AsgMaxSizeFlag, "2", "")
-	context = cli.NewContext(nil, flagSet, globalContext)
+	context = cli.NewContext(nil, flagSet, nil)
 	params = cliFlagsToCfnStackParams(context)
 	_, err = params.GetParameter(cloudformation.ParameterKeyAsgMaxSize)
 	assert.NoError(t, err, "Unexpected error getting parameter ParameterKeyAsgMaxSize")
@@ -463,16 +424,12 @@ func TestClusterUpForImageIdInput(t *testing.T) {
 		mockCloudformation.EXPECT().WaitUntilCreateComplete(stackName).Return(nil),
 	)
 
-	globalSet := flag.NewFlagSet("ecs-cli", 0)
-	globalSet.String("region", "us-west-1", "")
-	globalContext := cli.NewContext(nil, globalSet, nil)
-
 	flagSet := flag.NewFlagSet("ecs-cli-up", 0)
 	flagSet.Bool(command.CapabilityIAMFlag, true, "")
 	flagSet.String(command.KeypairNameFlag, "default", "")
 	flagSet.String(command.ImageIdFlag, imageID, "")
 
-	context := cli.NewContext(nil, flagSet, globalContext)
+	context := cli.NewContext(nil, flagSet, nil)
 	err := createCluster(context, newMockReadWriter(), mockECS, mockCloudformation, ami.NewStaticAmiIds())
 	assert.NoError(t, err, "Unexpected error bringing up cluster")
 }
@@ -482,7 +439,6 @@ func TestClusterUpWithClusterNameEmpty(t *testing.T) {
 	mockECS, mockCloudformation := setupTest(t)
 
 	globalSet := flag.NewFlagSet("ecs-cli", 0)
-	globalSet.String("region", "us-west-1", "")
 	globalContext := cli.NewContext(nil, globalSet, nil)
 
 	flagSet := flag.NewFlagSet("ecs-cli-up", 0)
@@ -497,13 +453,11 @@ func TestClusterUpWithClusterNameEmpty(t *testing.T) {
 func TestClusterUpWithoutRegion(t *testing.T) {
 	defer os.Clearenv()
 	mockECS, mockCloudformation := setupTest(t)
-
-	globalSet := flag.NewFlagSet("ecs-cli", 0)
-	globalContext := cli.NewContext(nil, globalSet, nil)
+	os.Unsetenv("AWS_REGION")
 
 	flagSet := flag.NewFlagSet("ecs-cli-up", 0)
 
-	context := cli.NewContext(nil, flagSet, globalContext)
+	context := cli.NewContext(nil, flagSet, nil)
 	err := createCluster(context, newMockReadWriter(), mockECS, mockCloudformation, ami.NewStaticAmiIds())
 	assert.Error(t, err, "Expected error bringing up cluster")
 }
@@ -527,14 +481,10 @@ func TestClusterDown(t *testing.T) {
 		mockCloudformation.EXPECT().WaitUntilDeleteComplete(stackName).Return(nil),
 		mockECS.EXPECT().DeleteCluster(clusterName).Return(clusterName, nil),
 	)
-	globalSet := flag.NewFlagSet("ecs-cli", 0)
-	globalSet.String("region", "us-west-1", "")
-	globalContext := cli.NewContext(nil, globalSet, nil)
-
 	flagSet := flag.NewFlagSet("ecs-cli-down", 0)
 	flagSet.Bool(command.ForceFlag, true, "")
 
-	context := cli.NewContext(nil, flagSet, globalContext)
+	context := cli.NewContext(nil, flagSet, nil)
 	err := deleteCluster(context, newMockReadWriter(), mockECS, mockCloudformation)
 	assert.NoError(t, err, "Unexpected error deleting cluster")
 }
@@ -543,13 +493,8 @@ func TestClusterDownWithoutForce(t *testing.T) {
 	defer os.Clearenv()
 	mockECS, mockCloudformation := setupTest(t)
 
-	globalSet := flag.NewFlagSet("ecs-cli", 0)
-	globalSet.String("region", "us-west-1", "")
-	globalContext := cli.NewContext(nil, globalSet, nil)
-
 	flagSet := flag.NewFlagSet("ecs-cli-down", 0)
-
-	context := cli.NewContext(nil, flagSet, globalContext)
+	context := cli.NewContext(nil, flagSet, nil)
 	err := deleteCluster(context, newMockReadWriter(), mockECS, mockCloudformation)
 	assert.Error(t, err, "Expected error when force deleting cluster")
 }
@@ -582,15 +527,11 @@ func TestClusterScale(t *testing.T) {
 	mockCloudformation.EXPECT().UpdateStack(stackName, gomock.Any()).Return("", nil)
 	mockCloudformation.EXPECT().WaitUntilUpdateComplete(stackName).Return(nil)
 
-	globalSet := flag.NewFlagSet("ecs-cli", 0)
-	globalSet.String("region", "us-west-1", "")
-	globalContext := cli.NewContext(nil, globalSet, nil)
-
 	flagSet := flag.NewFlagSet("ecs-cli-down", 0)
 	flagSet.Bool(command.CapabilityIAMFlag, true, "")
 	flagSet.String(command.AsgMaxSizeFlag, "1", "")
 
-	context := cli.NewContext(nil, flagSet, globalContext)
+	context := cli.NewContext(nil, flagSet, nil)
 	err := scaleCluster(context, newMockReadWriter(), mockECS, mockCloudformation)
 	assert.NoError(t, err, "Unexpected error scaling cluster")
 }
@@ -599,13 +540,10 @@ func TestClusterScaleWithoutIamCapability(t *testing.T) {
 	defer os.Clearenv()
 	mockECS, mockCloudformation := setupTest(t)
 
-	globalSet := flag.NewFlagSet("ecs-cli", 0)
-	globalContext := cli.NewContext(nil, globalSet, nil)
-
 	flagSet := flag.NewFlagSet("ecs-cli-up", 0)
 	flagSet.String(command.AsgMaxSizeFlag, "1", "")
 
-	context := cli.NewContext(nil, flagSet, globalContext)
+	context := cli.NewContext(nil, flagSet, nil)
 	err := scaleCluster(context, newMockReadWriter(), mockECS, mockCloudformation)
 	assert.Error(t, err, "Expected error scaling cluster when iam capability is not specified")
 }
@@ -614,13 +552,10 @@ func TestClusterScaleWithoutSize(t *testing.T) {
 	defer os.Clearenv()
 	mockECS, mockCloudformation := setupTest(t)
 
-	globalSet := flag.NewFlagSet("ecs-cli", 0)
-	globalContext := cli.NewContext(nil, globalSet, nil)
-
 	flagSet := flag.NewFlagSet("ecs-cli-up", 0)
 	flagSet.Bool(command.CapabilityIAMFlag, true, "")
 
-	context := cli.NewContext(nil, flagSet, globalContext)
+	context := cli.NewContext(nil, flagSet, nil)
 	err := scaleCluster(context, newMockReadWriter(), mockECS, mockCloudformation)
 	assert.Error(t, err, "Expected error scaling cluster when size is not specified")
 }
@@ -643,13 +578,9 @@ func TestClusterPSTaskGetInfoFail(t *testing.T) {
 	mockECS.EXPECT().GetTasksPages(gomock.Any(), gomock.Any()).Do(func(x, y interface{}) {
 	}).Return(errors.New("error"))
 
-	globalSet := flag.NewFlagSet("ecs-cli", 0)
-	globalSet.String("region", "us-west-1", "")
-	globalContext := cli.NewContext(nil, globalSet, nil)
-
 	flagSet := flag.NewFlagSet("ecs-cli-down", 0)
 
-	context := cli.NewContext(nil, flagSet, globalContext)
+	context := cli.NewContext(nil, flagSet, nil)
 	_, err = clusterPS(context, newMockReadWriter(), mockECS)
 	assert.Error(t, err, "Expected error in cluster ps")
 }

--- a/ecs-cli/modules/cli/compose/factory/factory_test.go
+++ b/ecs-cli/modules/cli/compose/factory/factory_test.go
@@ -35,7 +35,8 @@ const (
 func TestPopulateContext(t *testing.T) {
 	globalSet := flag.NewFlagSet("ecs-cli", 0)
 	globalContext := cli.NewContext(nil, globalSet, nil)
-	cliContext := cli.NewContext(nil, nil, globalContext)
+	flagSet := flag.NewFlagSet("ecs-cli-up", 0)
+	cliContext := cli.NewContext(nil, flagSet, globalContext)
 	ecsContext := &context.Context{}
 
 	// Create a temprorary directory for the dummy ecs config
@@ -49,12 +50,7 @@ func TestPopulateContext(t *testing.T) {
 	os.Setenv("AWS_REGION", "us-east-1")
 	os.Setenv("AWS_ACCESS_KEY", "AKIDEXAMPLE")
 	os.Setenv("AWS_SECRET_KEY", "secret")
-	defer func() {
-		os.Unsetenv("AWS_REGION")
-		os.Unsetenv("AWS_ACCESS_KEY")
-		os.Unsetenv("AWS_SECRET_KEY")
-		os.Unsetenv("HOME")
-	}()
+	defer os.Clearenv()
 
 	projectFactory := projectFactory{}
 	err = projectFactory.populateContext(ecsContext, cliContext)
@@ -74,7 +70,8 @@ func TestPopulateContextWithGlobalFlagOverrides(t *testing.T) {
 	overrides.String(command.ComposeFileNameFlag, composeFileNameTest, "")
 	overrides.String(command.ProjectNameFlag, projectNameTest, "")
 	parentContext := cli.NewContext(nil, overrides, nil)
-	cliContext := cli.NewContext(nil, nil, parentContext)
+	flagSet := flag.NewFlagSet("ecs-cli-up", 0)
+	cliContext := cli.NewContext(nil, flagSet, parentContext)
 	ecsContext := &context.Context{}
 
 	// Create a temprorary directory for the dummy ecs config

--- a/ecs-cli/modules/cli/image/image_app_test.go
+++ b/ecs-cli/modules/cli/image/image_app_test.go
@@ -87,8 +87,7 @@ func TestImagePush(t *testing.T) {
 			docker.AuthConfiguration{}).Return(nil),
 	)
 
-	globalContext := setGlobalFlags()
-	context := setAllPushImageFlags(globalContext)
+	context := setAllPushImageFlags()
 	err := pushImage(context, newMockReadWriter(), mockDocker, mockECR, mockSTS)
 	assert.NoError(t, err, "Error pushing image")
 }
@@ -111,10 +110,9 @@ func TestImagePushWithURI(t *testing.T) {
 			docker.AuthConfiguration{}).Return(nil),
 	)
 
-	globalContext := setGlobalFlags()
 	flagSet := flag.NewFlagSet("ecs-cli-push", 0)
 	flagSet.Parse([]string{repositoryWithURI})
-	context := cli.NewContext(nil, flagSet, globalContext)
+	context := cli.NewContext(nil, flagSet, nil)
 	err := pushImage(context, newMockReadWriter(), mockDocker, mockECR, mockSTS)
 	assert.NoError(t, err, "Error pushing image")
 }
@@ -135,8 +133,7 @@ func TestImagePushWhenRepositoryExists(t *testing.T) {
 			docker.AuthConfiguration{}).Return(nil),
 	)
 
-	globalContext := setGlobalFlags()
-	context := setAllPushImageFlags(globalContext)
+	context := setAllPushImageFlags()
 	err := pushImage(context, newMockReadWriter(), mockDocker, mockECR, mockSTS)
 	assert.NoError(t, err, "Error pushing image")
 }
@@ -145,9 +142,8 @@ func TestImagePushWithNoArguments(t *testing.T) {
 	mockECR, mockDocker, mockSTS := setupTestController(t)
 	setupEnvironmentVar()
 
-	globalContext := setGlobalFlags()
 	flagSet := flag.NewFlagSet("ecs-cli-push", 0)
-	context := cli.NewContext(nil, flagSet, globalContext)
+	context := cli.NewContext(nil, flagSet, nil)
 	err := pushImage(context, newMockReadWriter(), mockDocker, mockECR, mockSTS)
 	assert.Error(t, err, "Expect error pushing image")
 }
@@ -156,10 +152,9 @@ func TestImagePushWithTooManyArguments(t *testing.T) {
 	mockECR, mockDocker, mockSTS := setupTestController(t)
 	setupEnvironmentVar()
 
-	globalContext := setGlobalFlags()
 	flagSet := flag.NewFlagSet("ecs-cli-push", 0)
 	flagSet.Parse([]string{repository, image})
-	context := cli.NewContext(nil, flagSet, globalContext)
+	context := cli.NewContext(nil, flagSet, nil)
 	err := pushImage(context, newMockReadWriter(), mockDocker, mockECR, mockSTS)
 	assert.Error(t, err, "Expect error pushing image")
 }
@@ -173,8 +168,7 @@ func TestImagePushWhenGethAuthorizationTokenFail(t *testing.T) {
 		mockECR.EXPECT().GetAuthorizationTokenByID(gomock.Any()).Return(nil, errors.New("something failed")),
 	)
 
-	globalContext := setGlobalFlags()
-	context := setAllPushImageFlags(globalContext)
+	context := setAllPushImageFlags()
 	err := pushImage(context, newMockReadWriter(), mockDocker, mockECR, mockSTS)
 	assert.Error(t, err, "Expect error pushing image")
 }
@@ -191,8 +185,7 @@ func TestImagePushWhenTagImageFail(t *testing.T) {
 		mockDocker.EXPECT().TagImage(image, repositoryURI, tag).Return(errors.New("something failed")),
 	)
 
-	globalContext := setGlobalFlags()
-	context := setAllPushImageFlags(globalContext)
+	context := setAllPushImageFlags()
 	err := pushImage(context, newMockReadWriter(), mockDocker, mockECR, mockSTS)
 	assert.Error(t, err, "Expect error pushing image")
 }
@@ -211,8 +204,7 @@ func TestImagePushWhenCreateRepositoryFail(t *testing.T) {
 		mockECR.EXPECT().CreateRepository(repository).Return("", errors.New("something failed")),
 	)
 
-	globalContext := setGlobalFlags()
-	context := setAllPushImageFlags(globalContext)
+	context := setAllPushImageFlags()
 	err := pushImage(context, newMockReadWriter(), mockDocker, mockECR, mockSTS)
 	assert.Error(t, err, "Expect error pushing image")
 }
@@ -233,8 +225,7 @@ func TestImagePushFail(t *testing.T) {
 			docker.AuthConfiguration{}).Return(errors.New("something failed")),
 	)
 
-	globalContext := setGlobalFlags()
-	context := setAllPushImageFlags(globalContext)
+	context := setAllPushImageFlags()
 	err := pushImage(context, newMockReadWriter(), mockDocker, mockECR, mockSTS)
 	assert.Error(t, err, "Expect error pushing image")
 }
@@ -252,8 +243,7 @@ func TestImagePull(t *testing.T) {
 			docker.AuthConfiguration{}).Return(nil),
 	)
 
-	globalContext := setGlobalFlags()
-	context := setAllPullImageFlags(globalContext)
+	context := setAllPullImageFlags()
 	err := pullImage(context, newMockReadWriter(), mockDocker, mockECR, mockSTS)
 	assert.NoError(t, err, "Error pulling image")
 }
@@ -262,9 +252,8 @@ func TestImagePullWithoutImage(t *testing.T) {
 	mockECR, mockDocker, mockSTS := setupTestController(t)
 	setupEnvironmentVar()
 
-	globalContext := setGlobalFlags()
 	flagSet := flag.NewFlagSet("ecs-cli-pull", 0)
-	context := cli.NewContext(nil, flagSet, globalContext)
+	context := cli.NewContext(nil, flagSet, nil)
 	err := pullImage(context, newMockReadWriter(), mockDocker, mockECR, mockSTS)
 	assert.Error(t, err, "Expected error pulling image")
 }
@@ -278,8 +267,7 @@ func TestImagePullWhenGetAuthorizationTokenFail(t *testing.T) {
 		mockECR.EXPECT().GetAuthorizationTokenByID(gomock.Any()).Return(nil, errors.New("something failed")),
 	)
 
-	globalContext := setGlobalFlags()
-	context := setAllPullImageFlags(globalContext)
+	context := setAllPullImageFlags()
 	err := pullImage(context, newMockReadWriter(), mockDocker, mockECR, mockSTS)
 	assert.Error(t, err, "Expected error pulling image")
 }
@@ -297,8 +285,7 @@ func TestImagePullFail(t *testing.T) {
 			docker.AuthConfiguration{}).Return(errors.New("something failed")),
 	)
 
-	globalContext := setGlobalFlags()
-	context := setAllPullImageFlags(globalContext)
+	context := setAllPullImageFlags()
 	err := pullImage(context, newMockReadWriter(), mockDocker, mockECR, mockSTS)
 	assert.Error(t, err, "Expected error pulling image")
 }
@@ -325,9 +312,8 @@ func TestImageList(t *testing.T) {
 		}).Return(nil),
 	)
 
-	globalContext := setGlobalFlags()
 	flagSet := flag.NewFlagSet("ecs-cli-images", 0)
-	context := cli.NewContext(nil, flagSet, globalContext)
+	context := cli.NewContext(nil, flagSet, nil)
 	err := getImages(context, newMockReadWriter(), mockECR)
 	assert.NoError(t, err, "Error listing images")
 }
@@ -340,9 +326,8 @@ func TestImageListFail(t *testing.T) {
 		mockECR.EXPECT().GetImages(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.New("something failed")),
 	)
 
-	globalContext := setGlobalFlags()
 	flagSet := flag.NewFlagSet("ecs-cli-images", 0)
-	context := cli.NewContext(nil, flagSet, globalContext)
+	context := cli.NewContext(nil, flagSet, nil)
 	err := getImages(context, newMockReadWriter(), mockECR)
 	assert.Error(t, err, "Expected error listing images")
 }
@@ -404,20 +389,14 @@ func setupEnvironmentVar() {
 	}()
 }
 
-func setGlobalFlags() *cli.Context {
-	globalSet := flag.NewFlagSet("ecs-cli", 0)
-	globalSet.String("region", "us-west-1", "")
-	return cli.NewContext(nil, globalSet, nil)
-}
-
-func setAllPushImageFlags(globalContext *cli.Context) *cli.Context {
+func setAllPushImageFlags() *cli.Context {
 	flagSet := flag.NewFlagSet("ecs-cli-push", 0)
 	flagSet.Parse([]string{image})
-	return cli.NewContext(nil, flagSet, globalContext)
+	return cli.NewContext(nil, flagSet, nil)
 }
 
-func setAllPullImageFlags(globalContext *cli.Context) *cli.Context {
+func setAllPullImageFlags() *cli.Context {
 	flagSet := flag.NewFlagSet("ecs-cli-pull", 0)
 	flagSet.Parse([]string{image})
-	return cli.NewContext(nil, flagSet, globalContext)
+	return cli.NewContext(nil, flagSet, nil)
 }

--- a/ecs-cli/modules/clients/aws/ecs/client.go
+++ b/ecs-cli/modules/clients/aws/ecs/client.go
@@ -94,7 +94,8 @@ func (c *ecsClient) CreateCluster(clusterName string) (string, error) {
 		return "", err
 	}
 	log.WithFields(log.Fields{
-		"cluster": *resp.Cluster.ClusterName,
+		"cluster": aws.StringValue(resp.Cluster.ClusterName),
+		"region":  aws.StringValue(c.params.Session.Config.Region),
 	}).Info("Created cluster")
 
 	return *resp.Cluster.ClusterName, nil

--- a/ecs-cli/modules/commands/cluster/cluster_command.go
+++ b/ecs-cli/modules/commands/cluster/cluster_command.go
@@ -26,7 +26,7 @@ func UpCommand() cli.Command {
 		Usage:  "Creates the ECS cluster (if it does not already exist) and the AWS resources required to set up the cluster.",
 		Before: ecscli.BeforeApp,
 		Action: cluster.ClusterUp,
-		Flags:  clusterUpFlags(),
+		Flags:  append(clusterUpFlags(), command.OptionalClusterFlag(), command.OptionalRegionFlag()),
 	}
 }
 
@@ -35,7 +35,7 @@ func DownCommand() cli.Command {
 		Name:   "down",
 		Usage:  "Deletes the CloudFormation stack that was created by ecs-cli up and the associated resources. The --force option is required.",
 		Action: cluster.ClusterDown,
-		Flags:  clusterDownFlags(),
+		Flags:  append(clusterDownFlags(), command.OptionalClusterFlag(), command.OptionalRegionFlag()),
 	}
 }
 
@@ -44,7 +44,7 @@ func ScaleCommand() cli.Command {
 		Name:   "scale",
 		Usage:  "Modifies the number of container instances in your cluster. This command changes the desired and maximum instance count in the Auto Scaling group created by the ecs-cli up command. You can use this command to scale up (increase the number of instances) or scale down (decrease the number of instances) your cluster.",
 		Action: cluster.ClusterScale,
-		Flags:  clusterScaleFlags(),
+		Flags:  append(clusterScaleFlags(), command.OptionalClusterFlag(), command.OptionalRegionFlag()),
 	}
 }
 
@@ -53,6 +53,7 @@ func PsCommand() cli.Command {
 		Name:   "ps",
 		Usage:  "Lists all of the running containers in your ECS cluster",
 		Action: cluster.ClusterPS,
+		Flags:  []cli.Flag{command.OptionalClusterFlag(), command.OptionalRegionFlag()},
 	}
 }
 

--- a/ecs-cli/modules/commands/compose/compose_command.go
+++ b/ecs-cli/modules/commands/compose/compose_command.go
@@ -53,7 +53,7 @@ func ComposeCommand(factory composeFactory.ProjectFactory) cli.Command {
 		Name:   "compose",
 		Usage:  "Executes docker-compose-style commands on an ECS cluster.",
 		Before: ecscli.BeforeApp,
-		Flags:  composeFlags(),
+		Flags:  append(composeFlags(), command.OptionalClusterFlag(), command.OptionalRegionFlag()),
 		Subcommands: []cli.Command{
 			createCommand(factory),
 			psCommand(factory),

--- a/ecs-cli/modules/commands/configure/configure_command.go
+++ b/ecs-cli/modules/commands/configure/configure_command.go
@@ -21,6 +21,7 @@ import (
 	"github.com/urfave/cli"
 )
 
+// ConfigureCommand configure command help
 func ConfigureCommand() cli.Command {
 	return cli.Command{
 		Name:   "configure",
@@ -32,6 +33,13 @@ func ConfigureCommand() cli.Command {
 
 func configureFlags() []cli.Flag {
 	return []cli.Flag{
+		cli.StringFlag{
+			Name: flags.ClusterFlag + ", c",
+			Usage: fmt.Sprintf(
+				"Specifies the ECS cluster name to use. If the cluster does not exist, it is created when you try to add resources to it with the ecs-cli up command.",
+			),
+			EnvVar: "ECS_CLUSTER",
+		},
 		cli.StringFlag{
 			Name: flags.RegionFlag + ", r",
 			Usage: fmt.Sprintf(
@@ -60,15 +68,7 @@ func configureFlags() []cli.Flag {
 			),
 			EnvVar: "AWS_PROFILE",
 		},
-		cli.StringFlag{
-			Name: flags.ClusterFlag + ", c",
-			Usage: fmt.Sprintf(
-				"Specifies the ECS cluster name to use. If the cluster does not exist, it is created when you try to add resources to it with the ecs-cli up command.",
-			),
-			// TODO: Override behavior for all ecs-cli commands : CommandLineFlags > EnvVar > ConfigFile > Defaults
-			// Commenting it now to avoid user misunderstanding the behavior of this env var with other ecs-cli commands
-			// EnvVar: "ECS_CLUSTER",
-		},
+
 		cli.StringFlag{
 			Name:  flags.ComposeProjectNamePrefixFlag,
 			Value: flags.ComposeProjectNamePrefixDefaultValue,

--- a/ecs-cli/modules/commands/flags.go
+++ b/ecs-cli/modules/commands/flags.go
@@ -13,6 +13,12 @@
 
 package command
 
+import (
+	"fmt"
+
+	"github.com/urfave/cli"
+)
+
 // Flag names used by the cli.
 const (
 	// Configure
@@ -23,6 +29,7 @@ const (
 	AwsDefaultRegionEnvVar = "AWS_DEFAULT_REGION"
 	ProfileFlag            = "profile"
 	ClusterFlag            = "cluster"
+	ClusterEnvVar          = "ECS_CLUSTER"
 	VerboseFlag            = "verbose"
 
 	ComposeProjectNamePrefixFlag         = "compose-project-name-prefix"
@@ -68,3 +75,23 @@ const (
 	LoadBalancerNameFlag                    = "load-balancer-name"
 	RoleFlag                                = "role"
 )
+
+// OptionalClusterFlag inline overrides cluster
+func OptionalClusterFlag() cli.Flag {
+	return cli.StringFlag{
+		Name: ClusterFlag + ", c",
+		Usage: fmt.Sprintf(
+			"[Optional] Specifies the ECS cluster name to use. Defaults to the cluster configured using the configure command",
+		),
+	}
+}
+
+// OptionalRegionFlag inline overrides region
+func OptionalRegionFlag() cli.Flag {
+	return cli.StringFlag{
+		Name: RegionFlag + ", r",
+		Usage: fmt.Sprintf(
+			"[Optional] Specifies the AWS region to use. Defaults to the region configured using the configure command",
+		),
+	}
+}

--- a/ecs-cli/modules/commands/image/image_command.go
+++ b/ecs-cli/modules/commands/image/image_command.go
@@ -28,7 +28,7 @@ func PushCommand() cli.Command {
 		ArgsUsage: image.PushImageFormat,
 		Before:    app.BeforeApp,
 		Action:    image.ImagePush,
-		Flags:     imagePushFlags(),
+		Flags:     append(imagePushFlags(), command.OptionalRegionFlag()),
 	}
 }
 
@@ -40,7 +40,7 @@ func PullCommand() cli.Command {
 		ArgsUsage: image.PullImageFormat,
 		Before:    app.BeforeApp,
 		Action:    image.ImagePull,
-		Flags:     imagePullFlags(),
+		Flags:     append(imagePullFlags(), command.OptionalRegionFlag()),
 	}
 }
 
@@ -52,7 +52,7 @@ func ImagesCommand() cli.Command {
 		ArgsUsage: image.ListImageFormat,
 		Before:    app.BeforeApp,
 		Action:    image.ImageList,
-		Flags:     imagesFlags(),
+		Flags:     append(imageListFlags(), command.OptionalRegionFlag()),
 	}
 }
 
@@ -74,12 +74,8 @@ func imagePullFlags() []cli.Flag {
 	}
 }
 
-func imagesFlags() []cli.Flag {
+func imageListFlags() []cli.Flag {
 	return []cli.Flag{
-		cli.StringFlag{
-			Name:  command.RegistryIdFlag,
-			Usage: "[Optional] Specifies the the Amazon ECR registry ID to pull the image from. By default, images are pulled from the current AWS account.",
-		},
 		cli.BoolFlag{
 			Name:  command.TaggedFlag,
 			Usage: "[Optional] Filters the result to show only tagged images",

--- a/ecs-cli/modules/config/config.go
+++ b/ecs-cli/modules/config/config.go
@@ -127,7 +127,7 @@ func (cfg *CliConfig) getInitialCredentialProviders() []credentials.Provider {
 
 // getRegion gets the region to use from environment variables or ecs-cli's config file..
 func (cfg *CliConfig) getRegion() string {
-	// Order of credential resolution
+	// Order of region resolution
 	//  1) Environment Variable
 	//  2) ECS Config
 	// the rest are handled by session.NewSessionWithOptions invoked in ToAWSSession()

--- a/ecs-cli/modules/config/params_test.go
+++ b/ecs-cli/modules/config/params_test.go
@@ -95,9 +95,10 @@ func TestNewCliParamsFromConfig(t *testing.T) {
 	region := "us-east-1"
 
 	globalSet := flag.NewFlagSet("ecs-cli", 0)
-	globalSet.String("region", region, "")
 	globalContext := cli.NewContext(nil, globalSet, nil)
-	context := cli.NewContext(nil, nil, globalContext)
+	flagSet := flag.NewFlagSet("ecs-cli-up", 0)
+	flagSet.String("region", region, "")
+	context := cli.NewContext(nil, flagSet, globalContext)
 	rdwr := &mockReadWriter{}
 
 	os.Setenv("AWS_ACCESS_KEY", "AKIDEXAMPLE")
@@ -148,15 +149,17 @@ func TestNewCliParamsWhenPrefixKeysAreNotPresent(t *testing.T) {
 
 func defaultConfig() *cli.Context {
 	globalSet := flag.NewFlagSet("ecs-cli", 0)
-	globalSet.String("region", "us-east-1", "")
 	globalContext := cli.NewContext(nil, globalSet, nil)
-	return cli.NewContext(nil, nil, globalContext)
+	flagSet := flag.NewFlagSet("ecs-cli-up", 0)
+	flagSet.String("region", "us-east-1", "")
+	return cli.NewContext(nil, flagSet, globalContext)
 }
 
 func setupTest(t *testing.T) (*cli.Context, *mockReadWriter) {
 	globalSet := flag.NewFlagSet("ecs-cli", 0)
 	globalContext := cli.NewContext(nil, globalSet, nil)
-	context := cli.NewContext(nil, nil, globalContext)
+	flagSet := flag.NewFlagSet("ecs-cli-up", 0)
+	context := cli.NewContext(nil, flagSet, globalContext)
 	rdwr := &mockReadWriter{}
 	return context, rdwr
 }


### PR DESCRIPTION
Closes https://github.com/aws/amazon-ecs-cli/issues/174, #71

Order of region/cluster resolution:
1) inline flag
2) environment variable
3) ECS config