### PR TITLE
Update documentation on force flag for cluster down

### DIFF
--- a/ecs-cli/modules/commands/cluster/cluster_command.go
+++ b/ecs-cli/modules/commands/cluster/cluster_command.go
@@ -34,7 +34,7 @@ func UpCommand() cli.Command {
 func DownCommand() cli.Command {
 	return cli.Command{
 		Name:         "down",
-		Usage:        "Deletes the CloudFormation stack that was created by ecs-cli up and the associated resources. The --force option is required.",
+		Usage:        "Deletes the CloudFormation stack that was created by ecs-cli up and the associated resources.",
 		Action:       cluster.ClusterDown,
 		Flags:        append(clusterDownFlags(), flags.OptionalConfigFlags()...),
 		OnUsageError: flags.UsageErrorFactory("down"),
@@ -134,7 +134,7 @@ func clusterDownFlags() []cli.Flag {
 	return []cli.Flag{
 		cli.BoolFlag{
 			Name:  flags.ForceFlag + ", f",
-			Usage: "Acknowledges that this command permanently deletes resources.",
+			Usage: "[Optional] Acknowledges that this command permanently deletes resources.",
 		},
 	}
 }


### PR DESCRIPTION
```
~/go/src/github.com/aws/amazon-ecs-cli(dev)$ ecs-cli down --help
NAME:
   ecs-cli down - Deletes the CloudFormation stack that was created by ecs-cli up and the associated resources.

USAGE:
   ecs-cli down [command options] [arguments...]

OPTIONS:
   --force, -f                [Optional] Acknowledges that this command permanently deletes resources.
   --region value, -r value   [Optional] Specifies the AWS region to use. Defaults to the region configured using the configure command
   --cluster-config value     [Optional] Specifies the name of the ECS cluster configuration to use. Defaults to the default cluster configuration.
   --ecs-profile value        [Optional] Specifies the name of the ECS profile configuration to use. Defaults to the default profile configuration. [$ECS_PROFILE]
   --aws-profile value        [Optional] Use the AWS credentials from an existing named profile in ~/.aws/credentials. [$AWS_PROFILE]
   --cluster value, -c value  [Optional] Specifies the ECS cluster name to use. Defaults to the cluster configured using the configure command
   

```