### PR TITLE
Proposal for Automated Testing (Integration tests)

### DIFF
--- a/ecs-cli/integration-tests/EcsClient.go
+++ b/ecs-cli/integration-tests/EcsClient.go
@@ -1,0 +1,249 @@
+// Copyright 2015-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package integration
+
+import (
+	"fmt"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/config"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ecs"
+	"github.com/aws/aws-sdk-go/service/ecs/ecsiface"
+)
+
+// ecsChunkSize is the maximum number of elements to pass into a describe api
+const ecsChunkSize = 100
+
+type ProcessTasksAction func(tasks []*ecs.Task) error
+
+// ECSClient is an interface that specifies only the methods used from the sdk interface. Intended to make mocking and testing easier.
+type ECSClient interface {
+
+	// Cluster related
+	DeleteCluster(clusterName string) (string, error)
+	IsActiveCluster(clusterName string) (bool, error)
+
+	// Service related
+	DescribeService(serviceName string) (*ecs.DescribeServicesOutput, error)
+	DeleteService(serviceName string) error
+
+	// Task Definition related
+	DescribeTaskDefinition(taskDefinitionName string) (*ecs.TaskDefinition, error)
+
+	// Tasks related
+	GetTasksPages(listTasksInput *ecs.ListTasksInput, fn ProcessTasksAction) error
+	StopTask(taskID string) error
+	DescribeTasks(taskIds []*string) ([]*ecs.Task, error)
+
+	// Container Instance related
+	GetEC2InstanceIDs(containerInstanceArns []*string) (map[string]string, error)
+}
+
+// ecsClient implements ECSClient
+type ecsClient struct {
+	client ecsiface.ECSAPI
+	params *config.CliParams
+}
+
+// NewECSClient creates a new ECS client
+func NewECSClient(params *config.CliParams) ECSClient {
+	ecs := &ecsClient{}
+	ecs.Initialize(params)
+	return ecs
+}
+
+func (c *ecsClient) Initialize(params *config.CliParams) {
+	client := ecs.New(params.Session)
+	c.client = client
+	c.params = params
+}
+
+func (c *ecsClient) DeleteCluster(clusterName string) (string, error) {
+	resp, err := c.client.DeleteCluster(&ecs.DeleteClusterInput{Cluster: &clusterName})
+	if err != nil {
+		log.WithFields(log.Fields{
+			"cluster": clusterName,
+			"error":   err,
+		}).Error("Failed to Delete Cluster")
+		return "", err
+	}
+	log.WithFields(log.Fields{
+		"cluster": *resp.Cluster.ClusterName,
+	}).Info("Deleted cluster")
+	return *resp.Cluster.ClusterName, nil
+}
+
+func (c *ecsClient) DeleteService(serviceName string) error {
+	_, err := c.client.DeleteService(&ecs.DeleteServiceInput{
+		Service: aws.String(serviceName),
+		Cluster: aws.String(c.params.Cluster),
+	})
+	if err != nil {
+		log.WithFields(log.Fields{
+			"service": serviceName,
+			"error":   err,
+		}).Error("Error deleting service")
+		return err
+	}
+	log.WithFields(log.Fields{"service": serviceName}).Info("Deleted ECS service")
+	return nil
+}
+
+func (c *ecsClient) DescribeService(serviceName string) (*ecs.DescribeServicesOutput, error) {
+	output, err := c.client.DescribeServices(&ecs.DescribeServicesInput{
+		Services: []*string{aws.String(serviceName)},
+		Cluster:  aws.String(c.params.Cluster),
+	})
+	if err != nil {
+		log.WithFields(log.Fields{
+			"service": serviceName,
+			"error":   err,
+		}).Error("Error describing service")
+		return nil, err
+	}
+	return output, err
+}
+
+func (c *ecsClient) DescribeTaskDefinition(taskDefinitionName string) (*ecs.TaskDefinition, error) {
+	resp, err := c.client.DescribeTaskDefinition(&ecs.DescribeTaskDefinitionInput{
+		TaskDefinition: aws.String(taskDefinitionName),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return resp.TaskDefinition, nil
+
+}
+
+// GetTasksPages lists and describe tasks per page and executes the custom function supplied
+// any time any call returns error, the processing stops and appropriate error is returned
+func (c *ecsClient) GetTasksPages(listTasksInput *ecs.ListTasksInput, tasksFunc ProcessTasksAction) error {
+	listTasksInput.Cluster = aws.String(c.params.Cluster)
+	var outErr error
+	err := c.client.ListTasksPages(listTasksInput, func(page *ecs.ListTasksOutput, end bool) bool {
+		if len(page.TaskArns) == 0 {
+			return false
+		}
+		// describe this page of tasks
+		resp, err := c.DescribeTasks(page.TaskArns)
+		if err != nil {
+			outErr = err
+			return false
+		}
+		// execute custom function
+		if err = tasksFunc(resp); err != nil {
+			outErr = err
+			return false
+		}
+		return true
+	})
+
+	if err != nil {
+		log.WithFields(log.Fields{
+			"request": listTasksInput,
+			"error":   err,
+		}).Error("Error listing tasks")
+		return err
+	}
+	if outErr != nil {
+		return outErr
+	}
+	return nil
+}
+
+func (c *ecsClient) DescribeTasks(taskArns []*string) ([]*ecs.Task, error) {
+	descTasksRequest := &ecs.DescribeTasksInput{
+		Tasks:   taskArns,
+		Cluster: aws.String(c.params.Cluster),
+	}
+	descTasksResp, err := c.client.DescribeTasks(descTasksRequest)
+	if descTasksResp == nil || err != nil {
+		log.WithFields(log.Fields{
+			"request": descTasksResp,
+			"error":   err,
+		}).Error("Error describing tasks")
+		return nil, err
+	}
+	return descTasksResp.Tasks, nil
+}
+
+func (c *ecsClient) StopTask(taskID string) error {
+	_, err := c.client.StopTask(&ecs.StopTaskInput{
+		Cluster: aws.String(c.params.Cluster),
+		Task:    aws.String(taskID),
+	})
+	if err != nil {
+		log.WithFields(log.Fields{
+			"taskId": taskID,
+			"error":  err,
+		}).Error("Stop task failed")
+	}
+	return err
+}
+
+// GetEC2InstanceIds returns a map of container instance arn to ec2 instance id
+func (c *ecsClient) GetEC2InstanceIDs(containerInstanceArns []*string) (map[string]string, error) {
+	containerToEC2InstanceMap := map[string]string{}
+	for i := 0; i < len(containerInstanceArns); i += ecsChunkSize {
+		var chunk []*string
+		if i+ecsChunkSize > len(containerInstanceArns) {
+			chunk = containerInstanceArns[i:len(containerInstanceArns)]
+		} else {
+			chunk = containerInstanceArns[i : i+ecsChunkSize]
+		}
+		descrContainerInstances, err := c.client.DescribeContainerInstances(&ecs.DescribeContainerInstancesInput{
+			Cluster:            aws.String(c.params.Cluster),
+			ContainerInstances: chunk,
+		})
+		if err != nil {
+			log.WithFields(log.Fields{
+				"containerInstancesCount": len(containerInstanceArns),
+				"error":                   err,
+			}).Error("Error describing container instance")
+			return nil, err
+		}
+		for _, containerInstance := range descrContainerInstances.ContainerInstances {
+			if containerInstance.Ec2InstanceId != nil {
+				containerToEC2InstanceMap[aws.StringValue(containerInstance.ContainerInstanceArn)] = aws.StringValue(containerInstance.Ec2InstanceId)
+			}
+		}
+	}
+	return containerToEC2InstanceMap, nil
+}
+
+// IsActiveCluster returns true if the cluster exists and can be described.
+func (c *ecsClient) IsActiveCluster(clusterName string) (bool, error) {
+	output, err := c.client.DescribeClusters(&ecs.DescribeClustersInput{
+		Clusters: []*string{aws.String(clusterName)},
+	})
+
+	if err != nil {
+		return false, err
+	}
+
+	if len(output.Failures) > 0 {
+		return false, nil
+	} else if len(output.Clusters) == 0 {
+		return false, fmt.Errorf("Got an empty list of clusters while describing the cluster '%s'", clusterName)
+	}
+
+	status := aws.StringValue(output.Clusters[0].Status)
+	if "ACTIVE" == status {
+		return true, nil
+	}
+
+	log.WithFields(log.Fields{"cluster": clusterName, "status": status}).Debug("cluster status")
+	return false, nil
+}

--- a/ecs-cli/integration-tests/Proposal.md
+++ b/ecs-cli/integration-tests/Proposal.md
@@ -1,0 +1,57 @@
+<!--
+ Copyright 2015-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License"). You may
+ not use this file except in compliance with the License. A copy of the
+ License is located at
+
+ http://aws.amazon.com/apache2.0/
+
+ or in the "license" file accompanying this file. This file is distributed
+ on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ express or implied. See the License for the specific language governing
+ permissions and limitations under the License.
+-->
+
+# Introduction
+
+Currently the CLI only has unit tests for each package, there is no way to programmatically ensure that commands work as intended. This requires the team to waste time manually testing and running commands, and increases the likelihood of buggy code being released to the public (which decreases customer trust in our CLI).
+
+# Proposal
+
+## Tooling
+
+Many tools exist for testing command line tools, however, in general their purpose is to verify that the terminal output of a command is correct (Example https://en.wikipedia.org/wiki/Expect). For the ECS CLI, this should not be the primary goal- the output of many of our commands is not deterministic (for example, the output is often a stream of updates on the status of a cluster/service/task/etc). Moreover, the output that is most important to test from a user point of view, is not the terminal text output, but the affects of the command caused on AWS services. For example, our primary aim in testing the cluster up command is that a cluster is actually created in ECS with the correct number and type of instances, etc. (This is not to suggest however that output verification is not something that we would eventually want to have as well).
+
+Therefore, the AWS go SDK will be used to make calls to AWS to verify that the resources are correctly being created. The integration tests can be written in go, and committed to the existing ECS CLI repository.
+
+## Workflow
+
+Here is the flow for how the unit tests will work:
+1. TestMain function sets up AWS resources needed for the test
+  * Key Pairs
+  * Default clusters to deploy tasks/services to
+  * Configure the CLI
+2. Individual test cases will test commands
+  1. Use the `os` library to shell out command
+  2. Use the AWS SDK to verify that the correct affects on AWS resources have occurred (these checks could be deep or shallow, depending upon how much effort we want to put into these tests).
+
+
+## Demo
+
+This proposal is accompanied with a demo, which contains code to run a single very simple test case. This can be quickly built upon to create new test cases. It uses `go test`, the built in testing framework for Golang. The tests use testing.Short to ensure that IDEs like Atom won't automatically run the integration tests.
+(The demo is currently just skeleton code- 0.5-1 days of dedicated effort is needed to complete it.)
+
+## Plan
+
+At this point in time, no one on the team has enough bandwidth to dedicate the time necessary to make the unit tests a reality. Here is a more realistic plan for how we could add integration tests to the whole CLI:
+- 1-2 days more time can be spent to set things up and add a few basic test cases
+- Mandate that for every new pull request/feature, there must be new integration tests- over time this will allow us to slowly build up integration tests overtime, without slowing down the release of any individual feature much at all.
+
+## Design Concerns
+
+The main issue with any proposal for automated running of commands is that an AWS account will be needed for testing, and the tests themselves need to have credentials. In this proposal, this has been solved using environment variables to specify the credentials for an account. However, it is uncertain whether this is the best option- comment and counter proposals are welcomed. 
+
+## Future Work
+
+Eventually, the integration tests can be integrated with Travis and run automatically when someone creates a PR on Github.

--- a/ecs-cli/integration-tests/cluster_commands_test.go
+++ b/ecs-cli/integration-tests/cluster_commands_test.go
@@ -1,0 +1,21 @@
+// Copyright 2015-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package integration
+
+import "testing"
+
+func TestComposeUp(t *testing.T) {
+	LongRunningTest(t)
+
+}

--- a/ecs-cli/integration-tests/compose-files/docker-compose.override.yml
+++ b/ecs-cli/integration-tests/compose-files/docker-compose.override.yml
@@ -1,0 +1,10 @@
+version: '2'
+services:
+  wordpress:
+    image: wordpress
+    cpu_shares: 100
+    mem_limit: 524288000
+    ports:
+      - "80:80"
+    links:
+      - mysql

--- a/ecs-cli/integration-tests/compose-files/docker-compose.yml
+++ b/ecs-cli/integration-tests/compose-files/docker-compose.yml
@@ -1,0 +1,8 @@
+version: '2'
+services:
+  mysql:
+    image: mysql
+    cpu_shares: 100
+    mem_limit: 524288000
+    environment:
+      MYSQL_ROOT_PASSWORD: password

--- a/ecs-cli/integration-tests/example_commands_test.go
+++ b/ecs-cli/integration-tests/example_commands_test.go
@@ -1,0 +1,36 @@
+// Copyright 2015-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package integration
+
+import (
+	"os/exec"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestComposeServiceUp(t *testing.T) {
+	LongRunningTest(t)
+
+	// run the command
+	cmdArgs := []string{"compose", "service", "-f", "compose-files/docker-compose.yml", "up"}
+	if _, err := exec.Command("ecs-cli", cmdArgs...).Output(); err != nil {
+		assert.NoError(t, err, "Unexpected error when running compose service up command")
+	}
+
+	ecsClient, err := CreateEcsClient()
+	assert.NoError(t, err, "Unexpected Error creating ecs client")
+	ecsClient.DescribeService("compose-service-name-prefix-integration-tests") //TODO: Check that this is the right name
+
+}

--- a/ecs-cli/integration-tests/main_test.go
+++ b/ecs-cli/integration-tests/main_test.go
@@ -1,0 +1,121 @@
+// Copyright 2015-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package integration
+
+import (
+	"os"
+	"os/exec"
+	"testing"
+	"time"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/config"
+)
+
+const (
+	TestClusterPrefix = "Integration-Test-Main-Cluster-"
+)
+
+func TestMain(m *testing.M) {
+	if checkEnv() {
+		setup()
+		code := m.Run()
+		os.Exit(code)
+	} else {
+		logrus.Error("Environment Not Set")
+		os.Exit(1)
+	}
+}
+
+func GetDefaultClusterName() string {
+	return TestClusterPrefix + time.Now().UTC().Format("01-02--03_04_05PM")
+}
+
+// do setup for the integration tests
+func setup() error {
+	// Configure the cli
+	region := os.Getenv("INTEGRATION_TEST_PRIMARY_REGION")
+	accessKey := os.Getenv("INTEGRATION_TEST_ACCESS_KEY")
+	secretKey := os.Getenv("INTEGRATION_TEST_SECRET_KEY")
+	if err := ConfigureCommand(GetDefaultClusterName(), region, accessKey, secretKey); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func ConfigureCommand(cluster string, region string, accessKey string, secretKey string) error {
+	// ecs-cli configure --region $INTEGRATION_TEST_PRIMARY_REGION --access-key $INTEGRATION_TEST_ACCESS_KEY --secret-key $INTEGRATION_TEST_SECRET_KEY --cluster defualt
+	cmdArgs := []string{"configure", "--region", region, "--access-key", accessKey, "--secret-key", secretKey, "--cluster", cluster}
+	if _, err := exec.Command("ecs-cli", cmdArgs...).Output(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func ClusterUpCommand(cluster string, region string, accessKey string, secretKey string) error {
+	// ecs-cli configure --region $INTEGRATION_TEST_PRIMARY_REGION --access-key $INTEGRATION_TEST_ACCESS_KEY --secret-key $INTEGRATION_TEST_SECRET_KEY --cluster defualt
+	cmdArgs := []string{"configure", "--region", region, "--access-key", accessKey, "--secret-key", secretKey, "--cluster", cluster}
+	if _, err := exec.Command("ecs-cli", cmdArgs...).Output(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func CreateEcsClient() (ECSClient, error) {
+	ecsConfig := &config.CliConfig{}
+	ecsConfig.Cluster = GetDefaultClusterName()
+	ecsConfig.Region = os.Getenv("INTEGRATION_TEST_PRIMARY_REGION")
+	ecsConfig.AwsAccessKey = os.Getenv("INTEGRATION_TEST_ACCESS_KEY")
+	ecsConfig.AwsSecretKey = os.Getenv("INTEGRATION_TEST_SECRET_KEY")
+
+	svcSession, err := ecsConfig.ToAWSSession()
+	if err != nil {
+		return nil, err
+	}
+
+	params := &config.CliParams{
+		Cluster: ecsConfig.Cluster,
+		Session: svcSession,
+	}
+
+	return NewECSClient(params), nil
+}
+
+func LongRunningTest(t *testing.T) {
+	if testing.Short() {
+		// prevents test from running when -short flag is used
+		// Prevents Atom from auto-running the test
+		t.Skip("skipping test in short mode.")
+	}
+}
+
+func checkEnv() bool {
+	if os.Getenv("INTEGRATION_TEST_ACCESS_KEY") == "" {
+		return false
+	}
+	if os.Getenv("INTEGRATION_TEST_SECRET_KEY") == "" {
+		return false
+	}
+	if os.Getenv("INTEGRATION_TEST_PRIMARY_REGION") == "" {
+		return false
+	}
+	if os.Getenv("INTEGRATION_TEST_SECONDARY_REGION") == "" {
+		return false
+	}
+
+	return true
+}


### PR DESCRIPTION
`ecs-cli/integration-tests` contains:
- Proposal.md, the actual proposal (which I have copied here below because that is way more convenient)
- Some files which represent skeleton code for the integration tests

(What follows in the proposal)

# Introduction

Currently the CLI only has unit tests for each package, there is no way to programmatically ensure that commands work as intended. This requires the team to waste time manually testing and running commands, and increases the likelihood of buggy code being released to the public (which decreases customer trust in our CLI).

# Proposal

## Tooling

Many tools exist for testing command line tools, however, in general their purpose is to verify that the terminal output of a command is correct (Example https://en.wikipedia.org/wiki/Expect). For the ECS CLI, this should not be the primary goal- the output of many of our commands is not deterministic (for example, the output is often a stream of updates on the status of a cluster/service/task/etc). Moreover, the output that is most important to test from a user point of view, is not the terminal text output, but the affects of the command caused on AWS services. For example, our primary aim in testing the cluster up command is that a cluster is actually created in ECS with the correct number and type of instances, etc. (This is not to suggest however that output verification is not something that we would eventually want to have as well).

Therefore, the AWS go SDK will be used to make calls to AWS to verify that the resources are correctly being created. The integration tests can be written in go, and committed to the existing ECS CLI repository.

## Workflow

Here is the flow for how the unit tests will work:
1. TestMain function sets up AWS resources needed for the test
  * Key Pairs
  * Default clusters to deploy tasks/services to
  * Configure the CLI
2. Individual test cases will test commands
  1. Use the `os` library to shell out command
  2. Use the AWS SDK to verify that the correct affects on AWS resources have occurred (these checks could be deep or shallow, depending upon how much effort we want to put into these tests).


## Demo

This proposal is accompanied with a demo, which contains code to run a single very simple test case. This can be quickly built upon to create new test cases. It uses `go test`, the built in testing framework for Golang. The tests use testing.Short to ensure that IDEs like Atom won't automatically run the integration tests.
(The demo is currently just skeleton code- 0.5-1 days of dedicated effort is needed to complete it.)

## Plan

At this point in time, no one on the team has enough bandwidth to dedicate the time necessary to make the unit tests a reality. Here is a more realistic plan for how we could add integration tests to the whole CLI:
- 1-2 days more time can be spent to set things up and add a few basic test cases
- Mandate that for every new pull request/feature, there must be new integration tests- over time this will allow us to slowly build up integration tests overtime, without slowing down the release of any individual feature much at all.

## Design Concerns

The main issue with any proposal for automated running of commands is that an AWS account will be needed for testing, and the tests themselves need to have credentials. In this proposal, this has been solved using environment variables to specify the credentials for an account. However, it is uncertain whether this is the best option- comment and counter proposals are welcomed. 

## Future Work

Eventually, the integration tests can be integrated with Travis and run automatically when someone creates a PR on Github.