### PR TITLE
Add HealthCheckGracePeriod to compose service create and up

### DIFF
--- a/ecs-cli/modules/cli/compose/entity/service/service_test.go
+++ b/ecs-cli/modules/cli/compose/entity/service/service_test.go
@@ -135,16 +135,16 @@ func ecsParamsWithFargateNetworkConfig() *utils.ECSParams {
 	return &utils.ECSParams{
 		TaskDefinition: utils.EcsTaskDef{
 			ExecutionRole: "arn:aws:iam::123456789012:role/fargate_role",
-			NetworkMode: "awsvpc",
+			NetworkMode:   "awsvpc",
 			TaskSize: utils.TaskSize{
-				Cpu: "512",
+				Cpu:    "512",
 				Memory: "1GB",
 			},
 		},
 		RunParams: utils.RunParams{
 			NetworkConfiguration: utils.NetworkConfiguration{
 				AwsVpcConfiguration: utils.AwsVpcConfiguration{
-					Subnets: []string{"sg-bafff1ed", "sg-c0ffeefe"},
+					Subnets:        []string{"sg-bafff1ed", "sg-c0ffeefe"},
 					AssignPublicIp: utils.Enabled,
 				},
 			},
@@ -290,6 +290,51 @@ func TestCreateWithALB(t *testing.T) {
 	)
 }
 
+func TestCreateWithHealthCheckGracePeriodAndALB(t *testing.T) {
+	targetGroupArn := "targetGroupArn"
+	containerName := "containerName"
+	containerPort := 80
+	role := "role"
+	healthCheckGP := 60
+
+	flagSet := flag.NewFlagSet("ecs-cli-up", 0)
+	flagSet.String(flags.TargetGroupArnFlag, targetGroupArn, "")
+	flagSet.String(flags.ContainerNameFlag, containerName, "")
+	flagSet.String(flags.ContainerPortFlag, strconv.Itoa(containerPort), "")
+	flagSet.String(flags.RoleFlag, role, "")
+	flagSet.String(flags.HealthCheckGracePeriodFlag, strconv.Itoa(healthCheckGP), "")
+
+	cliContext := cli.NewContext(nil, flagSet, nil)
+
+	createServiceWithHealthCheckGPTest(
+		t,
+		cliContext,
+		&config.CLIParams{},
+		&utils.ECSParams{},
+		func(deploymentConfig *ecs.DeploymentConfiguration) {
+			assert.Nil(t, deploymentConfig.MaximumPercent, "DeploymentConfig.MaximumPercent should be nil")
+			assert.Nil(t, deploymentConfig.MinimumHealthyPercent, "DeploymentConfig.MinimumHealthyPercent should be nil")
+		},
+		func(loadBalancer *ecs.LoadBalancer, observedRole string) {
+			assert.NotNil(t, loadBalancer, "LoadBalancer should not be nil")
+			assert.Nil(t, loadBalancer.LoadBalancerName, "LoadBalancer.LoadBalancerName should be nil")
+			assert.Equal(t, targetGroupArn, aws.StringValue(loadBalancer.TargetGroupArn), "LoadBalancer.TargetGroupArn should match")
+			assert.Equal(t, containerName, aws.StringValue(loadBalancer.ContainerName), "LoadBalancer.ContainerName should match")
+			assert.Equal(t, int64(containerPort), aws.Int64Value(loadBalancer.ContainerPort), "LoadBalancer.ContainerPort should match")
+			assert.Equal(t, role, observedRole, "Role should match")
+		},
+		func(launchType string) {
+			assert.Empty(t, launchType)
+		},
+		func(networkConfig *ecs.NetworkConfiguration) {
+			assert.Nil(t, networkConfig, "NetworkConfiguration should be nil")
+		},
+		func(healthCheckGracePeriod *int64) {
+			assert.Equal(t, int64(healthCheckGP), *healthCheckGracePeriod, "HealthCheckGracePeriod should match")
+		},
+	)
+}
+
 // Specifies LoadBalancerName to test ELB
 func TestCreateWithELB(t *testing.T) {
 	loadbalancerName := "loadbalancerName"
@@ -331,10 +376,56 @@ func TestCreateWithELB(t *testing.T) {
 	)
 }
 
+func TestCreateWithHealthCheckGracePeriodAndELB(t *testing.T) {
+	loadbalancerName := "loadbalancerName"
+	containerName := "containerName"
+	containerPort := 80
+	role := "role"
+	healthCheckGP := 60
+
+	flagSet := flag.NewFlagSet("ecs-cli-up", 0)
+	flagSet.String(flags.LoadBalancerNameFlag, loadbalancerName, "")
+	flagSet.String(flags.ContainerNameFlag, containerName, "")
+	flagSet.String(flags.ContainerPortFlag, strconv.Itoa(containerPort), "")
+	flagSet.String(flags.RoleFlag, role, "")
+	flagSet.String(flags.HealthCheckGracePeriodFlag, strconv.Itoa(healthCheckGP), "")
+
+	cliContext := cli.NewContext(nil, flagSet, nil)
+
+	createServiceWithHealthCheckGPTest(
+		t,
+		cliContext,
+		&config.CLIParams{},
+		&utils.ECSParams{},
+		func(deploymentConfig *ecs.DeploymentConfiguration) {
+			assert.Nil(t, deploymentConfig.MaximumPercent, "DeploymentConfig.MaximumPercent should be nil")
+			assert.Nil(t, deploymentConfig.MinimumHealthyPercent, "DeploymentConfig.MinimumHealthyPercent should be nil")
+		},
+		func(loadBalancer *ecs.LoadBalancer, observedRole string) {
+			assert.NotNil(t, loadBalancer, "LoadBalancer should not be nil")
+			assert.Nil(t, loadBalancer.TargetGroupArn, "LoadBalancer.TargetGroupArn should be nil")
+			assert.Equal(t, loadbalancerName, aws.StringValue(loadBalancer.LoadBalancerName), "LoadBalancer.LoadBalancerName should match")
+			assert.Equal(t, containerName, aws.StringValue(loadBalancer.ContainerName), "LoadBalancer.ContainerName should match")
+			assert.Equal(t, int64(containerPort), aws.Int64Value(loadBalancer.ContainerPort), "LoadBalancer.ContainerPort should match")
+			assert.Equal(t, role, observedRole, "Role should match")
+		},
+		func(launchType string) {
+			assert.Empty(t, launchType)
+		},
+		func(networkConfig *ecs.NetworkConfiguration) {
+			assert.Nil(t, networkConfig, "NetworkConfiguration should be nil")
+		},
+		func(healthCheckGracePeriod *int64) {
+			assert.Equal(t, int64(healthCheckGP), *healthCheckGracePeriod, "HealthCheckGracePeriod should match")
+		},
+	)
+}
+
 type validateDeploymentConfiguration func(*ecs.DeploymentConfiguration)
 type validateLoadBalancer func(*ecs.LoadBalancer, string)
 type validateLaunchType func(string)
 type validateNetworkConfig func(*ecs.NetworkConfiguration)
+type validateHealthCheckGracePeriod func(*int64)
 
 func createServiceTest(t *testing.T,
 	cliContext *cli.Context,
@@ -344,6 +435,31 @@ func createServiceTest(t *testing.T,
 	validateLB validateLoadBalancer,
 	validateLT validateLaunchType,
 	validateNC validateNetworkConfig) {
+
+	createServiceWithHealthCheckGPTest(
+		t,
+		cliContext,
+		cliParams,
+		ecsParams,
+		validateDeploymentConfig,
+		validateLB,
+		validateLT,
+		validateNC,
+		func(healthCheckGP *int64) {
+			assert.Nil(t, healthCheckGP, "HealthCheckGracePeriod should be nil")
+		},
+	)
+}
+
+func createServiceWithHealthCheckGPTest(t *testing.T,
+	cliContext *cli.Context,
+	cliParams *config.CLIParams,
+	ecsParams *utils.ECSParams,
+	validateDeploymentConfig validateDeploymentConfiguration,
+	validateLB validateLoadBalancer,
+	validateLT validateLaunchType,
+	validateNC validateNetworkConfig,
+	validateHCGP validateHealthCheckGracePeriod) {
 
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -375,7 +491,8 @@ func createServiceTest(t *testing.T,
 			gomock.Any(), // deploymentConfig
 			gomock.Any(), // networkConfig
 			gomock.Any(), // launchType
-		).Do(func(a, b, c, d, e, f, g interface{}) {
+			gomock.Any(), // healthCheckGracePeriod
+		).Do(func(a, b, c, d, e, f, g, h interface{}) {
 			observedTaskDefID := b.(string)
 			assert.Equal(t, taskDefID, observedTaskDefID, "Task Definition name should match")
 
@@ -391,6 +508,9 @@ func createServiceTest(t *testing.T,
 
 			observedNetworkConfig := f.(*ecs.NetworkConfiguration)
 			validateNC(observedNetworkConfig)
+
+			observedHealthCheckGracePeriod := h.(*int64)
+			validateHCGP(observedHealthCheckGracePeriod)
 
 		}).Return(nil),
 	)

--- a/ecs-cli/modules/clients/aws/ecs/mock/client.go
+++ b/ecs-cli/modules/clients/aws/ecs/mock/client.go
@@ -56,14 +56,14 @@ func (_mr *_MockECSClientRecorder) CreateCluster(arg0 interface{}) *gomock.Call 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateCluster", arg0)
 }
 
-func (_m *MockECSClient) CreateService(_param0 string, _param1 string, _param2 *ecs.LoadBalancer, _param3 string, _param4 *ecs.DeploymentConfiguration, _param5 *ecs.NetworkConfiguration, _param6 string) error {
-	ret := _m.ctrl.Call(_m, "CreateService", _param0, _param1, _param2, _param3, _param4, _param5, _param6)
+func (_m *MockECSClient) CreateService(_param0 string, _param1 string, _param2 *ecs.LoadBalancer, _param3 string, _param4 *ecs.DeploymentConfiguration, _param5 *ecs.NetworkConfiguration, _param6 string, _param7 *int64) error {
+	ret := _m.ctrl.Call(_m, "CreateService", _param0, _param1, _param2, _param3, _param4, _param5, _param6, _param7)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-func (_mr *_MockECSClientRecorder) CreateService(arg0, arg1, arg2, arg3, arg4, arg5, arg6 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateService", arg0, arg1, arg2, arg3, arg4, arg5, arg6)
+func (_mr *_MockECSClientRecorder) CreateService(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateService", arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7)
 }
 
 func (_m *MockECSClient) DeleteCluster(_param0 string) (string, error) {
@@ -214,22 +214,22 @@ func (_mr *_MockECSClientRecorder) StopTask(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "StopTask", arg0)
 }
 
-func (_m *MockECSClient) UpdateService(_param0 string, _param1 string, _param2 int64, _param3 *ecs.DeploymentConfiguration, _param4 *ecs.NetworkConfiguration) error {
-	ret := _m.ctrl.Call(_m, "UpdateService", _param0, _param1, _param2, _param3, _param4)
+func (_m *MockECSClient) UpdateService(_param0 string, _param1 string, _param2 int64, _param3 *ecs.DeploymentConfiguration, _param4 *ecs.NetworkConfiguration, _param5 *int64) error {
+	ret := _m.ctrl.Call(_m, "UpdateService", _param0, _param1, _param2, _param3, _param4, _param5)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-func (_mr *_MockECSClientRecorder) UpdateService(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "UpdateService", arg0, arg1, arg2, arg3, arg4)
+func (_mr *_MockECSClientRecorder) UpdateService(arg0, arg1, arg2, arg3, arg4, arg5 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "UpdateService", arg0, arg1, arg2, arg3, arg4, arg5)
 }
 
-func (_m *MockECSClient) UpdateServiceCount(_param0 string, _param1 int64, _param2 *ecs.DeploymentConfiguration, _param3 *ecs.NetworkConfiguration) error {
-	ret := _m.ctrl.Call(_m, "UpdateServiceCount", _param0, _param1, _param2, _param3)
+func (_m *MockECSClient) UpdateServiceCount(_param0 string, _param1 int64, _param2 *ecs.DeploymentConfiguration, _param3 *ecs.NetworkConfiguration, _param4 *int64) error {
+	ret := _m.ctrl.Call(_m, "UpdateServiceCount", _param0, _param1, _param2, _param3, _param4)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-func (_mr *_MockECSClientRecorder) UpdateServiceCount(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "UpdateServiceCount", arg0, arg1, arg2, arg3)
+func (_mr *_MockECSClientRecorder) UpdateServiceCount(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "UpdateServiceCount", arg0, arg1, arg2, arg3, arg4)
 }

--- a/ecs-cli/modules/commands/compose/service/compose_service_command.go
+++ b/ecs-cli/modules/commands/compose/service/compose_service_command.go
@@ -158,6 +158,7 @@ func loadBalancerFlags() []cli.Flag {
 	containerPortUsageString := "[Optional] Specifies the port on the container to associate with the load balancer. This port must correspond to a containerPort in the service's task definition. This parameter is required if a load balancer or target group is specified."
 	loadBalancerNameUsageString := "[Optional] Specifies the name of a previously configured Elastic Load Balancing load balancer to associate with your service."
 	roleUsageString := "[Optional] Specifies the name or full Amazon Resource Name (ARN) of the IAM role that allows Amazon ECS to make calls to your load balancer or target group on your behalf. This parameter is required if you are using a load balancer or target group with your service. If you specify the role parameter, you must also specify a load balancer name or target group ARN, along with a container name and container port."
+	healthCheckGracePeriodString := "[Optional] Specifies the period of time, in seconds, that the Amazon ECS service scheduler should ignore unhealthy Elastic Load Balancing target health checks after a task has first started."
 
 	return []cli.Flag{
 		cli.StringFlag{
@@ -179,6 +180,10 @@ func loadBalancerFlags() []cli.Flag {
 		cli.StringFlag{
 			Name:  flags.RoleFlag,
 			Usage: roleUsageString,
+		},
+		cli.StringFlag{
+			Name:  flags.HealthCheckGracePeriodFlag,
+			Usage: healthCheckGracePeriodString,
 		},
 	}
 }

--- a/ecs-cli/modules/commands/flags/flags.go
+++ b/ecs-cli/modules/commands/flags/flags.go
@@ -102,6 +102,7 @@ const (
 	ContainerNameFlag                       = "container-name"
 	ContainerPortFlag                       = "container-port"
 	LoadBalancerNameFlag                    = "load-balancer-name"
+	HealthCheckGracePeriodFlag              = "health-check-grace-period"
 	RoleFlag                                = "role"
 	ComposeServiceTimeOutFlag               = "timeout"
 )


### PR DESCRIPTION
## specify HCGP on "compose service create"...
...with target group
```
.\bin\local\ecs-cli.exe compose --file .\httpd-new.yml --project-name httpd-new-test service create --target-group-arn arn:aws:elasticloadbalancing:ap-northeast-1:[...]:targetgroup/cli-tg-2/79a1e2ac87091435 --container-name httpd-new --container-port 80 --health-check-grace-period 25
time="2018-01-08T16:09:25-08:00" level=warning msg="Skipping unsupported YAML option..." option name=networks
time="2018-01-08T16:09:25-08:00" level=warning msg="Skipping unsupported YAML option for service..." option name=networks service name=httpd-new
time="2018-01-08T16:09:26-08:00" level=info msg="Using ECS task definition" TaskDefinition="httpd-new-test:4"
time="2018-01-08T16:09:27-08:00" level=info msg="Created an ECS service" health-check-grace-period=25 service=httpd-new-test taskDefinition="httpd-new-test:4"
```

...with load balancer name
```
.\bin\local\ecs-cli.exe compose --file .\httpd-new.yml --project-name httpd-new-test service create --load-balancer-name classic-lb --container-name httpd-new --container-port 80 --health-check-grace-period 25
time="2018-01-08T15:52:38-08:00" level=warning msg="Skipping unsupported YAML option..." option name=networks
time="2018-01-08T15:52:38-08:00" level=warning msg="Skipping unsupported YAML option for service..." option name=networks service name=httpd-new
time="2018-01-08T15:52:39-08:00" level=info msg="Using ECS task definition" TaskDefinition="httpd-new-test:4"
time="2018-01-08T15:52:40-08:00" level=info msg="Created an ECS service" health-check-grace-period=25 service=httpd-new-test taskDefinition="httpd-new-test:4"
```

...without TG or LB (error)
```
.\bin\local\ecs-cli.exe compose --file .\httpd-new.yml --project-name httpd-new-test service create --health-check-grace-period 25
time="2018-01-08T15:50:57-08:00" level=warning msg="Skipping unsupported YAML option..." option name=networks
time="2018-01-08T15:50:57-08:00" level=warning msg="Skipping unsupported YAML option for service..." option name=networks service name=httpd-new
time="2018-01-08T15:50:58-08:00" level=info msg="Using ECS task definition" TaskDefinition="httpd-new-test:4"
time="2018-01-08T15:50:58-08:00" level=error msg="Error creating service" error="InvalidParameterException: Health check grace period
is only valid for services configured to use load balancers\n\tstatus code: 400, request id: [...]" service=httpd-new-test
time="2018-01-08T15:50:58-08:00" level=fatal msg="InvalidParameterException: Health check grace period is only valid for services configured to use load balancers\n\tstatus code: 400, request id: [...]"
```

## specify HCGP on "compose service up"...
...with target group
```
.\bin\local\ecs-cli.exe compose --file .\httpd-new.yml --project-name httpd-new-test service up --target-group-arn arn:aws:elasticloadbalancing:ap-northeast-1:...:targetgroup/cli-tg-2/79a1e2ac87091435 --container-name httpd-new --container-port 80 --health-check-grace-period 25
time="2018-01-08T15:34:41-08:00" level=warning msg="Skipping unsupported YAML option..." option name=networks
time="2018-01-08T15:34:41-08:00" level=warning msg="Skipping unsupported YAML option for service..." option name=networks service name=httpd-new
time="2018-01-08T15:34:42-08:00" level=info msg="Using ECS task definition" TaskDefinition="httpd-new-test:4"
time="2018-01-08T15:34:43-08:00" level=info msg="Created an ECS service" health-check-grace-period=25 service=httpd-new-test taskDefinition="httpd-new-test:4"
time="2018-01-08T15:34:43-08:00" level=info msg="Updated ECS service successfully" desiredCount=1 health-check-grace-period=25 serviceName=httpd-new-test
time="2018-01-08T15:34:58-08:00" level=info msg="(service httpd-new-test) has reached a steady state." timestamp=2018-01-08 23:34:43 +0000 UTC
time="2018-01-08T15:35:29-08:00" level=info msg="(service httpd-new-test) has started 1 tasks: (task cf771889-6ea2-4086-a72f-4a733e14b42c)." timestamp=2018-01-08 23:35:23 +0000 UTC
time="2018-01-08T15:35:44-08:00" level=info msg="Service status" desiredCount=1 runningCount=1 serviceName=httpd-new-test
time="2018-01-08T15:35:44-08:00" level=info msg="ECS Service has reached a stable state" desiredCount=1 runningCount=1 serviceName=httpd-new-test
```

...with load balancer name
```
.\bin\local\ecs-cli.exe compose --file .\httpd-new.yml --project-name httpd-new-test service up --load-balancer-name classic-lb --container-name httpd-new --container-port 80 --health-check-grace-period 25
time="2018-01-08T15:44:46-08:00" level=warning msg="Skipping unsupported YAML option..." option name=networks
time="2018-01-08T15:44:46-08:00" level=warning msg="Skipping unsupported YAML option for service..." option name=networks service name=httpd-new
time="2018-01-08T15:44:47-08:00" level=info msg="Using ECS task definition" TaskDefinition="httpd-new-test:4"
time="2018-01-08T15:44:48-08:00" level=info msg="Created an ECS service" health-check-grace-period=25 service=httpd-new-test taskDefinition="httpd-new-test:4"
time="2018-01-08T15:44:48-08:00" level=info msg="Updated ECS service successfully" desiredCount=1 health-check-grace-period=25 serviceName=httpd-new-test
time="2018-01-08T15:45:04-08:00" level=info msg="(service httpd-new-test) has started 1 tasks: (task d6c39692-7660-4d88-ad30-78773c940868)." timestamp=2018-01-08 23:44:50 +0000 UTC
time="2018-01-08T15:45:19-08:00" level=info msg="Service status" desiredCount=1 runningCount=1 serviceName=httpd-new-test
time="2018-01-08T15:45:19-08:00" level=info msg="ECS Service has reached a stable state" desiredCount=1 runningCount=1 serviceName=httpd-new-test
```

...without TG or LB (error)
```
.\bin\local\ecs-cli.exe compose --file .\httpd-new.yml --project-name httpd-new-test service up --health-check-grace-period 25time="2018-01-08T15:49:01-08:00" level=warning msg="Skipping unsupported YAML option..." option name=networks
time="2018-01-08T15:49:01-08:00" level=warning msg="Skipping unsupported YAML option for service..." option name=networks service name=httpd-new
time="2018-01-08T15:49:02-08:00" level=info msg="Using ECS task definition" TaskDefinition="httpd-new-test:4"
time="2018-01-08T15:49:02-08:00" level=error msg="Error creating service" error="InvalidParameterException: Health check grace period
is only valid for services configured to use load balancers\n\tstatus code: 400, request id: [...]" service=httpd-new-test
time="2018-01-08T15:49:02-08:00" level=fatal msg="InvalidParameterException: Health check grace period is only valid for services configured to use load balancers\n\tstatus code: 400, request id: [...]"
```