### PR TITLE
Update compose service up and compose service start help text.

### DIFF
--- a/ecs-cli/modules/commands/compose/service/compose_service_command.go
+++ b/ecs-cli/modules/commands/compose/service/compose_service_command.go
@@ -76,7 +76,7 @@ func createServiceCommand(factory composeFactory.ProjectFactory) cli.Command {
 func startServiceCommand(factory composeFactory.ProjectFactory) cli.Command {
 	return cli.Command{
 		Name:   "start",
-		Usage:  "Starts one copy of each of the containers on the created ECS service. This command updates the desired count of the service to 1.",
+		Usage:  "Starts one copy of each of the containers on the created ECS service. If the service does not already exist, it sets the desired running count to 1.",
 		Action: compose.WithProject(factory, compose.ProjectStart, true),
 		Flags: []cli.Flag{
 			command.OptionalClusterFlag(),
@@ -89,7 +89,7 @@ func startServiceCommand(factory composeFactory.ProjectFactory) cli.Command {
 func upServiceCommand(factory composeFactory.ProjectFactory) cli.Command {
 	return cli.Command{
 		Name:   "up",
-		Usage:  "Creates an ECS service from your compose file (if it does not already exist) and runs one instance of that task on your cluster (a combination of create and start). This command updates the desired count of the service to 1.",
+		Usage:  "Creates an ECS service from your compose file (if it does not already exist) and runs one instance of that task on your cluster (a combination of create and start). If the service does not already exist, it sets the desired running count to 1.",
 		Action: compose.WithProject(factory, compose.ProjectUp, true),
 		Flags:  append(deploymentConfigFlags(true), append(loadBalancerFlags(), command.OptionalClusterFlag(), command.OptionalRegionFlag(), ComposeServiceTimeoutFlag())...),
 	}

--- a/ecs-cli/modules/commands/compose/service/compose_service_command.go
+++ b/ecs-cli/modules/commands/compose/service/compose_service_command.go
@@ -76,7 +76,7 @@ func createServiceCommand(factory composeFactory.ProjectFactory) cli.Command {
 func startServiceCommand(factory composeFactory.ProjectFactory) cli.Command {
 	return cli.Command{
 		Name:   "start",
-		Usage:  "Starts one copy of each of the containers on the created ECS service. If the service does not already exist, it sets the desired running count to 1.",
+		Usage:  "Starts one copy of each of the containers on the created ECS service. If the desired count is 0, it sets the desired running count to 1; otherwise this command is a no-op.",
 		Action: compose.WithProject(factory, compose.ProjectStart, true),
 		Flags: []cli.Flag{
 			command.OptionalClusterFlag(),
@@ -89,7 +89,7 @@ func startServiceCommand(factory composeFactory.ProjectFactory) cli.Command {
 func upServiceCommand(factory composeFactory.ProjectFactory) cli.Command {
 	return cli.Command{
 		Name:   "up",
-		Usage:  "Creates an ECS service from your compose file (if it does not already exist) and runs one instance of that task on your cluster (a combination of create and start). If the service does not already exist, it sets the desired running count to 1.",
+		Usage:  "Creates or Updates an ECS Service using your compose file. If the service is being created or has its desired count set to 0, then the desired count is set to 1. Otherwise, the service’s task definition is updated to reflect any changes to the compose file, and the desired count remains the same.",
 		Action: compose.WithProject(factory, compose.ProjectUp, true),
 		Flags:  append(deploymentConfigFlags(true), append(loadBalancerFlags(), command.OptionalClusterFlag(), command.OptionalRegionFlag(), ComposeServiceTimeoutFlag())...),
 	}

--- a/ecs-cli/modules/commands/compose/service/compose_service_command.go
+++ b/ecs-cli/modules/commands/compose/service/compose_service_command.go
@@ -76,7 +76,7 @@ func createServiceCommand(factory composeFactory.ProjectFactory) cli.Command {
 func startServiceCommand(factory composeFactory.ProjectFactory) cli.Command {
 	return cli.Command{
 		Name:   "start",
-		Usage:  "Starts one copy of each of the containers on the created ECS service. If the desired count is 0, it sets the desired running count to 1; otherwise this command is a no-op.",
+		Usage:  "Starts one copy of each of the containers on an existing ECS service by setting the desired count to 1 (only if the current desired count is 0).",
 		Action: compose.WithProject(factory, compose.ProjectStart, true),
 		Flags: []cli.Flag{
 			command.OptionalClusterFlag(),
@@ -89,7 +89,7 @@ func startServiceCommand(factory composeFactory.ProjectFactory) cli.Command {
 func upServiceCommand(factory composeFactory.ProjectFactory) cli.Command {
 	return cli.Command{
 		Name:   "up",
-		Usage:  "Creates or Updates an ECS Service using your compose file. If the service is being created or has its desired count set to 0, then the desired count is set to 1. Otherwise, the service’s task definition is updated to reflect any changes to the compose file, and the desired count remains the same.",
+		Usage:  "Creates a new ECS service or updates an existing one according to your compose file. For new services or existing services with a current desired count of 0, the desired count for the service is set to 1. For existing services with non-zero desired counts, a new task definition is created to reflect any changes to the compose file and the service is updated to use that task definition. In this case, the desired count does not change.",
 		Action: compose.WithProject(factory, compose.ProjectUp, true),
 		Flags:  append(deploymentConfigFlags(true), append(loadBalancerFlags(), command.OptionalClusterFlag(), command.OptionalRegionFlag(), ComposeServiceTimeoutFlag())...),
 	}


### PR DESCRIPTION
closes #325 

Compose Service Up:
- If the service does not exist, then it Creates the service, and calls Start to set the desired count to 1.
- If the service exist and has a desired count of 0, then Start is called to update it to 1.
- If a non-zero running count already exists, then it is unchanged. Update service called to update the service with a new version of the task definition. 

```
$ ecs-cli compose service up --help
NAME:
   ecs-cli compose service up - Creates a new ECS service or updates an existing one according to your compose file. For new services or existing services with a current desired count of 0, the desired count for the service is set to 1. For existing services with non-zero desired counts, a new task definition is created to reflect any changes to the compose file and the service is updated to use that task definition. In this case, the desired count does not change.

USAGE:
   ecs-cli compose service up [command options] [arguments...]

```

Compose Service Start:
- If desired count is 0, it sets it to 1
- Otherwise, its a no-op, and it just waits for the running count to equal the desired count and prints any service events.

```
$ ecs-cli compose service start --help
NAME:
   ecs-cli compose service start - Starts one copy of each of the containers on the created ECS service. If the desired count is 0, it sets the desired running count to 1; otherwise this command is a no-op.

USAGE:
   ecs-cli compose service start [command options] [arguments...]
```