### PR TITLE
Bug fixes and enhancements to multiple configurations changes

### DIFF
--- a/ecs-cli/modules/cli/configure/configure.go
+++ b/ecs-cli/modules/cli/configure/configure.go
@@ -72,7 +72,7 @@ func Migrate(context *cli.Context) error {
 	}
 
 	if !context.Bool(command.ForceFlag) {
-		if err = migrateWarning(oldConfig); err != nil {
+		if err = migrateWarning(*oldConfig); err != nil {
 			return err
 		}
 		scanner := bufio.NewScanner(os.Stdin)

--- a/ecs-cli/modules/cli/configure/configure_test.go
+++ b/ecs-cli/modules/cli/configure/configure_test.go
@@ -36,8 +36,10 @@ const (
 	awsAccessKey2            = "AKID2"
 	awsSecretKey             = "SKID"
 	awsSecretKey2            = "SKID2"
+	awsProfile               = "awsprofile"
 	composeServiceNamePrefix = "ecs-"
 	cfnStackNamePrefix       = "cfn-"
+	composeProjectNamePrefix = "ecs-compose-"
 )
 
 func createClusterConfig(name string, cluster string) *cli.Context {
@@ -480,4 +482,29 @@ aws_secret_access_key = SKID
 	assert.Equal(t, awsAccessKey, readConfig.AWSAccessKey, "Access Key mismatch in config.")
 	assert.Equal(t, awsSecretKey, readConfig.AWSSecretKey, "Secret Key name mismatch in config.")
 
+}
+
+func TestMigrateWarningConfigNotModified(t *testing.T) {
+	// Test case left for posterity. Currently migrateWarning
+	// uses pass by value so it can't modify the config.
+	cliConfig := config.CLIConfig{Cluster: clusterName,
+		Region:                   region,
+		AWSProfile:               awsProfile,
+		AWSAccessKey:             awsAccessKey,
+		AWSSecretKey:             awsSecretKey,
+		ComposeServiceNamePrefix: composeServiceNamePrefix,
+		ComposeProjectNamePrefix: composeProjectNamePrefix,
+		CFNStackNamePrefix:       cfnStackNamePrefix,
+		CFNStackName:             cfnStackNamePrefix,
+	}
+	migrateWarning(cliConfig)
+
+	assert.Equal(t, region, cliConfig.Region)
+	assert.Equal(t, awsProfile, cliConfig.AWSProfile)
+	assert.Equal(t, awsAccessKey, cliConfig.AWSAccessKey)
+	assert.Equal(t, awsSecretKey, cliConfig.AWSSecretKey)
+	assert.Equal(t, composeServiceNamePrefix, cliConfig.ComposeServiceNamePrefix)
+	assert.Equal(t, composeProjectNamePrefix, cliConfig.ComposeProjectNamePrefix)
+	assert.Equal(t, cfnStackNamePrefix, cliConfig.CFNStackNamePrefix)
+	assert.Equal(t, cfnStackNamePrefix, cliConfig.CFNStackName)
 }

--- a/ecs-cli/modules/cli/configure/migrate.go
+++ b/ecs-cli/modules/cli/configure/migrate.go
@@ -55,7 +55,7 @@ func hideCredsOldFile(data string) string {
 	return safeData
 }
 
-func migrateWarning(cliConfig *config.CLIConfig) error {
+func migrateWarning(cliConfig config.CLIConfig) error {
 	var oldConfig string
 	dest, err := config.NewDefaultDestination()
 	if err != nil {
@@ -67,7 +67,7 @@ func migrateWarning(cliConfig *config.CLIConfig) error {
 	}
 	oldConfig = string(dat)
 
-	hideCreds(cliConfig)
+	hideCreds(&cliConfig)
 	oldConfig = hideCredsOldFile(oldConfig)
 
 	optionalFields := ""

--- a/ecs-cli/modules/cli/configure/migrate.go
+++ b/ecs-cli/modules/cli/configure/migrate.go
@@ -123,8 +123,9 @@ credentials:
     aws_secret_access_key: {{.AWSSecretKey}}
 
 [WARN] Please read the following changes carefully: http://docs.aws.amazon.com/AmazonECS/latest/developerguide/ECS_CLI_Configuration.html
-- The --compose-project-name-prefix and --compose-service-name-prefix options are deprecated. You can specify your desired names with the --project-name option.
-- The --cfn-stack-name-prefix option has been removed. To use an existing CloudFormation stack, please specify the full stack name; otherwise, the stack name defaults to amazon-ecs-cli-setup-<cluster_name>.
+- The option --compose-project-name-prefix has been removed (name used for create task definition: <compose_project_name_prefix> + <project_name>). You can specify your desired name with the --project-name option.
+- The --compose-service-name-prefix option has been deprecated (name used for create service: <compose_service_name_prefix> + <project_name>). This field can still be configured; however, if it is not configured there is no longer a default value assigned.
+- The --cfn-stack-name-prefix option has been removed. To use an existing CloudFormation stack, please specify the full stack name using the --cfn-stack-name option; otherwise, the stack name defaults to amazon-ecs-cli-setup-<cluster_name>.
 
 Are you sure you want to migrate[y/n]?
 `

--- a/ecs-cli/modules/commands/compose/service/compose_service_command.go
+++ b/ecs-cli/modules/commands/compose/service/compose_service_command.go
@@ -76,7 +76,7 @@ func startServiceCommand(factory composeFactory.ProjectFactory) cli.Command {
 		Name:         "start",
 		Usage:        "Starts one copy of each of the containers on an existing ECS service by setting the desired count to 1 (only if the current desired count is 0).",
 		Action:       compose.WithProject(factory, compose.ProjectStart, true),
-		Flags:        command.OptionalConfigFlags(),
+		Flags:        append(command.OptionalConfigFlags(), ComposeServiceTimeoutFlag()),
 		OnUsageError: command.UsageErrorFactory("start"),
 	}
 }
@@ -86,7 +86,7 @@ func upServiceCommand(factory composeFactory.ProjectFactory) cli.Command {
 		Name:         "up",
 		Usage:        "Creates a new ECS service or updates an existing one according to your compose file. For new services or existing services with a current desired count of 0, the desired count for the service is set to 1. For existing services with non-zero desired counts, a new task definition is created to reflect any changes to the compose file and the service is updated to use that task definition. In this case, the desired count does not change.",
 		Action:       compose.WithProject(factory, compose.ProjectUp, true),
-		Flags:        append(deploymentConfigFlags(true), append(loadBalancerFlags(), command.OptionalConfigFlags()...)...),
+		Flags:        append(append(deploymentConfigFlags(true), append(loadBalancerFlags(), command.OptionalConfigFlags()...)...), ComposeServiceTimeoutFlag()),
 		OnUsageError: command.UsageErrorFactory("up"),
 	}
 }
@@ -107,7 +107,7 @@ func scaleServiceCommand(factory composeFactory.ProjectFactory) cli.Command {
 		Name:         "scale",
 		Usage:        "ecs-cli compose service scale [count] - scales the desired count of the service to the specified count",
 		Action:       compose.WithProject(factory, compose.ProjectScale, true),
-		Flags:        append(deploymentConfigFlags(false), command.OptionalConfigFlags()...),
+		Flags:        append(append(deploymentConfigFlags(false), command.OptionalConfigFlags()...), ComposeServiceTimeoutFlag()),
 		OnUsageError: command.UsageErrorFactory("scale"),
 	}
 }
@@ -117,7 +117,7 @@ func stopServiceCommand(factory composeFactory.ProjectFactory) cli.Command {
 		Name:         "stop",
 		Usage:        "Stops the running tasks that belong to the service created with the compose project. This command updates the desired count of the service to 0.",
 		Action:       compose.WithProject(factory, compose.ProjectStop, true),
-		Flags:        command.OptionalConfigFlags(),
+		Flags:        append(command.OptionalConfigFlags(), ComposeServiceTimeoutFlag()),
 		OnUsageError: command.UsageErrorFactory("stop"),
 	}
 }
@@ -128,7 +128,7 @@ func rmServiceCommand(factory composeFactory.ProjectFactory) cli.Command {
 		Aliases:      []string{"delete", "down"},
 		Usage:        "Updates the desired count of the service to 0 and then deletes the service.",
 		Action:       compose.WithProject(factory, compose.ProjectDown, true),
-		Flags:        command.OptionalConfigFlags(),
+		Flags:        append(command.OptionalConfigFlags(), ComposeServiceTimeoutFlag()),
 		OnUsageError: command.UsageErrorFactory("rm"),
 	}
 }

--- a/ecs-cli/modules/config/config_v1.go
+++ b/ecs-cli/modules/config/config_v1.go
@@ -33,10 +33,13 @@ const (
 	clusterKey                  = "cluster"
 	clustersKey                 = "clusters"
 	regionKey                   = "region"
+	iniConfigVersion            = 0
+	yamlConfigVersion           = 1
 )
 
 // CLIConfig is the top level struct representing the configuration information
 type CLIConfig struct {
+	Version                  int // which format version was the config file that was read. 1 == yaml, 0 == old ini
 	Cluster                  string
 	AWSProfile               string
 	Region                   string

--- a/ecs-cli/modules/config/params.go
+++ b/ecs-cli/modules/config/params.go
@@ -81,12 +81,15 @@ func NewCLIParams(context *cli.Context, rdwr ReadWriter) (*CLIParams, error) {
 	if err != nil {
 		return nil, err
 	}
-	if ecsConfig.CFNStackName == "" && ecsConfig.CFNStackNamePrefix != "" {
+
+	if ecsConfig.Version == iniConfigVersion {
 		ecsConfig.CFNStackName = ecsConfig.CFNStackNamePrefix + ecsConfig.Cluster
-	} else if ecsConfig.CFNStackName == "" {
-		// set default value
+	}
+
+	if ecsConfig.CFNStackName == "" {
 		ecsConfig.CFNStackName = ecscli.CFNStackNamePrefixDefaultValue + ecsConfig.Cluster
 	}
+
 	return &CLIParams{
 		Cluster:                  ecsConfig.Cluster,
 		Session:                  svcSession,

--- a/ecs-cli/modules/config/readwriter.go
+++ b/ecs-cli/modules/config/readwriter.go
@@ -81,6 +81,7 @@ func (rdwr *INIReadWriter) GetConfig(cliConfig *CLIConfig) error {
 	}
 
 	// Convert to the new CliConfig
+	cliConfig.Version = iniConfigVersion
 	cliConfig.Cluster = iniFormat.Cluster
 	cliConfig.Region = iniFormat.Region
 	cliConfig.AWSProfile = iniFormat.AwsProfile

--- a/ecs-cli/modules/config/readwriter_v1.go
+++ b/ecs-cli/modules/config/readwriter_v1.go
@@ -124,6 +124,9 @@ func readClusterConfig(path string, clusterConfigKey string, cliConfig *CLIConfi
 	cliConfig.Cluster = cluster.Cluster
 	cliConfig.ComposeServiceNamePrefix = cluster.ComposeServiceNamePrefix
 	cliConfig.CFNStackName = cluster.CFNStackName
+	// Fields must be explicitly set as empty because the iniReadWriter will set them to default
+	cliConfig.ComposeProjectNamePrefix = ""
+	cliConfig.CFNStackNamePrefix = ""
 	return nil
 
 }

--- a/ecs-cli/modules/config/readwriter_v1.go
+++ b/ecs-cli/modules/config/readwriter_v1.go
@@ -127,6 +127,7 @@ func readClusterConfig(path string, clusterConfigKey string, cliConfig *CLIConfi
 	// Fields must be explicitly set as empty because the iniReadWriter will set them to default
 	cliConfig.ComposeProjectNamePrefix = ""
 	cliConfig.CFNStackNamePrefix = ""
+	cliConfig.Version = yamlConfigVersion
 	return nil
 
 }
@@ -149,6 +150,7 @@ func readProfileConfig(path string, profileConfigKey string, cliConfig *CLIConfi
 	// Get the info out of the cluster
 	cliConfig.AWSSecretKey = profile.AWSSecretKey
 	cliConfig.AWSAccessKey = profile.AWSAccessKey
+	cliConfig.Version = yamlConfigVersion
 
 	return nil
 

--- a/ecs-cli/modules/config/readwriter_v1_test.go
+++ b/ecs-cli/modules/config/readwriter_v1_test.go
@@ -127,6 +127,7 @@ cfn-stack-name-prefix =
 	assert.Equal(t, testClusterName, readConfig.Cluster, "Cluster name mismatch in config.")
 	assert.Empty(t, readConfig.ComposeServiceNamePrefix, "Compose service prefix name should be empty.")
 	assert.Empty(t, readConfig.CFNStackName, "CFNStackName should be empty.")
+	assert.Equal(t, iniConfigVersion, readConfig.Version, "Expected ini config version to be set.")
 }
 
 func TestPrefixesDefaultOldINIFormat(t *testing.T) {
@@ -153,6 +154,7 @@ aws_secret_access_key =
 	assert.NoError(t, err, "Error reading config")
 	assert.Equal(t, ecscli.ComposeServiceNamePrefixDefaultValue, config.ComposeServiceNamePrefix, "ComposeServiceNamePrefix should be set to the default value.")
 	assert.Equal(t, ecscli.CFNStackNamePrefixDefaultValue, config.CFNStackNamePrefix, "CFNStackNamePrefix should be set to the default value.")
+	assert.Equal(t, iniConfigVersion, config.Version, "Expected ini config version to be set.")
 }
 
 func TestReadCredentialsFile(t *testing.T) {
@@ -186,12 +188,14 @@ ecs_profiles:
 	assert.NoError(t, err, "Error reading config")
 	assert.Equal(t, "default_key_id", config.AWSAccessKey, "Access Key should be present.")
 	assert.Equal(t, "default_key", config.AWSSecretKey, "Secret key should be present.")
+	assert.Equal(t, yamlConfigVersion, config.Version, "Expected yaml config version to be set.")
 
 	// Test read a specific profile
 	config, err = parser.Get("", "Alt")
 	assert.NoError(t, err, "Error reading config")
 	assert.Equal(t, "alt_key_id", config.AWSAccessKey, "Access Key should be present.")
 	assert.Equal(t, "alt_key", config.AWSSecretKey, "Secret key should be present.")
+	assert.Equal(t, yamlConfigVersion, config.Version, "Expected yaml config version to be set.")
 }
 
 func TestReadClusterConfigFile(t *testing.T) {
@@ -230,6 +234,7 @@ clusters:
 	assert.NoError(t, err, "Error reading config")
 	assert.Equal(t, "cli-demo-prod", config.Cluster, "Cluster should be present.")
 	assert.Equal(t, "us-east-2", config.Region, "Region should be present.")
+	assert.Equal(t, yamlConfigVersion, config.Version, "Expected yaml config version to be set.")
 
 	// Test read a specific config
 	config, err = parser.Get("gamma_config", "")
@@ -240,6 +245,7 @@ clusters:
 	assert.Equal(t, "cfn-custom-cli-demo-gamma", config.CFNStackName, "CFNStackName Name should be present.")
 	assert.Empty(t, config.CFNStackNamePrefix, "Expected CFNStackNamePrefix to be empty.")
 	assert.Empty(t, config.ComposeProjectNamePrefix, "Expected ComposeProjectNamePrefix to be empty.")
+	assert.Equal(t, yamlConfigVersion, config.Version, "Expected yaml config version to be set.")
 }
 
 func TestOverwriteINIConfigFile(t *testing.T) {
@@ -276,5 +282,6 @@ cfn-stack-name-prefix = amazon-ecs-cli-setup-
 	assert.Equal(t, testClusterName, readConfig.Cluster, "Cluster name mismatch in config.")
 	assert.Empty(t, readConfig.ComposeServiceNamePrefix, "Compose service prefix name should be empty.")
 	assert.Empty(t, readConfig.CFNStackName, "CFNStackName should be empty.")
+	assert.Equal(t, yamlConfigVersion, readConfig.Version, "Expected yaml config version to be set.")
 
 }

--- a/ecs-cli/modules/config/readwriter_v1_test.go
+++ b/ecs-cli/modules/config/readwriter_v1_test.go
@@ -200,6 +200,8 @@ clusters:
   gamma_config:
     cluster: cli-demo-gamma
     region: us-west-1
+    compose-service-name-prefix: custom-service-
+    cfn-stack-name: cfn-custom-cli-demo-gamma
   beta_config:
     cluster: cli-demo-beta
     region: us-west-2
@@ -234,6 +236,10 @@ clusters:
 	assert.NoError(t, err, "Error reading config")
 	assert.Equal(t, "cli-demo-gamma", config.Cluster, "Cluster should be present.")
 	assert.Equal(t, "us-west-1", config.Region, "Region should be present.")
+	assert.Equal(t, "custom-service-", config.ComposeServiceNamePrefix, "ComposeServiceNamePrefix should be present.")
+	assert.Equal(t, "cfn-custom-cli-demo-gamma", config.CFNStackName, "CFNStackName Name should be present.")
+	assert.Empty(t, config.CFNStackNamePrefix, "Expected CFNStackNamePrefix to be empty.")
+	assert.Empty(t, config.ComposeProjectNamePrefix, "Expected ComposeProjectNamePrefix to be empty.")
 }
 
 func TestOverwriteINIConfigFile(t *testing.T) {


### PR DESCRIPTION
- Bug Fix: Re-added the --timeout flag to compose service commands which had accidentally been removed. 
- Bug Fix: Use of a pointer in the migrate warning function caused the new credential file to be written with a scrambled key pair.
- Enhancement: Improve migrate warning text.
- Bug Fix: V1 ReadWriter now sets unused fields to be empty strings (ComposeProjectNamePrefix and CFNStacknamePrefix). This fixes a bug where the old iniReader was setting all fields to be default.
Bug Fix: Corrected logic for setting CFNStackName.