### PR TITLE
Move flags.go into own package

### DIFF
--- a/ecs-cli/modules/app.go
+++ b/ecs-cli/modules/app.go
@@ -15,13 +15,13 @@ package app
 
 import (
 	log "github.com/Sirupsen/logrus"
-	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/commands"
+	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/commands/flags"
 	"github.com/urfave/cli"
 )
 
 // BeforeApp is an action that is executed before any cli command.
 func BeforeApp(c *cli.Context) error {
-	if c.GlobalBool(command.VerboseFlag) || c.Bool(command.VerboseFlag) {
+	if c.GlobalBool(flags.VerboseFlag) || c.Bool(flags.VerboseFlag) {
 		log.SetLevel(log.DebugLevel)
 	}
 	return nil

--- a/ecs-cli/modules/app_test.go
+++ b/ecs-cli/modules/app_test.go
@@ -18,13 +18,13 @@ import (
 	"testing"
 
 	log "github.com/Sirupsen/logrus"
-	command "github.com/aws/amazon-ecs-cli/ecs-cli/modules/commands"
+	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/commands/flags"
 	"github.com/urfave/cli"
 )
 
 func TestBeforeApp(t *testing.T) {
 	flagSet := flag.NewFlagSet("ecs-cli", 0)
-	flagSet.Bool(command.VerboseFlag, true, "")
+	flagSet.Bool(flags.VerboseFlag, true, "")
 	cliContext := cli.NewContext(nil, flagSet, nil)
 
 	BeforeApp(cliContext)

--- a/ecs-cli/modules/cli/cluster/cluster_app_test.go
+++ b/ecs-cli/modules/cli/cluster/cluster_app_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/clients/aws/cloudformation"
 	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/clients/aws/cloudformation/mock"
 	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/clients/aws/ecs/mock"
-	command "github.com/aws/amazon-ecs-cli/ecs-cli/modules/commands"
+	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/commands/flags"
 	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/config"
 	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/config/ami"
 	"github.com/aws/aws-sdk-go/aws"
@@ -89,8 +89,8 @@ func TestClusterUp(t *testing.T) {
 	mocksForSuccessfulClusterUp(mockECS, mockCloudformation)
 
 	flagSet := flag.NewFlagSet("ecs-cli-up", 0)
-	flagSet.Bool(command.CapabilityIAMFlag, true, "")
-	flagSet.String(command.KeypairNameFlag, "default", "")
+	flagSet.Bool(flags.CapabilityIAMFlag, true, "")
+	flagSet.String(flags.KeypairNameFlag, "default", "")
 
 	context := cli.NewContext(nil, flagSet, nil)
 	err := createCluster(context, newMockReadWriter(), mockECS, mockCloudformation, ami.NewStaticAmiIds())
@@ -116,9 +116,9 @@ func TestClusterUpWithForce(t *testing.T) {
 	)
 
 	flagSet := flag.NewFlagSet("ecs-cli-up", 0)
-	flagSet.Bool(command.CapabilityIAMFlag, true, "")
-	flagSet.String(command.KeypairNameFlag, "default", "")
-	flagSet.Bool(command.ForceFlag, true, "")
+	flagSet.Bool(flags.CapabilityIAMFlag, true, "")
+	flagSet.String(flags.KeypairNameFlag, "default", "")
+	flagSet.Bool(flags.ForceFlag, true, "")
 
 	context := cli.NewContext(nil, flagSet, nil)
 	err := createCluster(context, newMockReadWriter(), mockECS, mockCloudformation, ami.NewStaticAmiIds())
@@ -150,9 +150,9 @@ func TestClusterUpWithoutPublicIP(t *testing.T) {
 	globalContext := cli.NewContext(nil, globalSet, nil)
 
 	flagSet := flag.NewFlagSet("ecs-cli-up", 0)
-	flagSet.Bool(command.CapabilityIAMFlag, true, "")
-	flagSet.String(command.KeypairNameFlag, "default", "")
-	flagSet.Bool(command.NoAutoAssignPublicIPAddressFlag, true, "")
+	flagSet.Bool(flags.CapabilityIAMFlag, true, "")
+	flagSet.String(flags.KeypairNameFlag, "default", "")
+	flagSet.Bool(flags.NoAutoAssignPublicIPAddressFlag, true, "")
 
 	context := cli.NewContext(nil, flagSet, globalContext)
 	err := createCluster(context, newMockReadWriter(), mockECS, mockCloudformation, ami.NewStaticAmiIds())
@@ -169,10 +169,10 @@ func TestClusterUpWithVPC(t *testing.T) {
 	mocksForSuccessfulClusterUp(mockECS, mockCloudformation)
 
 	flagSet := flag.NewFlagSet("ecs-cli-up", 0)
-	flagSet.Bool(command.CapabilityIAMFlag, true, "")
-	flagSet.String(command.KeypairNameFlag, "default", "")
-	flagSet.String(command.VpcIdFlag, vpcID, "")
-	flagSet.String(command.SubnetIdsFlag, subnetIds, "")
+	flagSet.Bool(flags.CapabilityIAMFlag, true, "")
+	flagSet.String(flags.KeypairNameFlag, "default", "")
+	flagSet.String(flags.VpcIdFlag, vpcID, "")
+	flagSet.String(flags.SubnetIdsFlag, subnetIds, "")
 
 	context := cli.NewContext(nil, flagSet, nil)
 	err := createCluster(context, newMockReadWriter(), mockECS, mockCloudformation, ami.NewStaticAmiIds())
@@ -188,9 +188,9 @@ func TestClusterUpWithAvailabilityZones(t *testing.T) {
 	mocksForSuccessfulClusterUp(mockECS, mockCloudformation)
 
 	flagSet := flag.NewFlagSet("ecs-cli-up", 0)
-	flagSet.Bool(command.CapabilityIAMFlag, true, "")
-	flagSet.String(command.KeypairNameFlag, "default", "")
-	flagSet.String(command.VpcAzFlag, vpcAZs, "")
+	flagSet.Bool(flags.CapabilityIAMFlag, true, "")
+	flagSet.String(flags.KeypairNameFlag, "default", "")
+	flagSet.String(flags.VpcAzFlag, vpcAZs, "")
 
 	context := cli.NewContext(nil, flagSet, nil)
 	err := createCluster(context, newMockReadWriter(), mockECS, mockCloudformation, ami.NewStaticAmiIds())
@@ -206,8 +206,8 @@ func TestClusterUpWithCustomRole(t *testing.T) {
 	mocksForSuccessfulClusterUp(mockECS, mockCloudformation)
 
 	flagSet := flag.NewFlagSet("ecs-cli-up", 0)
-	flagSet.String(command.KeypairNameFlag, "default", "")
-	flagSet.String(command.InstanceRoleFlag, instanceRole, "")
+	flagSet.String(flags.KeypairNameFlag, "default", "")
+	flagSet.String(flags.InstanceRoleFlag, instanceRole, "")
 
 	context := cli.NewContext(nil, flagSet, nil)
 	err := createCluster(context, newMockReadWriter(), mockECS, mockCloudformation, ami.NewStaticAmiIds())
@@ -226,9 +226,9 @@ func TestClusterUpWithTwoCustomRoles(t *testing.T) {
 	)
 
 	flagSet := flag.NewFlagSet("ecs-cli-up", 0)
-	flagSet.Bool(command.CapabilityIAMFlag, true, "")
-	flagSet.String(command.KeypairNameFlag, "default", "")
-	flagSet.String(command.InstanceRoleFlag, instanceRole, "")
+	flagSet.Bool(flags.CapabilityIAMFlag, true, "")
+	flagSet.String(flags.KeypairNameFlag, "default", "")
+	flagSet.String(flags.InstanceRoleFlag, instanceRole, "")
 
 	context := cli.NewContext(nil, flagSet, nil)
 	err := createCluster(context, newMockReadWriter(), mockECS, mockCloudformation, ami.NewStaticAmiIds())
@@ -247,9 +247,9 @@ func TestClusterUpWithDefaultAndCustomRoles(t *testing.T) {
 	)
 
 	flagSet := flag.NewFlagSet("ecs-cli-up", 0)
-	flagSet.Bool(command.CapabilityIAMFlag, true, "")
-	flagSet.String(command.KeypairNameFlag, "default", "")
-	flagSet.String(command.InstanceRoleFlag, instanceRole, "")
+	flagSet.Bool(flags.CapabilityIAMFlag, true, "")
+	flagSet.String(flags.KeypairNameFlag, "default", "")
+	flagSet.String(flags.InstanceRoleFlag, instanceRole, "")
 
 	context := cli.NewContext(nil, flagSet, nil)
 	err := createCluster(context, newMockReadWriter(), mockECS, mockCloudformation, ami.NewStaticAmiIds())
@@ -266,8 +266,8 @@ func TestClusterUpWithNoRoles(t *testing.T) {
 	)
 
 	flagSet := flag.NewFlagSet("ecs-cli-up", 0)
-	flagSet.Bool(command.CapabilityIAMFlag, false, "")
-	flagSet.String(command.KeypairNameFlag, "default", "")
+	flagSet.Bool(flags.CapabilityIAMFlag, false, "")
+	flagSet.String(flags.KeypairNameFlag, "default", "")
 
 	context := cli.NewContext(nil, flagSet, nil)
 	err := createCluster(context, newMockReadWriter(), mockECS, mockCloudformation, ami.NewStaticAmiIds())
@@ -281,8 +281,8 @@ func TestClusterUpWithoutKeyPair(t *testing.T) {
 	mocksForSuccessfulClusterUp(mockECS, mockCloudformation)
 
 	flagSet := flag.NewFlagSet("ecs-cli-up", 0)
-	flagSet.Bool(command.CapabilityIAMFlag, true, "")
-	flagSet.Bool(command.ForceFlag, true, "")
+	flagSet.Bool(flags.CapabilityIAMFlag, true, "")
+	flagSet.Bool(flags.ForceFlag, true, "")
 
 	context := cli.NewContext(nil, flagSet, nil)
 	err := createCluster(context, newMockReadWriter(), mockECS, mockCloudformation, ami.NewStaticAmiIds())
@@ -302,10 +302,10 @@ func TestClusterUpWithSecurityGroupWithoutVPC(t *testing.T) {
 	)
 
 	flagSet := flag.NewFlagSet("ecs-cli-up", 0)
-	flagSet.Bool(command.CapabilityIAMFlag, true, "")
-	flagSet.String(command.KeypairNameFlag, "default", "")
-	flagSet.Bool(command.ForceFlag, true, "")
-	flagSet.String(command.SecurityGroupFlag, securityGroupID, "")
+	flagSet.Bool(flags.CapabilityIAMFlag, true, "")
+	flagSet.String(flags.KeypairNameFlag, "default", "")
+	flagSet.Bool(flags.ForceFlag, true, "")
+	flagSet.String(flags.SecurityGroupFlag, securityGroupID, "")
 
 	context := cli.NewContext(nil, flagSet, nil)
 	err := createCluster(context, newMockReadWriter(), mockECS, mockCloudformation, ami.NewStaticAmiIds())
@@ -323,12 +323,12 @@ func TestClusterUpWith2SecurityGroups(t *testing.T) {
 	subnetIds := "subnet-04726b21,subnet-04346b21"
 
 	flagSet := flag.NewFlagSet("ecs-cli-up", 0)
-	flagSet.Bool(command.CapabilityIAMFlag, true, "")
-	flagSet.String(command.KeypairNameFlag, "default", "")
-	flagSet.Bool(command.ForceFlag, true, "")
-	flagSet.String(command.SecurityGroupFlag, securityGroupIds, "")
-	flagSet.String(command.VpcIdFlag, vpcId, "")
-	flagSet.String(command.SubnetIdsFlag, subnetIds, "")
+	flagSet.Bool(flags.CapabilityIAMFlag, true, "")
+	flagSet.String(flags.KeypairNameFlag, "default", "")
+	flagSet.Bool(flags.ForceFlag, true, "")
+	flagSet.String(flags.SecurityGroupFlag, securityGroupIds, "")
+	flagSet.String(flags.VpcIdFlag, vpcId, "")
+	flagSet.String(flags.SubnetIdsFlag, subnetIds, "")
 
 	context := cli.NewContext(nil, flagSet, nil)
 	err := createCluster(context, newMockReadWriter(), mockECS, mockCloudformation, ami.NewStaticAmiIds())
@@ -347,10 +347,10 @@ func TestClusterUpWithSubnetsWithoutVPC(t *testing.T) {
 	)
 
 	flagSet := flag.NewFlagSet("ecs-cli-up", 0)
-	flagSet.Bool(command.CapabilityIAMFlag, true, "")
-	flagSet.String(command.KeypairNameFlag, "default", "")
-	flagSet.Bool(command.ForceFlag, true, "")
-	flagSet.String(command.SubnetIdsFlag, subnetID, "")
+	flagSet.Bool(flags.CapabilityIAMFlag, true, "")
+	flagSet.String(flags.KeypairNameFlag, "default", "")
+	flagSet.Bool(flags.ForceFlag, true, "")
+	flagSet.String(flags.SubnetIdsFlag, subnetID, "")
 
 	context := cli.NewContext(nil, flagSet, nil)
 	err := createCluster(context, newMockReadWriter(), mockECS, mockCloudformation, ami.NewStaticAmiIds())
@@ -369,10 +369,10 @@ func TestClusterUpWithVPCWithoutSubnets(t *testing.T) {
 	)
 
 	flagSet := flag.NewFlagSet("ecs-cli-up", 0)
-	flagSet.Bool(command.CapabilityIAMFlag, true, "")
-	flagSet.String(command.KeypairNameFlag, "default", "")
-	flagSet.Bool(command.ForceFlag, true, "")
-	flagSet.String(command.VpcIdFlag, vpcID, "")
+	flagSet.Bool(flags.CapabilityIAMFlag, true, "")
+	flagSet.String(flags.KeypairNameFlag, "default", "")
+	flagSet.Bool(flags.ForceFlag, true, "")
+	flagSet.String(flags.VpcIdFlag, vpcID, "")
 
 	context := cli.NewContext(nil, flagSet, nil)
 	err := createCluster(context, newMockReadWriter(), mockECS, mockCloudformation, ami.NewStaticAmiIds())
@@ -392,11 +392,11 @@ func TestClusterUpWithAvailabilityZonesWithVPC(t *testing.T) {
 	)
 
 	flagSet := flag.NewFlagSet("ecs-cli-up", 0)
-	flagSet.Bool(command.CapabilityIAMFlag, true, "")
-	flagSet.String(command.KeypairNameFlag, "default", "")
-	flagSet.Bool(command.ForceFlag, true, "")
-	flagSet.String(command.VpcIdFlag, vpcID, "")
-	flagSet.String(command.VpcAzFlag, vpcAZs, "")
+	flagSet.Bool(flags.CapabilityIAMFlag, true, "")
+	flagSet.String(flags.KeypairNameFlag, "default", "")
+	flagSet.Bool(flags.ForceFlag, true, "")
+	flagSet.String(flags.VpcIdFlag, vpcID, "")
+	flagSet.String(flags.VpcAzFlag, vpcAZs, "")
 
 	context := cli.NewContext(nil, flagSet, nil)
 	err := createCluster(context, newMockReadWriter(), mockECS, mockCloudformation, ami.NewStaticAmiIds())
@@ -415,10 +415,10 @@ func TestClusterUpWithout2AvailabilityZones(t *testing.T) {
 	)
 
 	flagSet := flag.NewFlagSet("ecs-cli-up", 0)
-	flagSet.Bool(command.CapabilityIAMFlag, true, "")
-	flagSet.String(command.KeypairNameFlag, "default", "")
-	flagSet.Bool(command.ForceFlag, true, "")
-	flagSet.String(command.VpcAzFlag, vpcAZs, "")
+	flagSet.Bool(flags.CapabilityIAMFlag, true, "")
+	flagSet.String(flags.KeypairNameFlag, "default", "")
+	flagSet.Bool(flags.ForceFlag, true, "")
+	flagSet.String(flags.VpcAzFlag, vpcAZs, "")
 
 	context := cli.NewContext(nil, flagSet, nil)
 	err := createCluster(context, newMockReadWriter(), mockECS, mockCloudformation, ami.NewStaticAmiIds())
@@ -428,8 +428,8 @@ func TestClusterUpWithout2AvailabilityZones(t *testing.T) {
 func TestCliFlagsToCfnStackParams(t *testing.T) {
 
 	flagSet := flag.NewFlagSet("ecs-cli-up", 0)
-	flagSet.Bool(command.CapabilityIAMFlag, true, "")
-	flagSet.String(command.KeypairNameFlag, "default", "")
+	flagSet.Bool(flags.CapabilityIAMFlag, true, "")
+	flagSet.String(flags.KeypairNameFlag, "default", "")
 
 	context := cli.NewContext(nil, flagSet, nil)
 	params := cliFlagsToCfnStackParams(context)
@@ -438,7 +438,7 @@ func TestCliFlagsToCfnStackParams(t *testing.T) {
 	assert.Error(t, err, "Expected error for parameter ParameterKeyAsgMaxSize")
 	assert.Equal(t, cloudformation.ParameterNotFoundError, err, "Expect error to be ParameterNotFoundError")
 
-	flagSet.String(command.AsgMaxSizeFlag, "2", "")
+	flagSet.String(flags.AsgMaxSizeFlag, "2", "")
 	context = cli.NewContext(nil, flagSet, nil)
 	params = cliFlagsToCfnStackParams(context)
 	_, err = params.GetParameter(cloudformation.ParameterKeyAsgMaxSize)
@@ -469,9 +469,9 @@ func TestClusterUpForImageIdInput(t *testing.T) {
 	)
 
 	flagSet := flag.NewFlagSet("ecs-cli-up", 0)
-	flagSet.Bool(command.CapabilityIAMFlag, true, "")
-	flagSet.String(command.KeypairNameFlag, "default", "")
-	flagSet.String(command.ImageIdFlag, imageID, "")
+	flagSet.Bool(flags.CapabilityIAMFlag, true, "")
+	flagSet.String(flags.KeypairNameFlag, "default", "")
+	flagSet.String(flags.ImageIdFlag, imageID, "")
 
 	context := cli.NewContext(nil, flagSet, nil)
 	err := createCluster(context, newMockReadWriter(), mockECS, mockCloudformation, ami.NewStaticAmiIds())
@@ -486,8 +486,8 @@ func TestClusterUpWithClusterNameEmpty(t *testing.T) {
 	globalContext := cli.NewContext(nil, globalSet, nil)
 
 	flagSet := flag.NewFlagSet("ecs-cli-up", 0)
-	flagSet.Bool(command.CapabilityIAMFlag, true, "")
-	flagSet.String(command.KeypairNameFlag, "default", "")
+	flagSet.Bool(flags.CapabilityIAMFlag, true, "")
+	flagSet.String(flags.KeypairNameFlag, "default", "")
 
 	context := cli.NewContext(nil, flagSet, globalContext)
 	err := createCluster(context, &mockReadWriter{clusterName: ""}, mockECS, mockCloudformation, ami.NewStaticAmiIds())
@@ -527,7 +527,7 @@ func TestClusterDown(t *testing.T) {
 		mockECS.EXPECT().DeleteCluster(clusterName).Return(clusterName, nil),
 	)
 	flagSet := flag.NewFlagSet("ecs-cli-down", 0)
-	flagSet.Bool(command.ForceFlag, true, "")
+	flagSet.Bool(flags.ForceFlag, true, "")
 
 	context := cli.NewContext(nil, flagSet, nil)
 	err := deleteCluster(context, newMockReadWriter(), mockECS, mockCloudformation)
@@ -574,8 +574,8 @@ func TestClusterScale(t *testing.T) {
 	mockCloudformation.EXPECT().WaitUntilUpdateComplete(stackName).Return(nil)
 
 	flagSet := flag.NewFlagSet("ecs-cli-down", 0)
-	flagSet.Bool(command.CapabilityIAMFlag, true, "")
-	flagSet.String(command.AsgMaxSizeFlag, "1", "")
+	flagSet.Bool(flags.CapabilityIAMFlag, true, "")
+	flagSet.String(flags.AsgMaxSizeFlag, "1", "")
 
 	context := cli.NewContext(nil, flagSet, nil)
 	err := scaleCluster(context, newMockReadWriter(), mockECS, mockCloudformation)
@@ -587,7 +587,7 @@ func TestClusterScaleWithoutIamCapability(t *testing.T) {
 	mockECS, mockCloudformation := setupTest(t)
 
 	flagSet := flag.NewFlagSet("ecs-cli-up", 0)
-	flagSet.String(command.AsgMaxSizeFlag, "1", "")
+	flagSet.String(flags.AsgMaxSizeFlag, "1", "")
 
 	context := cli.NewContext(nil, flagSet, nil)
 	err := scaleCluster(context, newMockReadWriter(), mockECS, mockCloudformation)
@@ -599,7 +599,7 @@ func TestClusterScaleWithoutSize(t *testing.T) {
 	mockECS, mockCloudformation := setupTest(t)
 
 	flagSet := flag.NewFlagSet("ecs-cli-up", 0)
-	flagSet.Bool(command.CapabilityIAMFlag, true, "")
+	flagSet.Bool(flags.CapabilityIAMFlag, true, "")
 
 	context := cli.NewContext(nil, flagSet, nil)
 	err := scaleCluster(context, newMockReadWriter(), mockECS, mockCloudformation)

--- a/ecs-cli/modules/cli/compose/context/context.go
+++ b/ecs-cli/modules/cli/compose/context/context.go
@@ -22,7 +22,7 @@ import (
 	"github.com/Sirupsen/logrus"
 	ec2client "github.com/aws/amazon-ecs-cli/ecs-cli/modules/clients/aws/ec2"
 	ecsclient "github.com/aws/amazon-ecs-cli/ecs-cli/modules/clients/aws/ecs"
-	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/commands"
+	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/commands/flags"
 	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/config"
 	"github.com/docker/libcompose/project"
 	"github.com/urfave/cli"
@@ -59,7 +59,7 @@ func (context *Context) Open() error {
 // 2. Environment variable
 // 3. Current working directory
 func (context *Context) SetProjectName() error {
-	projectName := context.CLIContext.GlobalString(command.ProjectNameFlag)
+	projectName := context.CLIContext.GlobalString(flags.ProjectNameFlag)
 	if projectName != "" {
 		context.ProjectName = projectName
 		return nil

--- a/ecs-cli/modules/cli/compose/entity/service/service.go
+++ b/ecs-cli/modules/cli/compose/entity/service/service.go
@@ -22,7 +22,7 @@ import (
 	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/cli/compose/context"
 	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/cli/compose/entity"
 	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/cli/compose/entity/types"
-	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/commands"
+	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/commands/flags"
 	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/utils"
 	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/utils/cache"
 	composeutils "github.com/aws/amazon-ecs-cli/ecs-cli/modules/utils/compose"
@@ -60,11 +60,11 @@ func NewService(context *context.Context) entity.ProjectEntity {
 
 // LoadContext reads the context set in NewService and loads DeploymentConfiguration and LoadBalnacer
 func (s *Service) LoadContext() error {
-	maxPercent, err := getInt64FromCLIContext(s.Context(), command.DeploymentMaxPercentFlag)
+	maxPercent, err := getInt64FromCLIContext(s.Context(), flags.DeploymentMaxPercentFlag)
 	if err != nil {
 		return err
 	}
-	minHealthyPercent, err := getInt64FromCLIContext(s.Context(), command.DeploymentMinHealthyPercentFlag)
+	minHealthyPercent, err := getInt64FromCLIContext(s.Context(), flags.DeploymentMinHealthyPercentFlag)
 	if err != nil {
 		return err
 	}
@@ -74,11 +74,11 @@ func (s *Service) LoadContext() error {
 	}
 
 	// Load Balancer
-	role := s.Context().CLIContext.String(command.RoleFlag)
-	targetGroupArn := s.Context().CLIContext.String(command.TargetGroupArnFlag)
-	loadBalancerName := s.Context().CLIContext.String(command.LoadBalancerNameFlag)
-	containerName := s.Context().CLIContext.String(command.ContainerNameFlag)
-	containerPort, err := getInt64FromCLIContext(s.Context(), command.ContainerPortFlag)
+	role := s.Context().CLIContext.String(flags.RoleFlag)
+	targetGroupArn := s.Context().CLIContext.String(flags.TargetGroupArnFlag)
+	loadBalancerName := s.Context().CLIContext.String(flags.LoadBalancerNameFlag)
+	containerName := s.Context().CLIContext.String(flags.ContainerNameFlag)
+	containerPort, err := getInt64FromCLIContext(s.Context(), flags.ContainerPortFlag)
 	if err != nil {
 		return err
 	}
@@ -87,7 +87,7 @@ func (s *Service) LoadContext() error {
 	// The rest will be taken care off by the API call
 	if role != "" || targetGroupArn != "" || loadBalancerName != "" || containerName != "" || containerPort != nil {
 		if targetGroupArn != "" && loadBalancerName != "" {
-			return errors.Errorf("[--%s] and [--%s] flags cannot both be specified", command.LoadBalancerNameFlag, command.TargetGroupArnFlag)
+			return errors.Errorf("[--%s] and [--%s] flags cannot both be specified", flags.LoadBalancerNameFlag, flags.TargetGroupArnFlag)
 		}
 
 		s.loadBalancer = &ecs.LoadBalancer{
@@ -175,7 +175,7 @@ func (s *Service) Start() error {
 		// Read the custom error returned from describeService to see if the resource was missing
 		if strings.Contains(err.Error(), ecsMissingResourceCode) {
 			return fmt.Errorf("Please use '%s' command to create the service '%s' first",
-				command.CreateServiceCommandName, entity.GetServiceName(s))
+				flags.CreateServiceCommandName, entity.GetServiceName(s))
 		}
 		return err
 	}

--- a/ecs-cli/modules/cli/compose/entity/service/service_helper.go
+++ b/ecs-cli/modules/cli/compose/entity/service/service_helper.go
@@ -19,7 +19,7 @@ import (
 	"time"
 
 	log "github.com/Sirupsen/logrus"
-	ecscli "github.com/aws/amazon-ecs-cli/ecs-cli/modules/commands"
+	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/commands/flags"
 	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/utils/waiters"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ecs"
@@ -81,7 +81,7 @@ func waitForServiceTasks(service *Service, ecsServiceName string) error {
 	timeOut := float64(DefaultUpdateServiceTimeout)
 	actionInvokedAt := time.Now()
 
-	if val := service.Context().CLIContext.Float64(ecscli.ComposeServiceTimeOutFlag); val > 0 {
+	if val := service.Context().CLIContext.Float64(flags.ComposeServiceTimeOutFlag); val > 0 {
 		timeOut = val
 	} else if val < 0 {
 		return fmt.Errorf("Error with timeout flag: %f is not a valid timeout value", val)

--- a/ecs-cli/modules/cli/compose/entity/service/service_test.go
+++ b/ecs-cli/modules/cli/compose/entity/service/service_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/cli/compose/context"
 	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/cli/compose/entity"
 	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/clients/aws/ecs/mock"
-	command "github.com/aws/amazon-ecs-cli/ecs-cli/modules/commands"
+	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/commands/flags"
 	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/config"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ecs"
@@ -35,8 +35,8 @@ func TestCreateWithDeploymentConfig(t *testing.T) {
 	deploymentMinPercent := 100
 
 	flagSet := flag.NewFlagSet("ecs-cli-up", 0)
-	flagSet.String(command.DeploymentMaxPercentFlag, strconv.Itoa(deploymentMaxPercent), "")
-	flagSet.String(command.DeploymentMinHealthyPercentFlag, strconv.Itoa(deploymentMinPercent), "")
+	flagSet.String(flags.DeploymentMaxPercentFlag, strconv.Itoa(deploymentMaxPercent), "")
+	flagSet.String(flags.DeploymentMinHealthyPercentFlag, strconv.Itoa(deploymentMinPercent), "")
 	cliContext := cli.NewContext(nil, flagSet, nil)
 
 	createServiceTest(
@@ -79,10 +79,10 @@ func TestCreateWithALB(t *testing.T) {
 	role := "role"
 
 	flagSet := flag.NewFlagSet("ecs-cli-up", 0)
-	flagSet.String(command.TargetGroupArnFlag, targetGroupArn, "")
-	flagSet.String(command.ContainerNameFlag, containerName, "")
-	flagSet.String(command.ContainerPortFlag, strconv.Itoa(containerPort), "")
-	flagSet.String(command.RoleFlag, role, "")
+	flagSet.String(flags.TargetGroupArnFlag, targetGroupArn, "")
+	flagSet.String(flags.ContainerNameFlag, containerName, "")
+	flagSet.String(flags.ContainerPortFlag, strconv.Itoa(containerPort), "")
+	flagSet.String(flags.RoleFlag, role, "")
 
 	cliContext := cli.NewContext(nil, flagSet, nil)
 
@@ -112,10 +112,10 @@ func TestCreateWithELB(t *testing.T) {
 	role := "role"
 
 	flagSet := flag.NewFlagSet("ecs-cli-up", 0)
-	flagSet.String(command.LoadBalancerNameFlag, loadbalancerName, "")
-	flagSet.String(command.ContainerNameFlag, containerName, "")
-	flagSet.String(command.ContainerPortFlag, strconv.Itoa(containerPort), "")
-	flagSet.String(command.RoleFlag, role, "")
+	flagSet.String(flags.LoadBalancerNameFlag, loadbalancerName, "")
+	flagSet.String(flags.ContainerNameFlag, containerName, "")
+	flagSet.String(flags.ContainerPortFlag, strconv.Itoa(containerPort), "")
+	flagSet.String(flags.RoleFlag, role, "")
 
 	cliContext := cli.NewContext(nil, flagSet, nil)
 
@@ -199,7 +199,7 @@ func TestLoadContext(t *testing.T) {
 	deploymentMaxPercent := 150
 
 	flagSet := flag.NewFlagSet("ecs-cli-up", 0)
-	flagSet.String(command.DeploymentMaxPercentFlag, strconv.Itoa(deploymentMaxPercent), "")
+	flagSet.String(flags.DeploymentMaxPercentFlag, strconv.Itoa(deploymentMaxPercent), "")
 	cliContext := cli.NewContext(nil, flagSet, nil)
 	service := &Service{
 		projectContext: &context.Context{CLIContext: cliContext},
@@ -221,7 +221,7 @@ func TestLoadContextForIncorrectInput(t *testing.T) {
 	deploymentMaxPercent := "string"
 
 	flagSet := flag.NewFlagSet("ecs-cli-up", 0)
-	flagSet.String(command.DeploymentMaxPercentFlag, deploymentMaxPercent, "")
+	flagSet.String(flags.DeploymentMaxPercentFlag, deploymentMaxPercent, "")
 	cliContext := cli.NewContext(nil, flagSet, nil)
 	service := &Service{
 		projectContext: &context.Context{CLIContext: cliContext},
@@ -236,8 +236,8 @@ func TestLoadContextForLoadBalancerInputError(t *testing.T) {
 	loadBalancerName := "loadBalancerName"
 
 	flagSet := flag.NewFlagSet("ecs-cli-up", 0)
-	flagSet.String(command.TargetGroupArnFlag, targetGroupArn, "")
-	flagSet.String(command.LoadBalancerNameFlag, loadBalancerName, "")
+	flagSet.String(flags.TargetGroupArnFlag, targetGroupArn, "")
+	flagSet.String(flags.LoadBalancerNameFlag, loadBalancerName, "")
 	cliContext := cli.NewContext(nil, flagSet, nil)
 	service := &Service{
 		projectContext: &context.Context{CLIContext: cliContext},

--- a/ecs-cli/modules/cli/compose/factory/factory_test.go
+++ b/ecs-cli/modules/cli/compose/factory/factory_test.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/cli/compose/context"
 	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/cli/compose/project/mock"
-	command "github.com/aws/amazon-ecs-cli/ecs-cli/modules/commands"
+	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/commands/flags"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/urfave/cli"
@@ -104,8 +104,8 @@ func TestPopulateContextWithGlobalFlagOverrides(t *testing.T) {
 	composeFiles.Set(composeFileNameTest)
 	// test multiple --file
 	composeFiles.Set("docker-compose-test2.yml")
-	overrides.Var(composeFiles, command.ComposeFileNameFlag, "")
-	overrides.String(command.ProjectNameFlag, projectNameTest, "")
+	overrides.Var(composeFiles, flags.ComposeFileNameFlag, "")
+	overrides.String(flags.ProjectNameFlag, projectNameTest, "")
 	parentContext := cli.NewContext(nil, overrides, nil)
 	flagSet := flag.NewFlagSet("ecs-cli-up", 0)
 	cliContext := cli.NewContext(nil, flagSet, parentContext)

--- a/ecs-cli/modules/cli/compose/project/project.go
+++ b/ecs-cli/modules/cli/compose/project/project.go
@@ -20,7 +20,7 @@ import (
 	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/cli/compose/entity/service"
 	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/cli/compose/entity/task"
 
-	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/commands"
+	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/commands/flags"
 	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/utils/compose"
 	"github.com/docker/libcompose/config"
 	"github.com/docker/libcompose/project"
@@ -137,8 +137,8 @@ func (p *ecsProject) transformTaskDefinition() error {
 	// convert to task definition
 	logrus.Debug("Transforming yaml to task definition...")
 	taskDefinitionName := utils.GetTaskDefinitionName("", context.Context.ProjectName)
-	taskRoleArn := context.CLIContext.GlobalString(command.TaskRoleArnFlag)
-	ecsParamsFileName := context.CLIContext.GlobalString(command.ECSParamsFileNameFlag)
+	taskRoleArn := context.CLIContext.GlobalString(flags.TaskRoleArnFlag)
+	ecsParamsFileName := context.CLIContext.GlobalString(flags.ECSParamsFileNameFlag)
 
 	taskDefinition, err := utils.ConvertToTaskDefinition(taskDefinitionName, &context.Context, p.ServiceConfigs(), taskRoleArn, ecsParamsFileName)
 	if err != nil {

--- a/ecs-cli/modules/cli/compose/project/project_test.go
+++ b/ecs-cli/modules/cli/compose/project/project_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 
 	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/cli/compose/context"
-	command "github.com/aws/amazon-ecs-cli/ecs-cli/modules/commands"
+	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/commands/flags"
 	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/utils/compose"
 	"github.com/docker/libcompose/project"
 	"github.com/docker/libcompose/yaml"
@@ -308,7 +308,7 @@ func setupTestProject(t *testing.T) *ecsProject {
 	}
 
 	composeContext := flag.NewFlagSet("ecs-cli", 0)
-	composeContext.String(command.ProjectNameFlag, testProjectName, "")
+	composeContext.String(flags.ProjectNameFlag, testProjectName, "")
 	parentContext := cli.NewContext(nil, composeContext, nil)
 	cliContext := cli.NewContext(nil, nil, parentContext)
 

--- a/ecs-cli/modules/cli/configure/configure.go
+++ b/ecs-cli/modules/cli/configure/configure.go
@@ -20,7 +20,7 @@ import (
 	"strings"
 
 	"github.com/Sirupsen/logrus"
-	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/commands"
+	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/commands/flags"
 	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/config"
 	"github.com/pkg/errors"
 	"github.com/urfave/cli"
@@ -60,14 +60,14 @@ func Migrate(context *cli.Context) error {
 		return errors.Wrap(err, "Error reading old configuration file.")
 	}
 
-	if oldConfig.CFNStackNamePrefix == command.CFNStackNamePrefixDefaultValue {
+	if oldConfig.CFNStackNamePrefix == flags.CFNStackNamePrefixDefaultValue {
 		// if CFNStackName is default; don't store it.
 		oldConfig.CFNStackName = ""
 	} else {
 		oldConfig.CFNStackName = oldConfig.CFNStackNamePrefix + oldConfig.Cluster
 	}
 
-	if !context.Bool(command.ForceFlag) {
+	if !context.Bool(flags.ForceFlag) {
 		if err = migrateWarning(*oldConfig); err != nil {
 			return err
 		}
@@ -110,21 +110,21 @@ func Migrate(context *cli.Context) error {
 
 // Cluster is the callback for ConfigureCommand (cluster).
 func Cluster(context *cli.Context) error {
-	region := context.String(command.RegionFlag)
-	if err := fieldEmpty(region, command.RegionFlag); err != nil {
+	region := context.String(flags.RegionFlag)
+	if err := fieldEmpty(region, flags.RegionFlag); err != nil {
 		return err
 	}
-	clusterProfileName := context.String(command.ConfigNameFlag)
-	if err := fieldEmpty(clusterProfileName, command.ConfigNameFlag); err != nil {
+	clusterProfileName := context.String(flags.ConfigNameFlag)
+	if err := fieldEmpty(clusterProfileName, flags.ConfigNameFlag); err != nil {
 		return err
 	}
-	cluster := context.String(command.ClusterFlag)
-	if err := fieldEmpty(cluster, command.ClusterFlag); err != nil {
+	cluster := context.String(flags.ClusterFlag)
+	if err := fieldEmpty(cluster, flags.ClusterFlag); err != nil {
 		return err
 	}
 
-	cfnStackName := context.String(command.CFNStackNameFlag)
-	composeServiceNamePrefix := context.String(command.ComposeServiceNamePrefixFlag)
+	cfnStackName := context.String(flags.CFNStackNameFlag)
+	composeServiceNamePrefix := context.String(flags.ComposeServiceNamePrefixFlag)
 
 	clusterConfig := &config.Cluster{
 		Cluster:                  cluster,
@@ -145,18 +145,18 @@ func Cluster(context *cli.Context) error {
 	return nil
 }
 
-// Profile is the callback for Configure Profile subcommand.
+// Profile is the callback for Configure Profile subcommands.
 func Profile(context *cli.Context) error {
-	secretKey := context.String(command.SecretKeyFlag)
-	if err := fieldEmpty(secretKey, command.SecretKeyFlag); err != nil {
+	secretKey := context.String(flags.SecretKeyFlag)
+	if err := fieldEmpty(secretKey, flags.SecretKeyFlag); err != nil {
 		return err
 	}
-	accessKey := context.String(command.AccessKeyFlag)
-	if err := fieldEmpty(accessKey, command.AccessKeyFlag); err != nil {
+	accessKey := context.String(flags.AccessKeyFlag)
+	if err := fieldEmpty(accessKey, flags.AccessKeyFlag); err != nil {
 		return err
 	}
-	profileName := context.String(command.ProfileNameFlag)
-	if err := fieldEmpty(profileName, command.ProfileNameFlag); err != nil {
+	profileName := context.String(flags.ProfileNameFlag)
+	if err := fieldEmpty(profileName, flags.ProfileNameFlag); err != nil {
 		return err
 	}
 	profile := &config.Profile{
@@ -178,8 +178,8 @@ func Profile(context *cli.Context) error {
 
 // DefaultProfile is the callback for Configure Profile Default subcommand.
 func DefaultProfile(context *cli.Context) error {
-	profileName := context.String(command.ProfileNameFlag)
-	if err := fieldEmpty(profileName, command.ProfileNameFlag); err != nil {
+	profileName := context.String(flags.ProfileNameFlag)
+	if err := fieldEmpty(profileName, flags.ProfileNameFlag); err != nil {
 		return err
 	}
 
@@ -196,8 +196,8 @@ func DefaultProfile(context *cli.Context) error {
 
 // DefaultCluster is the callback for Configure Cluster Default subcommand.
 func DefaultCluster(context *cli.Context) error {
-	clusterName := context.String(command.ConfigNameFlag)
-	if err := fieldEmpty(clusterName, command.ConfigNameFlag); err != nil {
+	clusterName := context.String(flags.ConfigNameFlag)
+	if err := fieldEmpty(clusterName, flags.ConfigNameFlag); err != nil {
 		return err
 	}
 

--- a/ecs-cli/modules/cli/configure/configure_test.go
+++ b/ecs-cli/modules/cli/configure/configure_test.go
@@ -19,7 +19,7 @@ import (
 	"os"
 	"testing"
 
-	command "github.com/aws/amazon-ecs-cli/ecs-cli/modules/commands"
+	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/commands/flags"
 	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/urfave/cli"
@@ -43,19 +43,19 @@ const (
 )
 
 func createClusterConfig(name string, cluster string) *cli.Context {
-	flags := flag.NewFlagSet("ecs-cli", 0)
-	flags.String(command.RegionFlag, region, "")
-	flags.String(command.ClusterFlag, cluster, "")
-	flags.String(command.ConfigNameFlag, name, "")
-	return cli.NewContext(nil, flags, nil)
+	flagSet := flag.NewFlagSet("ecs-cli", 0)
+	flagSet.String(flags.RegionFlag, region, "")
+	flagSet.String(flags.ClusterFlag, cluster, "")
+	flagSet.String(flags.ConfigNameFlag, name, "")
+	return cli.NewContext(nil, flagSet, nil)
 }
 
 func createProfileConfig(name string, accessKey string, secretKey string) *cli.Context {
-	flags := flag.NewFlagSet("ecs-cli", 0)
-	flags.String(command.AccessKeyFlag, accessKey, "")
-	flags.String(command.SecretKeyFlag, secretKey, "")
-	flags.String(command.ProfileNameFlag, name, "")
-	return cli.NewContext(nil, flags, nil)
+	flagSet := flag.NewFlagSet("ecs-cli", 0)
+	flagSet.String(flags.AccessKeyFlag, accessKey, "")
+	flagSet.String(flags.SecretKeyFlag, secretKey, "")
+	flagSet.String(flags.ProfileNameFlag, name, "")
+	return cli.NewContext(nil, flagSet, nil)
 }
 
 func TestDefaultCluster(t *testing.T) {
@@ -173,10 +173,10 @@ func TestConfigureCluster(t *testing.T) {
 }
 
 func TestConfigureClusterNoCluster(t *testing.T) {
-	flags := flag.NewFlagSet("ecs-cli", 0)
-	flags.String(command.RegionFlag, region, "")
-	flags.String(command.ConfigNameFlag, profileName, "")
-	config1 := cli.NewContext(nil, flags, nil)
+	flagSet := flag.NewFlagSet("ecs-cli", 0)
+	flagSet.String(flags.RegionFlag, region, "")
+	flagSet.String(flags.ConfigNameFlag, profileName, "")
+	config1 := cli.NewContext(nil, flagSet, nil)
 
 	// Create a temporary directory for the dummy ecs config
 	tempDirName, err := ioutil.TempDir("", "test")
@@ -194,10 +194,10 @@ func TestConfigureClusterNoCluster(t *testing.T) {
 }
 
 func TestConfigureClusterNoRegion(t *testing.T) {
-	flags := flag.NewFlagSet("ecs-cli", 0)
-	flags.String(command.ClusterFlag, clusterName, "")
-	flags.String(command.ConfigNameFlag, profileName, "")
-	config1 := cli.NewContext(nil, flags, nil)
+	flagSet := flag.NewFlagSet("ecs-cli", 0)
+	flagSet.String(flags.ClusterFlag, clusterName, "")
+	flagSet.String(flags.ConfigNameFlag, profileName, "")
+	config1 := cli.NewContext(nil, flagSet, nil)
 
 	// Create a temporary directory for the dummy ecs config
 	tempDirName, err := ioutil.TempDir("", "test")
@@ -215,10 +215,10 @@ func TestConfigureClusterNoRegion(t *testing.T) {
 }
 
 func TestConfigureClusterNoConfigName(t *testing.T) {
-	flags := flag.NewFlagSet("ecs-cli", 0)
-	flags.String(command.ClusterFlag, clusterName, "")
-	flags.String(command.RegionFlag, region, "")
-	config1 := cli.NewContext(nil, flags, nil)
+	flagSet := flag.NewFlagSet("ecs-cli", 0)
+	flagSet.String(flags.ClusterFlag, clusterName, "")
+	flagSet.String(flags.RegionFlag, region, "")
+	config1 := cli.NewContext(nil, flagSet, nil)
 
 	// Create a temporary directory for the dummy ecs config
 	tempDirName, err := ioutil.TempDir("", "test")
@@ -235,10 +235,10 @@ func TestConfigureClusterNoConfigName(t *testing.T) {
 }
 
 func TestConfigureProfileNoAccessKey(t *testing.T) {
-	flags := flag.NewFlagSet("ecs-cli", 0)
-	flags.String(command.SecretKeyFlag, awsSecretKey, "")
-	flags.String(command.ProfileNameFlag, profileName, "")
-	config1 := cli.NewContext(nil, flags, nil)
+	flagSet := flag.NewFlagSet("ecs-cli", 0)
+	flagSet.String(flags.SecretKeyFlag, awsSecretKey, "")
+	flagSet.String(flags.ProfileNameFlag, profileName, "")
+	config1 := cli.NewContext(nil, flagSet, nil)
 
 	// Create a temporary directory for the dummy ecs config
 	tempDirName, err := ioutil.TempDir("", "test")
@@ -255,10 +255,10 @@ func TestConfigureProfileNoAccessKey(t *testing.T) {
 }
 
 func TestConfigureProfileNoSecretKey(t *testing.T) {
-	flags := flag.NewFlagSet("ecs-cli", 0)
-	flags.String(command.AccessKeyFlag, awsAccessKey, "")
-	flags.String(command.ProfileNameFlag, profileName, "")
-	config1 := cli.NewContext(nil, flags, nil)
+	flagSet := flag.NewFlagSet("ecs-cli", 0)
+	flagSet.String(flags.AccessKeyFlag, awsAccessKey, "")
+	flagSet.String(flags.ProfileNameFlag, profileName, "")
+	config1 := cli.NewContext(nil, flagSet, nil)
 
 	// Create a temporary directory for the dummy ecs config
 	tempDirName, err := ioutil.TempDir("", "test")
@@ -275,10 +275,10 @@ func TestConfigureProfileNoSecretKey(t *testing.T) {
 }
 
 func TestConfigureProfileNoProfileName(t *testing.T) {
-	flags := flag.NewFlagSet("ecs-cli", 0)
-	flags.String(command.AccessKeyFlag, awsAccessKey, "")
-	flags.String(command.SecretKeyFlag, awsSecretKey, "")
-	config1 := cli.NewContext(nil, flags, nil)
+	flagSet := flag.NewFlagSet("ecs-cli", 0)
+	flagSet.String(flags.AccessKeyFlag, awsAccessKey, "")
+	flagSet.String(flags.SecretKeyFlag, awsSecretKey, "")
+	config1 := cli.NewContext(nil, flagSet, nil)
 
 	// Create a temporary directory for the dummy ecs config
 	tempDirName, err := ioutil.TempDir("", "test")
@@ -365,9 +365,9 @@ cfn-stack-name-prefix = cfn-
 	assert.NoError(t, err)
 
 	// migrate
-	flags := flag.NewFlagSet("ecs-cli", 0)
-	flags.Bool(command.ForceFlag, true, "")
-	context := cli.NewContext(nil, flags, nil)
+	flagSet := flag.NewFlagSet("ecs-cli", 0)
+	flagSet.Bool(flags.ForceFlag, true, "")
+	context := cli.NewContext(nil, flagSet, nil)
 
 	err = Migrate(context)
 	assert.NoError(t, err, "Unexpected error configuring cluster")
@@ -416,9 +416,9 @@ cfn-stack-name-prefix =
 	assert.NoError(t, err)
 
 	// migrate
-	flags := flag.NewFlagSet("ecs-cli", 0)
-	flags.Bool(command.ForceFlag, true, "")
-	context := cli.NewContext(nil, flags, nil)
+	flagSet := flag.NewFlagSet("ecs-cli", 0)
+	flagSet.Bool(flags.ForceFlag, true, "")
+	context := cli.NewContext(nil, flagSet, nil)
 
 	err = Migrate(context)
 	assert.NoError(t, err, "Unexpected error configuring cluster")
@@ -464,9 +464,9 @@ aws_secret_access_key = SKID
 	assert.NoError(t, err)
 
 	// migrate
-	flags := flag.NewFlagSet("ecs-cli", 0)
-	flags.Bool(command.ForceFlag, true, "")
-	context := cli.NewContext(nil, flags, nil)
+	flagSet := flag.NewFlagSet("ecs-cli", 0)
+	flagSet.Bool(flags.ForceFlag, true, "")
+	context := cli.NewContext(nil, flagSet, nil)
 
 	err = Migrate(context)
 	assert.NoError(t, err, "Unexpected error configuring cluster")
@@ -477,7 +477,7 @@ aws_secret_access_key = SKID
 	assert.NoError(t, err, "Error reading config")
 	assert.Equal(t, region, readConfig.Region, "Region mismatch in config.")
 	assert.Equal(t, clusterName, readConfig.Cluster, "Cluster name mismatch in config.")
-	assert.Equal(t, command.ComposeServiceNamePrefixDefaultValue, readConfig.ComposeServiceNamePrefix, "Compose service prefix name should be default.")
+	assert.Equal(t, flags.ComposeServiceNamePrefixDefaultValue, readConfig.ComposeServiceNamePrefix, "Compose service prefix name should be default.")
 	assert.Empty(t, readConfig.CFNStackName, "CFNStackName should be empty.")
 	assert.Equal(t, awsAccessKey, readConfig.AWSAccessKey, "Access Key mismatch in config.")
 	assert.Equal(t, awsSecretKey, readConfig.AWSSecretKey, "Secret Key name mismatch in config.")

--- a/ecs-cli/modules/cli/image/image_app.go
+++ b/ecs-cli/modules/cli/image/image_app.go
@@ -25,7 +25,7 @@ import (
 	ecrclient "github.com/aws/amazon-ecs-cli/ecs-cli/modules/clients/aws/ecr"
 	stsclient "github.com/aws/amazon-ecs-cli/ecs-cli/modules/clients/aws/sts"
 	dockerclient "github.com/aws/amazon-ecs-cli/ecs-cli/modules/clients/docker"
-	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/commands"
+	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/commands/flags"
 	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/config"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ecr"
@@ -117,7 +117,7 @@ func ImageList(c *cli.Context) {
 }
 
 func pushImage(c *cli.Context, rdwr config.ReadWriter, dockerClient dockerclient.Client, ecrClient ecrclient.Client, stsClient stsclient.Client) error {
-	registryID := c.String(command.RegistryIdFlag)
+	registryID := c.String(flags.RegistryIdFlag)
 	args := c.Args()
 
 	if len(args) != 1 {
@@ -167,7 +167,7 @@ func pushImage(c *cli.Context, rdwr config.ReadWriter, dockerClient dockerclient
 }
 
 func pullImage(c *cli.Context, rdwr config.ReadWriter, dockerClient dockerclient.Client, ecrClient ecrclient.Client, stsClient stsclient.Client) error {
-	registryID := c.String(command.RegistryIdFlag)
+	registryID := c.String(flags.RegistryIdFlag)
 	args := c.Args()
 	if len(args) != 1 {
 		return fmt.Errorf("ecs-cli pull requires exactly 1 argument")
@@ -209,7 +209,7 @@ type imageInfo struct {
 }
 
 func getImages(c *cli.Context, rdwr config.ReadWriter, ecrClient ecrclient.Client) error {
-	registryID := c.String(command.RegistryIdFlag)
+	registryID := c.String(flags.RegistryIdFlag)
 	args := c.Args() // repository names
 
 	totalCount := 0
@@ -268,14 +268,14 @@ func printImageRow(w io.Writer, info imageInfo) {
 }
 
 func getTagStatus(c *cli.Context) string {
-	if c.Bool(command.TaggedFlag) && c.Bool(command.UntaggedFlag) {
+	if c.Bool(flags.TaggedFlag) && c.Bool(flags.UntaggedFlag) {
 		return ""
 	}
 
-	if c.Bool(command.TaggedFlag) {
+	if c.Bool(flags.TaggedFlag) {
 		return ecr.TagStatusTagged
 	}
-	if c.Bool(command.UntaggedFlag) {
+	if c.Bool(flags.UntaggedFlag) {
 		return ecr.TagStatusUntagged
 	}
 

--- a/ecs-cli/modules/commands/cluster/cluster_command.go
+++ b/ecs-cli/modules/commands/cluster/cluster_command.go
@@ -16,7 +16,7 @@ package clusterCommand
 import (
 	ecscli "github.com/aws/amazon-ecs-cli/ecs-cli/modules"
 	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/cli/cluster"
-	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/commands"
+	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/commands/flags"
 	"github.com/urfave/cli"
 )
 
@@ -26,8 +26,8 @@ func UpCommand() cli.Command {
 		Usage:        "Creates the ECS cluster (if it does not already exist) and the AWS resources required to set up the cluster.",
 		Before:       ecscli.BeforeApp,
 		Action:       cluster.ClusterUp,
-		Flags:        append(clusterUpFlags(), command.OptionalConfigFlags()...),
-		OnUsageError: command.UsageErrorFactory("up"),
+		Flags:        append(clusterUpFlags(), flags.OptionalConfigFlags()...),
+		OnUsageError: flags.UsageErrorFactory("up"),
 	}
 }
 
@@ -36,8 +36,8 @@ func DownCommand() cli.Command {
 		Name:         "down",
 		Usage:        "Deletes the CloudFormation stack that was created by ecs-cli up and the associated resources. The --force option is required.",
 		Action:       cluster.ClusterDown,
-		Flags:        append(clusterDownFlags(), command.OptionalConfigFlags()...),
-		OnUsageError: command.UsageErrorFactory("down"),
+		Flags:        append(clusterDownFlags(), flags.OptionalConfigFlags()...),
+		OnUsageError: flags.UsageErrorFactory("down"),
 	}
 }
 
@@ -46,8 +46,8 @@ func ScaleCommand() cli.Command {
 		Name:         "scale",
 		Usage:        "Modifies the number of container instances in your cluster. This command changes the desired and maximum instance count in the Auto Scaling group created by the ecs-cli up command. You can use this command to scale up (increase the number of instances) or scale down (decrease the number of instances) your cluster.",
 		Action:       cluster.ClusterScale,
-		Flags:        append(clusterScaleFlags(), command.OptionalConfigFlags()...),
-		OnUsageError: command.UsageErrorFactory("scale"),
+		Flags:        append(clusterScaleFlags(), flags.OptionalConfigFlags()...),
+		OnUsageError: flags.UsageErrorFactory("scale"),
 	}
 }
 
@@ -56,70 +56,70 @@ func PsCommand() cli.Command {
 		Name:         "ps",
 		Usage:        "Lists all of the running containers in your ECS cluster",
 		Action:       cluster.ClusterPS,
-		Flags:        command.OptionalConfigFlags(),
-		OnUsageError: command.UsageErrorFactory("ps"),
+		Flags:        flags.OptionalConfigFlags(),
+		OnUsageError: flags.UsageErrorFactory("ps"),
 	}
 }
 
 func clusterUpFlags() []cli.Flag {
 	return []cli.Flag{
 		cli.BoolFlag{
-			Name: command.VerboseFlag + ",debug",
+			Name: flags.VerboseFlag + ",debug",
 		},
 		cli.BoolFlag{
-			Name:  command.CapabilityIAMFlag,
+			Name:  flags.CapabilityIAMFlag,
 			Usage: "Acknowledges that this command may create IAM resources. Required if --instance-role is not specified.",
 		},
 		cli.StringFlag{
-			Name:  command.KeypairNameFlag,
+			Name:  flags.KeypairNameFlag,
 			Usage: "[Optional] Specifies the name of an existing Amazon EC2 key pair to enable SSH access to the EC2 instances in your cluster.",
 		},
 		cli.StringFlag{
-			Name:  command.AsgMaxSizeFlag,
+			Name:  flags.AsgMaxSizeFlag,
 			Usage: "[Optional] Specifies the number of instances to launch and register to the cluster. Defaults to 1.",
 		},
 		cli.StringFlag{
-			Name:  command.VpcAzFlag,
+			Name:  flags.VpcAzFlag,
 			Usage: "[Optional] Specifies a comma-separated list of 2 VPC Availability Zones in which to create subnets (these zones must have the available status). This option is recommended if you do not specify a VPC ID with the --vpc option. WARNING: Leaving this option blank can result in failure to launch container instances if an unavailable zone is chosen at random.",
 		},
 		cli.StringFlag{
-			Name:  command.SecurityGroupFlag,
+			Name:  flags.SecurityGroupFlag,
 			Usage: "[Optional] Specifies a comma-separated list of existing security groups to associate with your container instances. If you do not specify a security group here, then a new one is created.",
 		},
 		cli.StringFlag{
-			Name:  command.SourceCidrFlag,
+			Name:  flags.SourceCidrFlag,
 			Usage: "[Optional] Specifies a CIDR/IP range for the security group to use for container instances in your cluster. This parameter is ignored if an existing security group is specified with the --security-group option. Defaults to 0.0.0.0/0.",
 		},
 		cli.StringFlag{
-			Name:  command.EcsPortFlag,
+			Name:  flags.EcsPortFlag,
 			Usage: "[Optional] Specifies a port to open on the security group to use for container instances in your cluster. This parameter is ignored if an existing security group is specified with the --security-group option. Defaults to port 80.",
 		},
 		cli.StringFlag{
-			Name:  command.SubnetIdsFlag,
+			Name:  flags.SubnetIdsFlag,
 			Usage: "[Optional] Specifies a comma-separated list of existing VPC Subnet IDs in which to launch your container instances. This option is required if you specify a VPC with the --vpc option.",
 		},
 		cli.StringFlag{
-			Name:  command.VpcIdFlag,
+			Name:  flags.VpcIdFlag,
 			Usage: "[Optional] Specifies the ID of an existing VPC in which to launch your container instances. If you specify a VPC ID, you must specify a list of existing subnets in that VPC with the --subnets option. If you do not specify a VPC ID, a new VPC is created with two subnets.",
 		},
 		cli.StringFlag{
-			Name:  command.InstanceTypeFlag,
+			Name:  flags.InstanceTypeFlag,
 			Usage: "[Optional] Specifies the EC2 instance type for your container instances. Defaults to t2.micro.",
 		},
 		cli.StringFlag{
-			Name:  command.ImageIdFlag,
+			Name:  flags.ImageIdFlag,
 			Usage: "[Optional] Specify the AMI ID for your container instances. Defaults to amazon-ecs-optimized AMI.",
 		},
 		cli.BoolFlag{
-			Name:  command.NoAutoAssignPublicIPAddressFlag,
+			Name:  flags.NoAutoAssignPublicIPAddressFlag,
 			Usage: "[Optional] Do not assign public IP addresses to new instances in this VPC. Unless this option is specified, new instances in this VPC receive an automatically assigned public IP address.",
 		},
 		cli.BoolFlag{
-			Name:  command.ForceFlag + ", f",
+			Name:  flags.ForceFlag + ", f",
 			Usage: "[Optional] Forces the recreation of any existing resources that match your current configuration. This option is useful for cleaning up stale resources from previous failed attempts.",
 		},
 		cli.StringFlag{
-			Name:  command.InstanceRoleFlag,
+			Name:  flags.InstanceRoleFlag,
 			Usage: "[Optional] Specifies a custom IAM Role for instances in your cluster. Required if --capability-iam is not specified.",
 		},
 	}
@@ -128,7 +128,7 @@ func clusterUpFlags() []cli.Flag {
 func clusterDownFlags() []cli.Flag {
 	return []cli.Flag{
 		cli.BoolFlag{
-			Name:  command.ForceFlag + ", f",
+			Name:  flags.ForceFlag + ", f",
 			Usage: "Acknowledges that this command permanently deletes resources.",
 		},
 	}
@@ -137,11 +137,11 @@ func clusterDownFlags() []cli.Flag {
 func clusterScaleFlags() []cli.Flag {
 	return []cli.Flag{
 		cli.BoolFlag{
-			Name:  command.CapabilityIAMFlag,
+			Name:  flags.CapabilityIAMFlag,
 			Usage: "Acknowledges that this command may create IAM resources.",
 		},
 		cli.StringFlag{
-			Name:  command.AsgMaxSizeFlag,
+			Name:  flags.AsgMaxSizeFlag,
 			Usage: "Specifies the number of instances to maintain in your cluster.",
 		},
 	}

--- a/ecs-cli/modules/commands/compose/compose_command.go
+++ b/ecs-cli/modules/commands/compose/compose_command.go
@@ -17,7 +17,7 @@ import (
 	ecscli "github.com/aws/amazon-ecs-cli/ecs-cli/modules"
 	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/cli/compose"
 	composeFactory "github.com/aws/amazon-ecs-cli/ecs-cli/modules/cli/compose/factory"
-	command "github.com/aws/amazon-ecs-cli/ecs-cli/modules/commands"
+	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/commands/flags"
 	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/commands/compose/service"
 	"github.com/urfave/cli"
 )
@@ -58,7 +58,7 @@ func ComposeCommand(factory composeFactory.ProjectFactory) cli.Command {
 		Name:   "compose",
 		Usage:  "Executes docker-compose-style commands on an ECS cluster.",
 		Before: ecscli.BeforeApp,
-		Flags:  append(composeFlags(), command.OptionalConfigFlags()...),
+		Flags:  append(composeFlags(), flags.OptionalConfigFlags()...),
 		Subcommands: []cli.Command{
 			createCommand(factory),
 			psCommand(factory),
@@ -81,26 +81,26 @@ func ComposeCommand(factory composeFactory.ProjectFactory) cli.Command {
 func composeFlags() []cli.Flag {
 	return []cli.Flag{
 		cli.BoolFlag{
-			Name:  command.VerboseFlag + ",debug",
+			Name:  flags.VerboseFlag + ",debug",
 			Usage: "Increase the verbosity of command output to aid in diagnostics.",
 		},
 		cli.StringSliceFlag{
-			Name:   command.ComposeFileNameFlag + ",f",
+			Name:   flags.ComposeFileNameFlag + ",f",
 			Usage:  "Specifies one or more Docker compose files to use. Defaults to " + composeFileNameDefaultValue + " file, and an optional " + composeOverrideFileNameDefaultValue + " file.",
 			Value:  &cli.StringSlice{},
 			EnvVar: "COMPOSE_FILE",
 		},
 		cli.StringFlag{
-			Name:   command.ProjectNameFlag + ",p",
+			Name:   flags.ProjectNameFlag + ",p",
 			Usage:  "Specifies the project name to use. Defaults to the current directory name.",
 			EnvVar: "COMPOSE_PROJECT_NAME",
 		},
 		cli.StringFlag{
-			Name:  command.TaskRoleArnFlag,
+			Name:  flags.TaskRoleArnFlag,
 			Usage: "[Optional] Specifies the short name or full Amazon Resource Name (ARN) of the IAM role that containers in this task can assume. All containers in this task are granted the permissions that are specified in this role.",
 		},
 		cli.StringFlag{
-			Name:  command.ECSParamsFileNameFlag,
+			Name:  flags.ECSParamsFileNameFlag,
 			Usage: "[Optional] Specifies ecs-params file to use. Defaults to " + ecsParamsFileNameDefaultValue + " file, if one exists.",
 		},
 	}
@@ -111,8 +111,8 @@ func createCommand(factory composeFactory.ProjectFactory) cli.Command {
 		Name:         "create",
 		Usage:        "Creates an ECS task definition from your compose file. Note that we do not recommend using plain text environment variables for sensitive information, such as credential data.",
 		Action:       compose.WithProject(factory, compose.ProjectCreate, false),
-		Flags:        command.OptionalConfigFlags(),
-		OnUsageError: command.UsageErrorFactory("create"),
+		Flags:        flags.OptionalConfigFlags(),
+		OnUsageError: flags.UsageErrorFactory("create"),
 	}
 }
 
@@ -122,8 +122,8 @@ func psCommand(factory composeFactory.ProjectFactory) cli.Command {
 		Aliases:      []string{"list"},
 		Usage:        "Lists all the containers in your cluster that were started by the compose project.",
 		Action:       compose.WithProject(factory, compose.ProjectPs, false),
-		Flags:        command.OptionalConfigFlags(),
-		OnUsageError: command.UsageErrorFactory("ps"),
+		Flags:        flags.OptionalConfigFlags(),
+		OnUsageError: flags.UsageErrorFactory("ps"),
 	}
 }
 
@@ -132,8 +132,8 @@ func upCommand(factory composeFactory.ProjectFactory) cli.Command {
 		Name:         "up",
 		Usage:        "Creates an ECS task definition from your compose file (if it does not already exist) and runs one instance of that task on your cluster (a combination of create and start).",
 		Action:       compose.WithProject(factory, compose.ProjectUp, false),
-		Flags:        command.OptionalConfigFlags(),
-		OnUsageError: command.UsageErrorFactory("up"),
+		Flags:        flags.OptionalConfigFlags(),
+		OnUsageError: flags.UsageErrorFactory("up"),
 	}
 }
 
@@ -142,8 +142,8 @@ func startCommand(factory composeFactory.ProjectFactory) cli.Command {
 		Name:         "start",
 		Usage:        "Starts a single task from the task definition created from your compose file.",
 		Action:       compose.WithProject(factory, compose.ProjectStart, false),
-		Flags:        command.OptionalConfigFlags(),
-		OnUsageError: command.UsageErrorFactory("start"),
+		Flags:        flags.OptionalConfigFlags(),
+		OnUsageError: flags.UsageErrorFactory("start"),
 	}
 }
 
@@ -153,8 +153,8 @@ func runCommand(factory composeFactory.ProjectFactory) cli.Command {
 		Usage:        "Starts all containers overriding commands with the supplied one-off commands for the containers.",
 		ArgsUsage:    "[CONTAINER_NAME] [\"COMMAND ...\"] [CONTAINER_NAME] [\"COMMAND ...\"] ...",
 		Action:       compose.WithProject(factory, compose.ProjectRun, false),
-		Flags:        command.OptionalConfigFlags(),
-		OnUsageError: command.UsageErrorFactory("run"),
+		Flags:        flags.OptionalConfigFlags(),
+		OnUsageError: flags.UsageErrorFactory("run"),
 	}
 }
 
@@ -164,8 +164,8 @@ func stopCommand(factory composeFactory.ProjectFactory) cli.Command {
 		Aliases:      []string{"down"},
 		Usage:        "Stops all the running tasks created by the compose project.",
 		Action:       compose.WithProject(factory, compose.ProjectStop, false),
-		Flags:        command.OptionalConfigFlags(),
-		OnUsageError: command.UsageErrorFactory("stop"),
+		Flags:        flags.OptionalConfigFlags(),
+		OnUsageError: flags.UsageErrorFactory("stop"),
 	}
 }
 
@@ -174,7 +174,7 @@ func scaleCommand(factory composeFactory.ProjectFactory) cli.Command {
 		Name:         "scale",
 		Usage:        "ecs-cli compose scale [count] - scales the number of running tasks to the specified count.",
 		Action:       compose.WithProject(factory, compose.ProjectScale, false),
-		Flags:        command.OptionalConfigFlags(),
-		OnUsageError: command.UsageErrorFactory("scale"),
+		Flags:        flags.OptionalConfigFlags(),
+		OnUsageError: flags.UsageErrorFactory("scale"),
 	}
 }

--- a/ecs-cli/modules/commands/compose/service/compose_service_command.go
+++ b/ecs-cli/modules/commands/compose/service/compose_service_command.go
@@ -19,7 +19,7 @@ import (
 	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/cli/compose"
 	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/cli/compose/entity/service"
 	composeFactory "github.com/aws/amazon-ecs-cli/ecs-cli/modules/cli/compose/factory"
-	command "github.com/aws/amazon-ecs-cli/ecs-cli/modules/commands"
+	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/commands/flags"
 	"github.com/urfave/cli"
 )
 
@@ -57,7 +57,7 @@ func ServiceCommand(factory composeFactory.ProjectFactory) cli.Command {
 			stopServiceCommand(factory),
 			rmServiceCommand(factory),
 		},
-		Flags: command.OptionalConfigFlags(),
+		Flags: flags.OptionalConfigFlags(),
 	}
 }
 
@@ -66,8 +66,8 @@ func createServiceCommand(factory composeFactory.ProjectFactory) cli.Command {
 		Name:         "create",
 		Usage:        "Creates an ECS service from your compose file. The service is created with a desired count of 0, so no containers are started by this command. Note that we do not recommend using plain text environment variables for sensitive information, such as credential data.",
 		Action:       compose.WithProject(factory, compose.ProjectCreate, true),
-		Flags:        append(deploymentConfigFlags(true), append(loadBalancerFlags(), command.OptionalConfigFlags()...)...),
-		OnUsageError: command.UsageErrorFactory("create"),
+		Flags:        append(deploymentConfigFlags(true), append(loadBalancerFlags(), flags.OptionalConfigFlags()...)...),
+		OnUsageError: flags.UsageErrorFactory("create"),
 	}
 }
 
@@ -76,8 +76,8 @@ func startServiceCommand(factory composeFactory.ProjectFactory) cli.Command {
 		Name:         "start",
 		Usage:        "Starts one copy of each of the containers on an existing ECS service by setting the desired count to 1 (only if the current desired count is 0).",
 		Action:       compose.WithProject(factory, compose.ProjectStart, true),
-		Flags:        append(command.OptionalConfigFlags(), ComposeServiceTimeoutFlag()),
-		OnUsageError: command.UsageErrorFactory("start"),
+		Flags:        append(flags.OptionalConfigFlags(), ComposeServiceTimeoutFlag()),
+		OnUsageError: flags.UsageErrorFactory("start"),
 	}
 }
 
@@ -86,8 +86,8 @@ func upServiceCommand(factory composeFactory.ProjectFactory) cli.Command {
 		Name:         "up",
 		Usage:        "Creates a new ECS service or updates an existing one according to your compose file. For new services or existing services with a current desired count of 0, the desired count for the service is set to 1. For existing services with non-zero desired counts, a new task definition is created to reflect any changes to the compose file and the service is updated to use that task definition. In this case, the desired count does not change.",
 		Action:       compose.WithProject(factory, compose.ProjectUp, true),
-		Flags:        append(append(deploymentConfigFlags(true), append(loadBalancerFlags(), command.OptionalConfigFlags()...)...), ComposeServiceTimeoutFlag()),
-		OnUsageError: command.UsageErrorFactory("up"),
+		Flags:        append(append(deploymentConfigFlags(true), append(loadBalancerFlags(), flags.OptionalConfigFlags()...)...), ComposeServiceTimeoutFlag()),
+		OnUsageError: flags.UsageErrorFactory("up"),
 	}
 }
 
@@ -97,8 +97,8 @@ func psServiceCommand(factory composeFactory.ProjectFactory) cli.Command {
 		Aliases:      []string{"list"},
 		Usage:        "Lists all the containers in your cluster that belong to the service created with the compose project.",
 		Action:       compose.WithProject(factory, compose.ProjectPs, true),
-		Flags:        command.OptionalConfigFlags(),
-		OnUsageError: command.UsageErrorFactory("ps"),
+		Flags:        flags.OptionalConfigFlags(),
+		OnUsageError: flags.UsageErrorFactory("ps"),
 	}
 }
 
@@ -107,8 +107,8 @@ func scaleServiceCommand(factory composeFactory.ProjectFactory) cli.Command {
 		Name:         "scale",
 		Usage:        "ecs-cli compose service scale [count] - scales the desired count of the service to the specified count",
 		Action:       compose.WithProject(factory, compose.ProjectScale, true),
-		Flags:        append(append(deploymentConfigFlags(false), command.OptionalConfigFlags()...), ComposeServiceTimeoutFlag()),
-		OnUsageError: command.UsageErrorFactory("scale"),
+		Flags:        append(append(deploymentConfigFlags(false), flags.OptionalConfigFlags()...), ComposeServiceTimeoutFlag()),
+		OnUsageError: flags.UsageErrorFactory("scale"),
 	}
 }
 
@@ -117,8 +117,8 @@ func stopServiceCommand(factory composeFactory.ProjectFactory) cli.Command {
 		Name:         "stop",
 		Usage:        "Stops the running tasks that belong to the service created with the compose project. This command updates the desired count of the service to 0.",
 		Action:       compose.WithProject(factory, compose.ProjectStop, true),
-		Flags:        append(command.OptionalConfigFlags(), ComposeServiceTimeoutFlag()),
-		OnUsageError: command.UsageErrorFactory("stop"),
+		Flags:        append(flags.OptionalConfigFlags(), ComposeServiceTimeoutFlag()),
+		OnUsageError: flags.UsageErrorFactory("stop"),
 	}
 }
 
@@ -128,8 +128,8 @@ func rmServiceCommand(factory composeFactory.ProjectFactory) cli.Command {
 		Aliases:      []string{"delete", "down"},
 		Usage:        "Updates the desired count of the service to 0 and then deletes the service.",
 		Action:       compose.WithProject(factory, compose.ProjectDown, true),
-		Flags:        append(command.OptionalConfigFlags(), ComposeServiceTimeoutFlag()),
-		OnUsageError: command.UsageErrorFactory("rm"),
+		Flags:        append(flags.OptionalConfigFlags(), ComposeServiceTimeoutFlag()),
+		OnUsageError: flags.UsageErrorFactory("rm"),
 	}
 }
 
@@ -137,16 +137,16 @@ func deploymentConfigFlags(specifyDefaults bool) []cli.Flag {
 	maxPercentUsageString := "[Optional] Specifies the upper limit (as a percentage of the service's desiredCount) of the number of running tasks that can be running in a service during a deployment."
 	minHealthyPercentUsageString := "[Optional] Specifies the lower limit (as a percentage of the service's desiredCount) of the number of running tasks that must remain running and healthy in a service during a deployment."
 	if specifyDefaults {
-		maxPercentUsageString += fmt.Sprintf(" Defaults to %d.", command.DeploymentMaxPercentDefaultValue)
-		minHealthyPercentUsageString += fmt.Sprintf(" Defaults to %d.", command.DeploymentMinHealthyPercentDefaultValue)
+		maxPercentUsageString += fmt.Sprintf(" Defaults to %d.", flags.DeploymentMaxPercentDefaultValue)
+		minHealthyPercentUsageString += fmt.Sprintf(" Defaults to %d.", flags.DeploymentMinHealthyPercentDefaultValue)
 	}
 	return []cli.Flag{
 		cli.StringFlag{
-			Name:  command.DeploymentMaxPercentFlag,
+			Name:  flags.DeploymentMaxPercentFlag,
 			Usage: maxPercentUsageString,
 		},
 		cli.StringFlag{
-			Name:  command.DeploymentMinHealthyPercentFlag,
+			Name:  flags.DeploymentMinHealthyPercentFlag,
 			Usage: minHealthyPercentUsageString,
 		},
 	}
@@ -161,23 +161,23 @@ func loadBalancerFlags() []cli.Flag {
 
 	return []cli.Flag{
 		cli.StringFlag{
-			Name:  command.TargetGroupArnFlag,
+			Name:  flags.TargetGroupArnFlag,
 			Usage: targetGroupArnUsageString,
 		},
 		cli.StringFlag{
-			Name:  command.ContainerNameFlag,
+			Name:  flags.ContainerNameFlag,
 			Usage: containerNameUsageString,
 		},
 		cli.StringFlag{
-			Name:  command.ContainerPortFlag,
+			Name:  flags.ContainerPortFlag,
 			Usage: containerPortUsageString,
 		},
 		cli.StringFlag{
-			Name:  command.LoadBalancerNameFlag,
+			Name:  flags.LoadBalancerNameFlag,
 			Usage: loadBalancerNameUsageString,
 		},
 		cli.StringFlag{
-			Name:  command.RoleFlag,
+			Name:  flags.RoleFlag,
 			Usage: roleUsageString,
 		},
 	}
@@ -186,7 +186,7 @@ func loadBalancerFlags() []cli.Flag {
 // ComposeServiceTimeoutFlag allows user to specify a custom timeout
 func ComposeServiceTimeoutFlag() cli.Flag {
 	return cli.Float64Flag{
-		Name:  command.ComposeServiceTimeOutFlag,
+		Name:  flags.ComposeServiceTimeOutFlag,
 		Value: service.DefaultUpdateServiceTimeout,
 		Usage: fmt.Sprintf(
 			"Specifies the timeout value in minutes (decimals supported) to wait for the running task count to change. If the running task count has not changed for the specified period of time, then the CLI times out and returns an error. Setting the timeout to 0 will cause the command to return without checking for success.",

--- a/ecs-cli/modules/commands/configure/configure_command.go
+++ b/ecs-cli/modules/commands/configure/configure_command.go
@@ -18,7 +18,7 @@ import (
 
 	"github.com/Sirupsen/logrus"
 	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/cli/configure"
-	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/commands"
+	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/commands/flags"
 	"github.com/urfave/cli"
 )
 
@@ -39,7 +39,7 @@ func configureProfileCommand() cli.Command {
 		Usage:        "Stores a single profile.",
 		Action:       errorLogger(configure.Profile),
 		Flags:        configureProfileFlags(),
-		OnUsageError: command.UsageErrorFactory("profile"),
+		OnUsageError: flags.UsageErrorFactory("profile"),
 		Subcommands: []cli.Command{
 			defaultProfileCommand(),
 		},
@@ -52,7 +52,7 @@ func defaultProfileCommand() cli.Command {
 		Usage:        "Sets the default profile.",
 		Action:       errorLogger(configure.DefaultProfile),
 		Flags:        configureDefaultProfileFlags(),
-		OnUsageError: command.UsageErrorFactory("default"),
+		OnUsageError: flags.UsageErrorFactory("default"),
 	}
 }
 
@@ -62,7 +62,7 @@ func defaultClusterCommand() cli.Command {
 		Usage:        "Sets the default cluster config.",
 		Action:       errorLogger(configure.DefaultCluster),
 		Flags:        configureDefaultClusterFlags(),
-		OnUsageError: command.UsageErrorFactory("default"),
+		OnUsageError: flags.UsageErrorFactory("default"),
 	}
 }
 
@@ -73,13 +73,13 @@ func migrateCommand() cli.Command {
 		Action: errorLogger(configure.Migrate),
 		Flags: []cli.Flag{
 			cli.BoolFlag{
-				Name: command.ForceFlag,
+				Name: flags.ForceFlag,
 				Usage: fmt.Sprintf(
 					"[Optional] Omits the interactive description and confirmation step that normally occurs during the configuration file migration process.",
 				),
 			},
 		},
-		OnUsageError: command.UsageErrorFactory("migrate"),
+		OnUsageError: flags.UsageErrorFactory("migrate"),
 	}
 }
 
@@ -95,14 +95,14 @@ func ConfigureCommand() cli.Command {
 			defaultClusterCommand(),
 			migrateCommand(),
 		},
-		OnUsageError: command.UsageErrorFactory("configure"),
+		OnUsageError: flags.UsageErrorFactory("configure"),
 	}
 }
 
 func configureDefaultClusterFlags() []cli.Flag {
 	return []cli.Flag{
 		cli.StringFlag{
-			Name: command.ConfigNameFlag,
+			Name: flags.ConfigNameFlag,
 			Usage: fmt.Sprintf(
 				"Specifies the name of the cluster configuration to use by default.",
 			),
@@ -113,7 +113,7 @@ func configureDefaultClusterFlags() []cli.Flag {
 func configureDefaultProfileFlags() []cli.Flag {
 	return []cli.Flag{
 		cli.StringFlag{
-			Name: command.ProfileNameFlag,
+			Name: flags.ProfileNameFlag,
 			Usage: fmt.Sprintf(
 				"Specifies the name of the profile to use by default.",
 			),
@@ -124,21 +124,21 @@ func configureDefaultProfileFlags() []cli.Flag {
 func configureProfileFlags() []cli.Flag {
 	return []cli.Flag{
 		cli.StringFlag{
-			Name: command.AccessKeyFlag,
+			Name: flags.AccessKeyFlag,
 			Usage: fmt.Sprintf(
 				"Specifies the AWS access key to use. The ECS CLI uses the value of your $AWS_ACCESS_KEY_ID environment variable if it is set.",
 			),
 			EnvVar: "AWS_ACCESS_KEY_ID",
 		},
 		cli.StringFlag{
-			Name: command.SecretKeyFlag,
+			Name: flags.SecretKeyFlag,
 			Usage: fmt.Sprintf(
 				"Specifies the AWS secret key to use. The ECS CLI uses the value of your $AWS_SECRET_ACCESS_KEY environment variable if it is set.",
 			),
 			EnvVar: "AWS_SECRET_ACCESS_KEY",
 		},
 		cli.StringFlag{
-			Name:  command.ProfileNameFlag,
+			Name:  flags.ProfileNameFlag,
 			Value: "default",
 			Usage: fmt.Sprintf(
 				"Specifies the profile name to use for this configuration.",
@@ -150,34 +150,34 @@ func configureProfileFlags() []cli.Flag {
 func configureFlags() []cli.Flag {
 	return []cli.Flag{
 		cli.StringFlag{
-			Name: command.ClusterFlag + ", c",
+			Name: flags.ClusterFlag + ", c",
 			Usage: fmt.Sprintf(
 				"Specifies the ECS cluster name to use. If the cluster does not exist, it is created when you try to add resources to it with the ecs-cli up command.",
 			),
 			EnvVar: "ECS_CLUSTER",
 		},
 		cli.StringFlag{
-			Name: command.RegionFlag + ", r",
+			Name: flags.RegionFlag + ", r",
 			Usage: fmt.Sprintf(
-				"Specifies the AWS region to use. If the " + command.AwsRegionEnvVar + " environment variable is set when ecs-cli configure is run, then the AWS region is set to the value of that environment variable.",
+				"Specifies the AWS region to use. If the " + flags.AwsRegionEnvVar + " environment variable is set when ecs-cli configure is run, then the AWS region is set to the value of that environment variable.",
 			),
-			EnvVar: command.AwsRegionEnvVar,
+			EnvVar: flags.AwsRegionEnvVar,
 		},
 		cli.StringFlag{
-			Name:  command.ConfigNameFlag,
+			Name:  flags.ConfigNameFlag,
 			Value: "default",
 			Usage: fmt.Sprintf(
 				"Specifies the cluster configuration name to use for this configuration.",
 			),
 		},
 		cli.StringFlag{
-			Name: command.ComposeServiceNamePrefixFlag,
+			Name: flags.ComposeServiceNamePrefixFlag,
 			Usage: fmt.Sprintf(
 				"[Deprecated] Specifies the prefix added to an ECS service created from a compose file. Format <prefix><project-name>. (defaults to empty)",
 			),
 		},
 		cli.StringFlag{
-			Name: command.CFNStackNameFlag,
+			Name: flags.CFNStackNameFlag,
 			Usage: fmt.Sprintf(
 				"[Optional] Specifies the name of AWS CloudFormation stack created on ecs-cli up. (default: \"amazon-ecs-cli-setup-<cluster-name>\")",
 			),

--- a/ecs-cli/modules/commands/flags/flags.go
+++ b/ecs-cli/modules/commands/flags/flags.go
@@ -11,7 +11,7 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-package command
+package flags
 
 import (
 	"fmt"

--- a/ecs-cli/modules/commands/image/image_command.go
+++ b/ecs-cli/modules/commands/image/image_command.go
@@ -16,7 +16,7 @@ package imageCommand
 import (
 	"github.com/aws/amazon-ecs-cli/ecs-cli/modules"
 	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/cli/image"
-	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/commands"
+	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/commands/flags"
 	"github.com/urfave/cli"
 )
 
@@ -28,8 +28,8 @@ func PushCommand() cli.Command {
 		ArgsUsage:    image.PushImageFormat,
 		Before:       app.BeforeApp,
 		Action:       image.ImagePush,
-		Flags:        append(imagePushFlags(), command.OptionalRegionAndProfileFlags()...),
-		OnUsageError: command.UsageErrorFactory("push"),
+		Flags:        append(imagePushFlags(), flags.OptionalRegionAndProfileFlags()...),
+		OnUsageError: flags.UsageErrorFactory("push"),
 	}
 }
 
@@ -41,8 +41,8 @@ func PullCommand() cli.Command {
 		ArgsUsage:    image.PullImageFormat,
 		Before:       app.BeforeApp,
 		Action:       image.ImagePull,
-		Flags:        append(imagePullFlags(), command.OptionalRegionAndProfileFlags()...),
-		OnUsageError: command.UsageErrorFactory("pull"),
+		Flags:        append(imagePullFlags(), flags.OptionalRegionAndProfileFlags()...),
+		OnUsageError: flags.UsageErrorFactory("pull"),
 	}
 }
 
@@ -54,15 +54,15 @@ func ImagesCommand() cli.Command {
 		ArgsUsage:    image.ListImageFormat,
 		Before:       app.BeforeApp,
 		Action:       image.ImageList,
-		Flags:        append(imageListFlags(), command.OptionalRegionAndProfileFlags()...),
-		OnUsageError: command.UsageErrorFactory("images"),
+		Flags:        append(imageListFlags(), flags.OptionalRegionAndProfileFlags()...),
+		OnUsageError: flags.UsageErrorFactory("images"),
 	}
 }
 
 func imagePushFlags() []cli.Flag {
 	return []cli.Flag{
 		cli.StringFlag{
-			Name:  command.RegistryIdFlag,
+			Name:  flags.RegistryIdFlag,
 			Usage: "[Optional] Specifies the Amazon ECR registry ID to push the image to. By default, images are pushed to the current AWS account.",
 		},
 	}
@@ -71,7 +71,7 @@ func imagePushFlags() []cli.Flag {
 func imagePullFlags() []cli.Flag {
 	return []cli.Flag{
 		cli.StringFlag{
-			Name:  command.RegistryIdFlag,
+			Name:  flags.RegistryIdFlag,
 			Usage: "[Optional] Specifies the the Amazon ECR registry ID to pull the image from. By default, images are pulled from the current AWS account.",
 		},
 	}
@@ -80,11 +80,11 @@ func imagePullFlags() []cli.Flag {
 func imageListFlags() []cli.Flag {
 	return []cli.Flag{
 		cli.BoolFlag{
-			Name:  command.TaggedFlag,
+			Name:  flags.TaggedFlag,
 			Usage: "[Optional] Filters the result to show only tagged images",
 		},
 		cli.BoolFlag{
-			Name:  command.UntaggedFlag,
+			Name:  flags.UntaggedFlag,
 			Usage: "[Optional] Filters the result to show only untagged images",
 		},
 	}

--- a/ecs-cli/modules/commands/license/license_command.go
+++ b/ecs-cli/modules/commands/license/license_command.go
@@ -15,7 +15,7 @@ package licenseCommand
 
 import (
 	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/cli/license"
-	command "github.com/aws/amazon-ecs-cli/ecs-cli/modules/commands"
+	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/commands/flags"
 	"github.com/urfave/cli"
 )
 
@@ -25,6 +25,6 @@ func LicenseCommand() cli.Command {
 		Name:         "license",
 		Usage:        "Prints the LICENSE files for the ECS CLI and its dependencies.",
 		Action:       license.PrintLicense,
-		OnUsageError: command.UsageErrorFactory("license"),
+		OnUsageError: flags.UsageErrorFactory("license"),
 	}
 }

--- a/ecs-cli/modules/config/config_test.go
+++ b/ecs-cli/modules/config/config_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 	"time"
 
-	flags "github.com/aws/amazon-ecs-cli/ecs-cli/modules/commands"
+	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/commands/flags"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/aws/session"

--- a/ecs-cli/modules/config/config_v1.go
+++ b/ecs-cli/modules/config/config_v1.go
@@ -17,7 +17,7 @@ import (
 	"fmt"
 	"os"
 
-	flags "github.com/aws/amazon-ecs-cli/ecs-cli/modules/commands"
+	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/commands/flags"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"

--- a/ecs-cli/modules/config/params.go
+++ b/ecs-cli/modules/config/params.go
@@ -16,7 +16,7 @@ package config
 import (
 	"os"
 
-	ecscli "github.com/aws/amazon-ecs-cli/ecs-cli/modules/commands"
+	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/commands/flags"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/pkg/errors"
 	"github.com/urfave/cli"
@@ -46,8 +46,8 @@ func recursiveFlagSearch(context *cli.Context, flag string) string {
 
 // NewCLIParams creates a new ECSParams object from the config file.
 func NewCLIParams(context *cli.Context, rdwr ReadWriter) (*CLIParams, error) {
-	clusterConfig := recursiveFlagSearch(context, ecscli.ClusterConfigFlag)
-	profileConfig := recursiveFlagSearch(context, ecscli.ECSProfileFlag)
+	clusterConfig := recursiveFlagSearch(context, flags.ClusterConfigFlag)
+	profileConfig := recursiveFlagSearch(context, flags.ECSProfileFlag)
 	ecsConfig, err := rdwr.Get(clusterConfig, profileConfig)
 
 	if err != nil {
@@ -58,19 +58,19 @@ func NewCLIParams(context *cli.Context, rdwr ReadWriter) (*CLIParams, error) {
 	//  1) Inline flag
 	//  2) Environment Variable
 	//  3) ECS Config
-	if clusterFromEnv := os.Getenv(ecscli.ClusterEnvVar); clusterFromEnv != "" {
+	if clusterFromEnv := os.Getenv(flags.ClusterEnvVar); clusterFromEnv != "" {
 		ecsConfig.Cluster = clusterFromEnv
 	}
-	if clusterFromFlag := recursiveFlagSearch(context, ecscli.ClusterFlag); clusterFromFlag != "" {
+	if clusterFromFlag := recursiveFlagSearch(context, flags.ClusterFlag); clusterFromFlag != "" {
 		ecsConfig.Cluster = clusterFromFlag
 	}
 
 	//--region flag has the highest precedence to set ecs-cli region config.
-	if regionFromFlag := recursiveFlagSearch(context, ecscli.RegionFlag); regionFromFlag != "" {
+	if regionFromFlag := recursiveFlagSearch(context, flags.RegionFlag); regionFromFlag != "" {
 		ecsConfig.Region = regionFromFlag
 	}
 
-	if awsProfileFromFlag := recursiveFlagSearch(context, ecscli.AWSProfileFlag); awsProfileFromFlag != "" {
+	if awsProfileFromFlag := recursiveFlagSearch(context, flags.AWSProfileFlag); awsProfileFromFlag != "" {
 		ecsConfig.AWSProfile = awsProfileFromFlag
 		// unset Access Key and Secret Key, otherwise they will take precedence
 		ecsConfig.AWSAccessKey = ""
@@ -87,7 +87,7 @@ func NewCLIParams(context *cli.Context, rdwr ReadWriter) (*CLIParams, error) {
 	}
 
 	if ecsConfig.CFNStackName == "" {
-		ecsConfig.CFNStackName = ecscli.CFNStackNamePrefixDefaultValue + ecsConfig.Cluster
+		ecsConfig.CFNStackName = flags.CFNStackNamePrefixDefaultValue + ecsConfig.Cluster
 	}
 
 	return &CLIParams{

--- a/ecs-cli/modules/config/params_test.go
+++ b/ecs-cli/modules/config/params_test.go
@@ -19,7 +19,7 @@ import (
 	"os"
 	"testing"
 
-	ecscli "github.com/aws/amazon-ecs-cli/ecs-cli/modules/commands"
+	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/commands/flags"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/stretchr/testify/assert"
 	"github.com/urfave/cli"
@@ -204,7 +204,7 @@ func TestNewCliParamsWhenPrefixKeysAreNotPresentYAMLVersion(t *testing.T) {
 	assert.NoError(t, err, "Unexpected error when getting new cli params")
 	assert.Empty(t, params.ComposeProjectNamePrefix, "Expected ComposProjectNamePrefix to be empty")
 	assert.Empty(t, params.ComposeServiceNamePrefix, "Expected ComposeServiceNamePrefix to be empty")
-	assert.Equal(t, ecscli.CFNStackNamePrefixDefaultValue+clusterName, params.CFNStackName, "Expected CFNStackName to be default")
+	assert.Equal(t, flags.CFNStackNamePrefixDefaultValue+clusterName, params.CFNStackName, "Expected CFNStackName to be default")
 }
 
 func TestNewCliParamsWithAWSProfile(t *testing.T) {

--- a/ecs-cli/modules/config/readwriter.go
+++ b/ecs-cli/modules/config/readwriter.go
@@ -16,7 +16,7 @@ package config
 import (
 	"os"
 
-	ecscli "github.com/aws/amazon-ecs-cli/ecs-cli/modules/commands"
+	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/commands/flags"
 
 	"github.com/go-ini/ini"
 	"github.com/pkg/errors"
@@ -71,13 +71,13 @@ func (rdwr *INIReadWriter) GetConfig(cliConfig *CLIConfig) error {
 
 	// If Prefixes not found, set to defaults.
 	if !rdwr.IsKeyPresent(ecsSectionKey, composeProjectNamePrefixKey) {
-		iniFormat.ComposeProjectNamePrefix = ecscli.ComposeProjectNamePrefixDefaultValue
+		iniFormat.ComposeProjectNamePrefix = flags.ComposeProjectNamePrefixDefaultValue
 	}
 	if !rdwr.IsKeyPresent(ecsSectionKey, composeServiceNamePrefixKey) {
-		iniFormat.ComposeServiceNamePrefix = ecscli.ComposeServiceNamePrefixDefaultValue
+		iniFormat.ComposeServiceNamePrefix = flags.ComposeServiceNamePrefixDefaultValue
 	}
 	if !rdwr.IsKeyPresent(ecsSectionKey, cfnStackNamePrefixKey) {
-		iniFormat.CFNStackNamePrefix = ecscli.CFNStackNamePrefixDefaultValue
+		iniFormat.CFNStackNamePrefix = flags.CFNStackNamePrefixDefaultValue
 	}
 
 	// Convert to the new CliConfig

--- a/ecs-cli/modules/config/readwriter_v1_test.go
+++ b/ecs-cli/modules/config/readwriter_v1_test.go
@@ -18,7 +18,7 @@ import (
 	"os"
 	"testing"
 
-	ecscli "github.com/aws/amazon-ecs-cli/ecs-cli/modules/commands"
+	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/commands/flags"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -152,8 +152,8 @@ aws_secret_access_key =
 	parser := setupParser(t, dest, true)
 	config, err := parser.Get("", "")
 	assert.NoError(t, err, "Error reading config")
-	assert.Equal(t, ecscli.ComposeServiceNamePrefixDefaultValue, config.ComposeServiceNamePrefix, "ComposeServiceNamePrefix should be set to the default value.")
-	assert.Equal(t, ecscli.CFNStackNamePrefixDefaultValue, config.CFNStackNamePrefix, "CFNStackNamePrefix should be set to the default value.")
+	assert.Equal(t, flags.ComposeServiceNamePrefixDefaultValue, config.ComposeServiceNamePrefix, "ComposeServiceNamePrefix should be set to the default value.")
+	assert.Equal(t, flags.CFNStackNamePrefixDefaultValue, config.CFNStackNamePrefix, "CFNStackNamePrefix should be set to the default value.")
 	assert.Equal(t, iniConfigVersion, config.Version, "Expected ini config version to be set.")
 }
 


### PR DESCRIPTION
This fixes the inconsistent naming of the "command" package.