### PR TITLE
Remove go 1.6 from travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ os:
     - osx
 go_import_path: github.com/aws/amazon-ecs-cli
 go:
-    - 1.6
     - 1.7
     - 1.8
 script:


### PR DESCRIPTION
Versions older than 1.7.4 are not supported on MacOS Sierra and return a
fatal error MSpanList_Insert https://github.com/golang/go/issues/17492.

Fixes #384