### PR TITLE
Support multiple compose files with --file (or -f), and docker-compose.override.yml

### DIFF
--- a/ecs-cli/Godeps/Godeps.json
+++ b/ecs-cli/Godeps/Godeps.json
@@ -369,6 +369,16 @@
 			"Rev": "e30f1e79f3cd72542f2026ceec18d3bd67ab859c"
 		},
 		{
+			"ImportPath": "github.com/docker/libcompose/cli/app",
+			"Comment": "v0.4.0-44-g9e64d2c",
+			"Rev": "9e64d2cd796891a526a35749de10dfa89c3d9fe0"
+		},
+		{
+			"ImportPath": "github.com/docker/libcompose/cli/command",
+			"Comment": "v0.4.0-44-g9e64d2c",
+			"Rev": "9e64d2cd796891a526a35749de10dfa89c3d9fe0"
+		},
+		{
 			"ImportPath": "github.com/docker/libcompose/config",
 			"Comment": "v0.4.0-44-g9e64d2c",
 			"Rev": "9e64d2cd796891a526a35749de10dfa89c3d9fe0"
@@ -400,6 +410,11 @@
 		},
 		{
 			"ImportPath": "github.com/docker/libcompose/utils",
+			"Comment": "v0.4.0-44-g9e64d2c",
+			"Rev": "9e64d2cd796891a526a35749de10dfa89c3d9fe0"
+		},
+		{
+			"ImportPath": "github.com/docker/libcompose/version",
 			"Comment": "v0.4.0-44-g9e64d2c",
 			"Rev": "9e64d2cd796891a526a35749de10dfa89c3d9fe0"
 		},

--- a/ecs-cli/modules/cli/compose/factory/factory.go
+++ b/ecs-cli/modules/cli/compose/factory/factory.go
@@ -58,7 +58,14 @@ func (projectFactory projectFactory) Create(cliContext *cli.Context, isService b
 
 // populateContext sets the required CLI arguments to the context
 func (projectFactory projectFactory) populateContext(ecsContext *context.Context, cliContext *cli.Context) error {
-	// populate CLI context
+	/*
+	  populate CLI context
+	  libcomposecommand.Populate updates the composeFiles field in the context
+	  with the files specified by --file (or -f), or if no files are specfied,
+	  it looks for a docker-compose.yml and a docker-compose.override.yml.
+	  We rely on libcompose for this functionality; it should correctly mimic
+	  the behavior of docker-compose.
+	*/
 	libcomposecommand.Populate(&ecsContext.Context, cliContext)
 	ecsContext.ProjectName = cliContext.GlobalString(command.ProjectNameFlag)
 	ecsContext.CLIContext = cliContext

--- a/ecs-cli/modules/cli/compose/factory/factory.go
+++ b/ecs-cli/modules/cli/compose/factory/factory.go
@@ -14,12 +14,12 @@
 package factory
 
 import (
-	ecscompose "github.com/aws/amazon-ecs-cli/ecs-cli/modules/cli/compose/project"
 	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/cli/compose/context"
+	ecscompose "github.com/aws/amazon-ecs-cli/ecs-cli/modules/cli/compose/project"
 	command "github.com/aws/amazon-ecs-cli/ecs-cli/modules/commands"
-
 	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/config"
 	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/utils/compose"
+	libcomposecommand "github.com/docker/libcompose/cli/command"
 	"github.com/urfave/cli"
 )
 
@@ -59,8 +59,7 @@ func (projectFactory projectFactory) Create(cliContext *cli.Context, isService b
 // populateContext sets the required CLI arguments to the context
 func (projectFactory projectFactory) populateContext(ecsContext *context.Context, cliContext *cli.Context) error {
 	// populate CLI context
-	// TODO: Support multiple compose files
-	ecsContext.ComposeFiles = []string{cliContext.GlobalString(command.ComposeFileNameFlag)}
+	libcomposecommand.Populate(&ecsContext.Context, cliContext)
 	ecsContext.ProjectName = cliContext.GlobalString(command.ProjectNameFlag)
 	ecsContext.CLIContext = cliContext
 

--- a/ecs-cli/modules/cli/compose/factory/factory.go
+++ b/ecs-cli/modules/cli/compose/factory/factory.go
@@ -58,8 +58,9 @@ func (projectFactory projectFactory) Create(cliContext *cli.Context, isService b
 // populateContext sets the required CLI arguments to the context
 func (projectFactory projectFactory) populateContext(ecsContext *context.Context, cliContext *cli.Context) error {
 	/*
-		Populate the following libcompose fields to context
-		- ComposeFiles: reads from `--file` or `-f` flags. Defaults to `docker-compose.yml` and `docker-compose.override.yml` if no flags are specified.
+				Populate the following libcompose fields to context
+				- ComposeFiles: reads from `--file` or `-f` flags. Defaults to `docker-compose.yml` and `docker-compose.override.yml` if no flags are specified.
+		    - ProjectName: reads from `--project-name` or `-p` flags.
 	*/
 	libcomposecommand.Populate(&ecsContext.Context, cliContext)
 	ecsContext.CLIContext = cliContext

--- a/ecs-cli/modules/cli/compose/factory/factory.go
+++ b/ecs-cli/modules/cli/compose/factory/factory.go
@@ -58,9 +58,9 @@ func (projectFactory projectFactory) Create(cliContext *cli.Context, isService b
 // populateContext sets the required CLI arguments to the context
 func (projectFactory projectFactory) populateContext(ecsContext *context.Context, cliContext *cli.Context) error {
 	/*
-				Populate the following libcompose fields to context
-				- ComposeFiles: reads from `--file` or `-f` flags. Defaults to `docker-compose.yml` and `docker-compose.override.yml` if no flags are specified.
-		    - ProjectName: reads from `--project-name` or `-p` flags.
+	 Populate the following libcompose fields to context
+	 - ComposeFiles: reads from `--file` or `-f` flags. Defaults to `docker-compose.yml` and `docker-compose.override.yml` if no flags are specified.
+	 - ProjectName: reads from `--project-name` or `-p` flags.
 	*/
 	libcomposecommand.Populate(&ecsContext.Context, cliContext)
 	ecsContext.CLIContext = cliContext

--- a/ecs-cli/modules/cli/compose/factory/factory.go
+++ b/ecs-cli/modules/cli/compose/factory/factory.go
@@ -16,7 +16,6 @@ package factory
 import (
 	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/cli/compose/context"
 	ecscompose "github.com/aws/amazon-ecs-cli/ecs-cli/modules/cli/compose/project"
-	command "github.com/aws/amazon-ecs-cli/ecs-cli/modules/commands"
 	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/config"
 	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/utils/compose"
 	libcomposecommand "github.com/docker/libcompose/cli/command"
@@ -67,7 +66,6 @@ func (projectFactory projectFactory) populateContext(ecsContext *context.Context
 	  the behavior of docker-compose.
 	*/
 	libcomposecommand.Populate(&ecsContext.Context, cliContext)
-	ecsContext.ProjectName = cliContext.GlobalString(command.ProjectNameFlag)
 	ecsContext.CLIContext = cliContext
 
 	// reads and sets the parameters (required to create ECS Service Client) from the cli context to ecs context

--- a/ecs-cli/modules/cli/compose/factory/factory.go
+++ b/ecs-cli/modules/cli/compose/factory/factory.go
@@ -58,12 +58,8 @@ func (projectFactory projectFactory) Create(cliContext *cli.Context, isService b
 // populateContext sets the required CLI arguments to the context
 func (projectFactory projectFactory) populateContext(ecsContext *context.Context, cliContext *cli.Context) error {
 	/*
-	  populate CLI context
-	  libcomposecommand.Populate updates the composeFiles field in the context
-	  with the files specified by --file (or -f), or if no files are specfied,
-	  it looks for a docker-compose.yml and a docker-compose.override.yml.
-	  We rely on libcompose for this functionality; it should correctly mimic
-	  the behavior of docker-compose.
+		Populate the following libcompose fields to context
+		- ComposeFiles: reads from `--file` or `-f` flags. Defaults to `docker-compose.yml` and `docker-compose.override.yml` if no flags are specified.
 	*/
 	libcomposecommand.Populate(&ecsContext.Context, cliContext)
 	ecsContext.CLIContext = cliContext

--- a/ecs-cli/modules/cli/compose/factory/factory_test.go
+++ b/ecs-cli/modules/cli/compose/factory/factory_test.go
@@ -67,7 +67,11 @@ func TestPopulateContext(t *testing.T) {
 func TestPopulateContextWithGlobalFlagOverrides(t *testing.T) {
 	// populate when compose file and project name flag overrides are provided
 	overrides := flag.NewFlagSet("ecs-cli", 0)
-	overrides.String(command.ComposeFileNameFlag, composeFileNameTest, "")
+	composeFiles := &cli.StringSlice{}
+	composeFiles.Set(composeFileNameTest)
+	// test multiple --file
+	composeFiles.Set("docker-compose-test2.yml")
+	overrides.Var(composeFiles, command.ComposeFileNameFlag, "")
 	overrides.String(command.ProjectNameFlag, projectNameTest, "")
 	parentContext := cli.NewContext(nil, overrides, nil)
 	flagSet := flag.NewFlagSet("ecs-cli-up", 0)
@@ -96,7 +100,7 @@ func TestPopulateContextWithGlobalFlagOverrides(t *testing.T) {
 	err = projectFactory.populateContext(ecsContext, cliContext)
 
 	assert.NoError(t, err, "Unexpected error")
-	assert.Len(t, ecsContext.ComposeFiles, 1, "Expected composeFiles to be set")
+	assert.Len(t, ecsContext.ComposeFiles, 2, "Expected composeFiles to be set")
 	assert.Equal(t, composeFileNameTest, ecsContext.ComposeFiles[0], "Expected compose file to match")
 	assert.Equal(t, projectNameTest, ecsContext.ProjectName, "Expected project name to match")
 }

--- a/ecs-cli/modules/commands/compose/compose_command.go
+++ b/ecs-cli/modules/commands/compose/compose_command.go
@@ -42,8 +42,9 @@ import (
 //* --------------------------------------------------- */
 
 const (
-	composeFileNameDefaultValue = "docker-compose.yml"
-	containerNameFlag           = "name"
+	composeFileNameDefaultValue         = "docker-compose.yml"
+	composeOverrideFileNameDefaultValue = "docker-compose.override.yml"
+	containerNameFlag                   = "name"
 )
 
 // ComposeCommand provides a list of commands that operate on docker-compose.yml file and are integrated to run on ECS.
@@ -81,7 +82,7 @@ func composeFlags() []cli.Flag {
 		},
 		cli.StringSliceFlag{
 			Name:   command.ComposeFileNameFlag + ",f",
-			Usage:  "Specifies the Docker compose file to use. Defaults to " + composeFileNameDefaultValue + " file.",
+			Usage:  "Specifies one or more Docker compose files to use. Defaults to " + composeFileNameDefaultValue + " file, and an optional " + composeOverrideFileNameDefaultValue + " file.",
 			Value:  &cli.StringSlice{},
 			EnvVar: "COMPOSE_FILE",
 		},

--- a/ecs-cli/modules/commands/compose/compose_command.go
+++ b/ecs-cli/modules/commands/compose/compose_command.go
@@ -79,10 +79,10 @@ func composeFlags() []cli.Flag {
 			Name:  command.VerboseFlag + ",debug",
 			Usage: "Increase the verbosity of command output to aid in diagnostics.",
 		},
-		cli.StringFlag{
+		cli.StringSliceFlag{
 			Name:   command.ComposeFileNameFlag + ",f",
 			Usage:  "Specifies the Docker compose file to use. Defaults to " + composeFileNameDefaultValue + " file.",
-			Value:  composeFileNameDefaultValue,
+			Value:  &cli.StringSlice{},
 			EnvVar: "COMPOSE_FILE",
 		},
 		cli.StringFlag{

--- a/ecs-cli/vendor/github.com/docker/libcompose/cli/app/app.go
+++ b/ecs-cli/vendor/github.com/docker/libcompose/cli/app/app.go
@@ -1,0 +1,333 @@
+package app
+
+import (
+	"fmt"
+	"os"
+	"os/signal"
+	"strconv"
+	"strings"
+	"syscall"
+
+	"golang.org/x/net/context"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/docker/libcompose/project"
+	"github.com/docker/libcompose/project/options"
+	"github.com/docker/libcompose/version"
+	"github.com/urfave/cli"
+)
+
+// ProjectAction is an adapter to allow the use of ordinary functions as libcompose actions.
+// Any function that has the appropriate signature can be register as an action on a codegansta/cli command.
+//
+// cli.Command{
+//		Name:   "ps",
+//		Usage:  "List containers",
+//		Action: app.WithProject(factory, app.ProjectPs),
+//	}
+type ProjectAction func(project project.APIProject, c *cli.Context) error
+
+// BeforeApp is an action that is executed before any cli command.
+func BeforeApp(c *cli.Context) error {
+	if c.GlobalBool("verbose") {
+		logrus.SetLevel(logrus.DebugLevel)
+	}
+
+	if version.ShowWarning() {
+		logrus.Warning("Note: This is an experimental alternate implementation of the Compose CLI (https://github.com/docker/compose)")
+	}
+	return nil
+}
+
+// WithProject is a helper function to create a cli.Command action with a ProjectFactory.
+func WithProject(factory ProjectFactory, action ProjectAction) func(context *cli.Context) error {
+	return func(context *cli.Context) error {
+		p, err := factory.Create(context)
+		if err != nil {
+			logrus.Fatalf("Failed to read project: %v", err)
+		}
+		return action(p, context)
+	}
+}
+
+// ProjectPs lists the containers.
+func ProjectPs(p project.APIProject, c *cli.Context) error {
+	qFlag := c.Bool("q")
+	allInfo, err := p.Ps(context.Background(), c.Args()...)
+	if err != nil {
+		return cli.NewExitError(err.Error(), 1)
+	}
+	columns := []string{"Name", "Command", "State", "Ports"}
+	if qFlag {
+		columns = []string{"Id"}
+	}
+	os.Stdout.WriteString(allInfo.String(columns, !qFlag))
+	return nil
+}
+
+// ProjectPort prints the public port for a port binding.
+func ProjectPort(p project.APIProject, c *cli.Context) error {
+	if len(c.Args()) != 2 {
+		return cli.NewExitError("Please pass arguments in the form: SERVICE PORT", 1)
+	}
+
+	index := c.Int("index")
+	protocol := c.String("protocol")
+	serviceName := c.Args()[0]
+	privatePort := c.Args()[1]
+
+	port, err := p.Port(context.Background(), index, protocol, serviceName, privatePort)
+	if err != nil {
+		return cli.NewExitError(err.Error(), 1)
+	}
+	fmt.Println(port)
+	return nil
+}
+
+// ProjectStop stops all services.
+func ProjectStop(p project.APIProject, c *cli.Context) error {
+	err := p.Stop(context.Background(), c.Int("timeout"), c.Args()...)
+	if err != nil {
+		return cli.NewExitError(err.Error(), 1)
+	}
+	return nil
+}
+
+// ProjectDown brings all services down (stops and clean containers).
+func ProjectDown(p project.APIProject, c *cli.Context) error {
+	options := options.Down{
+		RemoveVolume:  c.Bool("volumes"),
+		RemoveImages:  options.ImageType(c.String("rmi")),
+		RemoveOrphans: c.Bool("remove-orphans"),
+	}
+	err := p.Down(context.Background(), options, c.Args()...)
+	if err != nil {
+		return cli.NewExitError(err.Error(), 1)
+	}
+	return nil
+}
+
+// ProjectBuild builds or rebuilds services.
+func ProjectBuild(p project.APIProject, c *cli.Context) error {
+	config := options.Build{
+		NoCache:     c.Bool("no-cache"),
+		ForceRemove: c.Bool("force-rm"),
+		Pull:        c.Bool("pull"),
+	}
+	err := p.Build(context.Background(), config, c.Args()...)
+	if err != nil {
+		return cli.NewExitError(err.Error(), 1)
+	}
+	return nil
+}
+
+// ProjectCreate creates all services but do not start them.
+func ProjectCreate(p project.APIProject, c *cli.Context) error {
+	options := options.Create{
+		NoRecreate:    c.Bool("no-recreate"),
+		ForceRecreate: c.Bool("force-recreate"),
+		NoBuild:       c.Bool("no-build"),
+	}
+	err := p.Create(context.Background(), options, c.Args()...)
+	if err != nil {
+		return cli.NewExitError(err.Error(), 1)
+	}
+	return nil
+}
+
+// ProjectUp brings all services up.
+func ProjectUp(p project.APIProject, c *cli.Context) error {
+	options := options.Up{
+		Create: options.Create{
+			NoRecreate:    c.Bool("no-recreate"),
+			ForceRecreate: c.Bool("force-recreate"),
+			NoBuild:       c.Bool("no-build"),
+			ForceBuild:    c.Bool("build"),
+		},
+	}
+	ctx, cancelFun := context.WithCancel(context.Background())
+	err := p.Up(ctx, options, c.Args()...)
+	if err != nil {
+		return cli.NewExitError(err.Error(), 1)
+	}
+	if !c.Bool("d") {
+		signalChan := make(chan os.Signal, 1)
+		cleanupDone := make(chan bool)
+		signal.Notify(signalChan, syscall.SIGINT, syscall.SIGTERM)
+		errChan := make(chan error)
+		go func() {
+			errChan <- p.Log(ctx, true, c.Args()...)
+		}()
+		go func() {
+			select {
+			case <-signalChan:
+				fmt.Printf("\nGracefully stopping...\n")
+				cancelFun()
+				ProjectStop(p, c)
+				cleanupDone <- true
+			case err := <-errChan:
+				if err != nil {
+					logrus.Fatal(err)
+				}
+				cleanupDone <- true
+			}
+		}()
+		<-cleanupDone
+		return nil
+	}
+	return nil
+}
+
+// ProjectRun runs a given command within a service's container.
+func ProjectRun(p project.APIProject, c *cli.Context) error {
+	if len(c.Args()) == 0 {
+		logrus.Fatal("No service specified")
+	}
+
+	serviceName := c.Args()[0]
+	commandParts := c.Args()[1:]
+
+	options := options.Run{
+		Detached: c.Bool("d"),
+	}
+
+	exitCode, err := p.Run(context.Background(), serviceName, commandParts, options)
+	if err != nil {
+		return cli.NewExitError(err.Error(), 1)
+	}
+	return cli.NewExitError("", exitCode)
+}
+
+// ProjectStart starts services.
+func ProjectStart(p project.APIProject, c *cli.Context) error {
+	err := p.Start(context.Background(), c.Args()...)
+	if err != nil {
+		return cli.NewExitError(err.Error(), 1)
+	}
+	return nil
+}
+
+// ProjectRestart restarts services.
+func ProjectRestart(p project.APIProject, c *cli.Context) error {
+	err := p.Restart(context.Background(), c.Int("timeout"), c.Args()...)
+	if err != nil {
+		return cli.NewExitError(err.Error(), 1)
+	}
+	return nil
+}
+
+// ProjectLog gets services logs.
+func ProjectLog(p project.APIProject, c *cli.Context) error {
+	err := p.Log(context.Background(), c.Bool("follow"), c.Args()...)
+	if err != nil {
+		return cli.NewExitError(err.Error(), 1)
+	}
+	return nil
+}
+
+// ProjectPull pulls images for services.
+func ProjectPull(p project.APIProject, c *cli.Context) error {
+	err := p.Pull(context.Background(), c.Args()...)
+	if err != nil && !c.Bool("ignore-pull-failures") {
+		return cli.NewExitError(err.Error(), 1)
+	}
+	return nil
+}
+
+// ProjectDelete deletes services.
+func ProjectDelete(p project.APIProject, c *cli.Context) error {
+	options := options.Delete{
+		RemoveVolume: c.Bool("v"),
+	}
+	if !c.Bool("force") {
+		stoppedContainers, err := p.Containers(context.Background(), project.Filter{
+			State: project.Stopped,
+		}, c.Args()...)
+		if err != nil {
+			return cli.NewExitError(err.Error(), 1)
+		}
+		if len(stoppedContainers) == 0 {
+			fmt.Println("No stopped containers")
+			return nil
+		}
+		fmt.Printf("Going to remove %v\nAre you sure? [yN]\n", strings.Join(stoppedContainers, ", "))
+		var answer string
+		_, err = fmt.Scanln(&answer)
+		if err != nil {
+			return cli.NewExitError(err.Error(), 1)
+		}
+		if answer != "y" && answer != "Y" {
+			return nil
+		}
+	}
+	err := p.Delete(context.Background(), options, c.Args()...)
+	if err != nil {
+		return cli.NewExitError(err.Error(), 1)
+	}
+	return nil
+}
+
+// ProjectKill forces stop service containers.
+func ProjectKill(p project.APIProject, c *cli.Context) error {
+	err := p.Kill(context.Background(), c.String("signal"), c.Args()...)
+	if err != nil {
+		return cli.NewExitError(err.Error(), 1)
+	}
+	return nil
+}
+
+// ProjectConfig validates and print the compose file.
+func ProjectConfig(p project.APIProject, c *cli.Context) error {
+	yaml, err := p.Config()
+	if err != nil {
+		return cli.NewExitError(err.Error(), 1)
+	}
+	if !c.Bool("quiet") {
+		fmt.Println(yaml)
+	}
+	return nil
+}
+
+// ProjectPause pauses service containers.
+func ProjectPause(p project.APIProject, c *cli.Context) error {
+	err := p.Pause(context.Background(), c.Args()...)
+	if err != nil {
+		return cli.NewExitError(err.Error(), 1)
+	}
+	return nil
+}
+
+// ProjectUnpause unpauses service containers.
+func ProjectUnpause(p project.APIProject, c *cli.Context) error {
+	err := p.Unpause(context.Background(), c.Args()...)
+	if err != nil {
+		return cli.NewExitError(err.Error(), 1)
+	}
+	return nil
+}
+
+// ProjectScale scales services.
+func ProjectScale(p project.APIProject, c *cli.Context) error {
+	servicesScale := map[string]int{}
+	for _, arg := range c.Args() {
+		kv := strings.SplitN(arg, "=", 2)
+		if len(kv) != 2 {
+			return cli.NewExitError(fmt.Sprintf("Invalid scale parameter: %s", arg), 2)
+		}
+
+		name := kv[0]
+
+		count, err := strconv.Atoi(kv[1])
+		if err != nil {
+			return cli.NewExitError(fmt.Sprintf("Invalid scale parameter: %v", err), 2)
+		}
+
+		servicesScale[name] = count
+	}
+
+	err := p.Scale(context.Background(), c.Int("timeout"), servicesScale)
+	if err != nil {
+		return cli.NewExitError(err.Error(), 0)
+	}
+	return nil
+}

--- a/ecs-cli/vendor/github.com/docker/libcompose/cli/app/events.go
+++ b/ecs-cli/vendor/github.com/docker/libcompose/cli/app/events.go
@@ -1,0 +1,56 @@
+package app
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"golang.org/x/net/context"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/docker/libcompose/project"
+	"github.com/docker/libcompose/project/events"
+	"github.com/urfave/cli"
+)
+
+// ProjectEvents listen for real-time events of containers.
+func ProjectEvents(p project.APIProject, c *cli.Context) error {
+	evts, err := p.Events(context.Background(), c.Args()...)
+	if err != nil {
+		return err
+	}
+	var printfn func(events.ContainerEvent)
+
+	if c.Bool("json") {
+		printfn = printJSON
+	} else {
+		printfn = printStd
+	}
+	for event := range evts {
+		printfn(event)
+	}
+	return nil
+}
+
+func printStd(event events.ContainerEvent) {
+	output := os.Stdout
+	fmt.Fprintf(output, "%s ", event.Time.Format("2006-01-02 15:04:05.999999999"))
+	fmt.Fprintf(output, "%s %s %s", event.Type, event.Event, event.ID)
+	attrs := []string{}
+	for attr, value := range event.Attributes {
+		attrs = append(attrs, fmt.Sprintf("%s=%s", attr, value))
+	}
+
+	fmt.Fprintf(output, " (%s)", strings.Join(attrs, ", "))
+	fmt.Fprint(output, "\n")
+}
+
+func printJSON(event events.ContainerEvent) {
+	json, err := json.Marshal(event)
+	if err != nil {
+		logrus.Warn(err)
+	}
+	output := os.Stdout
+	fmt.Fprintf(output, "%s", json)
+}

--- a/ecs-cli/vendor/github.com/docker/libcompose/cli/app/types.go
+++ b/ecs-cli/vendor/github.com/docker/libcompose/cli/app/types.go
@@ -1,0 +1,12 @@
+package app
+
+import (
+	"github.com/docker/libcompose/project"
+	"github.com/urfave/cli"
+)
+
+// ProjectFactory is an interface that helps creating libcompose project.
+type ProjectFactory interface {
+	// Create creates a libcompose project from the command line options (urfave cli context).
+	Create(c *cli.Context) (project.APIProject, error)
+}

--- a/ecs-cli/vendor/github.com/docker/libcompose/cli/app/version.go
+++ b/ecs-cli/vendor/github.com/docker/libcompose/cli/app/version.go
@@ -1,0 +1,52 @@
+package app
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+	"text/template"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/docker/libcompose/version"
+	"github.com/urfave/cli"
+)
+
+var versionTemplate = `Version:      {{.Version}} ({{.GitCommit}})
+Go version:   {{.GoVersion}}
+Built:        {{.BuildTime}}
+OS/Arch:      {{.Os}}/{{.Arch}}`
+
+// Version prints the libcompose version number and additionnal informations.
+func Version(c *cli.Context) error {
+	if c.Bool("short") {
+		fmt.Println(version.VERSION)
+		return nil
+	}
+
+	tmpl, err := template.New("").Parse(versionTemplate)
+	if err != nil {
+		logrus.Fatal(err)
+	}
+
+	v := struct {
+		Version   string
+		GitCommit string
+		GoVersion string
+		BuildTime string
+		Os        string
+		Arch      string
+	}{
+		Version:   version.VERSION,
+		GitCommit: version.GITCOMMIT,
+		GoVersion: runtime.Version(),
+		BuildTime: version.BUILDTIME,
+		Os:        runtime.GOOS,
+		Arch:      runtime.GOARCH,
+	}
+
+	if err := tmpl.Execute(os.Stdout, v); err != nil {
+		logrus.Fatal(err)
+	}
+	fmt.Printf("\n")
+	return nil
+}

--- a/ecs-cli/vendor/github.com/docker/libcompose/cli/command/command.go
+++ b/ecs-cli/vendor/github.com/docker/libcompose/cli/command/command.go
@@ -1,0 +1,395 @@
+package command
+
+import (
+	"os"
+	"strings"
+
+	"github.com/docker/libcompose/cli/app"
+	"github.com/docker/libcompose/project"
+	"github.com/urfave/cli"
+)
+
+// Populate updates the specified project context based on command line arguments and subcommands.
+func Populate(context *project.Context, c *cli.Context) {
+	// urfave/cli does not distinguish whether the first string in the slice comes from the envvar
+	// or is from a flag. Worse off, it appends the flag values to the envvar value instead of
+	// overriding it. To ensure the multifile envvar case is always handled, the first string
+	// must always be split. It gives a more consistent behavior, then, to split each string in
+	// the slice.
+	for _, v := range c.GlobalStringSlice("file") {
+		context.ComposeFiles = append(context.ComposeFiles, strings.Split(v, string(os.PathListSeparator))...)
+	}
+
+	if len(context.ComposeFiles) == 0 {
+		context.ComposeFiles = []string{"docker-compose.yml"}
+		if _, err := os.Stat("docker-compose.override.yml"); err == nil {
+			context.ComposeFiles = append(context.ComposeFiles, "docker-compose.override.yml")
+		}
+	}
+
+	context.ProjectName = c.GlobalString("project-name")
+}
+
+// CreateCommand defines the libcompose create subcommand.
+func CreateCommand(factory app.ProjectFactory) cli.Command {
+	return cli.Command{
+		Name:   "create",
+		Usage:  "Create all services but do not start",
+		Action: app.WithProject(factory, app.ProjectCreate),
+		Flags: []cli.Flag{
+			cli.BoolFlag{
+				Name:  "no-recreate",
+				Usage: "If containers already exist, don't recreate them. Incompatible with --force-recreate.",
+			},
+			cli.BoolFlag{
+				Name:  "force-recreate",
+				Usage: "Recreate containers even if their configuration and image haven't changed. Incompatible with --no-recreate.",
+			},
+			cli.BoolFlag{
+				Name:  "no-build",
+				Usage: "Don't build an image, even if it's missing.",
+			},
+		},
+	}
+}
+
+// ConfigCommand defines the libcompose config subcommand
+func ConfigCommand(factory app.ProjectFactory) cli.Command {
+	return cli.Command{
+		Name:   "config",
+		Usage:  "Validate and view the compose file.",
+		Action: app.WithProject(factory, app.ProjectConfig),
+		Flags: []cli.Flag{
+			cli.BoolFlag{
+				Name:  "quiet,q",
+				Usage: "Only validate the configuration, don't print anything.",
+			},
+		},
+	}
+}
+
+// BuildCommand defines the libcompose build subcommand.
+func BuildCommand(factory app.ProjectFactory) cli.Command {
+	return cli.Command{
+		Name:   "build",
+		Usage:  "Build or rebuild services.",
+		Action: app.WithProject(factory, app.ProjectBuild),
+		Flags: []cli.Flag{
+			cli.BoolFlag{
+				Name:  "no-cache",
+				Usage: "Do not use cache when building the image",
+			},
+			cli.BoolFlag{
+				Name:  "force-rm",
+				Usage: "Always remove intermediate containers",
+			},
+			cli.BoolFlag{
+				Name:  "pull",
+				Usage: "Always attempt to pull a newer version of the image",
+			},
+		},
+	}
+}
+
+// PsCommand defines the libcompose ps subcommand.
+func PsCommand(factory app.ProjectFactory) cli.Command {
+	return cli.Command{
+		Name:   "ps",
+		Usage:  "List containers",
+		Action: app.WithProject(factory, app.ProjectPs),
+		Flags: []cli.Flag{
+			cli.BoolFlag{
+				Name:  "q",
+				Usage: "Only display IDs",
+			},
+		},
+	}
+}
+
+// PortCommand defines the libcompose port subcommand.
+func PortCommand(factory app.ProjectFactory) cli.Command {
+	return cli.Command{
+		Name:   "port",
+		Usage:  "Print the public port for a port binding",
+		Action: app.WithProject(factory, app.ProjectPort),
+		Flags: []cli.Flag{
+			cli.StringFlag{
+				Name:  "protocol",
+				Usage: "tcp or udp ",
+				Value: "tcp",
+			},
+			cli.IntFlag{
+				Name:  "index",
+				Usage: "index of the container if there are multiple instances of a service",
+				Value: 1,
+			},
+		},
+	}
+}
+
+// UpCommand defines the libcompose up subcommand.
+func UpCommand(factory app.ProjectFactory) cli.Command {
+	return cli.Command{
+		Name:   "up",
+		Usage:  "Bring all services up",
+		Action: app.WithProject(factory, app.ProjectUp),
+		Flags: []cli.Flag{
+			cli.BoolFlag{
+				Name:  "d",
+				Usage: "Do not block and log",
+			},
+			cli.BoolFlag{
+				Name:  "no-build",
+				Usage: "Don't build an image, even if it's missing.",
+			},
+			cli.BoolFlag{
+				Name:  "no-recreate",
+				Usage: "If containers already exist, don't recreate them. Incompatible with --force-recreate.",
+			},
+			cli.BoolFlag{
+				Name:  "force-recreate",
+				Usage: "Recreate containers even if their configuration and image haven't changed. Incompatible with --no-recreate.",
+			},
+			cli.BoolFlag{
+				Name:  "build",
+				Usage: "Build images before starting containers.",
+			},
+		},
+	}
+}
+
+// StartCommand defines the libcompose start subcommand.
+func StartCommand(factory app.ProjectFactory) cli.Command {
+	return cli.Command{
+		Name:   "start",
+		Usage:  "Start services",
+		Action: app.WithProject(factory, app.ProjectStart),
+		Flags: []cli.Flag{
+			cli.BoolTFlag{
+				Name:  "d",
+				Usage: "Do not block and log",
+			},
+		},
+	}
+}
+
+// RunCommand defines the libcompose run subcommand.
+func RunCommand(factory app.ProjectFactory) cli.Command {
+	return cli.Command{
+		Name:   "run",
+		Usage:  "Run a one-off command",
+		Action: app.WithProject(factory, app.ProjectRun),
+		Flags: []cli.Flag{
+			cli.BoolFlag{
+				Name:  "d",
+				Usage: "Detached mode: Run container in the background, print new container name.",
+			},
+		},
+	}
+}
+
+// PullCommand defines the libcompose pull subcommand.
+func PullCommand(factory app.ProjectFactory) cli.Command {
+	return cli.Command{
+		Name:   "pull",
+		Usage:  "Pulls images for services",
+		Action: app.WithProject(factory, app.ProjectPull),
+		Flags: []cli.Flag{
+			cli.BoolFlag{
+				Name:  "ignore-pull-failures",
+				Usage: "Pull what it can and ignores images with pull failures.",
+			},
+		},
+	}
+}
+
+// LogsCommand defines the libcompose logs subcommand.
+func LogsCommand(factory app.ProjectFactory) cli.Command {
+	return cli.Command{
+		Name:   "logs",
+		Usage:  "Get service logs",
+		Action: app.WithProject(factory, app.ProjectLog),
+		Flags: []cli.Flag{
+			cli.BoolFlag{
+				Name:  "follow",
+				Usage: "Follow log output.",
+			},
+		},
+	}
+}
+
+// RestartCommand defines the libcompose restart subcommand.
+func RestartCommand(factory app.ProjectFactory) cli.Command {
+	return cli.Command{
+		Name:   "restart",
+		Usage:  "Restart services",
+		Action: app.WithProject(factory, app.ProjectRestart),
+		Flags: []cli.Flag{
+			cli.IntFlag{
+				Name:  "timeout,t",
+				Usage: "Specify a shutdown timeout in seconds.",
+				Value: 10,
+			},
+		},
+	}
+}
+
+// StopCommand defines the libcompose stop subcommand.
+func StopCommand(factory app.ProjectFactory) cli.Command {
+	return cli.Command{
+		Name:   "stop",
+		Usage:  "Stop services",
+		Action: app.WithProject(factory, app.ProjectStop),
+		Flags: []cli.Flag{
+			cli.IntFlag{
+				Name:  "timeout,t",
+				Usage: "Specify a shutdown timeout in seconds.",
+				Value: 10,
+			},
+		},
+	}
+}
+
+// DownCommand defines the libcompose stop subcommand.
+func DownCommand(factory app.ProjectFactory) cli.Command {
+	return cli.Command{
+		Name:   "down",
+		Usage:  "Stop and remove containers, networks, images, and volumes",
+		Action: app.WithProject(factory, app.ProjectDown),
+		Flags: []cli.Flag{
+			cli.BoolFlag{
+				Name:  "volumes,v",
+				Usage: "Remove data volumes",
+			},
+			cli.StringFlag{
+				Name:  "rmi",
+				Usage: "Remove images, type may be one of: 'all' to remove all images, or 'local' to remove only images that don't have an custom name set by the `image` field",
+			},
+			cli.BoolFlag{
+				Name:  "remove-orphans",
+				Usage: "Remove containers for services not defined in the Compose file",
+			},
+		},
+	}
+}
+
+// ScaleCommand defines the libcompose scale subcommand.
+func ScaleCommand(factory app.ProjectFactory) cli.Command {
+	return cli.Command{
+		Name:   "scale",
+		Usage:  "Scale services",
+		Action: app.WithProject(factory, app.ProjectScale),
+		Flags: []cli.Flag{
+			cli.IntFlag{
+				Name:  "timeout,t",
+				Usage: "Specify a shutdown timeout in seconds.",
+				Value: 10,
+			},
+		},
+	}
+}
+
+// RmCommand defines the libcompose rm subcommand.
+func RmCommand(factory app.ProjectFactory) cli.Command {
+	return cli.Command{
+		Name:   "rm",
+		Usage:  "Delete services",
+		Action: app.WithProject(factory, app.ProjectDelete),
+		Flags: []cli.Flag{
+			cli.BoolFlag{
+				Name:  "force,f",
+				Usage: "Allow deletion of all services",
+			},
+			cli.BoolFlag{
+				Name:  "v",
+				Usage: "Remove volumes associated with containers",
+			},
+		},
+	}
+}
+
+// KillCommand defines the libcompose kill subcommand.
+func KillCommand(factory app.ProjectFactory) cli.Command {
+	return cli.Command{
+		Name:   "kill",
+		Usage:  "Force stop service containers",
+		Action: app.WithProject(factory, app.ProjectKill),
+		Flags: []cli.Flag{
+			cli.StringFlag{
+				Name:  "signal,s",
+				Usage: "SIGNAL to send to the container",
+				Value: "SIGKILL",
+			},
+		},
+	}
+}
+
+// PauseCommand defines the libcompose pause subcommand.
+func PauseCommand(factory app.ProjectFactory) cli.Command {
+	return cli.Command{
+		Name:  "pause",
+		Usage: "Pause services.",
+		// ArgsUsage: "[SERVICE...]",
+		Action: app.WithProject(factory, app.ProjectPause),
+	}
+}
+
+// UnpauseCommand defines the libcompose unpause subcommand.
+func UnpauseCommand(factory app.ProjectFactory) cli.Command {
+	return cli.Command{
+		Name:  "unpause",
+		Usage: "Unpause services.",
+		// ArgsUsage: "[SERVICE...]",
+		Action: app.WithProject(factory, app.ProjectUnpause),
+	}
+}
+
+// EventsCommand defines the libcompose events subcommand
+func EventsCommand(factory app.ProjectFactory) cli.Command {
+	return cli.Command{
+		Name:   "events",
+		Usage:  "Receive real time events from containers.",
+		Action: app.WithProject(factory, app.ProjectEvents),
+		Flags: []cli.Flag{
+			cli.BoolFlag{
+				Name:  "json",
+				Usage: "Output events as a stream of json objects",
+			},
+		},
+	}
+}
+
+// VersionCommand defines the libcompose version subcommand.
+func VersionCommand(factory app.ProjectFactory) cli.Command {
+	return cli.Command{
+		Name:   "version",
+		Usage:  "Show version informations",
+		Action: app.Version,
+		Flags: []cli.Flag{
+			cli.BoolFlag{
+				Name:  "short",
+				Usage: "Shows only Compose's version number.",
+			},
+		},
+	}
+}
+
+// CommonFlags defines the flags that are in common for all subcommands.
+func CommonFlags() []cli.Flag {
+	return []cli.Flag{
+		cli.BoolFlag{
+			Name: "verbose,debug",
+		},
+		cli.StringSliceFlag{
+			Name:   "file,f",
+			Usage:  "Specify one or more alternate compose files (default: docker-compose.yml)",
+			Value:  &cli.StringSlice{},
+			EnvVar: "COMPOSE_FILE",
+		},
+		cli.StringFlag{
+			Name:   "project-name,p",
+			Usage:  "Specify an alternate project name (default: directory name)",
+			EnvVar: "COMPOSE_PROJECT_NAME",
+		},
+	}
+}

--- a/ecs-cli/vendor/github.com/docker/libcompose/cli/command/command.go
+++ b/ecs-cli/vendor/github.com/docker/libcompose/cli/command/command.go
@@ -228,7 +228,6 @@ func RestartCommand(factory app.ProjectFactory) cli.Command {
 			cli.IntFlag{
 				Name:  "timeout,t",
 				Usage: "Specify a shutdown timeout in seconds.",
-				Value: 10,
 			},
 		},
 	}
@@ -244,7 +243,6 @@ func StopCommand(factory app.ProjectFactory) cli.Command {
 			cli.IntFlag{
 				Name:  "timeout,t",
 				Usage: "Specify a shutdown timeout in seconds.",
-				Value: 10,
 			},
 		},
 	}
@@ -283,7 +281,6 @@ func ScaleCommand(factory app.ProjectFactory) cli.Command {
 			cli.IntFlag{
 				Name:  "timeout,t",
 				Usage: "Specify a shutdown timeout in seconds.",
-				Value: 10,
 			},
 		},
 	}

--- a/ecs-cli/vendor/github.com/docker/libcompose/version/version.go
+++ b/ecs-cli/vendor/github.com/docker/libcompose/version/version.go
@@ -1,0 +1,20 @@
+package version
+
+var (
+	// VERSION should be updated by hand at each release
+	VERSION = "0.4.0"
+
+	// GITCOMMIT will be overwritten automatically by the build system
+	GITCOMMIT = "HEAD"
+
+	// BUILDTIME will be overwritten automatically by the build system
+	BUILDTIME = ""
+
+	// SHOWWARNING might be overwritten by the build system to not show the warning
+	SHOWWARNING = "true"
+)
+
+// ShowWarning returns wether the warning should be printed or not
+func ShowWarning() bool {
+	return SHOWWARNING != "false"
+}


### PR DESCRIPTION
closes #57 #215 
- The `--file` flag can be used to specify multiple compose files
- Both `docker-compose.yml` and `docker-compose.override.yml` will be read if they exist and the `--file` flag is not used
- This mimics the behavior of docker-compose as described [here](https://docs.docker.com/compose/extends/#multiple-compose-files)


## Testing done

```sh
$ make test
env -i PATH=$PATH GOPATH=$GOPATH GOROOT=$GOROOT go test -timeout=120s -v -cover ./ecs-cli/modules/...
```

#### Tested with the following docker-compose files:

- Tests Volumes, Links, CPU, Memory

(each folder represents a test case)
[Test Docker files.zip](https://github.com/aws/amazon-ecs-cli/files/1090771/Test.Docker.files.zip)
[test6.zip](https://github.com/aws/amazon-ecs-cli/files/1106325/test6.zip)

