### PR TITLE
Add `--instance-role` flag to cluster up command

### DIFF
--- a/ecs-cli/modules/clients/aws/cloudformation/params.go
+++ b/ecs-cli/modules/clients/aws/cloudformation/params.go
@@ -35,6 +35,7 @@ const (
 	ParameterKeyCluster                  = "EcsCluster"
 	ParameterKeyAmiId                    = "EcsAmiId"
 	ParameterKeyAssociatePublicIPAddress = "AssociatePublicIpAddress"
+	ParameterKeyInstanceRole             = "InstanceRole"
 )
 
 var ParameterNotFoundError = errors.New("Parameter not found")

--- a/ecs-cli/modules/clients/aws/cloudformation/template.go
+++ b/ecs-cli/modules/clients/aws/cloudformation/template.go
@@ -150,6 +150,11 @@ var template = `
       "Type" : "String",
       "Description" : "ECS Cluster Name",
       "Default" : "default"
+    },
+    "InstanceRole" : {
+      "Type" : "String",
+      "Description" : "Optional - Instance IAM Role.",
+      "Default" : ""
     }
   },
   "Conditions": {
@@ -212,6 +217,14 @@ var template = `
             ""
           ]
         }
+      ]
+    },
+    "CreateEcsInstanceRole": {
+      "Fn::Equals": [
+        {
+          "Ref": "InstanceRole"
+        },
+        ""
       ]
     }
   },
@@ -382,7 +395,8 @@ var template = `
         } ]
       }
     },
-    "EcsInstancePolicy": {
+    "EcsInstanceRole": {
+      "Condition": "CreateEcsInstanceRole",
       "Type": "AWS::IAM::Role",
       "Properties": {
         "AssumeRolePolicyDocument": {
@@ -416,9 +430,15 @@ var template = `
       "Properties": {
         "Path": "/",
         "Roles": [
-          {
-            "Ref": "EcsInstancePolicy"
-          }
+          "Fn::If": [
+            "CreateEcsInstanceRole",
+            [ {
+              "Ref": "EcsInstanceRole"
+            } ],
+            {
+              "Ref": "InstanceRole"
+            }
+          ]
         ]
       }
     },

--- a/ecs-cli/modules/commands/cluster/cluster_command.go
+++ b/ecs-cli/modules/commands/cluster/cluster_command.go
@@ -68,7 +68,7 @@ func clusterUpFlags() []cli.Flag {
 		},
 		cli.BoolFlag{
 			Name:  command.CapabilityIAMFlag,
-			Usage: "Acknowledges that this command may create IAM resources.",
+			Usage: "Acknowledges that this command may create IAM resources. Required if --instance-role is not specified.",
 		},
 		cli.StringFlag{
 			Name:  command.AsgMaxSizeFlag,
@@ -113,6 +113,10 @@ func clusterUpFlags() []cli.Flag {
 		cli.BoolFlag{
 			Name:  command.ForceFlag + ", f",
 			Usage: "[Optional] Forces the recreation of any existing resources that match your current configuration. This option is useful for cleaning up stale resources from previous failed attempts.",
+		},
+		cli.StringFlag{
+			Name:  command.InstanceRoleFlag,
+			Usage: "[Optional] Specifies a custom IAM Role for instances in your cluster. Required if --capability-iam is not specified.",
 		},
 	}
 }

--- a/ecs-cli/modules/commands/flags.go
+++ b/ecs-cli/modules/commands/flags.go
@@ -48,6 +48,7 @@ const (
 	SubnetIdsFlag                   = "subnets"
 	VpcIdFlag                       = "vpc"
 	InstanceTypeFlag                = "instance-type"
+	InstanceRoleFlag                = "instance-role"
 	ImageIdFlag                     = "image-id"
 	KeypairNameFlag                 = "keypair"
 	CapabilityIAMFlag               = "capability-iam"


### PR DESCRIPTION
This allows the customer to specify the name of a custom IAM Role as the instance role for
their EC2 Instance Profile. NOTE: If the correct IAM Policy
(`AmazonEC2ContainerServiceforEC2Role`) is not attached to the custom instance
role, the create cluster command will succeed but no instances will be
launched.

If a custom role is specified, the `capability-iam` flag is not needed.

Closes #19.

## Testing done

#### Unit tests:
```sh
$ make test
```
#### Testing cluster up commands:
```sh
$ ecs-cli up --keypair my-keypair --size 2 --cluster my-test-cluster --instance-role ecsInstanceRole
```

#### Troubleshooting:
```sh
$ ecs-cli up --keypair my-keypair --size 2 --cluster my-test-cluster --instance-role foo --capability-iam
=> ERRO[0000] Error executing 'up': Cannot specify custom role when '--capability-iam' flag is set

$ ecs-cli up --keypair my-keypair --size 2 --cluster my-test-cluster
=> ERRO[0000] Error executing 'up': You must either specify a custom role with the '--instance-role' flag or set the '--capability-iam' flag 
```