### PR TITLE
Fixed bug with CFNStackName.

### DIFF
--- a/ecs-cli/modules/cli/configure/configure.go
+++ b/ecs-cli/modules/cli/configure/configure.go
@@ -64,9 +64,11 @@ func Migrate(context *cli.Context) error {
 		logrus.Warnf("Storing an AWS profile in the configuration file is no longer supported. Please use the %s flag inline in commands instead.", command.ProfileFlag)
 	}
 
-	if oldConfig.CFNStackName == (command.CFNStackNamePrefixDefaultValue + oldConfig.Cluster) {
+	if oldConfig.CFNStackNamePrefix == command.CFNStackNamePrefixDefaultValue {
 		// if CFNStackName is default; don't store it.
 		oldConfig.CFNStackName = ""
+	} else {
+		oldConfig.CFNStackName = oldConfig.CFNStackNamePrefix + oldConfig.Cluster
 	}
 
 	if !context.Bool(command.ForceFlag) {

--- a/ecs-cli/modules/config/config_v1.go
+++ b/ecs-cli/modules/config/config_v1.go
@@ -45,7 +45,7 @@ type CLIConfig struct {
 	ComposeServiceNamePrefix string
 	ComposeProjectNamePrefix string // Deprecated; remains for backwards compatibility
 	CFNStackName             string
-	CFNStackNamePrefix       string // Removed in new config; remains for backwards compatibility
+	CFNStackNamePrefix       string // Deprecated; remains for backwards compatibility
 }
 
 // Profile is a simple struct for storing a single profile config

--- a/ecs-cli/modules/config/config_v1.go
+++ b/ecs-cli/modules/config/config_v1.go
@@ -45,6 +45,7 @@ type CLIConfig struct {
 	ComposeServiceNamePrefix string
 	ComposeProjectNamePrefix string // Deprecated; remains for backwards compatibility
 	CFNStackName             string
+	CFNStackNamePrefix       string // Removed in new config; remains for backwards compatibility
 }
 
 // Profile is a simple struct for storing a single profile config

--- a/ecs-cli/modules/config/params.go
+++ b/ecs-cli/modules/config/params.go
@@ -74,12 +74,12 @@ func NewCLIParams(context *cli.Context, rdwr ReadWriter) (*CLIParams, error) {
 	if err != nil {
 		return nil, err
 	}
-
-	if ecsConfig.CFNStackName == "" {
+	if ecsConfig.CFNStackName == "" && ecsConfig.CFNStackNamePrefix != "" {
+		ecsConfig.CFNStackName = ecsConfig.CFNStackNamePrefix + ecsConfig.Cluster
+	} else if ecsConfig.CFNStackName == "" {
 		// set default value
 		ecsConfig.CFNStackName = ecscli.CFNStackNamePrefixDefaultValue + ecsConfig.Cluster
 	}
-
 	return &CLIParams{
 		Cluster:                  ecsConfig.Cluster,
 		Session:                  svcSession,

--- a/ecs-cli/modules/config/readwriter.go
+++ b/ecs-cli/modules/config/readwriter.go
@@ -88,7 +88,8 @@ func (rdwr *INIReadWriter) GetConfig(cliConfig *CLIConfig) error {
 	cliConfig.AWSSecretKey = iniFormat.AWSSecretKey
 	cliConfig.ComposeServiceNamePrefix = iniFormat.ComposeServiceNamePrefix
 	cliConfig.ComposeProjectNamePrefix = iniFormat.ComposeProjectNamePrefix
-	cliConfig.CFNStackName = iniFormat.CFNStackNamePrefix + iniFormat.Cluster
+	cliConfig.CFNStackNamePrefix = iniFormat.CFNStackNamePrefix
+
 	return nil
 }
 

--- a/ecs-cli/modules/config/readwriter_v1_test.go
+++ b/ecs-cli/modules/config/readwriter_v1_test.go
@@ -126,7 +126,7 @@ cfn-stack-name-prefix =
 	assert.NoError(t, err, "Error reading config")
 	assert.Equal(t, testClusterName, readConfig.Cluster, "Cluster name mismatch in config.")
 	assert.Empty(t, readConfig.ComposeServiceNamePrefix, "Compose service prefix name should be empty.")
-	assert.Equal(t, testClusterName, readConfig.CFNStackName, "CFNStackName should be set to cluster name.")
+	assert.Empty(t, readConfig.CFNStackName, "CFNStackName should be empty.")
 }
 
 func TestPrefixesDefaultOldINIFormat(t *testing.T) {
@@ -152,7 +152,7 @@ aws_secret_access_key =
 	config, err := parser.Get("", "")
 	assert.NoError(t, err, "Error reading config")
 	assert.Equal(t, ecscli.ComposeServiceNamePrefixDefaultValue, config.ComposeServiceNamePrefix, "ComposeServiceNamePrefix should be set to the default value.")
-	assert.Equal(t, ecscli.CFNStackNamePrefixDefaultValue+"test", config.CFNStackName, "CFNStackNamePrefix should be set to the default value.")
+	assert.Equal(t, ecscli.CFNStackNamePrefixDefaultValue, config.CFNStackNamePrefix, "CFNStackNamePrefix should be set to the default value.")
 }
 
 func TestReadCredentialsFile(t *testing.T) {


### PR DESCRIPTION
Prefix removal caused a bug in the case where the old ini style config is being read. If a flag is used to override the cluster name, then the CFN Stack Name will not be appropriately set based upon the value in the flag.