### PR TITLE
Cluster and Region flags allowed both before and after the subcommand for compose commands. 

### DIFF
--- a/ecs-cli/modules/commands/compose/compose_command.go
+++ b/ecs-cli/modules/commands/compose/compose_command.go
@@ -103,6 +103,10 @@ func createCommand(factory composeFactory.ProjectFactory) cli.Command {
 		Name:   "create",
 		Usage:  "Creates an ECS task definition from your compose file. Note that we do not recommend using plain text environment variables for sensitive information, such as credential data.",
 		Action: compose.WithProject(factory, compose.ProjectCreate, false),
+		Flags: []cli.Flag{
+			command.OptionalClusterFlag(),
+			command.OptionalRegionFlag(),
+		},
 	}
 }
 
@@ -112,6 +116,10 @@ func psCommand(factory composeFactory.ProjectFactory) cli.Command {
 		Aliases: []string{"list"},
 		Usage:   "Lists all the containers in your cluster that were started by the compose project.",
 		Action:  compose.WithProject(factory, compose.ProjectPs, false),
+		Flags: []cli.Flag{
+			command.OptionalClusterFlag(),
+			command.OptionalRegionFlag(),
+		},
 	}
 }
 
@@ -120,6 +128,10 @@ func upCommand(factory composeFactory.ProjectFactory) cli.Command {
 		Name:   "up",
 		Usage:  "Creates an ECS task definition from your compose file (if it does not already exist) and runs one instance of that task on your cluster (a combination of create and start).",
 		Action: compose.WithProject(factory, compose.ProjectUp, false),
+		Flags: []cli.Flag{
+			command.OptionalClusterFlag(),
+			command.OptionalRegionFlag(),
+		},
 	}
 }
 
@@ -128,6 +140,10 @@ func startCommand(factory composeFactory.ProjectFactory) cli.Command {
 		Name:   "start",
 		Usage:  "Starts a single task from the task definition created from your compose file.",
 		Action: compose.WithProject(factory, compose.ProjectStart, false),
+		Flags: []cli.Flag{
+			command.OptionalClusterFlag(),
+			command.OptionalRegionFlag(),
+		},
 	}
 }
 
@@ -137,6 +153,10 @@ func runCommand(factory composeFactory.ProjectFactory) cli.Command {
 		Usage:     "Starts all containers overriding commands with the supplied one-off commands for the containers.",
 		ArgsUsage: "[CONTAINER_NAME] [\"COMMAND ...\"] [CONTAINER_NAME] [\"COMMAND ...\"] ...",
 		Action:    compose.WithProject(factory, compose.ProjectRun, false),
+		Flags: []cli.Flag{
+			command.OptionalClusterFlag(),
+			command.OptionalRegionFlag(),
+		},
 	}
 }
 
@@ -146,6 +166,10 @@ func stopCommand(factory composeFactory.ProjectFactory) cli.Command {
 		Aliases: []string{"down"},
 		Usage:   "Stops all the running tasks created by the compose project.",
 		Action:  compose.WithProject(factory, compose.ProjectStop, false),
+		Flags: []cli.Flag{
+			command.OptionalClusterFlag(),
+			command.OptionalRegionFlag(),
+		},
 	}
 }
 
@@ -154,5 +178,9 @@ func scaleCommand(factory composeFactory.ProjectFactory) cli.Command {
 		Name:   "scale",
 		Usage:  "ecs-cli compose scale [count] - scales the number of running tasks to the specified count.",
 		Action: compose.WithProject(factory, compose.ProjectScale, false),
+		Flags: []cli.Flag{
+			command.OptionalClusterFlag(),
+			command.OptionalRegionFlag(),
+		},
 	}
 }

--- a/ecs-cli/modules/commands/compose/service/compose_service_command.go
+++ b/ecs-cli/modules/commands/compose/service/compose_service_command.go
@@ -56,6 +56,10 @@ func ServiceCommand(factory composeFactory.ProjectFactory) cli.Command {
 			stopServiceCommand(factory),
 			rmServiceCommand(factory),
 		},
+		Flags: []cli.Flag{
+			command.OptionalClusterFlag(),
+			command.OptionalRegionFlag(),
+		},
 	}
 }
 
@@ -64,7 +68,7 @@ func createServiceCommand(factory composeFactory.ProjectFactory) cli.Command {
 		Name:   "create",
 		Usage:  "Creates an ECS service from your compose file. The service is created with a desired count of 0, so no containers are started by this command. Note that we do not recommend using plain text environment variables for sensitive information, such as credential data.",
 		Action: compose.WithProject(factory, compose.ProjectCreate, true),
-		Flags:  append(deploymentConfigFlags(true), loadBalancerFlags()...),
+		Flags:  append(deploymentConfigFlags(true), append(loadBalancerFlags(), command.OptionalClusterFlag(), command.OptionalRegionFlag())...),
 	}
 }
 
@@ -73,6 +77,10 @@ func startServiceCommand(factory composeFactory.ProjectFactory) cli.Command {
 		Name:   "start",
 		Usage:  "Starts one copy of each of the containers on the created ECS service. This command updates the desired count of the service to 1.",
 		Action: compose.WithProject(factory, compose.ProjectStart, true),
+		Flags: []cli.Flag{
+			command.OptionalClusterFlag(),
+			command.OptionalRegionFlag(),
+		},
 	}
 }
 
@@ -81,7 +89,7 @@ func upServiceCommand(factory composeFactory.ProjectFactory) cli.Command {
 		Name:   "up",
 		Usage:  "Creates an ECS service from your compose file (if it does not already exist) and runs one instance of that task on your cluster (a combination of create and start). This command updates the desired count of the service to 1.",
 		Action: compose.WithProject(factory, compose.ProjectUp, true),
-		Flags:  append(deploymentConfigFlags(true), loadBalancerFlags()...),
+		Flags:  append(deploymentConfigFlags(true), append(loadBalancerFlags(), command.OptionalClusterFlag(), command.OptionalRegionFlag())...),
 	}
 }
 
@@ -91,6 +99,10 @@ func psServiceCommand(factory composeFactory.ProjectFactory) cli.Command {
 		Aliases: []string{"list"},
 		Usage:   "Lists all the containers in your cluster that belong to the service created with the compose project.",
 		Action:  compose.WithProject(factory, compose.ProjectPs, true),
+		Flags: []cli.Flag{
+			command.OptionalClusterFlag(),
+			command.OptionalRegionFlag(),
+		},
 	}
 }
 
@@ -99,7 +111,7 @@ func scaleServiceCommand(factory composeFactory.ProjectFactory) cli.Command {
 		Name:   "scale",
 		Usage:  "ecs-cli compose service scale [count] - scales the desired count of the service to the specified count",
 		Action: compose.WithProject(factory, compose.ProjectScale, true),
-		Flags:  deploymentConfigFlags(false),
+		Flags:  append(deploymentConfigFlags(false), command.OptionalClusterFlag(), command.OptionalRegionFlag()),
 	}
 }
 
@@ -108,6 +120,10 @@ func stopServiceCommand(factory composeFactory.ProjectFactory) cli.Command {
 		Name:   "stop",
 		Usage:  "Stops the running tasks that belong to the service created with the compose project. This command updates the desired count of the service to 0.",
 		Action: compose.WithProject(factory, compose.ProjectStop, true),
+		Flags: []cli.Flag{
+			command.OptionalClusterFlag(),
+			command.OptionalRegionFlag(),
+		},
 	}
 }
 
@@ -117,6 +133,10 @@ func rmServiceCommand(factory composeFactory.ProjectFactory) cli.Command {
 		Aliases: []string{"delete", "down"},
 		Usage:   "Updates the desired count of the service to 0 and then deletes the service.",
 		Action:  compose.WithProject(factory, compose.ProjectDown, true),
+		Flags: []cli.Flag{
+			command.OptionalClusterFlag(),
+			command.OptionalRegionFlag(),
+		},
 	}
 }
 

--- a/ecs-cli/modules/config/params.go
+++ b/ecs-cli/modules/config/params.go
@@ -37,6 +37,9 @@ func (p *CliParams) GetCfnStackName() string {
 	return fmt.Sprintf("%s%s", p.CFNStackNamePrefix, p.Cluster)
 }
 
+// Searches as far up the context as necesarry. This function works no matter
+// how many layers of nested subcommands there are. It is more powerful
+// than merely calling context.String and context.GlobalString
 func recursiveFlagSearch(context *cli.Context, flag string) string {
 	if context == nil {
 		return ""

--- a/ecs-cli/modules/config/params.go
+++ b/ecs-cli/modules/config/params.go
@@ -63,12 +63,18 @@ func NewCliParams(context *cli.Context, rdwr ReadWriter) (*CliParams, error) {
 	if clusterFromEnv := os.Getenv(ecscli.ClusterEnvVar); clusterFromEnv != "" {
 		ecsConfig.Cluster = clusterFromEnv
 	}
-	if clusterFromFlag := context.String(ecscli.ClusterFlag); clusterFromFlag != "" {
+	// First try to find the flag in the global string, then try to find the flag locally
+	if clusterFromFlag := context.GlobalString(ecscli.ClusterFlag); clusterFromFlag != "" {
+		ecsConfig.Cluster = clusterFromFlag
+	} else if clusterFromFlag := context.String(ecscli.ClusterFlag); clusterFromFlag != "" {
 		ecsConfig.Cluster = clusterFromFlag
 	}
 
-	// local --region flag has the highest precedence to set ecs-cli region config.
-	if regionFromFlag := context.String(ecscli.RegionFlag); regionFromFlag != "" {
+	//--region flag has the highest precedence to set ecs-cli region config.
+	// First try to find the flag in the global string, then try to find the flag locally
+	if regionFromFlag := context.GlobalString(ecscli.RegionFlag); regionFromFlag != "" {
+		ecsConfig.Region = regionFromFlag
+	} else if regionFromFlag := context.String(ecscli.RegionFlag); regionFromFlag != "" {
 		ecsConfig.Region = regionFromFlag
 	}
 


### PR DESCRIPTION
closes #270

Examples:
```sh
$ ecs-cli compose --cluster other --region us-east-2 up
$ ecs-cli compose up --cluster other --region us-east-2
```
Both will produce the desired behavior (cluster and region in the config is overridden) and both produce the same behavior.

## Testing done

#### Unit tests:
```sh
$ make test
```

#### Testing compose commands:

##### After subcommand:
```sh
$ ecs-cli compose create --cluster other --region us-east-2
$ ecs-cli compose start --cluster other --region us-east-2
$ ecs-cli compose up --cluster other --region us-east-2
$ ecs-cli compose ps --cluster other --region us-east-2
$ ecs-cli compose scale 2 --cluster other --region us-east-2
$ ecs-cli compose run --cluster other --region us-east-2
$ ecs-cli compose stop --cluster other --region us-east-2
$ ecs-cli compose down --cluster other --region us-east-2
```

##### Before subcommand:
```sh
$ ecs-cli compose --cluster other --region us-east-1 create
$ ecs-cli compose --cluster other --region us-east-1 start
$ ecs-cli compose --cluster other --region us-east-1 scale 2
$ ecs-cli compose --cluster other --region us-east-1 stop
$ ecs-cli compose --cluster other --region us-east-1 up
$ ecs-cli compose --cluster other --region us-east-1 down
```


#### Testing Compose Service Commands

##### After subcommand:
```sh
ecs-cli compose service create --cluster other --region us-east-1
ecs-cli compose service start --cluster other --region us-east-1
ecs-cli compose service up --cluster other --region us-east-1
ecs-cli compose service ps --cluster other --region us-east-1
ecs-cli compose service scale 2 --cluster other --region us-east-1
ecs-cli compose service stop --cluster other --region us-east-1
ecs-cli compose service down --cluster other --region us-east-1
```

##### Before subcommand:
```sh
ecs-cli compose service --cluster other --region us-east-1 start
ecs-cli compose service --cluster other --region us-east-1 scale 2
ecs-cli compose service --cluster other --region us-east-1 stop
ecs-cli compose service --cluster other --region us-east-1 ps
ecs-cli compose service --cluster other --region us-east-1 up
ecs-cli compose service --cluster other --region us-east-1 down
```

##### Before Before Subcommand:
```sh
ecs-cli compose --cluster other --region us-east-1 service start
ecs-cli compose --cluster other --region us-east-1 service scale 2
ecs-cli compose --cluster other --region us-east-1 service stop
ecs-cli compose --cluster other --region us-east-1 service ps
ecs-cli compose --cluster other --region us-east-1 service up
ecs-cli compose --cluster other --region us-east-1 service down
```
(presumably no one will ever use the command this way, but just in case they do- it works!)