### PR TITLE
[BUGFIX] Change default cluster MinSize to 0

### DIFF
--- a/ecs-cli/modules/clients/aws/cloudformation/template.go
+++ b/ecs-cli/modules/clients/aws/cloudformation/template.go
@@ -566,7 +566,7 @@ var template = `
             }
           ]
         },
-        "MinSize": "1",
+        "MinSize": "0",
         "MaxSize": {
           "Ref": "AsgMaxSize"
         },


### PR DESCRIPTION
Previously, the MinSize specified in the AutoScaling Group for a cluster
was 1 instance. This meant that customers would not be able to use the
ecs-cli scale command to scale their cluster down to 0. This change
fixes that issue.

Resolves #335