### PR TITLE
Add usage error for all commands

### DIFF
--- a/ecs-cli/modules/commands/compose/compose_command.go
+++ b/ecs-cli/modules/commands/compose/compose_command.go
@@ -74,7 +74,6 @@ func ComposeCommand(factory composeFactory.ProjectFactory) cli.Command {
 			// TODO, should honor restart policy in the compose yaml and create ECS Services accordingly
 			serviceCommand.ServiceCommand(factory),
 		},
-		OnUsageError: command.UsageErrorFactory("create"),
 	}
 }
 

--- a/ecs-cli/modules/commands/compose/service/compose_service_command.go
+++ b/ecs-cli/modules/commands/compose/service/compose_service_command.go
@@ -63,66 +63,73 @@ func ServiceCommand(factory composeFactory.ProjectFactory) cli.Command {
 
 func createServiceCommand(factory composeFactory.ProjectFactory) cli.Command {
 	return cli.Command{
-		Name:   "create",
-		Usage:  "Creates an ECS service from your compose file. The service is created with a desired count of 0, so no containers are started by this command. Note that we do not recommend using plain text environment variables for sensitive information, such as credential data.",
-		Action: compose.WithProject(factory, compose.ProjectCreate, true),
-		Flags:  append(deploymentConfigFlags(true), append(loadBalancerFlags(), command.OptionalConfigFlags()...)...),
+		Name:         "create",
+		Usage:        "Creates an ECS service from your compose file. The service is created with a desired count of 0, so no containers are started by this command. Note that we do not recommend using plain text environment variables for sensitive information, such as credential data.",
+		Action:       compose.WithProject(factory, compose.ProjectCreate, true),
+		Flags:        append(deploymentConfigFlags(true), append(loadBalancerFlags(), command.OptionalConfigFlags()...)...),
+		OnUsageError: command.UsageErrorFactory("create"),
 	}
 }
 
 func startServiceCommand(factory composeFactory.ProjectFactory) cli.Command {
 	return cli.Command{
-		Name:   "start",
-		Usage:  "Starts one copy of each of the containers on an existing ECS service by setting the desired count to 1 (only if the current desired count is 0).",
-		Action: compose.WithProject(factory, compose.ProjectStart, true),
-		Flags:  command.OptionalConfigFlags(),
+		Name:         "start",
+		Usage:        "Starts one copy of each of the containers on an existing ECS service by setting the desired count to 1 (only if the current desired count is 0).",
+		Action:       compose.WithProject(factory, compose.ProjectStart, true),
+		Flags:        command.OptionalConfigFlags(),
+		OnUsageError: command.UsageErrorFactory("start"),
 	}
 }
 
 func upServiceCommand(factory composeFactory.ProjectFactory) cli.Command {
 	return cli.Command{
-		Name:   "up",
-		Usage:  "Creates a new ECS service or updates an existing one according to your compose file. For new services or existing services with a current desired count of 0, the desired count for the service is set to 1. For existing services with non-zero desired counts, a new task definition is created to reflect any changes to the compose file and the service is updated to use that task definition. In this case, the desired count does not change.",
-		Action: compose.WithProject(factory, compose.ProjectUp, true),
-		Flags:  append(deploymentConfigFlags(true), append(loadBalancerFlags(), command.OptionalConfigFlags()...)...),
+		Name:         "up",
+		Usage:        "Creates a new ECS service or updates an existing one according to your compose file. For new services or existing services with a current desired count of 0, the desired count for the service is set to 1. For existing services with non-zero desired counts, a new task definition is created to reflect any changes to the compose file and the service is updated to use that task definition. In this case, the desired count does not change.",
+		Action:       compose.WithProject(factory, compose.ProjectUp, true),
+		Flags:        append(deploymentConfigFlags(true), append(loadBalancerFlags(), command.OptionalConfigFlags()...)...),
+		OnUsageError: command.UsageErrorFactory("up"),
 	}
 }
 
 func psServiceCommand(factory composeFactory.ProjectFactory) cli.Command {
 	return cli.Command{
-		Name:    "ps",
-		Aliases: []string{"list"},
-		Usage:   "Lists all the containers in your cluster that belong to the service created with the compose project.",
-		Action:  compose.WithProject(factory, compose.ProjectPs, true),
-		Flags:   command.OptionalConfigFlags(),
+		Name:         "ps",
+		Aliases:      []string{"list"},
+		Usage:        "Lists all the containers in your cluster that belong to the service created with the compose project.",
+		Action:       compose.WithProject(factory, compose.ProjectPs, true),
+		Flags:        command.OptionalConfigFlags(),
+		OnUsageError: command.UsageErrorFactory("ps"),
 	}
 }
 
 func scaleServiceCommand(factory composeFactory.ProjectFactory) cli.Command {
 	return cli.Command{
-		Name:   "scale",
-		Usage:  "ecs-cli compose service scale [count] - scales the desired count of the service to the specified count",
-		Action: compose.WithProject(factory, compose.ProjectScale, true),
-		Flags:  append(deploymentConfigFlags(false), command.OptionalConfigFlags()...),
+		Name:         "scale",
+		Usage:        "ecs-cli compose service scale [count] - scales the desired count of the service to the specified count",
+		Action:       compose.WithProject(factory, compose.ProjectScale, true),
+		Flags:        append(deploymentConfigFlags(false), command.OptionalConfigFlags()...),
+		OnUsageError: command.UsageErrorFactory("scale"),
 	}
 }
 
 func stopServiceCommand(factory composeFactory.ProjectFactory) cli.Command {
 	return cli.Command{
-		Name:   "stop",
-		Usage:  "Stops the running tasks that belong to the service created with the compose project. This command updates the desired count of the service to 0.",
-		Action: compose.WithProject(factory, compose.ProjectStop, true),
-		Flags:  command.OptionalConfigFlags(),
+		Name:         "stop",
+		Usage:        "Stops the running tasks that belong to the service created with the compose project. This command updates the desired count of the service to 0.",
+		Action:       compose.WithProject(factory, compose.ProjectStop, true),
+		Flags:        command.OptionalConfigFlags(),
+		OnUsageError: command.UsageErrorFactory("stop"),
 	}
 }
 
 func rmServiceCommand(factory composeFactory.ProjectFactory) cli.Command {
 	return cli.Command{
-		Name:    "rm",
-		Aliases: []string{"delete", "down"},
-		Usage:   "Updates the desired count of the service to 0 and then deletes the service.",
-		Action:  compose.WithProject(factory, compose.ProjectDown, true),
-		Flags:   command.OptionalConfigFlags(),
+		Name:         "rm",
+		Aliases:      []string{"delete", "down"},
+		Usage:        "Updates the desired count of the service to 0 and then deletes the service.",
+		Action:       compose.WithProject(factory, compose.ProjectDown, true),
+		Flags:        command.OptionalConfigFlags(),
+		OnUsageError: command.UsageErrorFactory("rm"),
 	}
 }
 

--- a/ecs-cli/modules/commands/configure/configure_command.go
+++ b/ecs-cli/modules/commands/configure/configure_command.go
@@ -18,7 +18,7 @@ import (
 
 	"github.com/Sirupsen/logrus"
 	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/cli/configure"
-	flags "github.com/aws/amazon-ecs-cli/ecs-cli/modules/commands"
+	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/commands"
 	"github.com/urfave/cli"
 )
 
@@ -35,10 +35,11 @@ func errorLogger(action configureAction) func(context *cli.Context) {
 
 func configureProfileCommand() cli.Command {
 	return cli.Command{
-		Name:   "profile",
-		Usage:  "Stores a single profile.",
-		Action: errorLogger(configure.Profile),
-		Flags:  configureProfileFlags(),
+		Name:         "profile",
+		Usage:        "Stores a single profile.",
+		Action:       errorLogger(configure.Profile),
+		Flags:        configureProfileFlags(),
+		OnUsageError: command.UsageErrorFactory("profile"),
 		Subcommands: []cli.Command{
 			defaultProfileCommand(),
 		},
@@ -47,19 +48,21 @@ func configureProfileCommand() cli.Command {
 
 func defaultProfileCommand() cli.Command {
 	return cli.Command{
-		Name:   "default",
-		Usage:  "Sets the default profile.",
-		Action: errorLogger(configure.DefaultProfile),
-		Flags:  configureDefaultProfileFlags(),
+		Name:         "default",
+		Usage:        "Sets the default profile.",
+		Action:       errorLogger(configure.DefaultProfile),
+		Flags:        configureDefaultProfileFlags(),
+		OnUsageError: command.UsageErrorFactory("default"),
 	}
 }
 
 func defaultClusterCommand() cli.Command {
 	return cli.Command{
-		Name:   "default",
-		Usage:  "Sets the default cluster config.",
-		Action: errorLogger(configure.DefaultCluster),
-		Flags:  configureDefaultClusterFlags(),
+		Name:         "default",
+		Usage:        "Sets the default cluster config.",
+		Action:       errorLogger(configure.DefaultCluster),
+		Flags:        configureDefaultClusterFlags(),
+		OnUsageError: command.UsageErrorFactory("default"),
 	}
 }
 
@@ -70,12 +73,13 @@ func migrateCommand() cli.Command {
 		Action: errorLogger(configure.Migrate),
 		Flags: []cli.Flag{
 			cli.BoolFlag{
-				Name: flags.ForceFlag,
+				Name: command.ForceFlag,
 				Usage: fmt.Sprintf(
 					"[Optional] Omits the interactive description and confirmation step that normally occurs during the configuration file migration process.",
 				),
 			},
 		},
+		OnUsageError: command.UsageErrorFactory("migrate"),
 	}
 }
 
@@ -91,13 +95,14 @@ func ConfigureCommand() cli.Command {
 			defaultClusterCommand(),
 			migrateCommand(),
 		},
+		OnUsageError: command.UsageErrorFactory("configure"),
 	}
 }
 
 func configureDefaultClusterFlags() []cli.Flag {
 	return []cli.Flag{
 		cli.StringFlag{
-			Name: flags.ConfigNameFlag,
+			Name: command.ConfigNameFlag,
 			Usage: fmt.Sprintf(
 				"Specifies the name of the cluster configuration to use by default.",
 			),
@@ -108,7 +113,7 @@ func configureDefaultClusterFlags() []cli.Flag {
 func configureDefaultProfileFlags() []cli.Flag {
 	return []cli.Flag{
 		cli.StringFlag{
-			Name: flags.ProfileNameFlag,
+			Name: command.ProfileNameFlag,
 			Usage: fmt.Sprintf(
 				"Specifies the name of the profile to use by default.",
 			),
@@ -119,21 +124,21 @@ func configureDefaultProfileFlags() []cli.Flag {
 func configureProfileFlags() []cli.Flag {
 	return []cli.Flag{
 		cli.StringFlag{
-			Name: flags.AccessKeyFlag,
+			Name: command.AccessKeyFlag,
 			Usage: fmt.Sprintf(
 				"Specifies the AWS access key to use. The ECS CLI uses the value of your $AWS_ACCESS_KEY_ID environment variable if it is set.",
 			),
 			EnvVar: "AWS_ACCESS_KEY_ID",
 		},
 		cli.StringFlag{
-			Name: flags.SecretKeyFlag,
+			Name: command.SecretKeyFlag,
 			Usage: fmt.Sprintf(
 				"Specifies the AWS secret key to use. The ECS CLI uses the value of your $AWS_SECRET_ACCESS_KEY environment variable if it is set.",
 			),
 			EnvVar: "AWS_SECRET_ACCESS_KEY",
 		},
 		cli.StringFlag{
-			Name:  flags.ProfileNameFlag,
+			Name:  command.ProfileNameFlag,
 			Value: "default",
 			Usage: fmt.Sprintf(
 				"Specifies the profile name to use for this configuration.",
@@ -145,34 +150,34 @@ func configureProfileFlags() []cli.Flag {
 func configureFlags() []cli.Flag {
 	return []cli.Flag{
 		cli.StringFlag{
-			Name: flags.ClusterFlag + ", c",
+			Name: command.ClusterFlag + ", c",
 			Usage: fmt.Sprintf(
 				"Specifies the ECS cluster name to use. If the cluster does not exist, it is created when you try to add resources to it with the ecs-cli up command.",
 			),
 			EnvVar: "ECS_CLUSTER",
 		},
 		cli.StringFlag{
-			Name: flags.RegionFlag + ", r",
+			Name: command.RegionFlag + ", r",
 			Usage: fmt.Sprintf(
-				"Specifies the AWS region to use. If the " + flags.AwsRegionEnvVar + " environment variable is set when ecs-cli configure is run, then the AWS region is set to the value of that environment variable.",
+				"Specifies the AWS region to use. If the " + command.AwsRegionEnvVar + " environment variable is set when ecs-cli configure is run, then the AWS region is set to the value of that environment variable.",
 			),
-			EnvVar: flags.AwsRegionEnvVar,
+			EnvVar: command.AwsRegionEnvVar,
 		},
 		cli.StringFlag{
-			Name:  flags.ConfigNameFlag,
+			Name:  command.ConfigNameFlag,
 			Value: "default",
 			Usage: fmt.Sprintf(
 				"Specifies the cluster configuration name to use for this configuration.",
 			),
 		},
 		cli.StringFlag{
-			Name: flags.ComposeServiceNamePrefixFlag,
+			Name: command.ComposeServiceNamePrefixFlag,
 			Usage: fmt.Sprintf(
 				"[Deprecated] Specifies the prefix added to an ECS service created from a compose file. Format <prefix><project-name>. (defaults to empty)",
 			),
 		},
 		cli.StringFlag{
-			Name: flags.CFNStackNameFlag,
+			Name: command.CFNStackNameFlag,
 			Usage: fmt.Sprintf(
 				"[Optional] Specifies the name of AWS CloudFormation stack created on ecs-cli up. (default: \"amazon-ecs-cli-setup-<cluster-name>\")",
 			),


### PR DESCRIPTION
Adds on usage error for:
- new configure commands
- old compose service commands which I forgot to add it to before

For a reminder of what this does, see this example:

```
$ ecs-cli configure profile default --cat
ERRO[0000] flag provided but not defined: -cat          
NAME:
   ecs-cli configure profile default - Sets the default profile.

USAGE:
   ecs-cli configure profile default [command options] [arguments...]

OPTIONS:
   --profile-name value  Specifies the name of the profile to use by default.
   
$ echo $?
1
```

Before OnUsageError was specified, the CLI would not set the unix exit code to be 1 (it would be 0, which is wrong). 