### PR TITLE
Support ECS fields in compose commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,20 @@ level than those provided by the Amazon ECS CLI. For more information about supp
 services and to download the AWS CLI, see the
 [AWS Command Line Interface](http://aws.amazon.com/cli/) product detail page.
 
+- [Installing](#Installing)
+	- [Latest version](#latest-version)
+		- [Download Links for within China](#download-links-for-within-china)
+	- [Download specific version](#)
+- [Configuring the CLI](#configuring-the-cli)
+- [Using the CLI](#using-the-cli)
+	- [Creating an ECS Cluster](#creating-an-ecs-cluster)
+	- [Starting/Running Tasks](#startingrunning-tasks)
+	- [Creating a Service](#creating-a-service)
+	- [Using ECS parameters](#using-ecs-parameters)
+- [Amazon ECS CLI Commands](#amazon-ecs-cli-commands)
+- [Contributing to the CLI](#contributing-to-the-cli)
+- [License](#license)
+
 ## Installing
 
 Download the binary archive for your platform, decompress the archive, and
@@ -89,8 +103,11 @@ OPTIONS:
 ```
 
 ## Using the CLI
+
+### Creating an ECS Cluster
 After installing the Amazon ECS CLI and configuring your credentials, you are ready to
 create an ECS cluster.
+
 
 ```
 $ ecs-cli help up
@@ -101,7 +118,7 @@ USAGE:
    command up [command options] [arguments...]
 
 OPTIONS:
-   --verbose, --debug                
+   --verbose, --debug
    --keypair value                   Specifies the name of an existing Amazon EC2 key pair to enable SSH access to the EC2 instances in your cluster.
    --capability-iam                  Acknowledges that this command may create IAM resources. Required if --instance-role is not specified.
    --size value                      [Optional] Specifies the number of instances to launch and register to the cluster. Defaults to 1.
@@ -152,11 +169,13 @@ described in the
 Alternatively, you may specify one or more existing security group IDs with the
 `--security-group` option.
 
+### Starting/Running Tasks
 After the cluster is created, you can run tasks – groups of containers – on the
 ECS cluster. First, author a
 [Docker Compose configuration file]( https://docs.docker.com/compose).
-You can run the configuration file locally using Docker Compose. Here is an
-example Docker Compose configuration file that creates a web page:
+You can run the configuration file locally using Docker Compose.
+
+Here is an example Docker Compose configuration file that creates a web page:
 
 ```
 version: '2'
@@ -180,6 +199,7 @@ fd8d5a69-87c5-46a4-80b6-51918092e600/web  RUNNING  54.209.244.64:80->80/tcp  ecs
 Navigate your web browser to the task’s IP address to see the sample app
 running in the ECS cluster.
 
+### Creating a Service
 You can also run tasks as services. The ECS service scheduler ensures that the
 specified number of tasks are constantly running and reschedules tasks when a
 task fails (for example, if the underlying container instance fails for some
@@ -203,6 +223,37 @@ $ ecs-cli compose --project-name wordpress-test service ps
 Name                                            State    Ports                      TaskDefinition
 34333aa6-e976-4096-991a-0ec4cd5af5bd/wordpress  RUNNING  54.186.138.217:80->80/tcp  ecscompose-wordpress-test:1
 34333aa6-e976-4096-991a-0ec4cd5af5bd/mysql      RUNNING                             ecscompose-wordpress-test:1
+```
+
+### Using ECS parameters
+
+Since there are certain fields in an ECS task definition that do not correspond to fields in a Docker Composefile, you can specify those values using the `--ecs-params` flag. Currently, the file supports the follow schema:
+
+```
+version: 1
+task_definition:
+  ecs_network_mode: string // supported string values: none, bridge, or host
+  task_role_arn: string
+```
+
+Example `ecs-params.yml` file:
+
+```
+version: 1
+task_definition:
+  ecs_network_mode: host
+  task_role_arn: myCustomRole
+```
+
+You can then start a task by calling:
+```
+ecs-cli compose --ecs-params my-ecs-params.yml up
+```
+
+If you have a file name `ecs-params.yml` in your current directory, `ecs-cli compose` will automatically read it without your having to set the `--ecs-params` flag value explicitly.
+
+```
+ecs-cli compose up
 ```
 
 ## Amazon ECS CLI Commands

--- a/ecs-cli/modules/cli/compose/entity/entity_helper.go
+++ b/ecs-cli/modules/cli/compose/entity/entity_helper.go
@@ -32,7 +32,7 @@ func SetupTaskDefinitionCache() cache.Cache {
 	if err != nil {
 		log.WithFields(log.Fields{
 			"error": err,
-		}).Warn("Unable to create cache for task definitions; extranious ones may be registered")
+		}).Warn("Unable to create cache for task definitions; extraneous ones may be registered")
 		tdCache = cache.NewNoopCache()
 	}
 	return tdCache
@@ -53,13 +53,9 @@ func GetOrCreateTaskDefinition(entity ProjectEntity) (*ecs.TaskDefinition, error
 		"TaskDefinition": taskDefinition,
 	}).Debug("Finding task definition in cache or creating if needed")
 
-	resp, err := entity.Context().ECSClient.RegisterTaskDefinitionIfNeeded(&ecs.RegisterTaskDefinitionInput{
-		Family:               taskDefinition.Family,
-		ContainerDefinitions: taskDefinition.ContainerDefinitions,
-		Volumes:              taskDefinition.Volumes,
-		TaskRoleArn:          taskDefinition.TaskRoleArn,
-		NetworkMode:          taskDefinition.NetworkMode,
-	}, entity.TaskDefinitionCache())
+	request := createRegisterTaskDefinitionRequest(taskDefinition)
+
+	resp, err := entity.Context().ECSClient.RegisterTaskDefinitionIfNeeded(request, entity.TaskDefinitionCache())
 
 	if err != nil {
 		composeutils.LogError(err, "Create task definition failed")
@@ -73,6 +69,25 @@ func GetOrCreateTaskDefinition(entity ProjectEntity) (*ecs.TaskDefinition, error
 	// update the taskdefinition of the entity with the newly received TaskDefinition
 	entity.SetTaskDefinition(resp)
 	return resp, nil
+}
+
+func createRegisterTaskDefinitionRequest(taskDefinition *ecs.TaskDefinition) *ecs.RegisterTaskDefinitionInput {
+	// Valid values for network mode are none, host or bridge. If no value
+	// is passed for network mode, ECS will set it to 'bridge' on most
+	// platforms, but Windows has different network modes. Passing nil allows ECS
+	// to do the right thing for each platform.
+	request := &ecs.RegisterTaskDefinitionInput{
+		Family:               taskDefinition.Family,
+		ContainerDefinitions: taskDefinition.ContainerDefinitions,
+		Volumes:              taskDefinition.Volumes,
+		TaskRoleArn:          taskDefinition.TaskRoleArn,
+	}
+
+	if networkMode := taskDefinition.NetworkMode; aws.StringValue(networkMode) != "" {
+		request.NetworkMode = taskDefinition.NetworkMode
+	}
+
+	return request
 }
 
 // Info returns a formatted list of containers (running and stopped) in the current cluster

--- a/ecs-cli/modules/cli/compose/entity/entity_helper.go
+++ b/ecs-cli/modules/cli/compose/entity/entity_helper.go
@@ -58,6 +58,7 @@ func GetOrCreateTaskDefinition(entity ProjectEntity) (*ecs.TaskDefinition, error
 		ContainerDefinitions: taskDefinition.ContainerDefinitions,
 		Volumes:              taskDefinition.Volumes,
 		TaskRoleArn:          taskDefinition.TaskRoleArn,
+		NetworkMode:          taskDefinition.NetworkMode,
 	}, entity.TaskDefinitionCache())
 
 	if err != nil {

--- a/ecs-cli/modules/cli/compose/factory/factory.go
+++ b/ecs-cli/modules/cli/compose/factory/factory.go
@@ -55,17 +55,20 @@ func (projectFactory projectFactory) Create(cliContext *cli.Context, isService b
 	return project, nil
 }
 
-// populateContext sets the required CLI arguments to the context
+// populateContext sets the required CLI arguments to the ECS context
 func (projectFactory projectFactory) populateContext(ecsContext *context.Context, cliContext *cli.Context) error {
 	/*
-	 Populate the following libcompose fields to context
-	 - ComposeFiles: reads from `--file` or `-f` flags. Defaults to `docker-compose.yml` and `docker-compose.override.yml` if no flags are specified.
-	 - ProjectName: reads from `--project-name` or `-p` flags.
+		Populate the following libcompose fields on the ECS context:
+		 - ComposeFiles: reads from `--file` or `-f` flags. Defaults to
+		 `docker-compose.yml` and `docker-compose.override.yml` if no flags are
+		 specified.
+		 - ProjectName: reads from `--project-name` or `-p` flags.
 	*/
 	libcomposecommand.Populate(&ecsContext.Context, cliContext)
 	ecsContext.CLIContext = cliContext
 
-	// reads and sets the parameters (required to create ECS Service Client) from the cli context to ecs context
+	// reads and sets the parameters (required to create ECS Service
+	// Client) from the cli context to ECS context
 	rdwr, err := config.NewReadWriter()
 	if err != nil {
 		utils.LogError(err, "Error loading config")
@@ -86,7 +89,7 @@ func (projectFactory projectFactory) populateContext(ecsContext *context.Context
 	return nil
 }
 
-// populateLibcomposeContext sets the required Libcompose lookup utilities to the context
+// populateLibcomposeContext sets the required Libcompose lookup utilities on the ECS context
 func (projectFactory projectFactory) populateLibcomposeContext(ecsContext *context.Context) error {
 	envLookup, err := utils.GetDefaultEnvironmentLookup()
 	if err != nil {

--- a/ecs-cli/modules/cli/compose/project/project.go
+++ b/ecs-cli/modules/cli/compose/project/project.go
@@ -20,10 +20,10 @@ import (
 	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/cli/compose/entity/service"
 	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/cli/compose/entity/task"
 
+	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/commands"
 	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/utils/compose"
 	"github.com/docker/libcompose/config"
 	"github.com/docker/libcompose/project"
-	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/commands"
 )
 
 // Project is the starting point for the compose app to interact with and issue commands
@@ -130,15 +130,18 @@ func (p *ecsProject) parseCompose() error {
 	return p.context.SetProjectName()
 }
 
-// transformTaskDefinition converts the compose yml and ecs-fields yml into an ECS task definition
+// transformTaskDefinition converts the compose yml and ecs-params yml into an ECS task definition
 func (p *ecsProject) transformTaskDefinition() error {
 	context := p.context
 
 	// convert to task definition
 	logrus.Debug("Transforming yaml to task definition...")
 	taskDefinitionName := utils.GetTaskDefinitionName(context.ECSParams.ComposeProjectNamePrefix, context.Context.ProjectName)
+
 	taskRoleArn := context.CLIContext.GlobalString(command.TaskRoleArnFlag)
-	taskDefinition, err := utils.ConvertToTaskDefinition(taskDefinitionName, &context.Context, p.ServiceConfigs(), taskRoleArn)
+	ecsParamsFileName := context.CLIContext.GlobalString(command.ECSParamsFileNameFlag)
+
+	taskDefinition, err := utils.ConvertToTaskDefinition(taskDefinitionName, &context.Context, p.ServiceConfigs(), taskRoleArn, ecsParamsFileName)
 	if err != nil {
 		return err
 	}

--- a/ecs-cli/modules/cli/compose/project/project.go
+++ b/ecs-cli/modules/cli/compose/project/project.go
@@ -115,20 +115,22 @@ func (p *ecsProject) Parse() error {
 	return p.transformTaskDefinition()
 }
 
-// parseCompose loads and parses the compose yml files
+// parseCompose sets data from the compose files on the ecsProject
 func (p *ecsProject) parseCompose() error {
-	// load the compose files using libcompose
 	logrus.Debug("Parsing the compose yaml...")
+	// libcompose.Project#Parse populates project information based on its
+	// context. It sets up the name, the composefile and the composebytes
+	// (the composefile content). This is where p.ServiceConfigs gets loaded.
 	if err := p.Project.Parse(); err != nil {
 		return err
 	}
 
 	// libcompose sanitizes the project name and removes any non alpha-numeric character.
-	// The following undo-es that and sets the project name as user defined it.
+	// The following undoes that and sets the project name as user defined it.
 	return p.context.SetProjectName()
 }
 
-// transformTaskDefinition converts the compose yml into task definition
+// transformTaskDefinition converts the compose yml and ecs-fields yml into an ECS task definition
 func (p *ecsProject) transformTaskDefinition() error {
 	context := p.context
 

--- a/ecs-cli/modules/commands/compose/compose_command.go
+++ b/ecs-cli/modules/commands/compose/compose_command.go
@@ -32,11 +32,14 @@ import (
 //   ecs-cli compose create      : creates ECS.TaskDefinition or gets from FS cache
 //   ecs-cli compose start       : invokes ECS.RunTask if count(running tasks) == 0
 //   ecs-cli compose up          : compose create ; compose start and does a deployment of new compose yml if changes were found
+//
 // List containers in or view details of the project:
 //   ecs-cli compose ps          : calls ECS.ListTasks (running and stopped) filtered with Task group: this project
+//
 // Modify containers
 //   ecs-cli compose scale       : calls ECS.RunTask/StopTask based on the count
 //   ecs-cli compose run         : calls ECS.RunTask with overrides
+//
 // Stop and delete the project
 //   ecs-cli compose stop        : calls ECS.StopTask and ECS deletes them (rm)
 //* --------------------------------------------------- */
@@ -44,6 +47,7 @@ import (
 const (
 	composeFileNameDefaultValue         = "docker-compose.yml"
 	composeOverrideFileNameDefaultValue = "docker-compose.override.yml"
+	ecsParamsFileNameDefaultValue       = "ecs-params.yml"
 	containerNameFlag                   = "name"
 )
 
@@ -95,6 +99,10 @@ func composeFlags() []cli.Flag {
 		cli.StringFlag{
 			Name:  command.TaskRoleArnFlag,
 			Usage: "[Optional] Specifies the short name or full Amazon Resource Name (ARN) of the IAM role that containers in this task can assume. All containers in this task are granted the permissions that are specified in this role.",
+		},
+		cli.StringFlag{
+			Name:  command.ECSParamsFileNameFlag,
+			Usage: "[Optional] Specifies ecs-params file to use. Defaults to " + ecsParamsFileNameDefaultValue + " file, if one exists.",
 		},
 	}
 }

--- a/ecs-cli/modules/commands/flags.go
+++ b/ecs-cli/modules/commands/flags.go
@@ -63,9 +63,10 @@ const (
 	UntaggedFlag   = "untagged"
 
 	// Compose
-	ProjectNameFlag     = "project-name"
-	ComposeFileNameFlag = "file"
-	TaskRoleArnFlag     = "task-role-arn"
+	ProjectNameFlag       = "project-name"
+	ComposeFileNameFlag   = "file"
+	TaskRoleArnFlag       = "task-role-arn"
+	ECSParamsFileNameFlag = "ecs-params"
 
 	// Compose Service
 	CreateServiceCommandName                = "create"

--- a/ecs-cli/modules/config/params.go
+++ b/ecs-cli/modules/config/params.go
@@ -37,7 +37,7 @@ func (p *CliParams) GetCfnStackName() string {
 	return fmt.Sprintf("%s%s", p.CFNStackNamePrefix, p.Cluster)
 }
 
-// Searches as far up the context as necesarry. This function works no matter
+// Searches as far up the context as necessary. This function works no matter
 // how many layers of nested subcommands there are. It is more powerful
 // than merely calling context.String and context.GlobalString
 func recursiveFlagSearch(context *cli.Context, flag string) string {

--- a/ecs-cli/modules/utils/compose/convert_task_definition.go
+++ b/ecs-cli/modules/utils/compose/convert_task_definition.go
@@ -119,10 +119,6 @@ func ConvertToTaskDefinition(taskDefinitionName string, context *project.Context
 		}
 	}
 
-	if networkMode == "" {
-		networkMode = "bridge"
-	}
-
 	taskDefinition := &ecs.TaskDefinition{
 		Family:               aws.String(taskDefinitionName),
 		ContainerDefinitions: containerDefinitions,


### PR DESCRIPTION
Closes #153 and #188.
Addresses most of #267.

Testing:

Compose file data:
```
~/sandbox/test_fields$ cat docker-compose.yml 
version: '2'
services:
  wordpress:
    image: wordpress
    cpu_shares: 100
    mem_limit: 52428800
    ports:
      - "80:80"
  mysql:
    image: mysql
    cpu_shares: 100
    mem_limit: 524288000
    environment:
      MYSQL_ROOT_PASSWORD: foobar
```
**NOTE**: cannot include "links" field in service definition if network mode is "host" (See: [network_mode in docker-compose](https://docs.docker.com/compose/compose-file/#network_mode))

ECS params data:
```
$ cat ecs-params.yml
version: 1
task_definition:
  ecs_network_mode: host 
```

Calling `compose service up`:
```
~ ecs-cli compose --file docker-compose.yml --ecs-params ecs-params.yml service up --cluster test-ecs-fields

INFO[0000] Using ECS task definition                     TaskDefinition="ecscompose-test_fields:11"
INFO[0000] Starting container...                         container="44a2aea0-024e-4b0b-9455-7e1f99a71696/mysql"
INFO[0000] Starting container...                         container="44a2aea0-024e-4b0b-9455-7e1f99a71696/wordpress"
INFO[0000] Describe ECS container status                 container="44a2aea0-024e-4b0b-9455-7e1f99a71696/mysql" desiredStatus=RUNNING lastStatus=PENDING taskDefinition="ecscompose-test_fields:11"
INFO[0000] Describe ECS container status                 container="44a2aea0-024e-4b0b-9455-7e1f99a71696/wordpress" desiredStatus=RUNNING lastStatus=PENDING taskDefinition="ecscompose-test_fields:11"
INFO[0006] Started container...                          container="44a2aea0-024e-4b0b-9455-7e1f99a71696/mysql" desiredStatus=RUNNING lastStatus=RUNNING taskDefinition="ecscompose-test_fields:11"
INFO[0006] Started container...                          container="44a2aea0-024e-4b0b-9455-7e1f99a71696/wordpress" desiredStatus=RUNNING lastStatus=RUNNING taskDefinition="ecscompose-test_fields:11"

```
Describing Task Definition created from previous `compose service up` command:
```
~/sandbox/test_fields$ aws ecs describe-task-definition --task-definition ecscompose-test_fields:3
{
    "taskDefinition": {
        "status": "ACTIVE", 
        "networkMode": "host", 
        "family": "ecscompose-test_fields", 
        "placementConstraints": [], 
        "requiresAttributes": [
            {
                "name": "com.amazonaws.ecs.capability.docker-remote-api.1.17"
            }, 
            {
                "name": "com.amazonaws.ecs.capability.docker-remote-api.1.18"
            }
        ], 
        "volumes": [], 
        "taskDefinitionArn": "arn:aws:ecs:us-west-2:<account>:task-definition/ecscompose-test_fields:11", 
        "containerDefinitions": [
            {
                "dnsSearchDomains": [], 
                "environment": [], 
                "readonlyRootFilesystem": false, 
                "name": "wordpress", 
                "links": [
                    "mysql"
                ], 
                "mountPoints": [], 
                "image": "wordpress", 
                "privileged": false, 
                "essential": true, 
                "portMappings": [
                    {
                        "protocol": "tcp", 
                        "containerPort": 80, 
                        "hostPort": 80
                    }
                ], 
                "dnsServers": [], 
                "dockerSecurityOptions": [], 
                "entryPoint": [], 
                "ulimits": [], 
                "memory": 50, 
                "command": [], 
                "extraHosts": [], 
                "cpu": 100, 
                "volumesFrom": [], 
                "dockerLabels": {}
            }, 
            {
                "dnsSearchDomains": [], 
                "environment": [
                    {
                        "name": "MYSQL_ROOT_PASSWORD", 
                        "value": "foobar"
                    }
                ], 
                "readonlyRootFilesystem": false, 
                "name": "mysql", 
                "links": [], 
                "mountPoints": [], 
                "image": "mysql", 
                "privileged": false, 
                "essential": true, 
                "portMappings": [], 
                "dnsServers": [], 
                "dockerSecurityOptions": [], 
                "entryPoint": [], 
                "ulimits": [], 
                "memory": 500, 
                "command": [], 
                "extraHosts": [], 
                "cpu": 100, 
                "volumesFrom": [], 
                "dockerLabels": {}
            }
        ], 
        "revision": 3
    }
}
```