### PR TITLE
Consistently return a non zero exit status for error conditions.

### DIFF
--- a/ecs-cli/main.go
+++ b/ecs-cli/main.go
@@ -53,5 +53,6 @@ func main() {
 		licenseCommand.LicenseCommand(),
 		composeCommand.ComposeCommand(composeFactory),
 	}
+
 	app.Run(os.Args)
 }

--- a/ecs-cli/modules/cli/cluster/cluster_app.go
+++ b/ecs-cli/modules/cli/cluster/cluster_app.go
@@ -59,61 +59,53 @@ func init() {
 func ClusterUp(c *cli.Context) {
 	rdwr, err := config.NewReadWriter()
 	if err != nil {
-		logrus.Error("Error executing 'up': ", err)
-		return
+		logrus.Fatal("Error executing 'up': ", err)
 	}
 
 	ecsClient := ecsclient.NewECSClient()
 	cfnClient := cloudformation.NewCloudformationClient()
 	amiIds := ami.NewStaticAmiIds()
 	if err := createCluster(c, rdwr, ecsClient, cfnClient, amiIds); err != nil {
-		logrus.Error("Error executing 'up': ", err)
-		return
+		logrus.Fatal("Error executing 'up': ", err)
 	}
 }
 
 func ClusterDown(c *cli.Context) {
 	rdwr, err := config.NewReadWriter()
 	if err != nil {
-		logrus.Error("Error executing 'down': ", err)
-		return
+		logrus.Fatal("Error executing 'down': ", err)
 	}
 
 	ecsClient := ecsclient.NewECSClient()
 	cfnClient := cloudformation.NewCloudformationClient()
 	if err := deleteCluster(c, rdwr, ecsClient, cfnClient); err != nil {
-		logrus.Error("Error executing 'down': ", err)
-		return
+		logrus.Fatal("Error executing 'down': ", err)
 	}
 }
 
 func ClusterScale(c *cli.Context) {
 	rdwr, err := config.NewReadWriter()
 	if err != nil {
-		logrus.Error("Error executing 'scale': ", err)
-		return
+		logrus.Fatal("Error executing 'scale': ", err)
 	}
 
 	ecsClient := ecsclient.NewECSClient()
 	cfnClient := cloudformation.NewCloudformationClient()
 	if err := scaleCluster(c, rdwr, ecsClient, cfnClient); err != nil {
-		logrus.Error("Error executing 'scale': ", err)
-		return
+		logrus.Fatal("Error executing 'scale': ", err)
 	}
 }
 
 func ClusterPS(c *cli.Context) {
 	rdwr, err := config.NewReadWriter()
 	if err != nil {
-		logrus.Error("Error executing 'ps ", err)
-		return
+		logrus.Fatal("Error executing 'ps ", err)
 	}
 
 	ecsClient := ecsclient.NewECSClient()
 	infoSet, err := clusterPS(c, rdwr, ecsClient)
 	if err != nil {
-		logrus.Error("Error executing 'ps ", err)
-		return
+		logrus.Fatal("Error executing 'ps ", err)
 	}
 	os.Stdout.WriteString(infoSet.String(container.ContainerInfoColumns, displayTitle))
 }

--- a/ecs-cli/modules/cli/compose/compose_app.go
+++ b/ecs-cli/modules/cli/compose/compose_app.go
@@ -21,7 +21,6 @@ import (
 	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/cli/compose/container"
 	composeFactory "github.com/aws/amazon-ecs-cli/ecs-cli/modules/cli/compose/factory"
 	ecscompose "github.com/aws/amazon-ecs-cli/ecs-cli/modules/cli/compose/project"
-	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/utils/compose"
 	"github.com/flynn/go-shlex"
 	"github.com/urfave/cli"
 )
@@ -141,12 +140,4 @@ func ProjectDown(p ecscompose.Project, c *cli.Context) {
 	if err != nil {
 		log.Fatal(err)
 	}
-}
-
-// common function for all unsupported operations
-func unsupportedOperation(c *cli.Context) {
-	log.WithFields(log.Fields{
-		"command": c.Command.Name,
-		"Error":   utils.ErrUnsupported,
-	}).Error("Unable to run command")
 }

--- a/ecs-cli/modules/cli/configure/configure.go
+++ b/ecs-cli/modules/cli/configure/configure.go
@@ -26,17 +26,15 @@ import (
 func Configure(context *cli.Context) {
 	ecsConfig, err := createECSConfigFromCli(context)
 	if err != nil {
-		logrus.Error("Error initializing: ", err)
-		return
+		logrus.Fatal("Error initializing: ", err)
 	}
 	rdwr, err := config.NewReadWriter()
 	if err != nil {
-		logrus.Error("Error initializing: ", err)
-		return
+		logrus.Fatal("Error initializing: ", err)
 	}
 	err = saveConfig(ecsConfig, rdwr, rdwr.Destination)
 	if err != nil {
-		logrus.Error("Error initializing: ", err)
+		logrus.Fatal("Error initializing: ", err)
 	}
 }
 

--- a/ecs-cli/modules/cli/image/image_app.go
+++ b/ecs-cli/modules/cli/image/image_app.go
@@ -53,27 +53,23 @@ const (
 func ImagePush(c *cli.Context) {
 	rdwr, err := config.NewReadWriter()
 	if err != nil {
-		logrus.Error("Error executing 'push': ", err)
-		return
+		logrus.Fatal("Error executing 'push': ", err)
 	}
 
 	ecsParams, err := config.NewCliParams(c, rdwr)
 	if err != nil {
-		logrus.Error("Error executing 'push': ", err)
-		return
+		logrus.Fatal("Error executing 'push': ", err)
 	}
 
 	dockerClient, err := dockerclient.NewClient()
 	if err != nil {
-		logrus.Error("Error executing 'push': ", err)
-		return
+		logrus.Fatal("Error executing 'push': ", err)
 	}
 	ecrClient := ecrclient.NewClient(ecsParams)
 	stsClient := stsclient.NewClient(ecsParams)
 
 	if err := pushImage(c, rdwr, dockerClient, ecrClient, stsClient); err != nil {
-		logrus.Error("Error executing 'push': ", err)
-		return
+		logrus.Fatal("Error executing 'push': ", err)
 	}
 }
 
@@ -81,27 +77,23 @@ func ImagePush(c *cli.Context) {
 func ImagePull(c *cli.Context) {
 	rdwr, err := config.NewReadWriter()
 	if err != nil {
-		logrus.Error("Error executing 'pull': ", err)
-		return
+		logrus.Fatal("Error executing 'pull': ", err)
 	}
 
 	ecsParams, err := config.NewCliParams(c, rdwr)
 	if err != nil {
-		logrus.Error("Error executing 'pull': ", err)
-		return
+		logrus.Fatal("Error executing 'pull': ", err)
 	}
 
 	dockerClient, err := dockerclient.NewClient()
 	if err != nil {
-		logrus.Error("Error executing 'pull': ", err)
-		return
+		logrus.Fatal("Error executing 'pull': ", err)
 	}
 	ecrClient := ecrclient.NewClient(ecsParams)
 	stsClient := stsclient.NewClient(ecsParams)
 
 	if err := pullImage(c, rdwr, dockerClient, ecrClient, stsClient); err != nil {
-		logrus.Error("Error executing 'pull': ", err)
-		return
+		logrus.Fatal("Error executing 'pull': ", err)
 	}
 }
 
@@ -109,19 +101,17 @@ func ImagePull(c *cli.Context) {
 func ImageList(c *cli.Context) {
 	rdwr, err := config.NewReadWriter()
 	if err != nil {
-		logrus.Error("Error executing 'images': ", err)
-		return
+		logrus.Fatal("Error executing 'images': ", err)
 	}
 
 	ecsParams, err := config.NewCliParams(c, rdwr)
 	if err != nil {
-		logrus.Error("Error executing 'images': ", err)
-		return
+		logrus.Fatal("Error executing 'images': ", err)
 	}
 
 	ecrClient := ecrclient.NewClient(ecsParams)
 	if err := getImages(c, rdwr, ecrClient); err != nil {
-		logrus.Error("Error executing 'images': ", err)
+		logrus.Fatal("Error executing 'images': ", err)
 		return
 	}
 }

--- a/ecs-cli/modules/commands/cluster/cluster_command.go
+++ b/ecs-cli/modules/commands/cluster/cluster_command.go
@@ -22,38 +22,42 @@ import (
 
 func UpCommand() cli.Command {
 	return cli.Command{
-		Name:   "up",
-		Usage:  "Creates the ECS cluster (if it does not already exist) and the AWS resources required to set up the cluster.",
-		Before: ecscli.BeforeApp,
-		Action: cluster.ClusterUp,
-		Flags:  append(clusterUpFlags(), command.OptionalClusterFlag(), command.OptionalRegionFlag()),
+		Name:         "up",
+		Usage:        "Creates the ECS cluster (if it does not already exist) and the AWS resources required to set up the cluster.",
+		Before:       ecscli.BeforeApp,
+		Action:       cluster.ClusterUp,
+		Flags:        append(clusterUpFlags(), command.OptionalClusterFlag(), command.OptionalRegionFlag()),
+		OnUsageError: command.UsageErrorFactory("up"),
 	}
 }
 
 func DownCommand() cli.Command {
 	return cli.Command{
-		Name:   "down",
-		Usage:  "Deletes the CloudFormation stack that was created by ecs-cli up and the associated resources. The --force option is required.",
-		Action: cluster.ClusterDown,
-		Flags:  append(clusterDownFlags(), command.OptionalClusterFlag(), command.OptionalRegionFlag()),
+		Name:         "down",
+		Usage:        "Deletes the CloudFormation stack that was created by ecs-cli up and the associated resources. The --force option is required.",
+		Action:       cluster.ClusterDown,
+		Flags:        append(clusterDownFlags(), command.OptionalClusterFlag(), command.OptionalRegionFlag()),
+		OnUsageError: command.UsageErrorFactory("down"),
 	}
 }
 
 func ScaleCommand() cli.Command {
 	return cli.Command{
-		Name:   "scale",
-		Usage:  "Modifies the number of container instances in your cluster. This command changes the desired and maximum instance count in the Auto Scaling group created by the ecs-cli up command. You can use this command to scale up (increase the number of instances) or scale down (decrease the number of instances) your cluster.",
-		Action: cluster.ClusterScale,
-		Flags:  append(clusterScaleFlags(), command.OptionalClusterFlag(), command.OptionalRegionFlag()),
+		Name:         "scale",
+		Usage:        "Modifies the number of container instances in your cluster. This command changes the desired and maximum instance count in the Auto Scaling group created by the ecs-cli up command. You can use this command to scale up (increase the number of instances) or scale down (decrease the number of instances) your cluster.",
+		Action:       cluster.ClusterScale,
+		Flags:        append(clusterScaleFlags(), command.OptionalClusterFlag(), command.OptionalRegionFlag()),
+		OnUsageError: command.UsageErrorFactory("scale"),
 	}
 }
 
 func PsCommand() cli.Command {
 	return cli.Command{
-		Name:   "ps",
-		Usage:  "Lists all of the running containers in your ECS cluster",
-		Action: cluster.ClusterPS,
-		Flags:  []cli.Flag{command.OptionalClusterFlag(), command.OptionalRegionFlag()},
+		Name:         "ps",
+		Usage:        "Lists all of the running containers in your ECS cluster",
+		Action:       cluster.ClusterPS,
+		Flags:        []cli.Flag{command.OptionalClusterFlag(), command.OptionalRegionFlag()},
+		OnUsageError: command.UsageErrorFactory("ps"),
 	}
 }
 

--- a/ecs-cli/modules/commands/compose/compose_command.go
+++ b/ecs-cli/modules/commands/compose/compose_command.go
@@ -70,6 +70,7 @@ func ComposeCommand(factory composeFactory.ProjectFactory) cli.Command {
 			// TODO, should honor restart policy in the compose yaml and create ECS Services accordingly
 			serviceCommand.ServiceCommand(factory),
 		},
+		OnUsageError: command.UsageErrorFactory("create"),
 	}
 }
 
@@ -107,6 +108,7 @@ func createCommand(factory composeFactory.ProjectFactory) cli.Command {
 			command.OptionalClusterFlag(),
 			command.OptionalRegionFlag(),
 		},
+		OnUsageError: command.UsageErrorFactory("create"),
 	}
 }
 
@@ -120,6 +122,7 @@ func psCommand(factory composeFactory.ProjectFactory) cli.Command {
 			command.OptionalClusterFlag(),
 			command.OptionalRegionFlag(),
 		},
+		OnUsageError: command.UsageErrorFactory("ps"),
 	}
 }
 
@@ -132,6 +135,7 @@ func upCommand(factory composeFactory.ProjectFactory) cli.Command {
 			command.OptionalClusterFlag(),
 			command.OptionalRegionFlag(),
 		},
+		OnUsageError: command.UsageErrorFactory("up"),
 	}
 }
 
@@ -144,6 +148,7 @@ func startCommand(factory composeFactory.ProjectFactory) cli.Command {
 			command.OptionalClusterFlag(),
 			command.OptionalRegionFlag(),
 		},
+		OnUsageError: command.UsageErrorFactory("start"),
 	}
 }
 
@@ -157,6 +162,7 @@ func runCommand(factory composeFactory.ProjectFactory) cli.Command {
 			command.OptionalClusterFlag(),
 			command.OptionalRegionFlag(),
 		},
+		OnUsageError: command.UsageErrorFactory("run"),
 	}
 }
 
@@ -170,6 +176,7 @@ func stopCommand(factory composeFactory.ProjectFactory) cli.Command {
 			command.OptionalClusterFlag(),
 			command.OptionalRegionFlag(),
 		},
+		OnUsageError: command.UsageErrorFactory("stop"),
 	}
 }
 
@@ -182,5 +189,6 @@ func scaleCommand(factory composeFactory.ProjectFactory) cli.Command {
 			command.OptionalClusterFlag(),
 			command.OptionalRegionFlag(),
 		},
+		OnUsageError: command.UsageErrorFactory("scale"),
 	}
 }

--- a/ecs-cli/modules/commands/configure/configure_command.go
+++ b/ecs-cli/modules/commands/configure/configure_command.go
@@ -24,10 +24,11 @@ import (
 // ConfigureCommand configure command help
 func ConfigureCommand() cli.Command {
 	return cli.Command{
-		Name:   "configure",
-		Usage:  "Configures your AWS credentials, the AWS region to use, and the ECS cluster name to use with the Amazon ECS CLI. The resulting configuration is stored in the ~/.ecs/config file.",
-		Action: configure.Configure,
-		Flags:  configureFlags(),
+		Name:         "configure",
+		Usage:        "Configures your AWS credentials, the AWS region to use, and the ECS cluster name to use with the Amazon ECS CLI. The resulting configuration is stored in the ~/.ecs/config file.",
+		Action:       configure.Configure,
+		Flags:        configureFlags(),
+		OnUsageError: flags.UsageErrorFactory("configure"),
 	}
 }
 

--- a/ecs-cli/modules/commands/flags.go
+++ b/ecs-cli/modules/commands/flags.go
@@ -15,7 +15,9 @@ package command
 
 import (
 	"fmt"
+	"os"
 
+	"github.com/Sirupsen/logrus"
 	"github.com/urfave/cli"
 )
 
@@ -96,5 +98,17 @@ func OptionalRegionFlag() cli.Flag {
 		Usage: fmt.Sprintf(
 			"[Optional] Specifies the AWS region to use. Defaults to the region configured using the configure command",
 		),
+	}
+}
+
+// UsageErrorFactory Returns a usage error function for the specified command
+func UsageErrorFactory(command string) func(*cli.Context, error, bool) error {
+	return func(c *cli.Context, err error, isSubcommand bool) error {
+		if err != nil {
+			logrus.Error(err)
+		}
+		cli.ShowCommandHelp(c, command)
+		os.Exit(1)
+		return err
 	}
 }

--- a/ecs-cli/modules/commands/image/image_command.go
+++ b/ecs-cli/modules/commands/image/image_command.go
@@ -23,36 +23,39 @@ import (
 // PushCommand push ECR image
 func PushCommand() cli.Command {
 	return cli.Command{
-		Name:      "push",
-		Usage:     "Push an image to an Amazon ECR repository.",
-		ArgsUsage: image.PushImageFormat,
-		Before:    app.BeforeApp,
-		Action:    image.ImagePush,
-		Flags:     append(imagePushFlags(), command.OptionalRegionFlag()),
+		Name:         "push",
+		Usage:        "Push an image to an Amazon ECR repository.",
+		ArgsUsage:    image.PushImageFormat,
+		Before:       app.BeforeApp,
+		Action:       image.ImagePush,
+		Flags:        append(imagePushFlags(), command.OptionalRegionFlag()),
+		OnUsageError: command.UsageErrorFactory("push"),
 	}
 }
 
 // PullCommand pull ECR image
 func PullCommand() cli.Command {
 	return cli.Command{
-		Name:      "pull",
-		Usage:     "Pull an image from an Amazon ECR repository.",
-		ArgsUsage: image.PullImageFormat,
-		Before:    app.BeforeApp,
-		Action:    image.ImagePull,
-		Flags:     append(imagePullFlags(), command.OptionalRegionFlag()),
+		Name:         "pull",
+		Usage:        "Pull an image from an Amazon ECR repository.",
+		ArgsUsage:    image.PullImageFormat,
+		Before:       app.BeforeApp,
+		Action:       image.ImagePull,
+		Flags:        append(imagePullFlags(), command.OptionalRegionFlag()),
+		OnUsageError: command.UsageErrorFactory("pull"),
 	}
 }
 
 // ImagesCommand list images in ECR
 func ImagesCommand() cli.Command {
 	return cli.Command{
-		Name:      "images",
-		Usage:     "List images an Amazon ECR repository.",
-		ArgsUsage: image.ListImageFormat,
-		Before:    app.BeforeApp,
-		Action:    image.ImageList,
-		Flags:     append(imageListFlags(), command.OptionalRegionFlag()),
+		Name:         "images",
+		Usage:        "List images an Amazon ECR repository.",
+		ArgsUsage:    image.ListImageFormat,
+		Before:       app.BeforeApp,
+		Action:       image.ImageList,
+		Flags:        append(imageListFlags(), command.OptionalRegionFlag()),
+		OnUsageError: command.UsageErrorFactory("images"),
 	}
 }
 

--- a/ecs-cli/modules/commands/license/license_command.go
+++ b/ecs-cli/modules/commands/license/license_command.go
@@ -15,14 +15,16 @@ package licenseCommand
 
 import (
 	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/cli/license"
+	command "github.com/aws/amazon-ecs-cli/ecs-cli/modules/commands"
 	"github.com/urfave/cli"
 )
 
 // LicenseCommand prints the license
 func LicenseCommand() cli.Command {
 	return cli.Command{
-		Name:   "license",
-		Usage:  "Prints the LICENSE files for the ECS CLI and its dependencies.",
-		Action: license.PrintLicense,
+		Name:         "license",
+		Usage:        "Prints the LICENSE files for the ECS CLI and its dependencies.",
+		Action:       license.PrintLicense,
+		OnUsageError: command.UsageErrorFactory("license"),
 	}
 }


### PR DESCRIPTION
closes #306 

(These changes were already reviews as part of #302; pulling them out into a separate PR so that this can be pushed sooner.)

- CLI now consistently returns a non-zero exit code if there is an error condition 
    - All commands now use `logrus.fatal` for error logging (previously it was a random mix of `logrus.error` and `logrus.fatal`. This change is necessary to make the simple integration tests work. 
    - Usage errors (incorrect flags, incorrect commands, etc) now set the exit code to be non-zero.

Examples:
```sh
$ ecs-cli configure cat
FATA[0000] Error initializing: Missing required argument 'cluster' 
$ echo $?
1
```

```sh
$ ecs-cli up --cat
ERRO[0000] flag provided but not defined: -cat   
.... <help text>... 
$ echo $?
1
```

```sh
$ ecs-cli compose up
ERRO[0000] Failed to find the compose file: docker-compose.yml 
ERRO[0000] Unable to open ECS Compose Project            error="open docker-compose.yml: no such file or directory"
FATA[0000] Unable to create and read ECS Compose Project  error="open docker-compose.yml: no such file or directory"
$ echo $?
1
```