### PR TITLE
Improved user experience in the compose service up command

### DIFF
--- a/ecs-cli/modules/cli/compose/entity/service/service_helper.go
+++ b/ecs-cli/modules/cli/compose/entity/service/service_helper.go
@@ -44,8 +44,7 @@ func (s eventSorter) Swap(i, j int) {
 func (s eventSorter) Less(i, j int) bool {
 	time1 := *s[i].CreatedAt
 	time2 := *s[j].CreatedAt
-	diff := time1.Sub(time2)
-	return diff.Seconds() < 0
+	return time1.Before(time2)
 }
 
 // logNewServiceEvents logs events that have not been logged yet
@@ -82,6 +81,9 @@ func waitForServiceTasks(service *Service, ecsServiceName string) error {
 	if val := service.Context().CLIContext.Float64(ecscli.ComposeServiceTimeOutFlag); val > 0 {
 		timeOut = val
 	}
+
+	log.Infof("Command in waiter: %s", service.Context().CLIContext.Command.Name)
+	log.Infof("Flag: %f", service.Context().CLIContext.Float64(ecscli.ComposeServiceTimeOutFlag))
 
 	return waiters.WaitUntilComplete(func(retryCount int) (bool, error) {
 

--- a/ecs-cli/modules/cli/compose/entity/service/service_helper.go
+++ b/ecs-cli/modules/cli/compose/entity/service/service_helper.go
@@ -15,16 +15,65 @@ package service
 
 import (
 	"fmt"
+	"sort"
+	"time"
 
 	log "github.com/Sirupsen/logrus"
+	ecscli "github.com/aws/amazon-ecs-cli/ecs-cli/modules/commands"
 	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/utils/waiters"
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ecs"
 )
+
+const TimeOutUpdateService = 1
+
+// serviceEvents is a wrapper for []*ecs.ServiceEvent
+// that allows us to reverse it
+type reverser []*ecs.ServiceEvent
+
+func (s reverser) Len() int {
+	return len(s)
+}
+func (s reverser) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+func (s reverser) Less(i, j int) bool {
+	time1 := *s[i].CreatedAt
+	time2 := *s[j].CreatedAt
+	diff := time1.Sub(time2)
+	return diff.Seconds() < 0
+}
+
+// logNewServiceEvents logs events that have not been logged yet
+func logNewServiceEvents(loggedEvents map[string]bool, events []*ecs.ServiceEvent) {
+
+	// the slice comes ordered so that newer events are first. Logically, we
+	// want to print older events first- so we reverse it
+	sort.Sort(reverser(events))
+	for _, event := range events {
+		if _, ok := loggedEvents[*event.Id]; !ok {
+			// New event that has not been logged yet
+			loggedEvents[*event.Id] = true
+			log.Infof("Service Event %s", event.String())
+		}
+	}
+
+}
 
 // waitForServiceTasks continuously polls ECS (by calling describeService) and waits for service to get stable
 // with desiredCount == runningCount
 func waitForServiceTasks(service *Service, ecsServiceName string) error {
 	timeoutMessage := fmt.Sprintf("Timeout waiting for service %s to get stable", ecsServiceName)
+
+	eventsLogged := make(map[string]bool)
+	var lastRunningCount int64
+	lastRunningCountChangedAt := time.Now()
+	timeOut := float64(TimeOutUpdateService)
+	log.Warnf("Command in Waiter: %s", service.Context().CLIContext.Command.Name)
+
+	if val := service.Context().CLIContext.Float64(ecscli.ComposeServiceTimeOutFlag); val > 0 {
+		timeOut = val
+	}
 
 	return waiters.WaitUntilComplete(func(retryCount int) (bool, error) {
 
@@ -41,16 +90,30 @@ func waitForServiceTasks(service *Service, ecsServiceName string) error {
 			"desiredCount": desiredCount,
 			"runningCount": runningCount,
 		}
+
+		// The deployment was successful
 		if len(ecsService.Deployments) == 1 && desiredCount == runningCount {
 			log.WithFields(logFields).Info("ECS Service has reached a stable state")
 			return true, nil
 		}
 
-		if retryCount%2 == 0 {
+		// Log information only if things have changed
+		// running count has changed
+		if runningCount != lastRunningCount {
+			lastRunningCount = runningCount
+			lastRunningCountChangedAt = time.Now()
 			log.WithFields(logFields).Info("Describe ECS Service status")
-		} else {
-			log.WithFields(logFields).Debug("Describe ECS Service status")
 		}
+
+		// log new service events
+		if len(ecsService.Events) > 0 {
+			logNewServiceEvents(eventsLogged, ecsService.Events)
+		}
+
+		if time.Since(lastRunningCountChangedAt).Minutes() > timeOut {
+			return true, fmt.Errorf("Deployment has not completed: Running count has not changed for %.2f minutes", timeOut)
+		}
+
 		return false, nil
 	}, service, timeoutMessage, true)
 }

--- a/ecs-cli/modules/cli/compose/entity/service/service_helper.go
+++ b/ecs-cli/modules/cli/compose/entity/service/service_helper.go
@@ -86,7 +86,7 @@ func waitForServiceTasks(service *Service, ecsServiceName string) error {
 	} else if val < 0 {
 		return fmt.Errorf("Error with timeout flag: %f is not a valid timeout value", val)
 	} else {
-		log.Warn("Timeout was specified as zero- abandoning all checks, and returning.")
+		log.Warn("Timeout was specified as zero; abandoning all checks and returning.")
 		return nil
 	}
 

--- a/ecs-cli/modules/cli/compose/entity/service/service_helper.go
+++ b/ecs-cli/modules/cli/compose/entity/service/service_helper.go
@@ -59,7 +59,9 @@ func logNewServiceEvents(loggedEvents map[string]bool, events []*ecs.ServiceEven
 			// New event that has not been logged yet
 			loggedEvents[*event.Id] = true
 			if commandTime.Sub(*event.CreatedAt).Seconds() < PrintOnlyNewEvents {
-				log.Infof("Service Event %s", event.String())
+				log.WithFields(log.Fields{
+					"timestamp": *event.CreatedAt},
+				).Info(*event.Message)
 			}
 		}
 	}

--- a/ecs-cli/modules/cli/compose/entity/service/service_helper.go
+++ b/ecs-cli/modules/cli/compose/entity/service/service_helper.go
@@ -25,7 +25,10 @@ import (
 	"github.com/aws/aws-sdk-go/service/ecs"
 )
 
-const TimeOutUpdateService = 1
+// TimeOutUpdateService is the time that the CLI will wait to check if the
+// count of running tasks is changing. If it has not changed then an error is thrown
+// after TimeOutUpdateService minutes
+const TimeOutUpdateService = 5
 
 // serviceEvents is a wrapper for []*ecs.ServiceEvent
 // that allows us to reverse it

--- a/ecs-cli/modules/cli/compose/entity/service/service_helper.go
+++ b/ecs-cli/modules/cli/compose/entity/service/service_helper.go
@@ -86,7 +86,7 @@ func waitForServiceTasks(service *Service, ecsServiceName string) error {
 	} else if val < 0 {
 		return fmt.Errorf("Error with timeout flag: %f is not a valid timeout value", val)
 	} else {
-		log.Warn("Timeout was specified as zero; abandoning all checks and returning.")
+		log.Warn("Timeout was specified as zero. Your service deployment may not have completed yet.")
 		return nil
 	}
 
@@ -109,7 +109,7 @@ func waitForServiceTasks(service *Service, ecsServiceName string) error {
 		if runningCount != lastRunningCount {
 			lastRunningCount = runningCount
 			lastRunningCountChangedAt = time.Now()
-			log.WithFields(logFields).Info("Describe ECS Service status")
+			log.WithFields(logFields).Info("Service status")
 		}
 
 		// log new service events

--- a/ecs-cli/modules/cli/compose/entity/service/service_helper.go
+++ b/ecs-cli/modules/cli/compose/entity/service/service_helper.go
@@ -75,7 +75,6 @@ func waitForServiceTasks(service *Service, ecsServiceName string) error {
 	var lastRunningCount int64
 	lastRunningCountChangedAt := time.Now()
 	timeOut := float64(TimeOutUpdateService)
-	log.Warnf("Command in Waiter: %s", service.Context().CLIContext.Command.Name)
 	timeWhenFunctionCalled := time.Now()
 
 	if val := service.Context().CLIContext.Float64(ecscli.ComposeServiceTimeOutFlag); val > 0 {

--- a/ecs-cli/modules/cli/compose/entity/task/task_helper.go
+++ b/ecs-cli/modules/cli/compose/entity/task/task_helper.go
@@ -25,7 +25,7 @@ import (
 func waitForTasks(task *Task, taskArns map[string]bool) error {
 	timeoutMessage := "Timeout waiting for ECS tasks' status to match desired"
 
-	return waiters.WaitUntilComplete(func(retryCount int) (bool, error) {
+	return waiters.TaskWaitUntilTimeout(func(retryCount int) (bool, error) {
 		if len(taskArns) == 0 {
 			return true, nil
 		}
@@ -46,7 +46,7 @@ func waitForTasks(task *Task, taskArns map[string]bool) error {
 		}
 
 		return false, nil
-	}, task, timeoutMessage, false)
+	}, task, timeoutMessage)
 }
 
 // checkECSTasksStatus iterates through the ecsTasks and checks if the desired status is same as last status

--- a/ecs-cli/modules/cli/compose/entity/task/task_helper.go
+++ b/ecs-cli/modules/cli/compose/entity/task/task_helper.go
@@ -23,7 +23,7 @@ import (
 
 // WaitForTasks continuously polls ECS (by calling descibeTasks) and waits for tasks status to match desired
 func waitForTasks(task *Task, taskArns map[string]bool) error {
-	timeoutMessage := "Timeout waiting for ECS tasks' status to match desired"
+	timeoutMessage := "Timeout waiting for ECS running task count to match desired task count."
 
 	return waiters.TaskWaitUntilTimeout(func(retryCount int) (bool, error) {
 		if len(taskArns) == 0 {

--- a/ecs-cli/modules/commands/compose/service/compose_service_command.go
+++ b/ecs-cli/modules/commands/compose/service/compose_service_command.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 
 	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/cli/compose"
+	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/cli/compose/entity/service"
 	composeFactory "github.com/aws/amazon-ecs-cli/ecs-cli/modules/cli/compose/factory"
 	command "github.com/aws/amazon-ecs-cli/ecs-cli/modules/commands"
 	"github.com/urfave/cli"
@@ -89,7 +90,7 @@ func upServiceCommand(factory composeFactory.ProjectFactory) cli.Command {
 		Name:   "up",
 		Usage:  "Creates an ECS service from your compose file (if it does not already exist) and runs one instance of that task on your cluster (a combination of create and start). This command updates the desired count of the service to 1.",
 		Action: compose.WithProject(factory, compose.ProjectUp, true),
-		Flags:  append(deploymentConfigFlags(true), append(loadBalancerFlags(), command.OptionalClusterFlag(), command.OptionalRegionFlag())...),
+		Flags:  append(deploymentConfigFlags(true), append(loadBalancerFlags(), command.OptionalClusterFlag(), command.OptionalRegionFlag(), ComposeServiceTimeOutFlag())...),
 	}
 }
 
@@ -187,5 +188,16 @@ func loadBalancerFlags() []cli.Flag {
 			Name:  command.RoleFlag,
 			Usage: roleUsageString,
 		},
+	}
+}
+
+// OptionalRegionFlag inline overrides region
+func ComposeServiceTimeOutFlag() cli.Flag {
+	return cli.Float64Flag{
+		Name:  command.ComposeServiceTimeOutFlag,
+		Value: service.TimeOutUpdateService,
+		Usage: fmt.Sprintf(
+			"[Optional] Specifies the time out for the compose service up command.",
+		),
 	}
 }

--- a/ecs-cli/modules/commands/compose/service/compose_service_command.go
+++ b/ecs-cli/modules/commands/compose/service/compose_service_command.go
@@ -81,6 +81,7 @@ func startServiceCommand(factory composeFactory.ProjectFactory) cli.Command {
 		Flags: []cli.Flag{
 			command.OptionalClusterFlag(),
 			command.OptionalRegionFlag(),
+			ComposeServiceTimeOutFlag(),
 		},
 	}
 }
@@ -112,7 +113,7 @@ func scaleServiceCommand(factory composeFactory.ProjectFactory) cli.Command {
 		Name:   "scale",
 		Usage:  "ecs-cli compose service scale [count] - scales the desired count of the service to the specified count",
 		Action: compose.WithProject(factory, compose.ProjectScale, true),
-		Flags:  append(deploymentConfigFlags(false), command.OptionalClusterFlag(), command.OptionalRegionFlag()),
+		Flags:  append(deploymentConfigFlags(false), command.OptionalClusterFlag(), command.OptionalRegionFlag(), ComposeServiceTimeOutFlag()),
 	}
 }
 
@@ -124,6 +125,7 @@ func stopServiceCommand(factory composeFactory.ProjectFactory) cli.Command {
 		Flags: []cli.Flag{
 			command.OptionalClusterFlag(),
 			command.OptionalRegionFlag(),
+			ComposeServiceTimeOutFlag(),
 		},
 	}
 }
@@ -137,6 +139,7 @@ func rmServiceCommand(factory composeFactory.ProjectFactory) cli.Command {
 		Flags: []cli.Flag{
 			command.OptionalClusterFlag(),
 			command.OptionalRegionFlag(),
+			ComposeServiceTimeOutFlag(),
 		},
 	}
 }

--- a/ecs-cli/modules/commands/compose/service/compose_service_command.go
+++ b/ecs-cli/modules/commands/compose/service/compose_service_command.go
@@ -81,7 +81,7 @@ func startServiceCommand(factory composeFactory.ProjectFactory) cli.Command {
 		Flags: []cli.Flag{
 			command.OptionalClusterFlag(),
 			command.OptionalRegionFlag(),
-			ComposeServiceTimeOutFlag(),
+			ComposeServiceTimeoutFlag(),
 		},
 	}
 }
@@ -91,7 +91,7 @@ func upServiceCommand(factory composeFactory.ProjectFactory) cli.Command {
 		Name:   "up",
 		Usage:  "Creates an ECS service from your compose file (if it does not already exist) and runs one instance of that task on your cluster (a combination of create and start). This command updates the desired count of the service to 1.",
 		Action: compose.WithProject(factory, compose.ProjectUp, true),
-		Flags:  append(deploymentConfigFlags(true), append(loadBalancerFlags(), command.OptionalClusterFlag(), command.OptionalRegionFlag(), ComposeServiceTimeOutFlag())...),
+		Flags:  append(deploymentConfigFlags(true), append(loadBalancerFlags(), command.OptionalClusterFlag(), command.OptionalRegionFlag(), ComposeServiceTimeoutFlag())...),
 	}
 }
 
@@ -113,7 +113,7 @@ func scaleServiceCommand(factory composeFactory.ProjectFactory) cli.Command {
 		Name:   "scale",
 		Usage:  "ecs-cli compose service scale [count] - scales the desired count of the service to the specified count",
 		Action: compose.WithProject(factory, compose.ProjectScale, true),
-		Flags:  append(deploymentConfigFlags(false), command.OptionalClusterFlag(), command.OptionalRegionFlag(), ComposeServiceTimeOutFlag()),
+		Flags:  append(deploymentConfigFlags(false), command.OptionalClusterFlag(), command.OptionalRegionFlag(), ComposeServiceTimeoutFlag()),
 	}
 }
 
@@ -125,7 +125,7 @@ func stopServiceCommand(factory composeFactory.ProjectFactory) cli.Command {
 		Flags: []cli.Flag{
 			command.OptionalClusterFlag(),
 			command.OptionalRegionFlag(),
-			ComposeServiceTimeOutFlag(),
+			ComposeServiceTimeoutFlag(),
 		},
 	}
 }
@@ -139,7 +139,7 @@ func rmServiceCommand(factory composeFactory.ProjectFactory) cli.Command {
 		Flags: []cli.Flag{
 			command.OptionalClusterFlag(),
 			command.OptionalRegionFlag(),
-			ComposeServiceTimeOutFlag(),
+			ComposeServiceTimeoutFlag(),
 		},
 	}
 }
@@ -194,8 +194,8 @@ func loadBalancerFlags() []cli.Flag {
 	}
 }
 
-// ComposeServiceTimeOutFlag allows user to specify a custom timeout
-func ComposeServiceTimeOutFlag() cli.Flag {
+// ComposeServiceTimeoutFlag allows user to specify a custom timeout
+func ComposeServiceTimeoutFlag() cli.Flag {
 	return cli.Float64Flag{
 		Name:  command.ComposeServiceTimeOutFlag,
 		Value: service.DefaultUpdateServiceTimeout,

--- a/ecs-cli/modules/commands/compose/service/compose_service_command.go
+++ b/ecs-cli/modules/commands/compose/service/compose_service_command.go
@@ -198,7 +198,7 @@ func loadBalancerFlags() []cli.Flag {
 func ComposeServiceTimeOutFlag() cli.Flag {
 	return cli.Float64Flag{
 		Name:  command.ComposeServiceTimeOutFlag,
-		Value: service.TimeOutUpdateService,
+		Value: service.UpdateServiceTimeout,
 		Usage: fmt.Sprintf(
 			"[Optional] Specifies the time out for the compose service up command.",
 		),

--- a/ecs-cli/modules/commands/compose/service/compose_service_command.go
+++ b/ecs-cli/modules/commands/compose/service/compose_service_command.go
@@ -200,7 +200,7 @@ func ComposeServiceTimeOutFlag() cli.Flag {
 		Name:  command.ComposeServiceTimeOutFlag,
 		Value: service.DefaultUpdateServiceTimeout,
 		Usage: fmt.Sprintf(
-			"[Optional] Specifies the timeout to wait for the running task count to change. If the running task count has not changed for the specified period of time then the CLI will return an error.",
+			"[Optional] Specifies the floating point value timeout in minutes to wait for the running task count to change. If the running task count has not changed for the specified period of time then the CLI will return an error. Setting timeout to 0 will cause the command to return without checking for success.",
 		),
 	}
 }

--- a/ecs-cli/modules/commands/compose/service/compose_service_command.go
+++ b/ecs-cli/modules/commands/compose/service/compose_service_command.go
@@ -194,13 +194,13 @@ func loadBalancerFlags() []cli.Flag {
 	}
 }
 
-// OptionalRegionFlag inline overrides region
+// ComposeServiceTimeOutFlag allows user to specify a custom timeout
 func ComposeServiceTimeOutFlag() cli.Flag {
 	return cli.Float64Flag{
 		Name:  command.ComposeServiceTimeOutFlag,
-		Value: service.UpdateServiceTimeout,
+		Value: service.DefaultUpdateServiceTimeout,
 		Usage: fmt.Sprintf(
-			"[Optional] Specifies the time out for the compose service up command.",
+			"[Optional] Specifies the timeout to wait for the running task count to change. If the running task count has not changed for the specified period of time then the CLI will return an error.",
 		),
 	}
 }

--- a/ecs-cli/modules/commands/compose/service/compose_service_command.go
+++ b/ecs-cli/modules/commands/compose/service/compose_service_command.go
@@ -200,7 +200,7 @@ func ComposeServiceTimeoutFlag() cli.Flag {
 		Name:  command.ComposeServiceTimeOutFlag,
 		Value: service.DefaultUpdateServiceTimeout,
 		Usage: fmt.Sprintf(
-			"Specifies the timeout value in minutes (decimals supported) to wait for the running task count to change. If the running task count has not changed for the specified period of time, then the CLI times out and returns an error. The default timeout value is 5 minutes. Setting the timeout to 0 will cause the command to return without checking for success.",
+			"Specifies the timeout value in minutes (decimals supported) to wait for the running task count to change. If the running task count has not changed for the specified period of time, then the CLI times out and returns an error. Setting the timeout to 0 will cause the command to return without checking for success.",
 		),
 	}
 }

--- a/ecs-cli/modules/commands/compose/service/compose_service_command.go
+++ b/ecs-cli/modules/commands/compose/service/compose_service_command.go
@@ -200,7 +200,7 @@ func ComposeServiceTimeoutFlag() cli.Flag {
 		Name:  command.ComposeServiceTimeOutFlag,
 		Value: service.DefaultUpdateServiceTimeout,
 		Usage: fmt.Sprintf(
-			"[Optional] Specifies the floating point value timeout in minutes to wait for the running task count to change. If the running task count has not changed for the specified period of time then the CLI will return an error. Setting timeout to 0 will cause the command to return without checking for success.",
+			"Specifies the timeout value in minutes (decimals supported) to wait for the running task count to change. If the running task count has not changed for the specified period of time, then the CLI times out and returns an error. The default timeout value is 5 minutes. Setting the timeout to 0 will cause the command to return without checking for success.",
 		),
 	}
 }

--- a/ecs-cli/modules/commands/flags.go
+++ b/ecs-cli/modules/commands/flags.go
@@ -75,6 +75,7 @@ const (
 	ContainerPortFlag                       = "container-port"
 	LoadBalancerNameFlag                    = "load-balancer-name"
 	RoleFlag                                = "role"
+	ComposeServiceTimeOutFlag               = "time-out"
 )
 
 // OptionalClusterFlag inline overrides cluster

--- a/ecs-cli/modules/commands/flags.go
+++ b/ecs-cli/modules/commands/flags.go
@@ -75,7 +75,7 @@ const (
 	ContainerPortFlag                       = "container-port"
 	LoadBalancerNameFlag                    = "load-balancer-name"
 	RoleFlag                                = "role"
-	ComposeServiceTimeOutFlag               = "time-out"
+	ComposeServiceTimeOutFlag               = "timeout"
 )
 
 // OptionalClusterFlag inline overrides cluster


### PR DESCRIPTION
- Added a configurable timeout
`ecs-cli compose service up --timeout 5`
  - If the running count of tasks is still not at the desired count and has not changed for timeout minutes, then the CLI times out. 
  - timeout defaults to 5 minutes
  - This addresses the problems with the current behavior which cause large deployments to timeout even though progress in starting tasks is being made and the update will eventually succeed.
- Improved error/info messages
  - the service event logs are now printed 
  - new events are printed only (note that ECS may not always emit events)

Addresses #286
closes #269 

Help Text:

   --timeout value                         [Optional] Specifies the floating point value timeout in minutes to wait for the running task count to change. If the running task count has not changed for the specified period of time then the CLI will return an error. Setting timeout to 0 will cause the command to return without checking for success. (default: 5)


### Examples/Testing

### service up (update)
```
$ ecs-cli compose service up --timeout 5
INFO[0000] Using ECS task definition                     TaskDefinition="ecscompose-test2:8"
INFO[0000] ECS Service is already running                desiredCount=1 serviceName=ecscompose-service-test2                
INFO[0000] Describe ECS Service status                   desiredCount=1 runningCount=1 serviceName=ecscompose-service-test2
INFO[0000] (service ecscompose-service-test2) has started 1 tasks: (task ae4c2af5-bc96-477f-a17e-577ff1252b8c).  timestamp=2017-07-31 15:43:25 +0000 UTC
INFO[0000] (service ecscompose-service-test2) has reached a steady state.  timestamp=2017-07-31 15:43:37 +0000 UTC
INFO[0000] (service ecscompose-service-test2) was unable to place a task because no container instance met all of its requirements. The closest matching (container-instance 2656b713-3dc3-4f30-8294-717a9e2d346d) is already using a port required by your task. For more information, see the Troubleshooting section of the Amazon ECS Developer Guide.  timestamp=2017-08-01 15:54:33 +0000 UTC
FATA[0060] Deployment has not completed: Running count has not changed for 5.00 minutes 
```

### service down
```
$ ecs-cli compose service down
INFO[0000] Updated ECS service successfully              desiredCount=0 serviceName=ecscompose-service-test2
INFO[0000] Describe ECS Service status                   desiredCount=0 runningCount=1 serviceName=ecscompose-service-test2
INFO[0090] Describe ECS Service status                   desiredCount=0 runningCount=0 serviceName=ecscompose-service-test2
INFO[0090] (service ecscompose-service-test2) has stopped 1 running tasks: (task ae4c2af5-bc96-477f-a17e-577ff1252b8c).  timestamp=2017-08-01 22:10:54 +0000 UTC
INFO[0105] ECS Service has reached a stable state        desiredCount=0 runningCount=0 serviceName=ecscompose-service-test2
INFO[0106] Deleted ECS service                           service=ecscompose-service-test2
INFO[0106] ECS Service has reached a stable state        desiredCount=0 runningCount=0 serviceName=ecscompose-service-test2
```

### service scale
```
$ ecs-cli compose service scale 2 --timeout 1  
WARN[0000] Skipping unsupported YAML option...           option name=networks
WARN[0000] Skipping unsupported YAML option for service...  option name=networks service name=mysql
WARN[0000] Skipping unsupported YAML option for service...  option name=networks service name=wordpress
INFO[0000] Updated ECS service successfully              desiredCount=2 serviceName=ecscompose-service-test2                      
INFO[0000] Describe ECS Service status                   desiredCount=2 runningCount=1 serviceName=ecscompose-service-test2
INFO[0015] (service ecscompose-service-test2) was unable to place a task because no container instance met all of its requirements. The closest matching (container-instance 2656b713-3dc3-4f30-8294-717a9e2d346d) is already using a port required by your task. For more information, see the Troubleshooting section of the Amazon ECS Developer Guide.  timestamp=2017-08-01 23:57:23 +0000 UTC
FATA[0060] Deployment has not completed: Running count has not changed for 1.00 minutes 
```

### Service Start
```
wppttt test2 (master) $ ecs-cli compose service start --timeout 1
WARN[0000] Skipping unsupported YAML option...           option name=networks
WARN[0000] Skipping unsupported YAML option for service...  option name=networks service name=wordpress
WARN[0000] Skipping unsupported YAML option for service...  option name=networks service name=mysql
INFO[0000] Updated ECS service successfully              desiredCount=1 serviceName=ecscompose-service-test2           
INFO[0030] Describe ECS Service status                   desiredCount=1 runningCount=1 serviceName=ecscompose-service-test2
INFO[0030] (service ecscompose-service-test2) has started 1 tasks: (task b0041954-c3d9-4b19-a7d5-8c8263a98ff9).  timestamp=2017-08-01 23:40:58 +0000 UTC
INFO[0030] (service ecscompose-service-test2) has reached a steady state.  timestamp=2017-08-01 23:41:09 +0000 UTC
INFO[0030] ECS Service has reached a stable state        desiredCount=1 runningCount=1 serviceName=ecscompose-service-test2
```

### Service Stop
```
$ ecs-cli compose service stop --timeout 2
WARN[0000] Skipping unsupported YAML option...           option name=networks
WARN[0000] Skipping unsupported YAML option for service...  option name=networks service name=mysql
WARN[0000] Skipping unsupported YAML option for service...  option name=networks service name=wordpress
INFO[0000] Updated ECS service successfully              desiredCount=0 serviceName=ecscompose-service-test2                          
INFO[0000] Describe ECS Service status                   desiredCount=0 runningCount=1 serviceName=ecscompose-service-test2
INFO[0030] Describe ECS Service status                   desiredCount=0 runningCount=0 serviceName=ecscompose-service-test2
INFO[0030] (service ecscompose-service-test2) has stopped 1 running tasks: (task b8a4162f-9ae8-4402-8182-17f12ebce2f8).  timestamp=2017-08-02 00:19:15 +0000 UTC
INFO[0030] (service ecscompose-service-test2) has reached a steady state.  timestamp=2017-08-02 00:19:26 +0000 UTC
INFO[0030] ECS Service has reached a stable state        desiredCount=0 runningCount=0 serviceName=ecscompose-service-test2
```


### Service scale with tons of tasks
(also tested scale with 1000 ;D)
```
$ ecs-cli compose --file redis.yml service scale 50 --cluster BIG
INFO[0000] Updated ECS service successfully              desiredCount=50 serviceName=ecscompose-service-testBIG
INFO[0000] Describe ECS Service status                   desiredCount=50 runningCount=1 serviceName=ecscompose-service-testBIG
INFO[0015] Describe ECS Service status                   desiredCount=50 runningCount=19 serviceName=ecscompose-service-testBIG
INFO[0015] (service ecscompose-service-testBIG) has started 20 tasks: (task 28b60088-52b1-46c2-bd0f-19dd5a8bc3c8) (task 1adaddc2-78e9-40ab-8f89-198cff8f263c) (task 6490e1c6-6622-44fd-bf50-2ce47e03ad90) (task 12f3544c-4803-4b59-adcb-16d20749a7be) (task c9249bf7-f2a9-4067-bcb4-74efef0d3144) (task f12e49b6-2601-4af6-b4ec-e4b8c7887264) (task 7d47e6b9-3745-41ae-ac92-a9bfd6c5c8fe) (task b242b3dc-ddb6-4f2b-add8-b52817f790b4) (task 4792747b-02c7-43e2-a74d-a2c6c2f63f81) (task 11ed41fe-6045-428e-aed7-2577fed078d5) (task 12355da2-bb98-4d50-814e-2df40935b30d) (task e2cd7099-f0ea-4970-bca3-1744b467340a) (task a894b725-fe2f-4c3a-858b-54aaaabef858) (task baddca9b-1671-42a8-b0a4-900c516ab5d4) (task 847d17a1-278c-4b48-b97d-c83de11e41ca) (task b5748eb5-5bd5-4aa2-a226-1224c6c61595) (task 0851f4cd-b8ee-41cf-a510-c6a5ee7fb133) (task 979ad2df-74f6-46c0-9689-9af20737abff) (task 86f66da4-28c7-45ee-828b-aff58814224b) (task f786b3f2-fbc2-44c9-a4e9-d632f11fa4f4).  timestamp=2017-08-03 00:02:38 +0000 UTC
INFO[0030] Describe ECS Service status                   desiredCount=50 runningCount=41 serviceName=ecscompose-service-testBIG
INFO[0030] (service ecscompose-service-testBIG) has started 20 tasks: (task 6b7d32da-0c23-4e0c-858a-b5eaeb78bbec) (task 35002aed-a2d0-466b-94ce-8f0a5e288726) (task 3fd5b0a0-20e9-4d5e-ba77-c43a24236fe7) (task 984efeff-bfce-4a71-b3a3-4721820442e8) (task f84be0ec-e31e-4f5d-b5b6-a4716f922694) (task 0eea7970-32e9-400d-aa0b-8bf4999f245d) (task 86d3084a-2587-45c2-818f-6ae0d9c974d2) (task ed974240-1773-4a4f-8332-83169535a019) (task 02e8f99f-503f-4a5d-bc9a-1305a1fac3c2) (task 64cc11df-909d-47df-8e20-9eef894b6e7d) (task ecfb6e00-6a7a-4892-9f8c-da65f5bb4c53) (task d348f707-7ee1-4cef-a7a6-c94c7c6d4d93) (task 4a506859-21b5-4539-93f4-aa477c9427c9) (task 83734c49-e71b-4a00-ad3d-dac4f577aeb7) (task e952fd0f-1a28-4696-93bc-aa2fc63cdce1) (task 2eae0f6c-e944-4450-876b-a1850b4f2c93) (task 2b1a3e30-dbe8-4582-96af-83dfd92bb0a0) (task 5f852ccb-0f9c-4ffb-b3f9-df9a918dffdb) (task b3579e2a-7f06-4393-b61c-9fa6949b9c90) (task 62ded48e-83af-439f-84d2-a7a2487979b1).  timestamp=2017-08-03 00:02:48 +0000 UTC
INFO[0045] Describe ECS Service status                   desiredCount=50 runningCount=50 serviceName=ecscompose-service-testBIG
INFO[0045] (service ecscompose-service-testBIG) has started 9 tasks: (task 9a696013-5736-404d-a01d-52523e6e1391) (task 6b038e55-f58c-402a-b864-a1b56f8e3e2a) (task 847da4b2-8974-4264-a150-d313d12b215a) (task eacec388-ce95-4863-946f-33c6b6998c81) (task 6f575f65-0221-4cf2-b82f-41177024a306) (task 77d92e8e-e403-4c12-88d8-1f887589a1d6) (task 9d1b548f-befa-443b-845a-082af5b5eb48) (task f3605ab8-d556-44c9-9f10-477f816dbd4f) (task ab4bfdce-fdb8-4081-b1f2-f224072cf840).  timestamp=2017-08-03 00:02:57 +0000 UTC
INFO[0045] (service ecscompose-service-testBIG) has reached a steady state.  timestamp=2017-08-03 00:03:07 +0000 UTC
INFO[0045] ECS Service has reached a stable state        desiredCount=50 runningCount=50 serviceName=ecscompose-service-testBIG
```