### PR TITLE
PS command displays private IPs

### DIFF
--- a/ecs-cli/modules/cli/compose/entity/entity_helper.go
+++ b/ecs-cli/modules/cli/compose/entity/entity_helper.go
@@ -188,7 +188,6 @@ func getContainersForTasks(entity ProjectEntity, ecsTasks []*ecs.Task) ([]compos
 		if ec2ID != "" && ec2Instances[ec2ID] != nil {
 			ec2IPAddress = aws.StringValue(ec2Instances[ec2ID].PublicIpAddress)
 			if ec2IPAddress == "" {
-				// If Public IP is empty, use private IP
 				ec2IPAddress = aws.StringValue(ec2Instances[ec2ID].PrivateIpAddress)
 			}
 		}

--- a/ecs-cli/modules/cli/compose/entity/entity_helper.go
+++ b/ecs-cli/modules/cli/compose/entity/entity_helper.go
@@ -81,8 +81,7 @@ func Info(entity ProjectEntity, filterLocal bool) (project.InfoSet, error) {
 	if err != nil {
 		return nil, err
 	}
-	allInfo := composecontainer.ConvertContainersToInfoSet(containers)
-	return allInfo, nil
+	return composecontainer.ConvertContainersToInfoSet(containers), nil
 }
 
 // collectContainers gets all the desiredStatus=RUNNING and STOPPED tasks with EC2 IP Addresses
@@ -188,6 +187,10 @@ func getContainersForTasks(entity ProjectEntity, ecsTasks []*ecs.Task) ([]compos
 		var ec2IPAddress string
 		if ec2ID != "" && ec2Instances[ec2ID] != nil {
 			ec2IPAddress = aws.StringValue(ec2Instances[ec2ID].PublicIpAddress)
+			if ec2IPAddress == "" {
+				// If Public IP is empty, use private IP
+				ec2IPAddress = aws.StringValue(ec2Instances[ec2ID].PrivateIpAddress)
+			}
 		}
 		for _, container := range ecsTask.Containers {
 			result = append(result, composecontainer.NewContainer(ecsTask, ec2IPAddress, container))

--- a/ecs-cli/modules/cli/compose/entity/entity_test.go
+++ b/ecs-cli/modules/cli/compose/entity/entity_test.go
@@ -43,19 +43,19 @@ func TestGetContainersForTasks(t *testing.T) {
 			ContainerInstanceArn: aws.String(containerInstanceArn),
 		},
 	}
-	containerInstancesMap := make(map[string]string)
-	containerInstancesMap[containerInstanceArn] = ec2InstanceID
+	containerInstances := make(map[string]string)
+	containerInstances[containerInstanceArn] = ec2InstanceID
 
-	ec2InstancesMap := make(map[string]*ec2.Instance)
-	ec2InstancesMap[ec2InstanceID] = ec2Instance
+	ec2Instances := make(map[string]*ec2.Instance)
+	ec2Instances[ec2InstanceID] = ec2Instance
 
-	mockProjectEntity := setupMocks(t, []*string{aws.String(containerInstanceArn)}, containerInstancesMap,
-		[]*string{aws.String(ec2InstanceID)}, ec2InstancesMap)
+	mockProjectEntity := setupMocks(t, []*string{aws.String(containerInstanceArn)}, containerInstances,
+		[]*string{aws.String(ec2InstanceID)}, ec2Instances)
 
 	containers, err := getContainersForTasks(mockProjectEntity, ecsTasks)
 	assert.NoError(t, err, "Unexpected error when calling getContainersForTasks")
-	assert.Len(t, containers, 1, "Expects to have 1 containers")
-	assert.Equal(t, containers[0].Ec2IPAddress, aws.StringValue(ec2Instance.PublicIpAddress), "Expects PublicIpAddress to match")
+	assert.Len(t, containers, 1, "Expected to have 1 container")
+	assert.Equal(t, aws.StringValue(ec2Instance.PublicIpAddress), containers[0].Ec2IPAddress, "Expects PublicIpAddress to match")
 }
 
 func TestGetContainersForTasksPrivateIP(t *testing.T) {
@@ -73,19 +73,19 @@ func TestGetContainersForTasksPrivateIP(t *testing.T) {
 			ContainerInstanceArn: aws.String(containerInstanceArn),
 		},
 	}
-	containerInstancesMap := make(map[string]string)
-	containerInstancesMap[containerInstanceArn] = ec2InstanceID
+	containerInstances := make(map[string]string)
+	containerInstances[containerInstanceArn] = ec2InstanceID
 
-	ec2InstancesMap := make(map[string]*ec2.Instance)
-	ec2InstancesMap[ec2InstanceID] = ec2Instance
+	ec2Instances := make(map[string]*ec2.Instance)
+	ec2Instances[ec2InstanceID] = ec2Instance
 
-	mockProjectEntity := setupMocks(t, []*string{aws.String(containerInstanceArn)}, containerInstancesMap,
-		[]*string{aws.String(ec2InstanceID)}, ec2InstancesMap)
+	mockProjectEntity := setupMocks(t, []*string{aws.String(containerInstanceArn)}, containerInstances,
+		[]*string{aws.String(ec2InstanceID)}, ec2Instances)
 
 	containers, err := getContainersForTasks(mockProjectEntity, ecsTasks)
 	assert.NoError(t, err, "Unexpected error when calling getContainersForTasks")
-	assert.Len(t, containers, 1, "Expects to have 1 containers")
-	assert.Equal(t, containers[0].Ec2IPAddress, aws.StringValue(ec2Instance.PrivateIpAddress), "Expects PublicIpAddress to match")
+	assert.Len(t, containers, 1, "Expected to have 1 container")
+	assert.Equal(t, aws.StringValue(ec2Instance.PrivateIpAddress), containers[0].Ec2IPAddress, "Expects PublicIpAddress to match")
 }
 
 func TestGetContainersForTasksWithoutEc2InstanceID(t *testing.T) {
@@ -102,14 +102,14 @@ func TestGetContainersForTasksWithoutEc2InstanceID(t *testing.T) {
 			ContainerInstanceArn: aws.String(containerInstanceArn),
 		},
 	}
-	containerInstancesMap := make(map[string]string)
-	containerInstancesMap[containerInstanceArn] = ec2InstanceID
+	containerInstances := make(map[string]string)
+	containerInstances[containerInstanceArn] = ec2InstanceID
 
 	// No ec2InstanceID is found
-	ec2InstancesMap := make(map[string]*ec2.Instance)
+	ec2Instances := make(map[string]*ec2.Instance)
 
-	projectEntity := setupMocks(t, []*string{aws.String(containerInstanceArn)}, containerInstancesMap,
-		[]*string{aws.String(ec2InstanceID)}, ec2InstancesMap)
+	projectEntity := setupMocks(t, []*string{aws.String(containerInstanceArn)}, containerInstances,
+		[]*string{aws.String(ec2InstanceID)}, ec2Instances)
 
 	containers, err := getContainersForTasks(projectEntity, ecsTasks)
 	assert.NoError(t, err, "Unexpected error when calling getContainersForTasks")
@@ -131,8 +131,8 @@ func TestGetContainersForTasksErrorCases(t *testing.T) {
 			ContainerInstanceArn: aws.String(containerInstanceArn),
 		},
 	}
-	containerInstancesMap := make(map[string]string)
-	containerInstancesMap[containerInstanceArn] = ec2InstanceID
+	containerInstances := make(map[string]string)
+	containerInstances[containerInstanceArn] = ec2InstanceID
 
 	mockEc2, mockEcs, mockProjectEntity := setupTest(t)
 	mockContext := &context.Context{
@@ -151,7 +151,7 @@ func TestGetContainersForTasksErrorCases(t *testing.T) {
 	// DescribeInstances failed
 	gomock.InOrder(
 		mockProjectEntity.EXPECT().Context().Return(mockContext),
-		mockEcs.EXPECT().GetEC2InstanceIDs(gomock.Any()).Return(containerInstancesMap, nil),
+		mockEcs.EXPECT().GetEC2InstanceIDs(gomock.Any()).Return(containerInstances, nil),
 		mockProjectEntity.EXPECT().Context().Return(mockContext),
 		mockEc2.EXPECT().DescribeInstances(gomock.Any()).Return(nil, errors.New("something wrong")),
 	)

--- a/ecs-cli/modules/cli/compose/entity/entity_test.go
+++ b/ecs-cli/modules/cli/compose/entity/entity_test.go
@@ -61,7 +61,7 @@ func TestGetContainersForTasks(t *testing.T) {
 func TestGetContainersForTasksPrivateIP(t *testing.T) {
 	containerInstanceArn := "containerInstanceArn"
 	ec2InstanceID := "ec2InstanceId"
-	ec2Instance := &ec2.Instance{PrivateIpAddress: aws.String("publicIpAddress")}
+	ec2Instance := &ec2.Instance{PrivateIpAddress: aws.String("privateIpAddress")}
 
 	ecsTasks := []*ecs.Task{
 		&ecs.Task{


### PR DESCRIPTION
closes #310 

- Displays private IP if the instance doesn't have a public IP

Public IP (same as old functionality)
```
$ ecs-cli ps --cluster PublicIP                                       
Name                                            State    Ports                   TaskDefinition
f3b7b93d-af17-4cf0-b6b9-c7bf2c4b61b2/wordpress  RUNNING  13.59.2.148:80->80/tcp  ecscompose-test2:15
f3b7b93d-af17-4cf0-b6b9-c7bf2c4b61b2/mysql      RUNNING                          ecscompose-test2:15
```

Private IP
```
$ ecs-cli ps --cluster PrivateIP
Name                                            State    Ports                  TaskDefinition
3b06a88c-7c6b-4eb9-8c40-287fcad2a19e/wordpress  RUNNING  10.0.1.121:80->80/tcp  ecscompose-test2:15
3b06a88c-7c6b-4eb9-8c40-287fcad2a19e/mysql      RUNNING                         ecscompose-test2:15
```