### PR TITLE
Modifications to publishing scripts to support China Regions

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,19 @@ verify the integrity of your download.
 * Windows:
   * (Not yet implemented)
 
+#### Download Links for within China
+
+As of v0.6.2 the ECS CLI supports the cn-north-1 region in China. The following links are the exact same binaries, but they are localized within China to provide a faster download experience.
+
+* Linux:
+  * [https://s3.cn-north-1.amazonaws.com.cn/amazon-ecs-cli/ecs-cli-linux-amd64-latest](https://s3.cn-north-1.amazonaws.com.cn/amazon-ecs-cli/ecs-cli-linux-amd64-latest)
+  * [https://s3.cn-north-1.amazonaws.com.cn/amazon-ecs-cli/ecs-cli-linux-amd64-latest.md5](https://s3.cn-north-1.amazonaws.com.cn/amazon-ecs-cli/ecs-cli-linux-amd64-latest.md5)
+* Macintosh:
+  * [https://s3.cn-north-1.amazonaws.com.cn/amazon-ecs-cli/ecs-cli-darwin-amd64-latest](https://s3.cn-north-1.amazonaws.com.cn/amazon-ecs-cli/ecs-cli-darwin-amd64-latest)
+  * [https://s3.cn-north-1.amazonaws.com.cn/amazon-ecs-cli/ecs-cli-darwin-amd64-latest.md5](https://s3.cn-north-1.amazonaws.com.cn/amazon-ecs-cli/ecs-cli-darwin-amd64-latest.md5)
+  * Windows:
+    * (Not yet implemented)
+
 ### Download specific version
 Using the URLs above, replace `latest` with the desired tag, for example `v0.4.1`. After downloading, remember to rename the binary file to `ecs-cli`.
 

--- a/scripts/publish-functions.sh
+++ b/scripts/publish-functions.sh
@@ -44,10 +44,19 @@ s3_cp() {
 	if [[ ! -z "${AWS_PROFILE}" ]]; then
 		profile="--profile=${AWS_PROFILE}"
 	fi
+	if [[ ! -z "${AWS_PROFILE_PUSH}" ]]; then
+		profile_push="--profile=${AWS_PROFILE_PUSH}"
+	else
+		profile_push=$profile
+	fi
 	acl="public-read"
 	if [[ ! -z "${S3_ACL_OVERRIDE}" ]]; then
 		acl="${S3_ACL_OVERRIDE}"
 	fi
 	echo "Copying ${1} to ${2}"
-	aws ${profile} s3 cp "${1}" "${2}" "--acl=${acl}"
+	# for partitioned regions, we cannot copy files between buckets directly. Save it locally and copy it over
+	tmp=$(mktemp)
+	aws ${profile} s3 cp "${1}" "${tmp}"
+	aws ${profile_push} s3 cp "${tmp}" "${2}" "--acl=${acl}"
+	rm $tmp
 }

--- a/scripts/publish-staged
+++ b/scripts/publish-staged
@@ -33,6 +33,7 @@ usage() {
 	echo "Options"
 	echo "  -d  true|false  Dryrun (default is true)"
 	echo "  -p  PROFILE     AWS CLI Profile (default is none)"
+	echo "  -o  PROFILE     AWS CLI Profile for the bucket to push to (defaults to the profile specified with -p)"
 	echo "  -s  BUCKET      AWS S3 Bucket for staging"
 	echo "  -b  BUCKET      AWS S3 Bucket for publishing (default is ${PUBLISH_S3_BUCKET})"
 	echo "  -a  ACL         AWS S3 Object Canned ACL (default is public-read)"
@@ -50,7 +51,7 @@ publish_s3() {
 	done
 }
 
-while getopts ":d:p:s:b:i:a:h" opt; do
+while getopts ":d:p:o:s:b:i:a:h" opt; do
 	case ${opt} in
 		d)
 			if [[ "${OPTARG}" = "false" ]]; then
@@ -59,6 +60,9 @@ while getopts ":d:p:s:b:i:a:h" opt; do
 			;;
 		p)
 			AWS_PROFILE="${OPTARG}"
+			;;
+		o)
+			AWS_PROFILE_PUSH="${OPTARG}"
 			;;
 		s)
 			STAGE_S3_BUCKET="${OPTARG}"


### PR DESCRIPTION
- Updated scripts so that they can push to buckets across partitions (cn-north-1)
- One account is used to pull from the staging S3 bucket (alpha), and then another account is used for the push to the public S3 bucket- this is necessary because copying across partitions is not supported (the China regions are separated from the rest of AWS and require separate accounts).

Testing done:
```
$ ./scripts/publish-staged -d false -p cli -o cli-bjs -s ec2-madison-alpha-cli
Publishing as ecs-cli-linux-amd64-v0.6.2
RUNNING: s3_cp s3://ec2-madison-alpha-cli/ecs-cli-linux-amd64-v0.6.2 s3://amazon-ecs-cli/ecs-cli-linux-amd64-v0.6.2
Copying s3://ec2-madison-alpha-cli/ecs-cli-linux-amd64-v0.6.2 to s3://amazon-ecs-cli/ecs-cli-linux-amd64-v0.6.2
download: s3://ec2-madison-alpha-cli/ecs-cli-linux-amd64-v0.6.2 to ./temp
upload: ./temp to s3://amazon-ecs-cli/ecs-cli-linux-amd64-v0.6.2   
/Users/wppttt/go/src/github.com/aws/amazon-ecs-cli
RUNNING: s3_cp s3://ec2-madison-alpha-cli/ecs-cli-linux-amd64-v0.6.2.md5 s3://amazon-ecs-cli/ecs-cli-linux-amd64-v0.6.2.md5
Copying s3://ec2-madison-alpha-cli/ecs-cli-linux-amd64-v0.6.2.md5 to s3://amazon-ecs-cli/ecs-cli-linux-amd64-v0.6.2.md5
download: s3://ec2-madison-alpha-cli/ecs-cli-linux-amd64-v0.6.2.md5 to ./temp
upload: ./temp to s3://amazon-ecs-cli/ecs-cli-linux-amd64-v0.6.2.md5
/Users/wppttt/go/src/github.com/aws/amazon-ecs-cli
Publishing as ecs-cli-darwin-amd64-v0.6.2
RUNNING: s3_cp s3://ec2-madison-alpha-cli/ecs-cli-darwin-amd64-v0.6.2 s3://amazon-ecs-cli/ecs-cli-darwin-amd64-v0.6.2
Copying s3://ec2-madison-alpha-cli/ecs-cli-darwin-amd64-v0.6.2 to s3://amazon-ecs-cli/ecs-cli-darwin-amd64-v0.6.2
download: s3://ec2-madison-alpha-cli/ecs-cli-darwin-amd64-v0.6.2 to ./temp
upload: ./temp to s3://amazon-ecs-cli/ecs-cli-darwin-amd64-v0.6.2  
/Users/wppttt/go/src/github.com/aws/amazon-ecs-cli
RUNNING: s3_cp s3://ec2-madison-alpha-cli/ecs-cli-darwin-amd64-v0.6.2.md5 s3://amazon-ecs-cli/ecs-cli-darwin-amd64-v0.6.2.md5
Copying s3://ec2-madison-alpha-cli/ecs-cli-darwin-amd64-v0.6.2.md5 to s3://amazon-ecs-cli/ecs-cli-darwin-amd64-v0.6.2.md5
download: s3://ec2-madison-alpha-cli/ecs-cli-darwin-amd64-v0.6.2.md5 to ./temp
upload: ./temp to s3://amazon-ecs-cli/ecs-cli-darwin-amd64-v0.6.2.md5
/Users/wppttt/go/src/github.com/aws/amazon-ecs-cli
Publishing as ecs-cli-linux-amd64-73a3c25
RUNNING: s3_cp s3://ec2-madison-alpha-cli/ecs-cli-linux-amd64-73a3c25 s3://amazon-ecs-cli/ecs-cli-linux-amd64-73a3c25
Copying s3://ec2-madison-alpha-cli/ecs-cli-linux-amd64-73a3c25 to s3://amazon-ecs-cli/ecs-cli-linux-amd64-73a3c25
```
