### PR TITLE
Go get instead of install to retrieve code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ generate: $(SOURCES)
 .PHONY: generate-deps
 generate-deps:
 	go get github.com/tools/godep
-	go install github.com/golang/mock/mockgen
+	go get github.com/golang/mock/mockgen
 	go get golang.org/x/tools/cmd/goimports
 
 


### PR DESCRIPTION
What it says on the tin: using `go install` causes `make generate-deps` to fail.