### PR TITLE
Add support for building on Windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ docker-test:
 		golang:1.8 make test
 
 .PHONY: supported-platforms
-supported-platforms: $(LINUX_BINARY) $(DARWIN_BINARY)
+supported-platforms: $(LINUX_BINARY) $(DARWIN_BINARY) $(WINDOWS_BINARY)
 
 $(WINDOWS_BINARY): $(SOURCES)
 	@mkdir -p ./bin/windows-amd64

--- a/README.md
+++ b/README.md
@@ -48,7 +48,8 @@ verify the integrity of your download.
   * [https://s3.amazonaws.com/amazon-ecs-cli/ecs-cli-darwin-amd64-latest](https://s3.amazonaws.com/amazon-ecs-cli/ecs-cli-darwin-amd64-latest)
   * [https://s3.amazonaws.com/amazon-ecs-cli/ecs-cli-darwin-amd64-latest.md5](https://s3.amazonaws.com/amazon-ecs-cli/ecs-cli-darwin-amd64-latest.md5)
 * Windows:
-  * (Not yet implemented)
+  * [https://s3.amazonaws.com/amazon-ecs-cli/ecs-cli-windows-amd64-latest.exe](https://s3.amazonaws.com/amazon-ecs-cli/ecs-cli-windows-amd64-latest.exe)
+  * [https://s3.amazonaws.com/amazon-ecs-cli/ecs-cli-windows-amd64-latest.md5](https://s3.amazonaws.com/amazon-ecs-cli/ecs-cli-windows-amd64-latest.md5)
 
 #### Download Links for within China
 
@@ -60,8 +61,9 @@ As of v0.6.2 the ECS CLI supports the cn-north-1 region in China. The following 
 * Macintosh:
   * [https://s3.cn-north-1.amazonaws.com.cn/amazon-ecs-cli/ecs-cli-darwin-amd64-latest](https://s3.cn-north-1.amazonaws.com.cn/amazon-ecs-cli/ecs-cli-darwin-amd64-latest)
   * [https://s3.cn-north-1.amazonaws.com.cn/amazon-ecs-cli/ecs-cli-darwin-amd64-latest.md5](https://s3.cn-north-1.amazonaws.com.cn/amazon-ecs-cli/ecs-cli-darwin-amd64-latest.md5)
-  * Windows:
-    * (Not yet implemented)
+* Windows:
+  * [https://s3.cn-north-1.amazonaws.com.cn/amazon-ecs-cli/ecs-cli-windows-amd64-latest.exe](https://s3.cn-north-1.amazonaws.com.cn/amazon-ecs-cli/ecs-cli-windows-amd64-latest.exe)
+  * [https://s3.cn-north-1.amazonaws.com.cn/amazon-ecs-cli/ecs-cli-windows-amd64-latest.md5](https://s3.cn-north-1.amazonaws.com.cn/amazon-ecs-cli/ecs-cli-windows-amd64-latest.md5)
 
 ### Download specific version
 Using the URLs above, replace `latest` with the desired tag, for example `v0.4.1`. After downloading, remember to rename the binary file to `ecs-cli`.

--- a/ecs-cli/modules/config/destination.go
+++ b/ecs-cli/modules/config/destination.go
@@ -29,7 +29,13 @@ type Destination struct {
 	Mode *os.FileMode
 }
 
-// GetWindowsBaseDataPath returns the correct path to Append
+// getOSName returns runtime.GOOS
+// In unit tests it can be mocked
+var getOSName = func() string {
+	return runtime.GOOS
+}
+
+// GetWindowsBaseDataPath returns the correct path to append
 // to a user home directory to store application data.
 func GetWindowsBaseDataPath() string {
 	return filepath.Join("AppData", "local", "ecs")
@@ -58,8 +64,8 @@ func newDefaultDestination() (*Destination, error) {
 		return nil, err
 	}
 	path := filepath.Join(homeDir, ".ecs")
-	if runtime.GOOS == "windows" {
-		path = filepath.Join(homeDir, GetWindowsBaseDataPath(), "config")
+	if getOSName() == "windows" {
+		path = filepath.Join(homeDir, GetWindowsBaseDataPath())
 	}
 
 	return &Destination{Path: path, Mode: mode}, nil

--- a/ecs-cli/modules/config/destination.go
+++ b/ecs-cli/modules/config/destination.go
@@ -16,6 +16,7 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/utils"
@@ -26,6 +27,12 @@ import (
 type Destination struct {
 	Path string
 	Mode *os.FileMode
+}
+
+// GetWindowsBaseDataPath returns the correct path to Append
+// to a user home directory to store application data.
+func GetWindowsBaseDataPath() string {
+	return filepath.Join("AppData", "local", "ecs")
 }
 
 // GetFilePermissions is a utility method that gets permissions of a file.
@@ -50,7 +57,10 @@ func newDefaultDestination() (*Destination, error) {
 	if err != nil {
 		return nil, err
 	}
+	path := filepath.Join(homeDir, ".ecs")
+	if runtime.GOOS == "windows" {
+		path = filepath.Join(homeDir, GetWindowsBaseDataPath(), "config")
+	}
 
-	// TODO: Move to const.
-	return &Destination{Path: filepath.Join(homeDir, ".ecs"), Mode: mode}, nil
+	return &Destination{Path: path, Mode: mode}, nil
 }

--- a/ecs-cli/modules/config/destination_test.go
+++ b/ecs-cli/modules/config/destination_test.go
@@ -16,13 +16,20 @@ package config
 import (
 	"io/ioutil"
 	"os"
-	"strings"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
-func TestNewDefaultDestination(t *testing.T) {
+func TestNewDefaultDestinationLinux(t *testing.T) {
+	// Mock GetOSName in the test, then reset it after the test
+	oldGetOSName := getOSName
+	getOSName = func() string {
+		return "linux"
+	}
+	defer func() { getOSName = oldGetOSName }()
+
 	// Create a temprorary directory for the dummy ecs config
 	tempDirName, err := ioutil.TempDir("", "test")
 	if err != nil {
@@ -35,8 +42,54 @@ func TestNewDefaultDestination(t *testing.T) {
 
 	dest, err := newDefaultDestination()
 	assert.NoError(t, err, "Unexpected error creating new config path")
-	assert.Condition(t, func() bool {
-		return strings.HasSuffix(dest.Path, "ecs")
-	}, "Invalid suffix for ecs config path")
+	assert.Equal(t, filepath.Join(tempDirName, ".ecs"), dest.Path)
+	assert.True(t, dest.Mode.IsDir(), "Expected user home directory to be in directory mode")
+}
+
+func TestNewDefaultDestinationDarwin(t *testing.T) {
+	// Mock GetOSName in the test, then reset it after the test
+	oldGetOSName := getOSName
+	getOSName = func() string {
+		return "darwin"
+	}
+	defer func() { getOSName = oldGetOSName }()
+
+	// Create a temprorary directory for the dummy ecs config
+	tempDirName, err := ioutil.TempDir("", "test")
+	if err != nil {
+		t.Fatal("Error while creating the dummy ecs config directory")
+	}
+	defer os.Remove(tempDirName)
+
+	os.Setenv("HOME", tempDirName)
+	defer os.Unsetenv("HOME")
+
+	dest, err := newDefaultDestination()
+	assert.NoError(t, err, "Unexpected error creating new config path")
+	assert.Equal(t, filepath.Join(tempDirName, ".ecs"), dest.Path)
+	assert.True(t, dest.Mode.IsDir(), "Expected user home directory to be in directory mode")
+}
+
+func TestNewDefaultDestinationWindows(t *testing.T) {
+	// Mock GetOSName in the test, then reset it after the test
+	oldGetOSName := getOSName
+	getOSName = func() string {
+		return "windows"
+	}
+	defer func() { getOSName = oldGetOSName }()
+
+	// Create a temprorary directory for the dummy ecs config
+	tempDirName, err := ioutil.TempDir("", "test")
+	if err != nil {
+		t.Fatal("Error while creating the dummy ecs config directory")
+	}
+	defer os.Remove(tempDirName)
+
+	os.Setenv("HOME", tempDirName)
+	defer os.Unsetenv("HOME")
+
+	dest, err := newDefaultDestination()
+	assert.NoError(t, err, "Unexpected error creating new config path")
+	assert.Equal(t, filepath.Join(tempDirName, "AppData", "local", "ecs"), dest.Path)
 	assert.True(t, dest.Mode.IsDir(), "Expected user home directory to be in directory mode")
 }

--- a/ecs-cli/modules/utils/cache/fs_cache.go
+++ b/ecs-cli/modules/utils/cache/fs_cache.go
@@ -17,7 +17,9 @@ import (
 	"encoding/gob"
 	"os"
 	"path/filepath"
+	"runtime"
 
+	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/config"
 	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/utils"
 )
 
@@ -39,8 +41,11 @@ func cacheDir(name string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	// TODO, speciailize for windows, possibly OS X
-	return filepath.Join(homedir, ".cache", cachePrefix, name), nil
+	path := filepath.Join(homedir, ".cache", cachePrefix, name)
+	if runtime.GOOS == "windows" {
+		path = filepath.Join(homedir, config.GetWindowsBaseDataPath(), "cache")
+	}
+	return path, nil
 }
 
 type fsCache struct {

--- a/ecs-cli/modules/utils/cache/fs_cache.go
+++ b/ecs-cli/modules/utils/cache/fs_cache.go
@@ -27,6 +27,9 @@ import (
 var osOpen = os.Open
 var osCreate = os.Create
 var osMkdirAll = os.MkdirAll
+var getOSName = func() string {
+	return runtime.GOOS
+}
 
 // rw only for the user in-line with how most programs setup their cache
 // directories. Also, this directory could container sensitive-ish files due to
@@ -42,8 +45,8 @@ func cacheDir(name string) (string, error) {
 		return "", err
 	}
 	path := filepath.Join(homedir, ".cache", cachePrefix, name)
-	if runtime.GOOS == "windows" {
-		path = filepath.Join(homedir, config.GetWindowsBaseDataPath(), "cache")
+	if getOSName() == "windows" {
+		path = filepath.Join(homedir, config.GetWindowsBaseDataPath(), "cache", name)
 	}
 	return path, nil
 }

--- a/ecs-cli/modules/utils/cache/fs_cache_test.go
+++ b/ecs-cli/modules/utils/cache/fs_cache_test.go
@@ -53,7 +53,7 @@ func TestCacheDirLinux(t *testing.T) {
 	}
 	defer func() { getOSName = oldGetOSName }()
 
-	// Create a temprorary directory for the dummy ecs config
+	// Create a temporary directory for the dummy ecs config
 	tempDirName, err := ioutil.TempDir("", "test")
 	if err != nil {
 		t.Fatal("Error while creating the dummy ecs config directory")
@@ -76,7 +76,7 @@ func TestCacheDirDarwin(t *testing.T) {
 	}
 	defer func() { getOSName = oldGetOSName }()
 
-	// Create a temprorary directory for the dummy ecs config
+	// Create a temporary directory for the dummy ecs config
 	tempDirName, err := ioutil.TempDir("", "test")
 	if err != nil {
 		t.Fatal("Error while creating the dummy ecs config directory")
@@ -99,7 +99,7 @@ func TestCacheDirWindows(t *testing.T) {
 	}
 	defer func() { getOSName = oldGetOSName }()
 
-	// Create a temprorary directory for the dummy ecs config
+	// Create a temporary directory for the dummy ecs config
 	tempDirName, err := ioutil.TempDir("", "test")
 	if err != nil {
 		t.Fatal("Error while creating the dummy ecs config directory")
@@ -115,7 +115,7 @@ func TestCacheDirWindows(t *testing.T) {
 }
 
 func tempDir(t *testing.T) string {
-	// Create a temprorary directory for the dummy ecs config
+	// Create a temporary directory for the dummy ecs config
 	tempDirName, err := ioutil.TempDir("", "test")
 	assert.NoError(t, err, "Unexpected error while creating the dummy ecs config directory")
 	return tempDirName

--- a/ecs-cli/modules/utils/cache/fs_cache_test.go
+++ b/ecs-cli/modules/utils/cache/fs_cache_test.go
@@ -16,6 +16,7 @@ package cache
 import (
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -42,6 +43,75 @@ func TestCacheCreatesDir(t *testing.T) {
 	if dir != expected {
 		t.Errorf("expected %v, got %v", expected, dir)
 	}
+}
+
+func TestCacheDirLinux(t *testing.T) {
+	// Mock GetOSName in the test, then reset it after the test
+	oldGetOSName := getOSName
+	getOSName = func() string {
+		return "linux"
+	}
+	defer func() { getOSName = oldGetOSName }()
+
+	// Create a temprorary directory for the dummy ecs config
+	tempDirName, err := ioutil.TempDir("", "test")
+	if err != nil {
+		t.Fatal("Error while creating the dummy ecs config directory")
+	}
+	defer os.Remove(tempDirName)
+
+	os.Setenv("HOME", tempDirName)
+	defer os.Unsetenv("HOME")
+
+	path, err := cacheDir("name")
+	assert.NoError(t, err, "Unexpected error creating new config path")
+	assert.Equal(t, filepath.Join(tempDirName, ".cache", cachePrefix, "name"), path)
+}
+
+func TestCacheDirDarwin(t *testing.T) {
+	// Mock GetOSName in the test, then reset it after the test
+	oldGetOSName := getOSName
+	getOSName = func() string {
+		return "darwin"
+	}
+	defer func() { getOSName = oldGetOSName }()
+
+	// Create a temprorary directory for the dummy ecs config
+	tempDirName, err := ioutil.TempDir("", "test")
+	if err != nil {
+		t.Fatal("Error while creating the dummy ecs config directory")
+	}
+	defer os.Remove(tempDirName)
+
+	os.Setenv("HOME", tempDirName)
+	defer os.Unsetenv("HOME")
+
+	path, err := cacheDir("name")
+	assert.NoError(t, err, "Unexpected error creating new config path")
+	assert.Equal(t, filepath.Join(tempDirName, ".cache", cachePrefix, "name"), path)
+}
+
+func TestCacheDirWindows(t *testing.T) {
+	// Mock GetOSName in the test, then reset it after the test
+	oldGetOSName := getOSName
+	getOSName = func() string {
+		return "windows"
+	}
+	defer func() { getOSName = oldGetOSName }()
+
+	// Create a temprorary directory for the dummy ecs config
+	tempDirName, err := ioutil.TempDir("", "test")
+	if err != nil {
+		t.Fatal("Error while creating the dummy ecs config directory")
+	}
+	defer os.Remove(tempDirName)
+
+	os.Setenv("HOME", tempDirName)
+	defer os.Unsetenv("HOME")
+
+	path, err := cacheDir("name")
+	assert.NoError(t, err, "Unexpected error creating new config path")
+	assert.Equal(t, filepath.Join(tempDirName, "AppData", "local", "ecs", "cache", "name"), path)
 }
 
 func tempDir(t *testing.T) string {

--- a/scripts/publish-staged
+++ b/scripts/publish-staged
@@ -48,6 +48,9 @@ publish_s3() {
 		echo "Publishing as ecs-cli-darwin-amd64-${tag}"
 		dexec s3_pull_push "s3://${STAGE_S3_BUCKET}/ecs-cli-darwin-amd64-${tag}" "s3://${PUBLISH_S3_BUCKET}/ecs-cli-darwin-amd64-${tag}"
 		dexec s3_pull_push "s3://${STAGE_S3_BUCKET}/ecs-cli-darwin-amd64-${tag}.md5" "s3://${PUBLISH_S3_BUCKET}/ecs-cli-darwin-amd64-${tag}.md5"
+		echo "Publishing as ecs-cli-windows-amd64-${tag}.exe"
+		dexec s3_pull_push "s3://${STAGE_S3_BUCKET}/ecs-cli-windows-amd64-${tag}" "s3://${PUBLISH_S3_BUCKET}/ecs-cli-windows-amd64-${tag}.exe"
+		dexec s3_pull_push "s3://${STAGE_S3_BUCKET}/ecs-cli-windows-amd64-${tag}.md5" "s3://${PUBLISH_S3_BUCKET}/ecs-cli-windows-amd64-${tag}.md5"
 	done
 }
 

--- a/scripts/stage.sh
+++ b/scripts/stage.sh
@@ -103,8 +103,9 @@ if ! ${ALLOW_DIRTY}; then
 fi
 
 make docker-build
+mv bin/windows-amd64/ecs-cli.exe bin/windows-amd64/ecs-cli
 
-for platform in "linux-amd64" "darwin-amd64"; do
+for platform in "linux-amd64" "darwin-amd64" "windows-amd64"; do
 	artifact="bin/${platform}/ecs-cli"
 	artifact_md5="$(mktemp)"
 	md5sum "${artifact}" | sed 's/ .*//' > "${artifact_md5}"


### PR DESCRIPTION
Changes:
- `make windows-build` creates `ecs-cli` in `/bin/windows-amd64`
- `make docker-build` also now creates the windows binary as well. 
- The ECS CLI config directory is set as `%userprofile%\AppData\local\ecs` (`C:\\Users\<User>\AppData\local\ecs`) on Windows. 