### PR TITLE
Dynamically Pull AMI ID from S3

### DIFF
--- a/ecs-cli/modules/config/ami/ami.go
+++ b/ecs-cli/modules/config/ami/ami.go
@@ -13,7 +13,21 @@
 
 package ami
 
-import "fmt"
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"time"
+)
+
+const (
+	mainBucketS3URL     = "https://s3.amazonaws.com/ecs-ami-id/"
+	cnNorth1BucketS3URL = "https://s3.cn-north-1.amazonaws.com.cn/ecs-ami-id/"
+	// time out in milliseconds to wait to pull the bucket
+	requestTimeout = 1000
+
+	maxRetries = 2
+)
 
 // ECSAmiIds interface is used to get the ami id for a specified region.
 type ECSAmiIds interface {
@@ -46,10 +60,48 @@ func NewStaticAmiIds() ECSAmiIds {
 }
 
 func (c *staticAmiIds) Get(region string) (string, error) {
+	// first try to pull from the main bucket
+	if id, err := getIDFromS3(mainBucketS3URL+region, maxRetries); err == nil {
+		return id, nil
+	}
+
+	// if we could not reach the main bucket, try the bucket in China
+	if id, err := getIDFromS3(mainBucketS3URL+region, maxRetries); err == nil {
+		return id, nil
+	}
+
+	// Finally, if pulling from S3 failed, fall back to the hardcoded list of AMIs
+	// The hardcoded list may of course be slightly out of date
 	id, exists := c.regionToId[region]
 	if !exists {
 		return "", fmt.Errorf("Could not find ami id for region '%s'", region)
 	}
 
 	return id, nil
+}
+
+// getIDFromS3 attempts to http GET url for the specified number of times (retries).
+func getIDFromS3(url string, retries int) (string, error) {
+	timeout := time.Duration(requestTimeout * time.Millisecond)
+	client := http.Client{
+		Timeout: timeout,
+	}
+
+	var err error
+
+	for i := 0; i < retries; i++ {
+		var response *http.Response
+		response, err = client.Get(url)
+		if err != nil {
+			continue
+		}
+		defer response.Body.Close()
+		var body []byte
+		if body, err = ioutil.ReadAll(response.Body); err == nil {
+			return string(body), nil
+		}
+
+	}
+
+	return "", err
 }

--- a/ecs-cli/modules/config/ami/ami.go
+++ b/ecs-cli/modules/config/ami/ami.go
@@ -59,6 +59,12 @@ func NewStaticAmiIds() ECSAmiIds {
 	return &staticAmiIds{regionToId: regionToId}
 }
 
+// Get returns the AMI ID for a given region
+// It returns the AMI ID that it finds in:
+// 	1. The S3 bucket
+// 	2. The cn-north-1 mirror of the main S3 bucket
+// 	3. The hardcoded list (which may be slightly out of date. )
+// (#2 helps users in china who may be blocked from the main bucket)
 func (c *staticAmiIds) Get(region string) (string, error) {
 	// first try to pull from the main bucket
 	if id, err := getIDFromS3(mainBucketS3URL+region, maxRetries); err == nil {


### PR DESCRIPTION
## Problem:
Currently, the AMI IDs are hardcoded. This is annoying because every time a new AMI is released, a release for the CLI also has to take place. 

## Solution:
-Dynamically pull the AMI ID from S3
-- The S3 bucket would contain a set of files, the title of a file would be the region name (ex: "us-east-2"), and the contents of the file would be the most recent AMI ID for that region. 
-- A secondary mirror bucket will be created in the cn-north-1 region, to aid users in China who may be blocked from accessing sites outside of China. 
- The hardcoded list of AMI IDs will be used as a fallback- we can update this list every time we do a release (but we can allow it to become slightly out of date- and thus will not have to do a release every single time time an new AMI is released).

Note:
Comment/Suggestions are especially appreciated on the values of the fields `requestTimeout` and `maxRetries`.