### PR TITLE
Simple Integration tests

### DIFF
--- a/integration-tests/docker-compose.yml
+++ b/integration-tests/docker-compose.yml
@@ -1,0 +1,8 @@
+version: '2'
+services:
+  mysql:
+    image: mysql
+    cpu_shares: 100
+    mem_limit: 524288000
+    environment:
+      MYSQL_ROOT_PASSWORD: password1234

--- a/scripts/release_test.sh
+++ b/scripts/release_test.sh
@@ -1,0 +1,118 @@
+#
+# This scripts uploads run_commands.sh to the given ec2 instance and runs it.
+# It then also runs the run_commands.sh on your local OS X Machine
+#
+
+
+# EXAMPLE:
+# ./scripts/release_test.sh -c ReleaseTestCluster -r us-east-2
+# -a $AWS_ACCESS_KEY_ID -s $AWS_SECRET_ACCESS_KEY -k MyFirstKeyPair
+# -p ~/Downloads/KeyPair.pem -i ec2-18-220-215-243.us-east-2.compute.amazonaws.com
+# -m $HOME/releasedir -h 4ff2bfcd -v 0.6.5
+
+#default
+DEFAULT_TEST_RESULT_DIR="~/ecs-cli-test-results"
+
+usage() {
+	echo "Usage: ${0}"
+	echo
+	echo "This script runs a series of ECS CLI commands during a release."
+	echo "It also tests the cluster up command in all regions- verifying that the correct AMIs have been specified."
+	echo "It is designed to provide sanity checking for newly built OSX and Linux Binaries."
+	echo "However, it is called a sanity check for a reason, this script simply"
+	echo "checks if the commands run exited with code 0."
+	echo "Detailed test output can be examined manually in in the tesing dir on each machine."
+	echo "(unless you have overridden the test output directory)."
+	echo
+	echo "Required Arguments:"
+	echo "  -a  ACCESS KEY         The access key id for an AWS account."
+	echo "  -s  SECRET KEY         The secret key for an AWS account."
+	echo "  -k  KEY PAIR NAME      A keypair for the chosen region."
+	echo "  -p  KEY PAIR PATH      The path to the key pair needed to ssh into the given ec2 instance."
+	echo "  -i  INSTANCE URL       The public DNS for the ec2 instance created for linux testing."
+	echo "  -m  OS X TEST DIR      The directory on the OS X Machine to store test info and perform the tests."
+	echo "  -l  Linux TEST DIR     [Optional] The directory on the Linux Machine to store test info. Defaults to $DEFAULT_TEST_RESULT_DIR."
+	echo "  -h  hash               The 7 char git hash for this CLI version."
+	echo "  -v  version            The version number for the CLI. Ex: 0.6.5"
+	echo "  -h                     Display this help message"
+}
+
+# ARGS: cluster c, region r, access a, secret s, keypair k , keypath p, instance_url i, mac_dir,
+while getopts ":c:r:a:s:k:p:i:m:l:v:h:" opt; do
+	case ${opt} in
+		c)
+			cluster="${OPTARG}"
+			;;
+		r)
+			region="${OPTARG}"
+			;;
+		a)
+			access="${OPTARG}"
+			;;
+		s)
+			secret="${OPTARG}"
+			;;
+		k)
+			keypair="${OPTARG}"
+			;;
+		p)
+			keypath="${OPTARG}"
+			;;
+		i)
+			instance_url="${OPTARG}"
+			;;
+		m)
+			mac_dir="${OPTARG}"
+			;;
+		l)
+			linux_dir="${OPTARG}"
+			;;
+		v)
+			version="${OPTARG}"
+			;;
+		h)
+			hash="${OPTARG}"
+			;;
+		\?)
+			echo "Invalid option -${OPTARG}" >&2
+			usage
+			exit 1
+			;;
+		:)
+			echo "Option -${OPTARG} requires an argument." >&2
+			usage
+			exit 1
+			;;
+		h)
+			usage
+			exit 0
+			;;
+	esac
+done
+
+if [ -z "${instance_url}" ]; then
+	usage
+	exit 1
+fi
+
+if [ -z "${linux_dir}" ]; then
+	linux_dir=$DEFAULT_TEST_RESULT_DIR
+fi
+
+# run locally on mac first
+cd  $mac_dir
+curl -o ecs-cli https://s3.amazonaws.com/amazon-ecs-cli/ecs-cli-darwin-amd64-latest
+curl -o ecs-cli-"${version}" https://s3.amazonaws.com/amazon-ecs-cli/ecs-cli-darwin-amd64-v"${version}"
+curl -o ecs-cli-"${hash}" https://s3.amazonaws.com/amazon-ecs-cli/ecs-cli-darwin-amd64-v"${hash}"
+
+cluster=${cluster} region=${region} access=${access} secret=${secret} keypair=${keypair} keypath=${keypath} instance_url=${instance_url} TEST_RESULT_DIR=${linux_dir} version=${version} hash=${hash} release='true' linux='true' ./run_commands.sh
+
+
+
+
+# Run on Linux
+scp -i $keypath $(dirname "${0}")/../integration-tests/docker-compose.yml "ec2-user@${instance_url}":~/
+scp -i $keypath $(dirname "${0}")/run_commands.sh "ec2-user@${instance_url}":~/
+# ARGS: cluster c, region r, access a, secret s, keypair k , keypath p, instance_url i, gitname u, branch b
+ssh -i $keypath "ec2-user@${instance_url}" "chmod +x run_commands.sh"
+ssh -i $keypath "ec2-user@${instance_url}" "cluster=${cluster} region=${region} access=${access} secret=${secret} keypair=${keypair} keypath=${keypath} instance_url=${instance_url} TEST_RESULT_DIR=${linux_dir} version=${version} hash=${hash} release='true' linux='true' ./run_commands.sh"

--- a/scripts/release_test.sh
+++ b/scripts/release_test.sh
@@ -99,7 +99,7 @@ if [ -z "${linux_dir}" ]; then
 	linux_dir=$DEFAULT_TEST_RESULT_DIR
 fi
 
-# run locally on mac first
+run locally on mac first
 cp $(dirname "${0}")/run_commands.sh $mac_dir/
 cp $(dirname "${0}")/../integration-tests/docker-compose.yml $mac_dir/
 cd $mac_dir

--- a/scripts/release_test.sh
+++ b/scripts/release_test.sh
@@ -100,13 +100,16 @@ if [ -z "${linux_dir}" ]; then
 fi
 
 # run locally on mac first
-cd  $mac_dir
+cp $(dirname "${0}")/run_commands.sh $mac_dir/
+cp $(dirname "${0}")/../integration-tests/docker-compose.yml $mac_dir/
+cd $mac_dir
 curl -o ecs-cli https://s3.amazonaws.com/amazon-ecs-cli/ecs-cli-darwin-amd64-latest
 curl -o ecs-cli-"${version}" https://s3.amazonaws.com/amazon-ecs-cli/ecs-cli-darwin-amd64-v"${version}"
-curl -o ecs-cli-"${hash}" https://s3.amazonaws.com/amazon-ecs-cli/ecs-cli-darwin-amd64-v"${hash}"
+curl -o ecs-cli-"${hash}" https://s3.amazonaws.com/amazon-ecs-cli/ecs-cli-darwin-amd64-"${hash}"
+chmod +x run_commands.sh
+cluster=${cluster} region=${region} access=${access} secret=${secret} keypair=${keypair} keypath=${keypath} instance_url=${instance_url} TEST_RESULT_DIR=${mac_dir} version=${version} hash=${hash} release='yes' ./run_commands.sh;
 
-cluster=${cluster} region=${region} access=${access} secret=${secret} keypair=${keypair} keypath=${keypath} instance_url=${instance_url} TEST_RESULT_DIR=${linux_dir} version=${version} hash=${hash} release='true' linux='true' ./run_commands.sh
-
+cd -
 
 
 
@@ -115,4 +118,4 @@ scp -i $keypath $(dirname "${0}")/../integration-tests/docker-compose.yml "ec2-u
 scp -i $keypath $(dirname "${0}")/run_commands.sh "ec2-user@${instance_url}":~/
 # ARGS: cluster c, region r, access a, secret s, keypair k , keypath p, instance_url i, gitname u, branch b
 ssh -i $keypath "ec2-user@${instance_url}" "chmod +x run_commands.sh"
-ssh -i $keypath "ec2-user@${instance_url}" "cluster=${cluster} region=${region} access=${access} secret=${secret} keypair=${keypair} keypath=${keypath} instance_url=${instance_url} TEST_RESULT_DIR=${linux_dir} version=${version} hash=${hash} release='true' linux='true' ./run_commands.sh"
+ssh -i $keypath "ec2-user@${instance_url}" "cluster=${cluster} region=${region} access=${access} secret=${secret} keypair=${keypair} keypath=${keypath} instance_url=${instance_url} TEST_RESULT_DIR=${linux_dir} version=${version} hash=${hash} release='yes' linux='yes' ./run_commands.sh"

--- a/scripts/run_commands.sh
+++ b/scripts/run_commands.sh
@@ -37,40 +37,27 @@ expect_success_no_log() {
 	fi
 }
 
-# install git and go
-echo "TYPE y|yes then enter to proceed."
-sudo yum install git go >> ~/ecs-cli-test-results/test_log.txt
-# have to respond yes to prompt
-# get CLI
-export GOPATH="$HOME/go"
-go get github.com/aws/amazon-ecs-cli >> ~/ecs-cli-test-results/test_log.txt
-cd $GOPATH/src/github.com/aws/amazon-ecs-cli
-url="https://github.com/"
-url+=$gitname
-url+="/amazon-ecs-cli.git"
-git remote add fork $url &>> ~/ecs-cli-test-results/test_log.txt
-git fetch fork &>> ~/ecs-cli-test-results/test_log.txt
-git checkout "fork/${branch}"
-make build
-
-rm ~/ecs-cli-test-results/test_output.txt # clean up from past tests
+rm ~/ecs-cli-test-results/test_output.txt # clean up from past tests (in case this instance has been used before)
+# create the results directory and file; in case this instance is being used for the first time
+mkdir ~/ecs-cli-test-results/
+touch ~/ecs-cli-test-results/test_output.txt
 
 # test commands
 
 # configure
-expect_success_no_log ./bin/local/ecs-cli configure --region $region --access-key $access --secret-key $secret --cluster $cluster
+expect_success_no_log ./ecs-cli configure --region $region --access-key $access --secret-key $secret --cluster $cluster
 # up
-expect_success ./bin/local/ecs-cli up --capability-iam --keypair $keypair --size 1 --instance-type t2.medium --force
+expect_success ./ecs-cli up --capability-iam --keypair $keypair --size 1 --instance-type t2.medium --force
 # create a service
-expect_success ./bin/local/ecs-cli compose --file ./integration-tests/docker-compose.yml service up
+expect_success ./ecs-cli compose --file ./integration-tests/docker-compose.yml service up
 # take down service
-expect_success ./bin/local/ecs-cli compose --file ./integration-tests/docker-compose.yml service down
+expect_success ./ecs-cli compose --file ./integration-tests/docker-compose.yml service down
 # create a task
-expect_success ./bin/local/ecs-cli compose --file ./integration-tests/docker-compose.yml up
+expect_success ./ecs-cli compose --file ./integration-tests/docker-compose.yml up
 # take down task
-expect_success ./bin/local/ecs-cli compose --file ./integration-tests/docker-compose.yml down
+expect_success ./ecs-cli compose --file ./integration-tests/docker-compose.yml down
 # take down cluster
-expect_success ./bin/local/ecs-cli down --force
+expect_success ./ecs-cli down --force
 
 
 # Sanity Check- search output file for error messages

--- a/scripts/run_commands.sh
+++ b/scripts/run_commands.sh
@@ -42,6 +42,28 @@ rm ~/ecs-cli-test-results/test_output.txt # clean up from past tests (in case th
 mkdir ~/ecs-cli-test-results/
 touch ~/ecs-cli-test-results/test_output.txt
 
+if ! [ -z "${gitname}" ]; then
+	# Not testing local changes, testing a branch instead
+	echo "Testing $branch"
+	# install git and go
+	echo "TYPE y|yes then enter to proceed."
+	sudo yum install git go >> ~/ecs-cli-test-results/test_log.txt
+	# have to respond yes to prompt
+	# get CLI
+	export GOPATH="$HOME/go"
+	go get github.com/aws/amazon-ecs-cli >> ~/ecs-cli-test-results/test_log.txt
+	cd $GOPATH/src/github.com/aws/amazon-ecs-cli
+	url="https://github.com/"
+	url+=$gitname
+	url+="/amazon-ecs-cli.git"
+	git remote add fork $url &>> ~/ecs-cli-test-results/test_log.txt
+	git fetch fork &>> ~/ecs-cli-test-results/test_log.txt
+	git checkout "fork/${branch}"
+	make build
+
+	cd bin/local/
+fi
+
 # test commands
 
 # configure

--- a/scripts/run_commands.sh
+++ b/scripts/run_commands.sh
@@ -3,7 +3,6 @@
 # The full output of the test script is stored in $TEST_RESULT_DIR.
 # The necessary env variables will be set by test_commands.sh using the
 # command line arguments provided to it.
-#
 
 declare -i FAILURES
 FAILURES=0

--- a/scripts/run_commands.sh
+++ b/scripts/run_commands.sh
@@ -1,0 +1,92 @@
+#
+# This scripts runs on the ec2 instance. It is uploaded to the EC2 instance by
+# test_commands.sh
+# The necessary env variables will be set by test_commands.sh using the
+# command line arguments provided to it.
+#
+
+declare -i FAILURES
+FAILURES=0
+
+RED='\033[1;31m'
+GREEN='\033[1;32m'
+LRED='\033[0;31m'
+LGREEN='\033[0;32m'
+NC='\033[0m' # No Color
+
+expect_success() {
+	if "${@}" &>> ~/ecs-cli-test-results/test_output.txt; then
+		echo -e "${GREEN}SUCCEEDED${NC}: ${LGREEN}${@}${NC}"
+	else
+		echo "-------"
+		echo -e "${RED}FAILED${NC}: ${LRED}${@}${NC}"
+		echo "-------"
+		FAILURES+=1
+	fi
+}
+
+# used for commands that whose arguments might contain sensitive information
+expect_success_no_log() {
+	if "${@}" &>> ~/ecs-cli-test-results/test_output.txt; then
+		echo -e "${GREEN}SUCCEEDED${NC}: ${LGREEN}${1} ${2}${NC}"
+	else
+		echo "-------"
+		echo -e "${RED}FAILED${NC}: ${LRED}${1} ${2}${NC}"
+		echo "-------"
+		FAILURES+=1
+	fi
+}
+
+# install git and go
+echo "TYPE y|yes then enter to proceed."
+sudo yum install git go >> ~/ecs-cli-test-results/test_log.txt
+# have to respond yes to prompt
+# get CLI
+export GOPATH="$HOME/go"
+go get github.com/aws/amazon-ecs-cli >> ~/ecs-cli-test-results/test_log.txt
+cd $GOPATH/src/github.com/aws/amazon-ecs-cli
+url="https://github.com/"
+url+=$gitname
+url+="/amazon-ecs-cli.git"
+git remote add fork $url &>> ~/ecs-cli-test-results/test_log.txt
+git fetch fork &>> ~/ecs-cli-test-results/test_log.txt
+git checkout "fork/${branch}"
+make build
+
+rm ~/ecs-cli-test-results/test_output.txt # clean up from past tests
+
+# test commands
+
+# configure
+expect_success_no_log ./bin/local/ecs-cli configure --region $region --access-key $access --secret-key $secret --cluster $cluster
+# up
+expect_success ./bin/local/ecs-cli up --capability-iam --keypair $keypair --size 1 --instance-type t2.medium --force
+# create a service
+expect_success ./bin/local/ecs-cli compose --file ./integration-tests/docker-compose.yml service up
+# take down service
+expect_success ./bin/local/ecs-cli compose --file ./integration-tests/docker-compose.yml service down
+# create a task
+expect_success ./bin/local/ecs-cli compose --file ./integration-tests/docker-compose.yml up
+# take down task
+expect_success ./bin/local/ecs-cli compose --file ./integration-tests/docker-compose.yml down
+# take down cluster
+expect_success ./bin/local/ecs-cli down --force
+
+
+# Sanity Check- search output file for error messages
+cat ~/ecs-cli-test-results/test_output.txt | grep -i "err" > ~/ecs-cli-test-results/errors.txt
+cat ~/ecs-cli-test-results/test_output.txt | grep -i "fatal" >> ~/ecs-cli-test-results/errors.txt
+echo -e "${RED}"
+cat ~/ecs-cli-test-results/errors.txt
+echo -e "${NC}"
+
+echo "ALL TESTS COMPLETE"
+if [[ $FAILURES -eq 0 ]]; then
+	echo "--------------------"
+	echo -e "${GREEN}ALL TESTS SUCCEEDED.${NC}"
+	echo "--------------------"
+else
+	echo "--------------------"
+	echo -e "${RED}${FAILURES} TEST FAILURES${NC}"
+	echo "--------------------"
+fi

--- a/scripts/run_commands.sh
+++ b/scripts/run_commands.sh
@@ -45,7 +45,7 @@ touch $TEST_RESULT_DIR/test_output.txt
 if ! [ -z "${gitname}" ]; then
 	# Not testing local changes, testing a branch instead
 	echo "TYPE y|yes to proceed and install git and go on the EC2 instance."
-	sudo yum install git go >> $TEST_RESULT_DIR/test_log.txt
+	sudo yum install git go >> $TEST_RESULT_DIR/test_log.txt # yum requires the user to confirm the install
 	# have to respond yes to prompt
 	# get CLI
 	export GOPATH="$HOME/go"

--- a/scripts/run_commands.sh
+++ b/scripts/run_commands.sh
@@ -67,17 +67,17 @@ expect_success_no_log ./ecs-cli configure --region $region --access-key $access 
 # up
 expect_success ./ecs-cli up --capability-iam --keypair $keypair --size 2 --instance-type t2.medium --force
 # Service workflow: create, start, scale, stop, down
-expect_success ./ecs-cli compose --file ~/docker-compose.yml service create
-expect_success ./ecs-cli compose --file ~/docker-compose.yml service start
-expect_success ./ecs-cli compose --file ~/docker-compose.yml service scale 2
-expect_success ./ecs-cli compose --file ~/docker-compose.yml service stop
-expect_success ./ecs-cli compose --file ~/docker-compose.yml service down
+expect_success ./ecs-cli compose --project-name test1 --file ~/docker-compose.yml service create
+expect_success ./ecs-cli compose --project-name test1 --file ~/docker-compose.yml service start
+expect_success ./ecs-cli compose --project-name test1 --file ~/docker-compose.yml service scale 2
+expect_success ./ecs-cli compose --project-name test1 --file ~/docker-compose.yml service stop
+expect_success ./ecs-cli compose --project-name test1 --file ~/docker-compose.yml service down
 # create a service
-expect_success ./ecs-cli compose --file ~/docker-compose.yml service up
+expect_success ./ecs-cli compose --project-name test2 --file ~/docker-compose.yml service up
 # ps on the service
-expect_success ./ecs-cli compose --file ~/docker-compose.yml service ps
+expect_success ./ecs-cli compose --project-name test2 --file ~/docker-compose.yml service ps
 # take down service
-expect_success ./ecs-cli compose --file ~/docker-compose.yml service down
+expect_success ./ecs-cli compose --project-name test2 --file ~/docker-compose.yml service down
 # create a task
 expect_success ./ecs-cli compose --file ~/docker-compose.yml up
 # ps the task

--- a/scripts/run_commands.sh
+++ b/scripts/run_commands.sh
@@ -78,6 +78,7 @@ if ! [ -z "${release}" ]; then
 		curl -o ecs-cli https://s3.amazonaws.com/amazon-ecs-cli/ecs-cli-linux-amd64-latest
 		curl -o ecs-cli-"${version}" https://s3.amazonaws.com/amazon-ecs-cli/ecs-cli-linux-amd64-v"${version}"
 		curl -o ecs-cli-"${hash}" https://s3.amazonaws.com/amazon-ecs-cli/ecs-cli-linux-amd64-"${hash}"
+		echo "" # add new line
 	fi
 
 	# check that the 3 binaries are the same

--- a/scripts/test_commands.sh
+++ b/scripts/test_commands.sh
@@ -1,0 +1,91 @@
+#
+# This scripts uploads run_commands.sh to the given ec2 instance and runs it.
+#
+
+
+# EXAMPLE:
+# ./scripts/test_commands.sh -c IntegrationTestCluster -r us-east-2
+# -a $AWS_ACCESS_KEY_ID -s $AWS_SECRET_ACCESS_KEY -k MyFirstKeyPair
+# -p ~/Downloads/KeyPair.pem -i ec2-18-220-215-243.us-east-2.compute.amazonaws.com
+# -u PettitWesley -b master
+
+usage() {
+	echo "Usage: ${0}"
+	echo
+	echo "This script runs a series of ECS CLI commands on a fresh EC2 instance."
+	echo "It is designed to provide integration tests for the ECS CLI."
+	echo "However, it is called sanity check for a reason, this script simply"
+	echo "checks if the commands run exited with code 0."
+	echo "More detailed test output can be examined manually in"
+	echo "~/ecs-cli-test-results/test_output.txt, on the ec2 instance."
+	echo
+	echo "Required Arguments:"
+	echo "  -c  CLUSTER            A name for the cluster that will be created/used in the tests."
+	echo "  -r  REGION             Region to create AWS resources in."
+	echo "  -a  ACCESS KEY         The access key id for an AWS account."
+	echo "  -s  SECRET KEY         The secret key for an AWS account."
+	echo "  -k  KEY PAIR NAME      A keypair for the chosen region."
+	echo "  -p  KEY PAIR PATH      The path to the key pair needed to ssh into the given ec2 instance."
+	echo "  -i  INSTANCE URL       The public DNS for the ec2 instance created for testing."
+	echo "  -u  GITHUB USERNAME    The testers github username."
+	echo "  -b  BRANCH             The branch on github that will be tested."
+	echo "  -h                     Display this help message"
+}
+
+# ARGS: cluster c, region r, access a, secret s, keypair k , keypath p, instance_url i, gitname u, branch b
+while getopts ":c:r:a:s:k:p:i:u:b:" opt; do
+	case ${opt} in
+		c)
+			cluster="${OPTARG}"
+			;;
+		r)
+			region="${OPTARG}"
+			;;
+		a)
+			access="${OPTARG}"
+			;;
+		s)
+			secret="${OPTARG}"
+			;;
+		k)
+			keypair="${OPTARG}"
+			;;
+		p)
+			keypath="${OPTARG}"
+			;;
+		i)
+			instance_url="${OPTARG}"
+			;;
+		u)
+			gitname="${OPTARG}"
+			;;
+		b)
+			branch="${OPTARG}"
+			;;
+		\?)
+			echo "Invalid option -${OPTARG}" >&2
+			usage
+			exit 1
+			;;
+		:)
+			echo "Option -${OPTARG} requires an argument." >&2
+			usage
+			exit 1
+			;;
+		h)
+			usage
+			exit 0
+			;;
+	esac
+done
+
+if [ -z "${instance_url}" ]; then
+	usage
+	exit 1
+fi
+
+scp -i $keypath $(dirname "${0}")/run_commands.sh "ec2-user@${instance_url}":~/
+# exit 1
+# ARGS: cluster c, region r, access a, secret s, keypair k , keypath p, instance_url i, gitname u, branch b
+ssh -i $keypath "ec2-user@${instance_url}" "chmod +x run_commands.sh"
+ssh -i $keypath "ec2-user@${instance_url}" "cluster=${cluster} region=${region} access=${access} secret=${secret} keypair=${keypair} keypath=${keypath} instance_url=${instance_url} gitname=${gitname} branch=${branch} ./run_commands.sh"

--- a/scripts/test_commands.sh
+++ b/scripts/test_commands.sh
@@ -8,6 +8,8 @@
 # -a $AWS_ACCESS_KEY_ID -s $AWS_SECRET_ACCESS_KEY -k MyFirstKeyPair
 # -p ~/Downloads/KeyPair.pem -i ec2-18-220-215-243.us-east-2.compute.amazonaws.com
 
+TEST_RESULT_DIR="~/ecs-cli-test-results"
+
 usage() {
 	echo "Usage: ${0}"
 	echo
@@ -19,7 +21,7 @@ usage() {
 	echo "then the script pulls and tests a branch on Github."
 	echo "Otherwise it tests local changes."
 	echo "More detailed test output can be examined manually in"
-	echo "~/ecs-cli-test-results/test_output.txt, on the ec2 instance."
+	echo "$TEST_RESULT_DIR/test_output.txt, on the ec2 instance."
 	echo
 	echo "Required Arguments:"
 	echo "  -c  CLUSTER            A name for the cluster that will be created/used in the tests."
@@ -95,4 +97,4 @@ fi
 scp -i $keypath $(dirname "${0}")/run_commands.sh "ec2-user@${instance_url}":~/
 # ARGS: cluster c, region r, access a, secret s, keypair k , keypath p, instance_url i, gitname u, branch b
 ssh -i $keypath "ec2-user@${instance_url}" "chmod +x run_commands.sh"
-ssh -i $keypath "ec2-user@${instance_url}" "cluster=${cluster} region=${region} access=${access} secret=${secret} keypair=${keypair} keypath=${keypath} instance_url=${instance_url} gitname=${gitname} branch=${branch} ./run_commands.sh"
+ssh -i $keypath "ec2-user@${instance_url}" "cluster=${cluster} region=${region} access=${access} secret=${secret} keypair=${keypair} keypath=${keypath} instance_url=${instance_url} gitname=${gitname} branch=${branch} TEST_RESULT_DIR=${TEST_RESULT_DIR} ./run_commands.sh"

--- a/scripts/test_commands.sh
+++ b/scripts/test_commands.sh
@@ -94,6 +94,7 @@ if [ -z "${gitname}" ]; then
 	scp -i $keypath $(dirname "${0}")/../bin/linux-amd64/ecs-cli "ec2-user@${instance_url}":~/
 fi
 
+scp -i $keypath $(dirname "${0}")/../integration-tests/docker-compose.yml "ec2-user@${instance_url}":~/
 scp -i $keypath $(dirname "${0}")/run_commands.sh "ec2-user@${instance_url}":~/
 # ARGS: cluster c, region r, access a, secret s, keypair k , keypath p, instance_url i, gitname u, branch b
 ssh -i $keypath "ec2-user@${instance_url}" "chmod +x run_commands.sh"


### PR DESCRIPTION
closes #306 

## Features
- Script runs a series of ECS CLI commands on an ec2 instance. 
- This script does not provide full integration tests- it only checks the exit code of the command (it additionally also scans the output of the commands for the words "error" or "fatal" and then displays any lines with those words to the user). I think of it as a "sanity check" for any code change.
- The raw output of each command is stored in `~/test_output.txt`.
- Set up information is logged to `~/test_log.txt`
- Pulls code from a given Github username, and a given branch (ie. its meant to test code on your fork of the ECS CLI).
- Runs tests on a provided ec2 instance.
- It prints results in color!!!

## Example
```
./scripts/test_commands.sh -c IntegrationTestCluster -r us-east-2
-a $AWS_ACCESS_KEY_ID -s $AWS_SECRET_ACCESS_KEY -k MyFirstKeyPair
-p ~/Downloads/KeyPair.pem -i ec2-18-220-215-243.us-east-2.compute.amazonaws.com
-u PettitWesley -b master
```
Failures:
<img width="570" alt="screen shot 2017-08-24 at 2 04 40 pm" src="https://user-images.githubusercontent.com/29443996/29851207-b765df82-8ce7-11e7-8f42-4413a0da2769.png">

Success:
<img width="570" alt="screen shot 2017-08-29 at 5 31 52 pm" src="https://user-images.githubusercontent.com/29443996/29851220-c35e2538-8ce7-11e7-8cbd-e55fe06d1693.png">


