### PR TITLE
Fixed issues identified by running GoASTScanner

### DIFF
--- a/ecs-cli/main.go
+++ b/ecs-cli/main.go
@@ -16,6 +16,7 @@ package main
 import (
 	"os"
 
+	"github.com/Sirupsen/logrus"
 	ecscompose "github.com/aws/amazon-ecs-cli/ecs-cli/modules/cli/compose/factory"
 	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/commands/cluster"
 	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/commands/compose"
@@ -54,5 +55,8 @@ func main() {
 		composeCommand.ComposeCommand(composeFactory),
 	}
 
-	app.Run(os.Args)
+	err := app.Run(os.Args)
+	if err != nil {
+		logrus.Debug(err)
+	}
 }

--- a/ecs-cli/modules/cli/cluster/cluster_app.go
+++ b/ecs-cli/modules/cli/cluster/cluster_app.go
@@ -335,7 +335,10 @@ func scaleCluster(context *cli.Context, rdwr config.ReadWriter, ecsClient ecscli
 	}
 
 	// Populate update params for the cfn stack
-	cfnParams := cloudformation.NewCfnStackParamsForUpdate()
+	cfnParams, err := cloudformation.NewCfnStackParamsForUpdate()
+	if err != nil {
+		return err
+	}
 	cfnParams.Add(cloudformation.ParameterKeyAsgMaxSize, size)
 
 	// Update the stack.

--- a/ecs-cli/modules/clients/aws/cloudformation/params.go
+++ b/ecs-cli/modules/clients/aws/cloudformation/params.go
@@ -88,13 +88,16 @@ func NewCfnStackParams() *CfnStackParams {
 }
 
 // NewCfnStackParamsForUpdate creates a new object of CfnStackParams struct and populates it for updating the stack.
-func NewCfnStackParamsForUpdate() *CfnStackParams {
+func NewCfnStackParamsForUpdate() (*CfnStackParams, error) {
 	params := NewCfnStackParams()
 	for _, key := range parameterKeyNames {
 		// Set UsePreviousValue = true for all the stack parameters.
-		params.AddWithUsePreviousValue(key, true)
+		err := params.AddWithUsePreviousValue(key, true)
+		if err != nil {
+			return nil, err
+		}
 	}
-	return params
+	return params, nil
 }
 
 // Add adds a key and the value for the same to the cloudformation parameters. If the key already

--- a/ecs-cli/modules/clients/aws/cloudformation/params_test.go
+++ b/ecs-cli/modules/clients/aws/cloudformation/params_test.go
@@ -17,6 +17,7 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestAddAndValidate(t *testing.T) {
@@ -72,11 +73,10 @@ func TestAddAndValidate(t *testing.T) {
 }
 
 func TestAddWithUsePreviousValueAndValidate(t *testing.T) {
-	cfnParams := NewCfnStackParamsForUpdate()
-	err := cfnParams.Validate()
-	if err != nil {
-		t.Error("Error validating params for update: ", err)
-	}
+	cfnParams, err := NewCfnStackParamsForUpdate()
+	assert.NoError(t, err, "Unexpected error getting New CFN Stack Params")
+	err = cfnParams.Validate()
+	assert.NoError(t, err, "Error validating params for update")
 
 	params := cfnParams.Get()
 	if 0 == len(params) {

--- a/ecs-cli/modules/clients/aws/ecs/client.go
+++ b/ecs-cli/modules/clients/aws/ecs/client.go
@@ -285,10 +285,6 @@ func cachedTaskDefinitionRevisionIsActive(cachedTaskDefinition *ecs.TaskDefiniti
 	return *taskDefinitionOfRecord.Status == ecs.TaskDefinitionStatusActive
 }
 
-// constructTaskDefinitionCacheHash computes md5sum of the region, awsAccountId and the requested task definition data
-// BUG(juanrhenals) The requested Task Definition data (taskDefinitionRequest) is not created in a deterministic fashion because there are maps within
-// the request ecs.RegisterTaskDefinitionInput structure, and map iteration in Go is not deterministic. We need to fix this.
-// FIXED(pzimmermann) using a marshalled json representation for the task definition data to be deterministic
 func (c *ecsClient) constructTaskDefinitionCacheHash(taskDefinition *ecs.TaskDefinition, request *ecs.RegisterTaskDefinitionInput) string {
 	// Get the region from the ecsClient configuration
 	region := aws.StringValue(c.params.Session.Config.Region)

--- a/ecs-cli/modules/commands/flags.go
+++ b/ecs-cli/modules/commands/flags.go
@@ -108,7 +108,10 @@ func UsageErrorFactory(command string) func(*cli.Context, error, bool) error {
 		if err != nil {
 			logrus.Error(err)
 		}
-		cli.ShowCommandHelp(c, command)
+		err = cli.ShowCommandHelp(c, command)
+		if err != nil {
+			logrus.Debug(err)
+		}
 		os.Exit(1)
 		return err
 	}

--- a/ecs-cli/modules/version/gen/version-gen.go
+++ b/ecs-cli/modules/version/gen/version-gen.go
@@ -85,7 +85,10 @@ func gitHash() string {
 // cleanliness.
 func main() {
 
-	versionStr, _ := ioutil.ReadFile(filepath.Join("..", "..", "..", "VERSION"))
+	versionStr, err := ioutil.ReadFile(filepath.Join("..", "..", "..", "VERSION"))
+	if err != nil {
+		log.Fatal(err)
+	}
 
 	// default values
 	info := versionInfo{


### PR DESCRIPTION
Fixed issues identified by running [github.com/GoASTScanner/gas](https://github.com/GoASTScanner/gas). 

Below are the results from running the scanning tool; I fixed a subset of the issues that were important. (Several of the warnings were for ignoring returned errors for standard library functions that are used to print to stdout; I ignored these warnings.)
[gas_results.txt](https://github.com/aws/amazon-ecs-cli/files/1436122/gas_results.txt)
