### PR TITLE
Make ecs-cli scale compatible with CFN templates created by the ECS Console and past versions of the ECS CLI

### DIFF
--- a/ecs-cli/modules/cli/cluster/cluster_app.go
+++ b/ecs-cli/modules/cli/cluster/cluster_app.go
@@ -355,12 +355,13 @@ func scaleCluster(context *cli.Context, rdwr config.ReadWriter, ecsClient ecscli
 	// Validate that we have a cfn stack for the cluster
 	cfnClient.Initialize(cliParams)
 	stackName := cliParams.CFNStackName
-	if err := cfnClient.ValidateStackExists(stackName); err != nil {
+	existingParameters, err := cfnClient.GetStackParameters(stackName)
+	if err != nil {
 		return fmt.Errorf("CloudFormation stack not found for cluster '%s'", cliParams.Cluster)
 	}
 
 	// Populate update params for the cfn stack
-	cfnParams, err := cloudformation.NewCfnStackParamsForUpdate()
+	cfnParams, err := cloudformation.NewCfnStackParamsForUpdate(existingParameters)
 	if err != nil {
 		return err
 	}

--- a/ecs-cli/modules/clients/aws/cloudformation/client.go
+++ b/ecs-cli/modules/clients/aws/cloudformation/client.go
@@ -98,6 +98,7 @@ type CloudformationClient interface {
 	WaitUntilUpdateComplete(string) error
 	ValidateStackExists(string) error
 	DescribeNetworkResources(string) error
+	GetStackParameters(string) ([]*cloudformation.Parameter, error)
 }
 
 // cloudformationClient implements CloudFormationClient.
@@ -168,6 +169,23 @@ func (c *cloudformationClient) UpdateStack(stackName string, params *CfnStackPar
 func (c *cloudformationClient) ValidateStackExists(stackName string) error {
 	_, err := c.describeStack(stackName)
 	return err
+}
+
+// describeStack describes the stack and gets the stack status.
+func (c *cloudformationClient) GetStackParameters(stackName string) ([]*cloudformation.Parameter, error) {
+	output, err := c.client.DescribeStacks(&cloudformation.DescribeStacksInput{
+		StackName: aws.String(stackName),
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	if len(output.Stacks) == 0 {
+		return nil, fmt.Errorf("Could not describe stack '%s'", stackName)
+	}
+
+	return output.Stacks[0].Parameters, nil
 }
 
 // WaitUntilCreateComplete waits until the stack creation completes.

--- a/ecs-cli/modules/clients/aws/cloudformation/mock/client.go
+++ b/ecs-cli/modules/clients/aws/cloudformation/mock/client.go
@@ -19,6 +19,7 @@ package mock_cloudformation
 import (
 	cloudformation "github.com/aws/amazon-ecs-cli/ecs-cli/modules/clients/aws/cloudformation"
 	config "github.com/aws/amazon-ecs-cli/ecs-cli/modules/config"
+	cloudformation0 "github.com/aws/aws-sdk-go/service/cloudformation"
 	gomock "github.com/golang/mock/gomock"
 )
 
@@ -72,6 +73,17 @@ func (_m *MockCloudformationClient) DescribeNetworkResources(_param0 string) err
 
 func (_mr *_MockCloudformationClientRecorder) DescribeNetworkResources(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeNetworkResources", arg0)
+}
+
+func (_m *MockCloudformationClient) GetStackParameters(_param0 string) ([]*cloudformation0.Parameter, error) {
+	ret := _m.ctrl.Call(_m, "GetStackParameters", _param0)
+	ret0, _ := ret[0].([]*cloudformation0.Parameter)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockCloudformationClientRecorder) GetStackParameters(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetStackParameters", arg0)
 }
 
 func (_m *MockCloudformationClient) Initialize(_param0 *config.CLIParams) {

--- a/ecs-cli/modules/clients/aws/cloudformation/params.go
+++ b/ecs-cli/modules/clients/aws/cloudformation/params.go
@@ -89,11 +89,11 @@ func NewCfnStackParams() *CfnStackParams {
 }
 
 // NewCfnStackParamsForUpdate creates a new object of CfnStackParams struct and populates it for updating the stack.
-func NewCfnStackParamsForUpdate() (*CfnStackParams, error) {
+func NewCfnStackParamsForUpdate(existingParams []*cloudformation.Parameter) (*CfnStackParams, error) {
 	params := NewCfnStackParams()
-	for _, key := range parameterKeyNames {
+	for _, param := range existingParams {
 		// Set UsePreviousValue = true for all the stack parameters.
-		err := params.AddWithUsePreviousValue(key, true)
+		err := params.AddWithUsePreviousValue(aws.StringValue(param.ParameterKey), true)
 		if err != nil {
 			return nil, err
 		}

--- a/ecs-cli/modules/clients/aws/cloudformation/params_test.go
+++ b/ecs-cli/modules/clients/aws/cloudformation/params_test.go
@@ -17,6 +17,7 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/cloudformation"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -72,11 +73,17 @@ func TestAddAndValidate(t *testing.T) {
 	}
 }
 
-func TestAddWithUsePreviousValueAndValidate(t *testing.T) {
-	cfnParams, err := NewCfnStackParamsForUpdate()
+func TestAddWithUsePreviousValue(t *testing.T) {
+	existingParameters := []*cloudformation.Parameter{
+		&cloudformation.Parameter{
+			ParameterKey: aws.String("SomeParam1"),
+		},
+		&cloudformation.Parameter{
+			ParameterKey: aws.String("SomeParam2"),
+		},
+	}
+	cfnParams, err := NewCfnStackParamsForUpdate(existingParameters)
 	assert.NoError(t, err, "Unexpected error getting New CFN Stack Params")
-	err = cfnParams.Validate()
-	assert.NoError(t, err, "Error validating params for update")
 
 	params := cfnParams.Get()
 	if 0 == len(params) {
@@ -98,10 +105,6 @@ func TestAddWithUsePreviousValueAndValidate(t *testing.T) {
 	err = cfnParams.AddWithUsePreviousValue(ParameterKeyAsgMaxSize, false)
 	if err != nil {
 		t.Errorf("Error adding parameter with use previous value '%s': '%v'", ParameterKeyAsgMaxSize, err)
-	}
-	err = cfnParams.Validate()
-	if err == nil {
-		t.Errorf("Expected error for param '%s' when usePrevious is false and value is not set", ParameterKeyAsgMaxSize)
 	}
 
 	size := "3"


### PR DESCRIPTION
* Bugfix - `ecs-cli scale` now works with old versions of the CFN template. Fixes #330 
* Enhancement - `ecs-cli scale` can scale any cluster created by the ECS Console 


Testing done:

```
$ ecs-cli configure --cluster OLD --region ca-central-1 --cfn-stack-name amazon-ecs-cli-setup-OLD
$ ecs-cli scale --size 4 --capability-iam
INFO[0001] Waiting for your cluster resources to be updated... 
INFO[0001] Cloudformation stack status                   stackStatus="UPDATE_IN_PROGRESS"
$ ecs-cli configure --cluster LinuxConsole --region ca-central-1 --cfn-stack-name EC2ContainerService-LinuxConsole
INFO[0000] Saved ECS CLI cluster configuration default. 
$ ecs-cli scale --size 2 --capability-iam
INFO[0001] Waiting for your cluster resources to be updated... 
INFO[0001] Cloudformation stack status                   stackStatus="UPDATE_IN_PROGRESS"
$ ecs-cli configure --cluster LinuxConsoleSpot --region ca-central-1 --cfn-stack-name EC2ContainerService-LinuxConsoleSpot
INFO[0000] Saved ECS CLI cluster configuration default. 
$ ecs-cli scale --size 2 --capability-iam
INFO[0001] Waiting for your cluster resources to be updated... 
INFO[0001] Cloudformation stack status                   stackStatus="UPDATE_IN_PROGRESS"
$ ecs-cli configure --cluster WindowsConsole --region ca-central-1 --cfn-stack-name EC2ContainerService-WindowsConsole
INFO[0000] Saved ECS CLI cluster configuration default. 
$ ecs-cli scale --size 2 --capability-iam
INFO[0001] Waiting for your cluster resources to be updated... 
INFO[0001] Cloudformation stack status                   stackStatus="UPDATE_IN_PROGRESS"
```