### PR TITLE
Bugfix: Typo in Roles field in IAM Instance Profile

### DIFF
--- a/ecs-cli/modules/clients/aws/cloudformation/template.go
+++ b/ecs-cli/modules/clients/aws/cloudformation/template.go
@@ -432,9 +432,9 @@ var template = `
         "Roles": [
           "Fn::If": [
             "CreateEcsInstanceRole",
-            [ {
+            {
               "Ref": "EcsInstanceRole"
-            } ],
+            },
             {
               "Ref": "InstanceRole"
             }


### PR DESCRIPTION
Introduced a bug in `c07bc184`:
```
$ ecs-cli up --capability-iam --keypair hhh-2 --size 1 --cluster test
INFO[0000] Created cluster                               cluster=test region=us-west-2
INFO[0000] Waiting for your cluster resources to be created... 
INFO[0001] Cloudformation stack status                   stackStatus="CREATE_IN_PROGRESS"
ERRO[0061] Failure event                                 reason="Value of property Roles must be of type List of String" resourceType="AWS::IAM::InstanceProfile"
```
This change fixes this error and maintains original functionality of the clusterUp command with default IAM Instance Role.

```
$ ecs-cli up --capability-iam --keypair hhh-2 --size 1 --cluster test
INFO[0000] Created cluster                               cluster=test region=us-west-2
INFO[0000] Waiting for your cluster resources to be created... 
INFO[0001] Cloudformation stack status                   stackStatus="CREATE_IN_PROGRESS"
INFO[0061] Cloudformation stack status                   stackStatus="CREATE_IN_PROGRESS"
INFO[0121] Cloudformation stack status                   stackStatus="CREATE_IN_PROGRESS"
INFO[0182] Cloudformation stack status                   stackStatus="CREATE_IN_PROGRESS"

$ ecs-cli up --keypair hhh-2 --size 1 --cluster test2
ERRO[0000] Error executing 'up': You must either specify a custom role with the '--instance-role' flag or set the '--capability-iam' flag 

$ ecs-cli up --keypair hhh-2 --size 1 --cluster test2 --instance-role ECSInstanceRole
INFO[0000] Created cluster                               cluster=test2 region=us-west-2
INFO[0001] Waiting for your cluster resources to be created... 
INFO[0001] Cloudformation stack status                   stackStatus="CREATE_IN_PROGRESS"
^[[AINFO[0061] Cloudformation stack status                   stackStatus="CREATE_IN_PROGRESS"
INFO[0121] Cloudformation stack status                   stackStatus="CREATE_IN_PROGRESS"
INFO[0182] Cloudformation stack status                   stackStatus="CREATE_IN_PROGRESS"
```

`make test` also passes.

