### PR TITLE
Removed prefixes from the configs. Implemented migrate command.

### DIFF
--- a/ecs-cli/modules/cli/cluster/cluster_app.go
+++ b/ecs-cli/modules/cli/cluster/cluster_app.go
@@ -167,7 +167,7 @@ func createCluster(context *cli.Context, rdwr config.ReadWriter, ecsClient ecscl
 
 	// Check if cfn stack already exists
 	cfnClient.Initialize(ecsParams)
-	stackName := ecsParams.GetCFNStackName()
+	stackName := ecsParams.CFNStackName
 	var deleteStack bool
 	if err = cfnClient.ValidateStackExists(stackName); err == nil {
 		if !isForceSet(context) {
@@ -284,7 +284,7 @@ func deleteCluster(context *cli.Context, rdwr config.ReadWriter, ecsClient ecscl
 
 	// Validate that a cfn stack exists for the cluster
 	cfnClient.Initialize(ecsParams)
-	stackName := ecsParams.GetCFNStackName()
+	stackName := ecsParams.CFNStackName
 	if err := cfnClient.ValidateStackExists(stackName); err != nil {
 		return fmt.Errorf("CloudFormation stack not found for cluster '%s'", ecsParams.Cluster)
 	}
@@ -334,7 +334,7 @@ func scaleCluster(context *cli.Context, rdwr config.ReadWriter, ecsClient ecscli
 
 	// Validate that we have a cfn stack for the cluster
 	cfnClient.Initialize(ecsParams)
-	stackName := ecsParams.GetCFNStackName()
+	stackName := ecsParams.CFNStackName
 	if err := cfnClient.ValidateStackExists(stackName); err != nil {
 		return fmt.Errorf("CloudFormation stack not found for cluster '%s'", ecsParams.Cluster)
 	}

--- a/ecs-cli/modules/cli/cluster/cluster_app_test.go
+++ b/ecs-cli/modules/cli/cluster/cluster_app_test.go
@@ -46,7 +46,7 @@ type mockReadWriter struct {
 
 func (rdwr *mockReadWriter) Get(cluster string, profile string) (*config.CLIConfig, error) {
 	cliConfig := config.NewCLIConfig(rdwr.clusterName)
-	cliConfig.CFNStackNamePrefix = ""
+	cliConfig.CFNStackName = rdwr.clusterName
 	return cliConfig, nil
 }
 
@@ -474,7 +474,8 @@ func TestClusterUpWithoutRegion(t *testing.T) {
 func TestClusterDown(t *testing.T) {
 	newCliParams = func(context *cli.Context, rdwr config.ReadWriter) (*config.CLIParams, error) {
 		return &config.CLIParams{
-			Cluster: clusterName,
+			Cluster:      clusterName,
+			CFNStackName: stackName,
 		}, nil
 	}
 
@@ -522,7 +523,8 @@ func TestDeleteClusterPrompt(t *testing.T) {
 func TestClusterScale(t *testing.T) {
 	newCliParams = func(context *cli.Context, rdwr config.ReadWriter) (*config.CLIParams, error) {
 		return &config.CLIParams{
-			Cluster: clusterName,
+			Cluster:      clusterName,
+			CFNStackName: stackName,
 		}, nil
 	}
 	defer os.Clearenv()

--- a/ecs-cli/modules/cli/compose/entity/entity_helper.go
+++ b/ecs-cli/modules/cli/compose/entity/entity_helper.go
@@ -237,7 +237,8 @@ func GetTaskGroup(entity ProjectEntity) string {
 
 // GetTaskDefinitionFamily returns the family name
 func GetTaskDefinitionFamily(entity ProjectEntity) string {
-	return composeutils.GetTaskDefinitionFamily(getProjectPrefix(entity), GetProjectName(entity))
+	// ComposeProjectNamePrefix is deprecated, but its use must remain for backwards compatibility
+	return entity.Context().ECSParams.ComposeProjectNamePrefix + GetProjectName(entity)
 }
 
 // GetProjectName returns the name of the project that was set in the context we are working with

--- a/ecs-cli/modules/cli/compose/project/project.go
+++ b/ecs-cli/modules/cli/compose/project/project.go
@@ -20,10 +20,10 @@ import (
 	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/cli/compose/entity/service"
 	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/cli/compose/entity/task"
 
+	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/commands"
 	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/utils/compose"
 	"github.com/docker/libcompose/config"
 	"github.com/docker/libcompose/project"
-	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/commands"
 )
 
 // Project is the starting point for the compose app to interact with and issue commands
@@ -134,7 +134,7 @@ func (p *ecsProject) transformTaskDefinition() error {
 
 	// convert to task definition
 	logrus.Debug("Transforming yaml to task definition...")
-	taskDefinitionName := utils.GetTaskDefinitionName(context.ECSParams.ComposeProjectNamePrefix, context.Context.ProjectName)
+	taskDefinitionName := utils.GetTaskDefinitionName("", context.Context.ProjectName)
 	taskRoleArn := context.CLIContext.GlobalString(command.TaskRoleArnFlag)
 	taskDefinition, err := utils.ConvertToTaskDefinition(taskDefinitionName, &context.Context, p.ServiceConfigs(), taskRoleArn)
 	if err != nil {

--- a/ecs-cli/modules/cli/configure/configure.go
+++ b/ecs-cli/modules/cli/configure/configure.go
@@ -44,7 +44,15 @@ func Cluster(context *cli.Context) error {
 		return err
 	}
 
-	clusterConfig := &config.Cluster{Cluster: cluster, Region: region}
+	cfnStackName := context.String(command.CFNStackNameFlag)
+	composeServiceNamePrefix := context.String(command.ComposeServiceNamePrefixFlag)
+
+	clusterConfig := &config.Cluster{
+		Cluster:                  cluster,
+		Region:                   region,
+		CFNStackName:             cfnStackName,
+		ComposeServiceNamePrefix: composeServiceNamePrefix,
+	}
 
 	rdwr, err := config.NewReadWriter()
 	if err != nil {
@@ -54,6 +62,7 @@ func Cluster(context *cli.Context) error {
 		return errors.Wrap(err, "Error saving cluster configuration")
 	}
 
+	logrus.Infof("Saved ECS CLI cluster configuration %s.", clusterProfileName)
 	return nil
 }
 
@@ -71,7 +80,10 @@ func Profile(context *cli.Context) error {
 	if err := fieldEmpty(profileName, command.ProfileNameFlag); err != nil {
 		return err
 	}
-	profile := &config.Profile{AWSAccessKey: accessKey, AWSSecretKey: secretKey}
+	profile := &config.Profile{
+		AWSAccessKey: accessKey,
+		AWSSecretKey: secretKey,
+	}
 
 	rdwr, err := config.NewReadWriter()
 	if err != nil {
@@ -81,6 +93,7 @@ func Profile(context *cli.Context) error {
 		return errors.Wrap(err, "Error saving profile")
 	}
 
+	logrus.Infof("Saved ECS CLI profile configuration %s.", profileName)
 	return nil
 }
 

--- a/ecs-cli/modules/cli/configure/configure_test.go
+++ b/ecs-cli/modules/cli/configure/configure_test.go
@@ -26,16 +26,18 @@ import (
 )
 
 const (
-	clusterName   = "defaultCluster"
-	secondCluster = "alternateCluster"
-	stackName     = "defaultCluster"
-	profileName   = "defaultProfile"
-	profileName2  = "alternate"
-	region        = "us-west-1"
-	awsAccessKey  = "AKID"
-	awsAccessKey2 = "AKID2"
-	awsSecretKey  = "SKID"
-	awsSecretKey2 = "SKID2"
+	clusterName              = "defaultCluster"
+	secondCluster            = "alternateCluster"
+	stackName                = "defaultCluster"
+	profileName              = "defaultProfile"
+	profileName2             = "alternate"
+	region                   = "us-west-1"
+	awsAccessKey             = "AKID"
+	awsAccessKey2            = "AKID2"
+	awsSecretKey             = "SKID"
+	awsSecretKey2            = "SKID2"
+	composeServiceNamePrefix = "ecs-"
+	cfnStackNamePrefix       = "cfn-"
 )
 
 func createClusterConfig(name string, cluster string) *cli.Context {
@@ -57,7 +59,7 @@ func createProfileConfig(name string, accessKey string, secretKey string) *cli.C
 func TestDefaultCluster(t *testing.T) {
 	config1 := createClusterConfig(profileName, clusterName)
 	config2 := createClusterConfig(profileName2, secondCluster)
-	// Create a temprorary directory for the dummy ecs config
+	// Create a temporary directory for the dummy ecs config
 	tempDirName, err := ioutil.TempDir("", "test")
 	if err != nil {
 		t.Fatal("Error while creating the dummy ecs config directory")
@@ -80,9 +82,8 @@ func TestDefaultCluster(t *testing.T) {
 	assert.NoError(t, err, "Error reading config")
 	assert.Equal(t, region, readConfig.Region, "Region mismatch in config.")
 	assert.Equal(t, secondCluster, readConfig.Cluster, "Cluster name mismatch in config.")
-	assert.Empty(t, readConfig.ComposeProjectNamePrefix, "Compose project prefix name should be empty.")
 	assert.Empty(t, readConfig.ComposeServiceNamePrefix, "Compose service prefix name should be empty.")
-	assert.Empty(t, readConfig.CFNStackNamePrefix, "CFNStackNamePrefix should be empty.")
+	assert.Empty(t, readConfig.CFNStackName, "CFNStackName should be empty.")
 
 }
 
@@ -90,7 +91,7 @@ func TestDefaultProfile(t *testing.T) {
 	config1 := createProfileConfig(profileName, awsAccessKey, awsSecretKey)
 	config2 := createProfileConfig(profileName2, awsAccessKey2, awsSecretKey2)
 
-	// Create a temprorary directory for the dummy ecs config
+	// Create a temporary directory for the dummy ecs config
 	tempDirName, err := ioutil.TempDir("", "test")
 	if err != nil {
 		t.Fatal("Error while creating the dummy ecs config directory")
@@ -113,16 +114,15 @@ func TestDefaultProfile(t *testing.T) {
 	assert.NoError(t, err, "Error reading config")
 	assert.Equal(t, awsAccessKey2, readConfig.AWSAccessKey, "Access Key mismatch in config.")
 	assert.Equal(t, awsSecretKey2, readConfig.AWSSecretKey, "Secret Key name mismatch in config.")
-	assert.Empty(t, readConfig.ComposeProjectNamePrefix, "Compose project prefix name should be empty.")
 	assert.Empty(t, readConfig.ComposeServiceNamePrefix, "Compose service prefix name should be empty.")
-	assert.Empty(t, readConfig.CFNStackNamePrefix, "CFNStackNamePrefix should be empty.")
+	assert.Empty(t, readConfig.CFNStackName, "CFNStackName should be empty.")
 
 }
 
 func TestConfigureProfile(t *testing.T) {
 	config1 := createProfileConfig(profileName, awsAccessKey, awsSecretKey)
 
-	// Create a temprorary directory for the dummy ecs config
+	// Create a temporary directory for the dummy ecs config
 	tempDirName, err := ioutil.TempDir("", "test")
 	if err != nil {
 		t.Fatal("Error while creating the dummy ecs config directory")
@@ -140,15 +140,14 @@ func TestConfigureProfile(t *testing.T) {
 	assert.NoError(t, err, "Error reading config")
 	assert.Equal(t, awsAccessKey, readConfig.AWSAccessKey, "Access Key mismatch in config.")
 	assert.Equal(t, awsSecretKey, readConfig.AWSSecretKey, "Secret Key name mismatch in config.")
-	assert.Empty(t, readConfig.ComposeProjectNamePrefix, "Compose project prefix name should be empty.")
 	assert.Empty(t, readConfig.ComposeServiceNamePrefix, "Compose service prefix name should be empty.")
-	assert.Empty(t, readConfig.CFNStackNamePrefix, "CFNStackNamePrefix should be empty.")
+	assert.Empty(t, readConfig.CFNStackName, "CFNStackName should be empty.")
 
 }
 
 func TestConfigureCluster(t *testing.T) {
 	config1 := createClusterConfig(profileName, clusterName)
-	// Create a temprorary directory for the dummy ecs config
+	// Create a temporary directory for the dummy ecs config
 	tempDirName, err := ioutil.TempDir("", "test")
 	if err != nil {
 		t.Fatal("Error while creating the dummy ecs config directory")
@@ -166,9 +165,8 @@ func TestConfigureCluster(t *testing.T) {
 	assert.NoError(t, err, "Error reading config")
 	assert.Equal(t, region, readConfig.Region, "Region mismatch in config.")
 	assert.Equal(t, clusterName, readConfig.Cluster, "Cluster name mismatch in config.")
-	assert.Empty(t, readConfig.ComposeProjectNamePrefix, "Compose project prefix name should be empty.")
 	assert.Empty(t, readConfig.ComposeServiceNamePrefix, "Compose service prefix name should be empty.")
-	assert.Empty(t, readConfig.CFNStackNamePrefix, "CFNStackNamePrefix should be empty.")
+	assert.Empty(t, readConfig.CFNStackName, "CFNStackName should be empty.")
 
 }
 
@@ -178,7 +176,7 @@ func TestConfigureClusterNoCluster(t *testing.T) {
 	flags.String(command.ConfigNameFlag, profileName, "")
 	config1 := cli.NewContext(nil, flags, nil)
 
-	// Create a temprorary directory for the dummy ecs config
+	// Create a temporary directory for the dummy ecs config
 	tempDirName, err := ioutil.TempDir("", "test")
 	if err != nil {
 		t.Fatal("Error while creating the dummy ecs config directory")
@@ -199,7 +197,7 @@ func TestConfigureClusterNoRegion(t *testing.T) {
 	flags.String(command.ConfigNameFlag, profileName, "")
 	config1 := cli.NewContext(nil, flags, nil)
 
-	// Create a temprorary directory for the dummy ecs config
+	// Create a temporary directory for the dummy ecs config
 	tempDirName, err := ioutil.TempDir("", "test")
 	if err != nil {
 		t.Fatal("Error while creating the dummy ecs config directory")
@@ -220,7 +218,7 @@ func TestConfigureClusterNoConfigName(t *testing.T) {
 	flags.String(command.RegionFlag, region, "")
 	config1 := cli.NewContext(nil, flags, nil)
 
-	// Create a temprorary directory for the dummy ecs config
+	// Create a temporary directory for the dummy ecs config
 	tempDirName, err := ioutil.TempDir("", "test")
 	if err != nil {
 		t.Fatal("Error while creating the dummy ecs config directory")
@@ -240,7 +238,7 @@ func TestConfigureProfileNoAccessKey(t *testing.T) {
 	flags.String(command.ProfileNameFlag, profileName, "")
 	config1 := cli.NewContext(nil, flags, nil)
 
-	// Create a temprorary directory for the dummy ecs config
+	// Create a temporary directory for the dummy ecs config
 	tempDirName, err := ioutil.TempDir("", "test")
 	if err != nil {
 		t.Fatal("Error while creating the dummy ecs config directory")
@@ -260,7 +258,7 @@ func TestConfigureProfileNoSecretKey(t *testing.T) {
 	flags.String(command.ProfileNameFlag, profileName, "")
 	config1 := cli.NewContext(nil, flags, nil)
 
-	// Create a temprorary directory for the dummy ecs config
+	// Create a temporary directory for the dummy ecs config
 	tempDirName, err := ioutil.TempDir("", "test")
 	if err != nil {
 		t.Fatal("Error while creating the dummy ecs config directory")
@@ -280,7 +278,7 @@ func TestConfigureProfileNoProfileName(t *testing.T) {
 	flags.String(command.SecretKeyFlag, awsSecretKey, "")
 	config1 := cli.NewContext(nil, flags, nil)
 
-	// Create a temprorary directory for the dummy ecs config
+	// Create a temporary directory for the dummy ecs config
 	tempDirName, err := ioutil.TempDir("", "test")
 	if err != nil {
 		t.Fatal("Error while creating the dummy ecs config directory")
@@ -297,7 +295,7 @@ func TestConfigureProfileNoProfileName(t *testing.T) {
 func TestDefaultClusterDoesNotExist(t *testing.T) {
 	config1 := createClusterConfig(profileName, clusterName)
 	config2 := createClusterConfig(profileName2, secondCluster)
-	// Create a temprorary directory for the dummy ecs config
+	// Create a temporary directory for the dummy ecs config
 	tempDirName, err := ioutil.TempDir("", "test")
 	if err != nil {
 		t.Fatal("Error while creating the dummy ecs config directory")
@@ -317,7 +315,7 @@ func TestDefaultProfileDoesNotExist(t *testing.T) {
 	config1 := createProfileConfig(profileName, awsAccessKey, awsSecretKey)
 	config2 := createProfileConfig(profileName2, awsAccessKey2, awsSecretKey2)
 
-	// Create a temprorary directory for the dummy ecs config
+	// Create a temporary directory for the dummy ecs config
 	tempDirName, err := ioutil.TempDir("", "test")
 	if err != nil {
 		t.Fatal("Error while creating the dummy ecs config directory")

--- a/ecs-cli/modules/cli/configure/migrate.go
+++ b/ecs-cli/modules/cli/configure/migrate.go
@@ -1,0 +1,130 @@
+// Copyright 2015-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package configure
+
+import (
+	"fmt"
+	"html/template"
+	"io/ioutil"
+	"os"
+	"strings"
+
+	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/config"
+)
+
+func maskSecret(secret string) (out string) {
+	if secret != "" {
+		mask := strings.Repeat("*", len(secret)-2)
+		out = strings.Replace(secret, secret[:len(secret)-2], mask, 1)
+	}
+	return out
+}
+
+func hideCreds(cliConfig *config.CLIConfig) {
+	if cliConfig.AWSSecretKey != "" {
+		cliConfig.AWSSecretKey = maskSecret(cliConfig.AWSSecretKey)
+	}
+}
+
+func hideCredsOldFile(data string) string {
+	safeData := ""
+	lines := strings.Split(data, "\n")
+	for _, line := range lines {
+		if strings.Contains(line, "aws_secret_access_key") {
+			parts := strings.Split(line, "=")
+			if strings.TrimSpace(parts[1]) != "" {
+				safeData += fmt.Sprintf("%v= %v", parts[0], maskSecret(parts[1]))
+			}
+		} else {
+			safeData = safeData + line
+		}
+		safeData += "\n"
+	}
+
+	return safeData
+}
+
+func migrateWarning(cliConfig *config.CLIConfig) error {
+	var oldConfig string
+	dest, err := config.NewDefaultDestination()
+	if err != nil {
+		return err
+	}
+	dat, err := ioutil.ReadFile(config.ConfigFilePath(dest))
+	if err != nil {
+		return err
+	}
+	oldConfig = string(dat)
+
+	hideCreds(cliConfig)
+	oldConfig = hideCredsOldFile(oldConfig)
+
+	optionalFields := ""
+
+	if cliConfig.ComposeServiceNamePrefix != "" {
+		optionalFields += "compose-service-name-prefix: " + cliConfig.ComposeServiceNamePrefix + "\n"
+	}
+
+	if cliConfig.CFNStackName != "" {
+		optionalFields += "cfn-stack-name: " + cliConfig.CFNStackName + "\n"
+	}
+
+	// format template
+	data := map[string]interface{}{
+		"OldConfig":       oldConfig,
+		"Cluster":         cliConfig.Cluster,
+		"Region":          cliConfig.Region,
+		"AWSAccessKey":    cliConfig.AWSAccessKey,
+		"AWSSecretKey":    cliConfig.AWSSecretKey,
+		"Optional_Fields": optionalFields,
+	}
+
+	t := template.Must(template.New("message").Parse(messageTemplate))
+	if err := t.Execute(os.Stdout, data); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+var messageTemplate = `
+Old configuration file
+-----------------------------------------------------
+~/.ecs/config
+{{.OldConfig}}
+
+New configuration files
+-----------------------------------------------------
+~/.ecs/config
+version: v1
+default: default
+cluster-configurations:
+  default:
+    cluster: {{.Cluster}}
+    region: {{.Region}}
+    {{.Optional_Fields}}
+
+~/.ecs/credentials
+default: default
+credentials:
+  default:
+    aws_access_key_id: {{.AWSAccessKey}}
+    aws_secret_access_key: {{.AWSSecretKey}}
+
+[WARN] Please read the following changes carefully: http://docs.aws.amazon.com/AmazonECS/latest/developerguide/ECS_CLI_Configuration.html
+- The --compose-project-name-prefix and --compose-service-name-prefix options are deprecated. You can specify your desired names with the --project-name option.
+- The --cfn-stack-name-prefix option has been removed. To use an existing CloudFormation stack, please specify the full stack name; otherwise, the stack name defaults to amazon-ecs-cli-setup-<cluster_name>.
+
+Are you sure you want to migrate[y/n]?
+`

--- a/ecs-cli/modules/commands/configure/configure_command.go
+++ b/ecs-cli/modules/commands/configure/configure_command.go
@@ -145,28 +145,19 @@ func configureFlags() []cli.Flag {
 			Name:  flags.ConfigNameFlag,
 			Value: "default",
 			Usage: fmt.Sprintf(
-				"Specifies the cluster config name to use for this configuration.",
+				"Specifies the cluster configuration name to use for this configuration.",
 			),
 		},
 		cli.StringFlag{
-			Name:  flags.ComposeProjectNamePrefixFlag,
-			Value: flags.ComposeProjectNamePrefixDefaultValue,
+			Name: flags.ComposeServiceNamePrefixFlag,
 			Usage: fmt.Sprintf(
-				"[Optional] Specifies the prefix added to an ECS task definition created from a compose file. Format <prefix><project-name>.",
+				"[Deprecated] Specifies the prefix added to an ECS service created from a compose file. Format <prefix><project-name>. (defaults to empty)",
 			),
 		},
 		cli.StringFlag{
-			Name:  flags.ComposeServiceNamePrefixFlag,
-			Value: flags.ComposeServiceNamePrefixDefaultValue,
+			Name: flags.CFNStackNameFlag,
 			Usage: fmt.Sprintf(
-				"[Optional] Specifies the prefix added to an ECS service created from a compose file. Format <prefix><project-name>.",
-			),
-		},
-		cli.StringFlag{
-			Name:  flags.CFNStackNamePrefixFlag,
-			Value: flags.CFNStackNamePrefixDefaultValue,
-			Usage: fmt.Sprintf(
-				"[Optional] Specifies the prefix added to the AWS CloudFormation stack created on ecs-cli up. Format <prefix><cluster-name>.",
+				"[Optional] Specifies the name of AWS CloudFormation stack created on ecs-cli up. (default: \"amazon-ecs-cli-setup-<cluster-name>\")",
 			),
 		},
 	}

--- a/ecs-cli/modules/commands/configure/configure_command.go
+++ b/ecs-cli/modules/commands/configure/configure_command.go
@@ -63,6 +63,22 @@ func defaultClusterCommand() cli.Command {
 	}
 }
 
+func migrateCommand() cli.Command {
+	return cli.Command{
+		Name:   "migrate",
+		Usage:  "Migrates a legacy ECS CLI configuration file to the current YAML format.",
+		Action: errorLogger(configure.Migrate),
+		Flags: []cli.Flag{
+			cli.BoolFlag{
+				Name: flags.ForceFlag,
+				Usage: fmt.Sprintf(
+					"[Optional] Omits the interactive description and confirmation step that normally occurs during the configuration file migration process.",
+				),
+			},
+		},
+	}
+}
+
 // ConfigureCommand configure command help
 func ConfigureCommand() cli.Command {
 	return cli.Command{
@@ -73,6 +89,7 @@ func ConfigureCommand() cli.Command {
 		Subcommands: []cli.Command{
 			configureProfileCommand(),
 			defaultClusterCommand(),
+			migrateCommand(),
 		},
 	}
 }

--- a/ecs-cli/modules/commands/flags.go
+++ b/ecs-cli/modules/commands/flags.go
@@ -40,7 +40,7 @@ const (
 	ComposeProjectNamePrefixDefaultValue = "ecscompose-"
 	ComposeServiceNamePrefixFlag         = "compose-service-name-prefix"
 	ComposeServiceNamePrefixDefaultValue = ComposeProjectNamePrefixDefaultValue + "service-"
-	CFNStackNamePrefixFlag               = "cfn-stack-name-prefix"
+	CFNStackNameFlag                     = "cfn-stack-name"
 	CFNStackNamePrefixDefaultValue       = "amazon-ecs-cli-setup-"
 
 	// Cluster

--- a/ecs-cli/modules/config/config_v1.go
+++ b/ecs-cli/modules/config/config_v1.go
@@ -42,9 +42,9 @@ type CLIConfig struct {
 	Region                   string
 	AWSAccessKey             string
 	AWSSecretKey             string
-	ComposeProjectNamePrefix string
 	ComposeServiceNamePrefix string
-	CFNStackNamePrefix       string
+	ComposeProjectNamePrefix string // Deprecated; remains for backwards compatibility
+	CFNStackName             string
 }
 
 // Profile is a simple struct for storing a single profile config
@@ -57,7 +57,8 @@ type Profile struct {
 type Cluster struct {
 	Cluster                  string `yaml:"cluster"`
 	Region                   string `yaml:"region"`
-	ComposeServiceNamePrefix string `yaml:"compose-service-name-prefix"`
+	ComposeServiceNamePrefix string `yaml:"compose-service-name-prefix,omitempty"`
+	CFNStackName             string `yaml:"cfn-stack-name,omitempty"`
 }
 
 // ClusterConfig is the top level struct representing the cluster config file

--- a/ecs-cli/modules/config/destination.go
+++ b/ecs-cli/modules/config/destination.go
@@ -39,8 +39,8 @@ func GetFilePermissions(fileName string) (*os.FileMode, error) {
 	return &mode, nil
 }
 
-// newDefaultDestination creates a new Destination object.
-func newDefaultDestination() (*Destination, error) {
+// NewDefaultDestination creates a new Destination object.
+func NewDefaultDestination() (*Destination, error) {
 	homeDir, err := utils.GetHomeDir()
 	if err != nil {
 		return nil, errors.Wrap(err, "Error finding Home directory to store config file")

--- a/ecs-cli/modules/config/destination_test.go
+++ b/ecs-cli/modules/config/destination_test.go
@@ -33,7 +33,7 @@ func TestNewDefaultDestination(t *testing.T) {
 	os.Setenv("HOME", tempDirName)
 	defer os.Unsetenv("HOME")
 
-	dest, err := newDefaultDestination()
+	dest, err := NewDefaultDestination()
 	assert.NoError(t, err, "Unexpected error creating new config path")
 	assert.Condition(t, func() bool {
 		return strings.HasSuffix(dest.Path, "ecs")

--- a/ecs-cli/modules/config/params.go
+++ b/ecs-cli/modules/config/params.go
@@ -14,7 +14,6 @@
 package config
 
 import (
-	"fmt"
 	"os"
 
 	ecscli "github.com/aws/amazon-ecs-cli/ecs-cli/modules/commands"
@@ -27,14 +26,9 @@ import (
 type CLIParams struct {
 	Cluster                  string
 	Session                  *session.Session
-	ComposeProjectNamePrefix string
 	ComposeServiceNamePrefix string
-	CFNStackNamePrefix       string
-}
-
-// GetCFNStackName <cfn_stack_name_prefix> + <cluster_name>
-func (p *CLIParams) GetCFNStackName() string {
-	return fmt.Sprintf("%s%s", p.CFNStackNamePrefix, p.Cluster)
+	ComposeProjectNamePrefix string // Deprecated; remains for backwards compatibility
+	CFNStackName             string
 }
 
 // Searches as far up the context as necesarry. This function works no matter
@@ -81,11 +75,16 @@ func NewCLIParams(context *cli.Context, rdwr ReadWriter) (*CLIParams, error) {
 		return nil, err
 	}
 
+	if ecsConfig.CFNStackName == "" {
+		// set default value
+		ecsConfig.CFNStackName = ecscli.CFNStackNamePrefixDefaultValue + ecsConfig.Cluster
+	}
+
 	return &CLIParams{
 		Cluster:                  ecsConfig.Cluster,
 		Session:                  svcSession,
-		ComposeProjectNamePrefix: ecsConfig.ComposeProjectNamePrefix,
 		ComposeServiceNamePrefix: ecsConfig.ComposeServiceNamePrefix,
-		CFNStackNamePrefix:       ecsConfig.CFNStackNamePrefix,
+		ComposeProjectNamePrefix: ecsConfig.ComposeProjectNamePrefix, // deprecated; remains for backwards compatibility
+		CFNStackName:             ecsConfig.CFNStackName,
 	}, nil
 }

--- a/ecs-cli/modules/config/readwriter.go
+++ b/ecs-cli/modules/config/readwriter.go
@@ -86,9 +86,9 @@ func (rdwr *INIReadWriter) GetConfig(cliConfig *CLIConfig) error {
 	cliConfig.AWSProfile = iniFormat.AwsProfile
 	cliConfig.AWSAccessKey = iniFormat.AWSAccessKey
 	cliConfig.AWSSecretKey = iniFormat.AWSSecretKey
-	cliConfig.ComposeProjectNamePrefix = iniFormat.ComposeProjectNamePrefix
 	cliConfig.ComposeServiceNamePrefix = iniFormat.ComposeServiceNamePrefix
-	cliConfig.CFNStackNamePrefix = iniFormat.CFNStackNamePrefix
+	cliConfig.ComposeProjectNamePrefix = iniFormat.ComposeProjectNamePrefix
+	cliConfig.CFNStackName = iniFormat.CFNStackNamePrefix + iniFormat.Cluster
 	return nil
 }
 
@@ -99,7 +99,7 @@ func (rdwr *INIReadWriter) IsKeyPresent(section, key string) bool {
 
 func newINIConfig(dest *Destination) (*ini.File, error) {
 	iniCfg := ini.Empty()
-	path := configFilePath(dest)
+	path := ConfigFilePath(dest)
 	if _, err := os.Stat(path); err == nil {
 		if err = iniCfg.Append(path); err != nil {
 			return nil, errors.Wrap(err, "Failed to initialize ini reader")

--- a/ecs-cli/modules/config/readwriter_v1_test.go
+++ b/ecs-cli/modules/config/readwriter_v1_test.go
@@ -71,7 +71,7 @@ func TestConfigPermissions(t *testing.T) {
 	// Create config file and confirm it has expected initial permissions
 	saveClusterConfig(t, parser, dest)
 
-	path := configFilePath(dest)
+	path := ConfigFilePath(dest)
 	confirmConfigMode(t, path, configFileMode)
 
 	// Now set the config mode to something bad
@@ -116,7 +116,7 @@ cfn-stack-name-prefix =
 	assert.NoError(t, err, "Could not create config directory")
 	defer os.RemoveAll(dest.Path)
 
-	err = ioutil.WriteFile(configFilePath(dest), []byte(configContents), *dest.Mode)
+	err = ioutil.WriteFile(ConfigFilePath(dest), []byte(configContents), *dest.Mode)
 	assert.NoError(t, err)
 
 	// Reinitialize from the written file.
@@ -125,9 +125,8 @@ cfn-stack-name-prefix =
 	readConfig, err := parser.Get("", "")
 	assert.NoError(t, err, "Error reading config")
 	assert.Equal(t, testClusterName, readConfig.Cluster, "Cluster name mismatch in config.")
-	assert.Empty(t, readConfig.ComposeProjectNamePrefix, "Compose project prefix name should be empty.")
 	assert.Empty(t, readConfig.ComposeServiceNamePrefix, "Compose service prefix name should be empty.")
-	assert.Empty(t, readConfig.CFNStackNamePrefix, "CFNStackNamePrefix should be empty.")
+	assert.Equal(t, testClusterName, readConfig.CFNStackName, "CFNStackName should be set to cluster name.")
 }
 
 func TestPrefixesDefaultOldINIFormat(t *testing.T) {
@@ -152,9 +151,8 @@ aws_secret_access_key =
 	parser := setupParser(t, dest, true)
 	config, err := parser.Get("", "")
 	assert.NoError(t, err, "Error reading config")
-	assert.Equal(t, ecscli.ComposeProjectNamePrefixDefaultValue, config.ComposeProjectNamePrefix, "ComposeProjectNamePrefix should be set to the default value.")
 	assert.Equal(t, ecscli.ComposeServiceNamePrefixDefaultValue, config.ComposeServiceNamePrefix, "ComposeServiceNamePrefix should be set to the default value.")
-	assert.Equal(t, ecscli.CFNStackNamePrefixDefaultValue, config.CFNStackNamePrefix, "CFNStackNamePrefix should be set to the default value.")
+	assert.Equal(t, ecscli.CFNStackNamePrefixDefaultValue+"test", config.CFNStackName, "CFNStackNamePrefix should be set to the default value.")
 }
 
 func TestReadCredentialsFile(t *testing.T) {
@@ -270,8 +268,7 @@ cfn-stack-name-prefix = amazon-ecs-cli-setup-
 	readConfig, err := parser.Get("", "")
 	assert.NoError(t, err, "Error reading config")
 	assert.Equal(t, testClusterName, readConfig.Cluster, "Cluster name mismatch in config.")
-	assert.Empty(t, readConfig.ComposeProjectNamePrefix, "Compose project prefix name should be empty.")
 	assert.Empty(t, readConfig.ComposeServiceNamePrefix, "Compose service prefix name should be empty.")
-	assert.Empty(t, readConfig.CFNStackNamePrefix, "CFNStackNamePrefix should be empty.")
+	assert.Empty(t, readConfig.CFNStackName, "CFNStackName should be empty.")
 
 }

--- a/ecs-cli/modules/utils/compose/name.go
+++ b/ecs-cli/modules/utils/compose/name.go
@@ -45,11 +45,6 @@ func GetServiceName(prefix, projectName string) string {
 	return fmt.Sprintf("%s%s", prefix, projectName)
 }
 
-// GetTaskDefinitionFamily returns the task definition family name
-func GetTaskDefinitionFamily(prefix, projectName string) string {
-	return fmt.Sprintf("%s%s", prefix, projectName)
-}
-
 // GetTaskGroup returns <task-group-prefix><task-definition-family> used for grouping tasks
 func GetTaskGroup(prefix, projectName string) string {
 	return fmt.Sprintf("%s:%s%s", TaskGroupPrefix, prefix, projectName)


### PR DESCRIPTION
Implements #252

- New Migrate command allows users to migrate their config from the old format to the new format
- Removed the prefixes from the config according to proposal #252 
- Added unit test for Migrate command; all relevant pre-existing tests were modified for the removal of the prefixes.