### PR TITLE
Add aws-profile flag

### DIFF
--- a/ecs-cli/modules/commands/flags.go
+++ b/ecs-cli/modules/commands/flags.go
@@ -110,7 +110,7 @@ func OptionalRegionAndProfileFlags() []cli.Flag {
 		cli.StringFlag{
 			Name: AWSProfileNameFlag,
 			Usage: fmt.Sprintf(
-				"[Optional] Use your AWS credentials from an existing named profile in ~/.aws/credentials.",
+				"[Optional]  Use the AWS credentials from an existing named profile in ~/.aws/credentials.",
 			),
 		},
 	}

--- a/ecs-cli/modules/commands/flags.go
+++ b/ecs-cli/modules/commands/flags.go
@@ -35,6 +35,7 @@ const (
 	ProfileConfigFlag      = "ecs-profile"
 	ProfileNameFlag        = "profile-name"
 	ConfigNameFlag         = "config-name"
+	AWSProfileNameFlag     = "aws-profile"
 
 	ComposeProjectNamePrefixFlag         = "compose-project-name-prefix"
 	ComposeProjectNamePrefixDefaultValue = "ecscompose-"
@@ -85,6 +86,7 @@ const (
 // OptionalRegionFlag inline overrides region
 // OptionalClusterConfigFlag specifies the cluster profile to read from config
 // OptionalProfileConfigFlag specifies the credentials profile to read from the config
+// OptionalAWSProfileFlag specifies the AWS Profile to use for credential information
 func OptionalRegionAndProfileFlags() []cli.Flag {
 	return []cli.Flag{
 		cli.StringFlag{
@@ -103,6 +105,12 @@ func OptionalRegionAndProfileFlags() []cli.Flag {
 			Name: ProfileConfigFlag,
 			Usage: fmt.Sprintf(
 				"[Optional] Specifies the name of the ECS profle configuration to use. Defaults to the default profile configuration.",
+			),
+		},
+		cli.StringFlag{
+			Name: AWSProfileNameFlag,
+			Usage: fmt.Sprintf(
+				"[Optional] Use your AWS credentials from an existing named profile in ~/.aws/credentials.",
 			),
 		},
 	}

--- a/ecs-cli/modules/config/params.go
+++ b/ecs-cli/modules/config/params.go
@@ -70,6 +70,13 @@ func NewCLIParams(context *cli.Context, rdwr ReadWriter) (*CLIParams, error) {
 		ecsConfig.Region = regionFromFlag
 	}
 
+	if awsProfileFromFlag := recursiveFlagSearch(context, ecscli.AWSProfileNameFlag); awsProfileFromFlag != "" {
+		ecsConfig.AWSProfile = awsProfileFromFlag
+		// unset Access Key and Secret Key, otherwise they will take precedence
+		ecsConfig.AWSAccessKey = ""
+		ecsConfig.AWSSecretKey = ""
+	}
+
 	svcSession, err := ecsConfig.ToAWSSession()
 	if err != nil {
 		return nil, err

--- a/ecs-cli/modules/config/params_test.go
+++ b/ecs-cli/modules/config/params_test.go
@@ -187,7 +187,6 @@ aws_secret_access_key = aws-secret
 	mode := fileInfo.Mode()
 	err = os.MkdirAll(tempDirName+"/.aws", mode)
 	assert.NoError(t, err, "Could not create aws config directory")
-	defer os.RemoveAll(tempDirName)
 	err = ioutil.WriteFile(tempDirName+"/.aws/credentials", []byte(configContents), mode)
 	assert.NoError(t, err)
 

--- a/ecs-cli/modules/config/params_test.go
+++ b/ecs-cli/modules/config/params_test.go
@@ -15,6 +15,7 @@ package config
 
 import (
 	"flag"
+	"io/ioutil"
 	"os"
 	"testing"
 
@@ -28,6 +29,11 @@ import (
 const (
 	composeServiceNamePrefix = "ecs-service-"
 	cfnStackName             = "cfn-stack-ecs"
+	awsAccess                = "ecs-access"
+	awsSecret                = "ecs-secret"
+	awsAccessAWSProfile      = "aws-access"
+	awsSecretAWSProfile      = "aws-secret"
+	awsProfileName           = "awsprofile"
 )
 
 // mockReadWriter implements ReadWriter interface to return just the cluster
@@ -154,6 +160,50 @@ func TestNewCliParamsWhenPrefixKeysAreNotPresent(t *testing.T) {
 	assert.NoError(t, err, "Unexpected error when getting new cli params")
 	assert.Empty(t, params.ComposeServiceNamePrefix, "Expected ComposeServiceNamePrefix to be empty")
 	assert.Equal(t, ecscli.CFNStackNamePrefixDefaultValue+clusterName, params.CFNStackName, "Expected CFNStackName to be default")
+}
+
+func TestNewCliParamsWithAWSProfile(t *testing.T) {
+	// Keys in env vars take highest precedence; ensure they are not set
+	os.Unsetenv("AWS_ACCESS_KEY")
+	os.Unsetenv("AWS_SECRET_KEY")
+
+	configContents := `[awsprofile]
+aws_access_key_id = aws-access
+aws_secret_access_key = aws-secret
+`
+	// Create a temporary directory for the dummy aws config
+	tempDirName, err := ioutil.TempDir("", "test")
+	if err != nil {
+		t.Fatal("Error while creating the dummy ecs config directory")
+	}
+	os.Setenv("HOME", tempDirName)
+	os.Setenv("AWS_DEFAULT_REGION", region)
+	defer os.Clearenv()
+	defer os.RemoveAll(tempDirName)
+
+	// save the aws config
+	fileInfo, err := os.Stat(tempDirName)
+	assert.NoError(t, err)
+	mode := fileInfo.Mode()
+	err = os.MkdirAll(tempDirName+"/.aws", mode)
+	assert.NoError(t, err, "Could not create aws config directory")
+	defer os.RemoveAll(tempDirName)
+	err = ioutil.WriteFile(tempDirName+"/.aws/credentials", []byte(configContents), mode)
+	assert.NoError(t, err)
+
+	globalSet := flag.NewFlagSet("ecs-cli", 0)
+	globalContext := cli.NewContext(nil, globalSet, nil)
+	flagSet := flag.NewFlagSet("ecs-cli-up", 0)
+	flagSet.String("aws-profile", awsProfileName, "")
+	context := cli.NewContext(nil, flagSet, globalContext)
+	rdwr := &mockReadWriter{}
+
+	params, err := NewCLIParams(context, rdwr)
+	assert.NoError(t, err)
+	creds, err := params.Session.Config.Credentials.Get()
+	assert.NoError(t, err)
+	assert.Equal(t, awsAccessAWSProfile, creds.AccessKeyID, "Expected AWS Access Key to be read from the AWS Profile")
+	assert.Equal(t, awsSecretAWSProfile, creds.SecretAccessKey, "Expected AWS Secret Access Key to be read from the AWS Profile")
 }
 
 func defaultConfig() *cli.Context {


### PR DESCRIPTION
The old CLI allowed the storing of a name of an AWS Profile in the configuration file. That functionality has been removed, instead, a new flag `--aws-profile` has been added to all commands that allows the name of an AWS Profile to be specified inline.