### PR TITLE
Support aws_session_token in ECS Profiles

### DIFF
--- a/ecs-cli/modules/cli/configure/configure.go
+++ b/ecs-cli/modules/cli/configure/configure.go
@@ -161,13 +161,15 @@ func Profile(context *cli.Context) error {
 	if err := fieldEmpty(accessKey, flags.AccessKeyFlag); err != nil {
 		return err
 	}
+	sessionToken := context.String(flags.SessionTokenFlag)
 	profileName := context.String(flags.ProfileNameFlag)
 	if err := fieldEmpty(profileName, flags.ProfileNameFlag); err != nil {
 		return err
 	}
 	profile := &config.Profile{
-		AWSAccessKey: accessKey,
-		AWSSecretKey: secretKey,
+		AWSAccessKey:    accessKey,
+		AWSSecretKey:    secretKey,
+		AWSSessionToken: sessionToken,
 	}
 
 	rdwr, err := config.NewReadWriter()

--- a/ecs-cli/modules/cli/configure/configure_test.go
+++ b/ecs-cli/modules/cli/configure/configure_test.go
@@ -36,6 +36,7 @@ const (
 	awsAccessKey2            = "AKID2"
 	awsSecretKey             = "SKID"
 	awsSecretKey2            = "SKID2"
+	awsSessionToken          = "token"
 	awsProfile               = "awsprofile"
 	composeServiceNamePrefix = "ecs-"
 	cfnStackNamePrefix       = "cfn-"
@@ -56,6 +57,15 @@ func createProfileConfig(name string, accessKey string, secretKey string) *cli.C
 	flagSet.String(flags.AccessKeyFlag, accessKey, "")
 	flagSet.String(flags.SecretKeyFlag, secretKey, "")
 	flagSet.String(flags.ProfileNameFlag, name, "")
+	return cli.NewContext(nil, flagSet, nil)
+}
+
+func createProfileConfigWithSessionToken(name string, accessKey string, secretKey string, sessionToken string) *cli.Context {
+	flagSet := flag.NewFlagSet("ecs-cli", 0)
+	flagSet.String(flags.AccessKeyFlag, accessKey, "")
+	flagSet.String(flags.SecretKeyFlag, secretKey, "")
+	flagSet.String(flags.ProfileNameFlag, name, "")
+	flagSet.String(flags.SessionTokenFlag, sessionToken, "")
 	return cli.NewContext(nil, flagSet, nil)
 }
 
@@ -124,7 +134,7 @@ func TestDefaultProfile(t *testing.T) {
 }
 
 func TestConfigureProfile(t *testing.T) {
-	config1 := createProfileConfig(profileName, awsAccessKey, awsSecretKey)
+	config1 := createProfileConfigWithSessionToken(profileName, awsAccessKey, awsSecretKey, awsSessionToken)
 
 	// Create a temporary directory for the dummy ecs config
 	tempDirName, err := ioutil.TempDir("", "test")

--- a/ecs-cli/modules/commands/configure/configure_command.go
+++ b/ecs-cli/modules/commands/configure/configure_command.go
@@ -144,6 +144,13 @@ func configureProfileFlags() []cli.Flag {
 				"Specifies the profile name to use for this configuration.",
 			),
 		},
+		cli.StringFlag{
+			Name: flags.SessionTokenFlag,
+			Usage: fmt.Sprintf(
+				"Specifies the AWS session token to use. The ECS CLI uses the value of your $AWS_SESSION_TOKEN environment variable if it is set.",
+			),
+			EnvVar: "AWS_SESSION_TOKEN",
+		},
 	}
 }
 

--- a/ecs-cli/modules/commands/configure/configure_command.go
+++ b/ecs-cli/modules/commands/configure/configure_command.go
@@ -147,7 +147,7 @@ func configureProfileFlags() []cli.Flag {
 		cli.StringFlag{
 			Name: flags.SessionTokenFlag,
 			Usage: fmt.Sprintf(
-				"Specifies the AWS session token to use. The ECS CLI uses the value of your $AWS_SESSION_TOKEN environment variable if it is set.",
+				"[Optional] Specifies the AWS session token to use. The ECS CLI uses the value of your $AWS_SESSION_TOKEN environment variable if it is set.",
 			),
 			EnvVar: "AWS_SESSION_TOKEN",
 		},

--- a/ecs-cli/modules/commands/flags/flags.go
+++ b/ecs-cli/modules/commands/flags/flags.go
@@ -26,6 +26,7 @@ const (
 	// Configure
 	AccessKeyFlag           = "access-key"
 	SecretKeyFlag           = "secret-key"
+	SessionTokenFlag        = "session-token"
 	RegionFlag              = "region"
 	AwsRegionEnvVar         = "AWS_REGION"
 	AwsDefaultRegionEnvVar  = "AWS_DEFAULT_REGION"

--- a/ecs-cli/modules/config/config_v1.go
+++ b/ecs-cli/modules/config/config_v1.go
@@ -31,6 +31,7 @@ const (
 	cfnStackNamePrefixKey       = "cfn-stack-name-prefix"
 	awsAccessKey                = "aws_access_key_id"
 	awsSecretKey                = "aws_secret_access_key"
+	awsSessionToken             = "aws_session_token"
 	clusterKey                  = "cluster"
 	clustersKey                 = "clusters"
 	regionKey                   = "region"
@@ -46,6 +47,7 @@ type CLIConfig struct {
 	Region                   string
 	AWSAccessKey             string
 	AWSSecretKey             string
+	AWSSessionToken          string
 	ComposeServiceNamePrefix string
 	ComposeProjectNamePrefix string // Deprecated; remains for backwards compatibility
 	CFNStackName             string
@@ -55,8 +57,9 @@ type CLIConfig struct {
 
 // Profile is a simple struct for storing a single profile config
 type Profile struct {
-	AWSAccessKey string `yaml:"aws_access_key_id"`
-	AWSSecretKey string `yaml:"aws_secret_access_key"`
+	AWSAccessKey    string `yaml:"aws_access_key_id"`
+	AWSSecretKey    string `yaml:"aws_secret_access_key"`
+	AWSSessionToken string `yaml:"aws_session_token,omitempty"`
 }
 
 // Cluster is a simple struct for storing a single cluster config
@@ -159,7 +162,7 @@ func isDefaultECSProfileCase(cfg *CLIConfig) bool {
 
 func sessionFromECSConfig(cfg *CLIConfig, region string, svcConfig *aws.Config) (*session.Session, error) {
 	if cfg.AWSSecretKey != "" {
-		return sessionFromKeys(region, cfg.AWSAccessKey, cfg.AWSSecretKey, svcConfig)
+		return sessionFromKeys(region, cfg.AWSAccessKey, cfg.AWSSecretKey, cfg.AWSSessionToken, svcConfig)
 	}
 
 	return sessionFromProfile(cfg.AWSProfile, region, svcConfig)
@@ -188,9 +191,9 @@ func sessionFromProfile(profile string, region string, svcConfig *aws.Config) (*
 	})
 }
 
-func sessionFromKeys(region string, awsAccess string, awsSecret string, svcConfig *aws.Config) (*session.Session, error) {
+func sessionFromKeys(region string, awsAccess string, awsSecret string, sessionToken string, svcConfig *aws.Config) (*session.Session, error) {
 	svcConfig.Region = aws.String(region)
-	svcConfig.Credentials = credentials.NewStaticCredentials(awsAccess, awsSecret, "")
+	svcConfig.Credentials = credentials.NewStaticCredentials(awsAccess, awsSecret, sessionToken)
 	return session.NewSession(svcConfig)
 }
 

--- a/ecs-cli/modules/config/readwriter_v1.go
+++ b/ecs-cli/modules/config/readwriter_v1.go
@@ -158,6 +158,7 @@ func readProfileConfig(path string, profileConfigKey string, cliConfig *CLIConfi
 	// Get the info out of the cluster
 	cliConfig.AWSSecretKey = profile.AWSSecretKey
 	cliConfig.AWSAccessKey = profile.AWSAccessKey
+	cliConfig.AWSSessionToken = profile.AWSSessionToken
 	cliConfig.Version = yamlConfigVersion
 
 	return nil

--- a/ecs-cli/modules/config/readwriter_v1_test.go
+++ b/ecs-cli/modules/config/readwriter_v1_test.go
@@ -168,6 +168,7 @@ ecs_profiles:
   Alt:
     aws_access_key_id: alt_key_id
     aws_secret_access_key: alt_key
+    aws_session_token: alt_token
 `
 
 	dest, err := newMockDestination()
@@ -197,6 +198,7 @@ ecs_profiles:
 	assert.NoError(t, err, "Error reading config")
 	assert.Equal(t, "alt_key_id", config.AWSAccessKey, "Access Key should be present.")
 	assert.Equal(t, "alt_key", config.AWSSecretKey, "Secret key should be present.")
+	assert.Equal(t, "alt_token", config.AWSSessionToken, "Session token should be present.")
 	assert.Equal(t, yamlConfigVersion, config.Version, "Expected yaml config version to be set.")
 }
 


### PR DESCRIPTION
- Closes #409 

Usage:

```
$ ecs-cli configure profile --access-key ACCESS --secret-key SECRET --session-token TOKEN
INFO[0000] Saved ECS CLI profile configuration default. 
$ cat credentials 
version: v1
default: default
ecs_profiles:
  default:
    aws_access_key_id: ACCESS
    aws_secret_access_key: SECRET
    aws_session_token: TOKEN
```

Without session token:

```
$ ecs-cli configure profile --access-key ACCESS --secret-key SECRET
INFO[0000] Saved ECS CLI profile configuration default. 
$ cat credentials 
version: v1
default: default
ecs_profiles:
  default:
    aws_access_key_id: ACCESS
    aws_secret_access_key: SECRET
```