### PR TITLE
Add force-deployment flag to compose service start and up

### DIFF
--- a/ecs-cli/modules/cli/compose/entity/service/service.go
+++ b/ecs-cli/modules/cli/compose/entity/service/service.go
@@ -266,7 +266,7 @@ func (s *Service) Up() error {
 		return err
 	}
 
-	err = s.Context().ECSClient.UpdateService(ecsServiceName, newTaskDefinitionId, newCount, deploymentConfig, networkConfig, s.healthCheckGP)
+	err = s.Context().ECSClient.UpdateService(ecsServiceName, newTaskDefinitionId, newCount, deploymentConfig, networkConfig, s.healthCheckGP, false)
 	if err != nil {
 		return err
 	}
@@ -420,7 +420,7 @@ func (s *Service) updateService(count int64) error {
 		return err
 	}
 
-	if err = s.Context().ECSClient.UpdateServiceCount(serviceName, count, deploymentConfig, networkConfig, s.healthCheckGP); err != nil {
+	if err = s.Context().ECSClient.UpdateServiceCount(serviceName, count, deploymentConfig, networkConfig, s.healthCheckGP, false); err != nil {
 		return err
 	}
 

--- a/ecs-cli/modules/cli/compose/entity/service/service_test.go
+++ b/ecs-cli/modules/cli/compose/entity/service/service_test.go
@@ -465,15 +465,7 @@ func createServiceWithHealthCheckGPTest(t *testing.T,
 	defer ctrl.Finish()
 
 	taskDefID := "taskDefinitionId"
-	taskDefArn := "arn/" + taskDefID
-
-	taskDefinition := ecs.TaskDefinition{
-		Family:               aws.String("family"),
-		ContainerDefinitions: []*ecs.ContainerDefinition{},
-		Volumes:              []*ecs.Volume{},
-	}
-	respTaskDef := taskDefinition
-	respTaskDef.TaskDefinitionArn = aws.String(taskDefArn)
+	taskDefArn, taskDefinition, registerTaskDefResponse := getTestTaskDef(taskDefID)
 
 	mockEcs := mock_ecs.NewMockECSClient(ctrl)
 	gomock.InOrder(
@@ -481,7 +473,7 @@ func createServiceWithHealthCheckGPTest(t *testing.T,
 			// verify input fields
 			req := x.(*ecs.RegisterTaskDefinitionInput)
 			assert.Equal(t, aws.StringValue(taskDefinition.Family), aws.StringValue(req.Family), "Task Definition family should match")
-		}).Return(&respTaskDef, nil),
+		}).Return(&registerTaskDefResponse, nil),
 
 		mockEcs.EXPECT().CreateService(
 			gomock.Any(), // serviceName
@@ -600,4 +592,316 @@ func TestServiceRun(t *testing.T) {
 	service := NewService(&context.Context{})
 	err := service.Run(map[string][]string{})
 	assert.Error(t, err, "Expected unsupported error")
+}
+
+// Up Service tests
+
+type UpdateServiceParams struct {
+	serviceName            string
+	taskDefinition         string
+	count                  int64
+	deploymentConfig       *ecs.DeploymentConfiguration
+	networkConfig          *ecs.NetworkConfiguration
+	healthCheckGracePeriod *int64
+	forceDeployment        bool
+}
+
+func TestUpdateExistingServiceWithForceFlag(t *testing.T) {
+	// define test flag set
+	forceFlagValue := true
+
+	flagSet := flag.NewFlagSet("ecs-cli-up", 0)
+	flagSet.Bool(flags.ForceDeploymentFlag, forceFlagValue, "")
+	cliContext := cli.NewContext(nil, flagSet, nil)
+
+	// define existing service
+	serviceName := "test-service"
+	existingService := &ecs.Service{
+		TaskDefinition: aws.String("arn/test-task-def"),
+		Status:         aws.String("ACTIVE"),
+		DesiredCount:   aws.Int64(0),
+		ServiceName:    aws.String(serviceName),
+	}
+
+	// define expected client input given the above info
+	expectedInput := getDefaultUpdateInput()
+	expectedInput.serviceName = serviceName
+	expectedInput.forceDeployment = forceFlagValue
+
+	// call tests
+	upServiceWithCurrentTaskDefTest(t, cliContext, &config.CLIParams{}, &utils.ECSParams{}, expectedInput, existingService)
+	upServiceWithNewTaskDefTest(t, cliContext, &config.CLIParams{}, &utils.ECSParams{}, expectedInput, existingService)
+}
+
+func TestUpdateExistingServiceWithNewDeploymentConfig(t *testing.T) {
+	// define test flag set
+	deploymentMaxPercent := 200
+	deploymentMinPercent := 100
+
+	flagSet := flag.NewFlagSet("ecs-cli-up", 0)
+	flagSet.String(flags.DeploymentMaxPercentFlag, strconv.Itoa(deploymentMaxPercent), "")
+	flagSet.String(flags.DeploymentMinHealthyPercentFlag, strconv.Itoa(deploymentMinPercent), "")
+	cliContext := cli.NewContext(nil, flagSet, nil)
+
+	// define existing service
+	serviceName := "test-service"
+	existingService := &ecs.Service{
+		TaskDefinition: aws.String("arn/test-task-def"),
+		Status:         aws.String("ACTIVE"),
+		DesiredCount:   aws.Int64(0),
+		ServiceName:    aws.String(serviceName),
+	}
+
+	// define expected client input given the above info
+	expectedInput := getDefaultUpdateInput()
+	expectedInput.serviceName = serviceName
+	expectedInput.deploymentConfig = &ecs.DeploymentConfiguration{
+		MaximumPercent:        aws.Int64(int64(deploymentMaxPercent)),
+		MinimumHealthyPercent: aws.Int64(int64(deploymentMinPercent)),
+	}
+
+	// call tests
+	upServiceWithCurrentTaskDefTest(t, cliContext, &config.CLIParams{}, &utils.ECSParams{}, expectedInput, existingService)
+	upServiceWithNewTaskDefTest(t, cliContext, &config.CLIParams{}, &utils.ECSParams{}, expectedInput, existingService)
+}
+
+func TestUpdateExistingServiceWithNewHCGP(t *testing.T) {
+	// define test flag set
+	healthCheckGracePeriod := 200
+
+	flagSet := flag.NewFlagSet("ecs-cli-up", 0)
+	flagSet.String(flags.HealthCheckGracePeriodFlag, strconv.Itoa(healthCheckGracePeriod), "")
+	cliContext := cli.NewContext(nil, flagSet, nil)
+
+	// define existing service
+	serviceName := "test-service"
+	existingService := &ecs.Service{
+		TaskDefinition: aws.String("arn/test-task-def"),
+		Status:         aws.String("ACTIVE"),
+		DesiredCount:   aws.Int64(0),
+		ServiceName:    aws.String(serviceName),
+		LoadBalancers:  []*ecs.LoadBalancer{}, // LB required for HCGP, but not verified before calling client
+	}
+
+	// define expected client input given the above info
+	expectedInput := getDefaultUpdateInput()
+	expectedInput.serviceName = serviceName
+	expectedInput.healthCheckGracePeriod = aws.Int64(int64(healthCheckGracePeriod))
+
+	// call tests
+	upServiceWithCurrentTaskDefTest(t, cliContext, &config.CLIParams{}, &utils.ECSParams{}, expectedInput, existingService)
+	upServiceWithNewTaskDefTest(t, cliContext, &config.CLIParams{}, &utils.ECSParams{}, expectedInput, existingService)
+}
+
+func TestUpdateExistingServiceWithDesiredCountOverOne(t *testing.T) {
+	// define test values
+	existingDesiredCount := 2
+
+	flagSet := flag.NewFlagSet("ecs-cli-up", 0)
+	cliContext := cli.NewContext(nil, flagSet, nil)
+
+	// define existing service
+	serviceName := "test-service"
+	existingService := &ecs.Service{
+		TaskDefinition: aws.String("arn/test-task-def"),
+		Status:         aws.String("ACTIVE"),
+		DesiredCount:   aws.Int64(int64(existingDesiredCount)), // existing count > 1
+		ServiceName:    aws.String(serviceName),
+	}
+
+	// define expected client input given the above info
+	expectedInput := getDefaultUpdateInput()
+	expectedInput.serviceName = serviceName
+	expectedInput.count = *aws.Int64(int64(existingDesiredCount))
+
+	// call tests
+	upServiceWithCurrentTaskDefTest(t, cliContext, &config.CLIParams{}, &utils.ECSParams{}, expectedInput, existingService)
+	upServiceWithNewTaskDefTest(t, cliContext, &config.CLIParams{}, &utils.ECSParams{}, expectedInput, existingService)
+}
+
+func getDefaultUpdateInput() UpdateServiceParams {
+	return UpdateServiceParams{
+		deploymentConfig: &ecs.DeploymentConfiguration{},
+		count:            1,
+	}
+}
+
+func upServiceWithCurrentTaskDefTest(t *testing.T,
+	cliContext *cli.Context,
+	cliParams *config.CLIParams,
+	ecsParams *utils.ECSParams,
+	expectedInput UpdateServiceParams,
+	existingService *ecs.Service) {
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	// setup expected task def
+	taskDefID := "taskDefinitionId"
+	if existingService != nil {
+		// set to existing if provided
+		taskDefID = entity.GetIdFromArn(existingService.TaskDefinition)
+	}
+	taskDefArn, taskDefinition, registerTaskDefResponse := getTestTaskDef(taskDefID)
+
+	// setup DescribeService() response
+	describeServiceResponse := getDescribeServiceTestResponse(existingService)
+
+	mockEcs := mock_ecs.NewMockECSClient(ctrl)
+	gomock.InOrder(
+		mockEcs.EXPECT().DescribeService(gomock.Any()).Return(describeServiceResponse, nil),
+
+		mockEcs.EXPECT().RegisterTaskDefinitionIfNeeded(gomock.Any(), gomock.Any()).Do(func(x, y interface{}) {
+			verifyTaskDefinitionInput(t, taskDefinition, x.(*ecs.RegisterTaskDefinitionInput))
+		}).Return(&registerTaskDefResponse, nil),
+
+		mockEcs.EXPECT().UpdateServiceCount(
+			gomock.Any(), // serviceName
+			gomock.Any(), // count
+			gomock.Any(), // deploymentConfig
+			gomock.Any(), // networkConfig
+			gomock.Any(), // healthCheckGracePeriod
+			gomock.Any(), // force
+		).Do(func(a, b, c, d, e, f interface{}) {
+			// validate the client is called with the expected inputs
+			observedInput := UpdateServiceParams{
+				serviceName:            a.(string),
+				count:                  b.(int64),
+				deploymentConfig:       c.(*ecs.DeploymentConfiguration),
+				networkConfig:          d.(*ecs.NetworkConfiguration),
+				healthCheckGracePeriod: e.(*int64),
+				forceDeployment:        f.(bool),
+			}
+			assert.Equal(t, expectedInput, observedInput)
+
+		}).Return(nil),
+	)
+
+	context := &context.Context{
+		ECSClient:  mockEcs,
+		CLIParams:  cliParams,
+		CLIContext: cliContext,
+		ECSParams:  ecsParams,
+	}
+	if existingService != nil {
+		context.ProjectName = *existingService.ServiceName
+	}
+	service := NewService(context)
+	err := service.LoadContext()
+	assert.NoError(t, err, "Unexpected error while loading context in create service test")
+
+	service.SetTaskDefinition(&taskDefinition)
+	err = service.Up()
+	assert.NoError(t, err, "Unexpected error while create")
+
+	// task definition should be set
+	assert.Equal(t, taskDefArn, aws.StringValue(service.TaskDefinition().TaskDefinitionArn), "TaskDefArn should match")
+}
+
+func upServiceWithNewTaskDefTest(t *testing.T,
+	cliContext *cli.Context,
+	cliParams *config.CLIParams,
+	ecsParams *utils.ECSParams,
+	expectedInput UpdateServiceParams,
+	existingService *ecs.Service) {
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	// setup expected (new) task def
+	taskDefID := "newTaskDefinitionId"
+	taskDefArn, taskDefinition, registerTaskDefResponse := getTestTaskDef(taskDefID)
+
+	// expect input to include new task def
+	expectedInput.taskDefinition = taskDefID
+
+	// setup DescribeService() response
+	describeServiceResponse := getDescribeServiceTestResponse(existingService)
+
+	mockEcs := mock_ecs.NewMockECSClient(ctrl)
+	gomock.InOrder(
+		mockEcs.EXPECT().DescribeService(gomock.Any()).Return(describeServiceResponse, nil),
+
+		mockEcs.EXPECT().RegisterTaskDefinitionIfNeeded(gomock.Any(), gomock.Any()).Do(func(x, y interface{}) {
+			verifyTaskDefinitionInput(t, taskDefinition, x.(*ecs.RegisterTaskDefinitionInput))
+		}).Return(&registerTaskDefResponse, nil),
+
+		mockEcs.EXPECT().UpdateService(
+			gomock.Any(), // serviceName
+			gomock.Any(), // taskDefinition
+			gomock.Any(), // count
+			gomock.Any(), // deploymentConfig
+			gomock.Any(), // networkConfig
+			gomock.Any(), // healthCheckGracePeriod
+			gomock.Any(), // force
+		).Do(func(a, b, c, d, e, f, g interface{}) {
+			// validate the client is called with the expected inputs
+			observedInput := UpdateServiceParams{
+				serviceName:            a.(string),
+				taskDefinition:         b.(string),
+				count:                  c.(int64),
+				deploymentConfig:       d.(*ecs.DeploymentConfiguration),
+				networkConfig:          e.(*ecs.NetworkConfiguration),
+				healthCheckGracePeriod: f.(*int64),
+				forceDeployment:        g.(bool),
+			}
+			assert.Equal(t, expectedInput, observedInput)
+
+		}).Return(nil),
+	)
+
+	context := &context.Context{
+		ECSClient:  mockEcs,
+		CLIParams:  cliParams,
+		CLIContext: cliContext,
+		ECSParams:  ecsParams,
+	}
+	service := NewService(context)
+	err := service.LoadContext()
+	assert.NoError(t, err, "Unexpected error while loading context in create service test")
+
+	service.SetTaskDefinition(&taskDefinition)
+	err = service.Up()
+	assert.NoError(t, err, "Unexpected error while create")
+
+	// task definition should be set
+	assert.Equal(t, taskDefArn, aws.StringValue(service.TaskDefinition().TaskDefinitionArn), "TaskDefArn should match")
+}
+
+func getDescribeServiceTestResponse(existingService *ecs.Service) *ecs.DescribeServicesOutput {
+	describeFailure := &ecs.Failure{
+		Reason: aws.String("MISSING"),
+		Arn:    aws.String("arn:missing-service"),
+	}
+	existingServiceResponse := &ecs.DescribeServicesOutput{
+		Failures: []*ecs.Failure{},
+		Services: []*ecs.Service{existingService},
+	}
+	emptyDescribeServiceResponse := &ecs.DescribeServicesOutput{
+		Failures: []*ecs.Failure{describeFailure},
+		Services: []*ecs.Service{},
+	}
+	if existingService != nil {
+		return existingServiceResponse
+	}
+	return emptyDescribeServiceResponse
+}
+
+func getTestTaskDef(taskDefID string) (taskDefArn string, taskDefinition, registerTaskDefResponse ecs.TaskDefinition) {
+	taskDefArn = "arn/" + taskDefID
+	taskDefinition = ecs.TaskDefinition{
+		Family:               aws.String("family"),
+		ContainerDefinitions: []*ecs.ContainerDefinition{},
+		Volumes:              []*ecs.Volume{},
+	}
+	registerTaskDefResponse = taskDefinition
+	registerTaskDefResponse.TaskDefinitionArn = aws.String(taskDefArn)
+
+	return taskDefArn, taskDefinition, registerTaskDefResponse
+}
+
+func verifyTaskDefinitionInput(t *testing.T,
+	taskDef ecs.TaskDefinition,
+	regInput *ecs.RegisterTaskDefinitionInput) {
+	assert.Equal(t, aws.StringValue(taskDef.Family), aws.StringValue(regInput.Family), "Task Definition family should match")
 }

--- a/ecs-cli/modules/clients/aws/ecs/client.go
+++ b/ecs-cli/modules/clients/aws/ecs/client.go
@@ -191,7 +191,7 @@ func (c *ecsClient) UpdateService(serviceName, taskDefinition string, count int6
 		Service:                 aws.String(serviceName),
 		Cluster:                 aws.String(c.params.Cluster),
 		DeploymentConfiguration: deploymentConfig,
-		ForceNewDeployment:		&force,
+		ForceNewDeployment:      &force,
 	}
 
 	if healthCheckGracePeriod != nil {

--- a/ecs-cli/modules/clients/aws/ecs/client.go
+++ b/ecs-cli/modules/clients/aws/ecs/client.go
@@ -45,8 +45,8 @@ type ECSClient interface {
 
 	// Service related
 	CreateService(serviceName, taskDefName string, loadBalancer *ecs.LoadBalancer, role string, deploymentConfig *ecs.DeploymentConfiguration, networkConfig *ecs.NetworkConfiguration, launchType string, healthCheckGracePeriod *int64) error
-	UpdateServiceCount(serviceName string, count int64, deploymentConfig *ecs.DeploymentConfiguration, networkConfig *ecs.NetworkConfiguration, healthCheckGracePeriod *int64) error
-	UpdateService(serviceName, taskDefinitionName string, count int64, deploymentConfig *ecs.DeploymentConfiguration, networkConfig *ecs.NetworkConfiguration, healthCheckGracePeriod *int64) error
+	UpdateServiceCount(serviceName string, count int64, deploymentConfig *ecs.DeploymentConfiguration, networkConfig *ecs.NetworkConfiguration, healthCheckGracePeriod *int64, force bool) error
+	UpdateService(serviceName, taskDefinitionName string, count int64, deploymentConfig *ecs.DeploymentConfiguration, networkConfig *ecs.NetworkConfiguration, healthCheckGracePeriod *int64, force bool) error
 	DescribeService(serviceName string) (*ecs.DescribeServicesOutput, error)
 	DeleteService(serviceName string) error
 
@@ -181,16 +181,17 @@ func (c *ecsClient) CreateService(serviceName, taskDefName string, loadBalancer 
 	return nil
 }
 
-func (c *ecsClient) UpdateServiceCount(serviceName string, count int64, deploymentConfig *ecs.DeploymentConfiguration, networkConfig *ecs.NetworkConfiguration, healthCheckGracePeriod *int64) error {
-	return c.UpdateService(serviceName, "", count, deploymentConfig, networkConfig, healthCheckGracePeriod)
+func (c *ecsClient) UpdateServiceCount(serviceName string, count int64, deploymentConfig *ecs.DeploymentConfiguration, networkConfig *ecs.NetworkConfiguration, healthCheckGracePeriod *int64, force bool) error {
+	return c.UpdateService(serviceName, "", count, deploymentConfig, networkConfig, healthCheckGracePeriod, force)
 }
 
-func (c *ecsClient) UpdateService(serviceName, taskDefinition string, count int64, deploymentConfig *ecs.DeploymentConfiguration, networkConfig *ecs.NetworkConfiguration, healthCheckGracePeriod *int64) error {
+func (c *ecsClient) UpdateService(serviceName, taskDefinition string, count int64, deploymentConfig *ecs.DeploymentConfiguration, networkConfig *ecs.NetworkConfiguration, healthCheckGracePeriod *int64, force bool) error {
 	input := &ecs.UpdateServiceInput{
 		DesiredCount:            aws.Int64(count),
 		Service:                 aws.String(serviceName),
 		Cluster:                 aws.String(c.params.Cluster),
 		DeploymentConfiguration: deploymentConfig,
+		ForceNewDeployment:		&force,
 	}
 
 	if healthCheckGracePeriod != nil {

--- a/ecs-cli/modules/clients/aws/ecs/mock/client.go
+++ b/ecs-cli/modules/clients/aws/ecs/mock/client.go
@@ -214,22 +214,22 @@ func (_mr *_MockECSClientRecorder) StopTask(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "StopTask", arg0)
 }
 
-func (_m *MockECSClient) UpdateService(_param0 string, _param1 string, _param2 int64, _param3 *ecs.DeploymentConfiguration, _param4 *ecs.NetworkConfiguration, _param5 *int64) error {
-	ret := _m.ctrl.Call(_m, "UpdateService", _param0, _param1, _param2, _param3, _param4, _param5)
+func (_m *MockECSClient) UpdateService(_param0 string, _param1 string, _param2 int64, _param3 *ecs.DeploymentConfiguration, _param4 *ecs.NetworkConfiguration, _param5 *int64, _param6 bool) error {
+	ret := _m.ctrl.Call(_m, "UpdateService", _param0, _param1, _param2, _param3, _param4, _param5, _param6)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-func (_mr *_MockECSClientRecorder) UpdateService(arg0, arg1, arg2, arg3, arg4, arg5 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "UpdateService", arg0, arg1, arg2, arg3, arg4, arg5)
+func (_mr *_MockECSClientRecorder) UpdateService(arg0, arg1, arg2, arg3, arg4, arg5, arg6 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "UpdateService", arg0, arg1, arg2, arg3, arg4, arg5, arg6)
 }
 
-func (_m *MockECSClient) UpdateServiceCount(_param0 string, _param1 int64, _param2 *ecs.DeploymentConfiguration, _param3 *ecs.NetworkConfiguration, _param4 *int64) error {
-	ret := _m.ctrl.Call(_m, "UpdateServiceCount", _param0, _param1, _param2, _param3, _param4)
+func (_m *MockECSClient) UpdateServiceCount(_param0 string, _param1 int64, _param2 *ecs.DeploymentConfiguration, _param3 *ecs.NetworkConfiguration, _param4 *int64, _param5 bool) error {
+	ret := _m.ctrl.Call(_m, "UpdateServiceCount", _param0, _param1, _param2, _param3, _param4, _param5)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-func (_mr *_MockECSClientRecorder) UpdateServiceCount(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "UpdateServiceCount", arg0, arg1, arg2, arg3, arg4)
+func (_mr *_MockECSClientRecorder) UpdateServiceCount(arg0, arg1, arg2, arg3, arg4, arg5 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "UpdateServiceCount", arg0, arg1, arg2, arg3, arg4, arg5)
 }

--- a/ecs-cli/modules/commands/compose/service/compose_service_command.go
+++ b/ecs-cli/modules/commands/compose/service/compose_service_command.go
@@ -76,7 +76,7 @@ func startServiceCommand(factory composeFactory.ProjectFactory) cli.Command {
 		Name:         "start",
 		Usage:        "Starts one copy of each of the containers on an existing ECS service by setting the desired count to 1 (only if the current desired count is 0).",
 		Action:       compose.WithProject(factory, compose.ProjectStart, true),
-		Flags:        append(flags.OptionalConfigFlags(), ComposeServiceTimeoutFlag(), flags.OptionalCreateLogsFlag()),
+		Flags:        append(append(flags.OptionalConfigFlags(), ComposeServiceTimeoutFlag(), flags.OptionalCreateLogsFlag()), ForceNewDeploymentFlag()),
 		OnUsageError: flags.UsageErrorFactory("start"),
 	}
 }
@@ -86,7 +86,7 @@ func upServiceCommand(factory composeFactory.ProjectFactory) cli.Command {
 		Name:         "up",
 		Usage:        "Creates a new ECS service or updates an existing one according to your compose file. For new services or existing services with a current desired count of 0, the desired count for the service is set to 1. For existing services with non-zero desired counts, a new task definition is created to reflect any changes to the compose file and the service is updated to use that task definition. In this case, the desired count does not change.",
 		Action:       compose.WithProject(factory, compose.ProjectUp, true),
-		Flags:        append(append(append(deploymentConfigFlags(true), append(loadBalancerFlags(), flags.OptionalConfigFlags()...)...), ComposeServiceTimeoutFlag()), flags.OptionalLaunchTypeFlag(), flags.OptionalCreateLogsFlag()),
+		Flags:        append(append(append(append(deploymentConfigFlags(true), append(loadBalancerFlags(), flags.OptionalConfigFlags()...)...), ComposeServiceTimeoutFlag()), flags.OptionalLaunchTypeFlag(), flags.OptionalCreateLogsFlag()), ForceNewDeploymentFlag()),
 		OnUsageError: flags.UsageErrorFactory("up"),
 	}
 }
@@ -196,5 +196,12 @@ func ComposeServiceTimeoutFlag() cli.Flag {
 		Usage: fmt.Sprintf(
 			"Specifies the timeout value in minutes (decimals supported) to wait for the running task count to change. If the running task count has not changed for the specified period of time, then the CLI times out and returns an error. Setting the timeout to 0 will cause the command to return without checking for success.",
 		),
+	}
+}
+
+func ForceNewDeploymentFlag() cli.Flag {
+	return cli.BoolFlag{
+		Name:  flags.ForceDeploymentFlag,
+		Usage: "[Optional] Whether or not to force a new deployment of the service.",
 	}
 }

--- a/ecs-cli/modules/commands/flags/flags.go
+++ b/ecs-cli/modules/commands/flags/flags.go
@@ -106,6 +106,7 @@ const (
 	HealthCheckGracePeriodFlag              = "health-check-grace-period"
 	RoleFlag                                = "role"
 	ComposeServiceTimeOutFlag               = "timeout"
+	ForceDeploymentFlag                     = "force-deployment"
 )
 
 // OptionalRegionAndProfileFlags provides these flags:


### PR DESCRIPTION
## Usage examples
"compose service start" with --force-deployment on already running service
```
$>  .\bin\local\ecs-cli.exe compose --file .\httpd-new.yml --project-name httpd-new-test service start --force-deployment

time="2018-01-22T16:51:39-08:00" level=warning msg="Skipping unsupported YAML option..." option name=networks
time="2018-01-22T16:51:39-08:00" level=warning msg="Skipping unsupported YAML option for service..." option name=networks service name=httpd-new
time="2018-01-22T16:51:40-08:00" level=info msg="Forcing new deployment of running ECS Service" desiredCount=1 force-deployment=true serviceName=httpd-new-test
time="2018-01-22T16:51:40-08:00" level=info msg="Updated ECS service successfully" desiredCount=1 force-deployment=true serviceName=httpd-new-test
time="2018-01-22T16:51:40-08:00" level=info msg="Service status" desiredCount=1 runningCount=1 serviceName=httpd-new-test
time="2018-01-22T16:52:11-08:00" level=info msg="(service httpd-new-test) has started 1 tasks: (task 927ba872-4e52-4e62-a0bb-e6fb086b5130)." timestamp=2018-01-23 00:51:52 +0000 UTC
time="2018-01-22T16:52:11-08:00" level=info msg="(service httpd-new-test) has stopped 1 running tasks: (task 67c3535a-00cf-404e-b05f-5e7076d912d4)." timestamp=2018-01-23 00:52:05 +0000 UTC
time="2018-01-22T16:52:26-08:00" level=info msg="ECS Service has reached a stable state" desiredCount=1 runningCount=1 serviceName=httpd-new-test
```

"compose service up" with --force-deployment on already running service
```
$>  .\bin\local\ecs-cli.exe compose --file .\httpd-new.yml --project-name httpd-new-test service up --force-deployment

time="2018-01-22T16:43:36-08:00" level=warning msg="Skipping unsupported YAML option..." option name=networks
time="2018-01-22T16:43:36-08:00" level=warning msg="Skipping unsupported YAML option for service..." option name=networks service name=httpd-new
time="2018-01-22T16:43:37-08:00" level=info msg="Using ECS task definition" TaskDefinition="httpd-new-test:4" httpd-new-testtime="2018-01-22T16:43:37-08:00" level=info msg="Updated ECS service successfully" desiredCount=1 force-deployment=true serviceName=httpd-new-test
time="2018-01-22T16:43:37-08:00" level=info msg="Service status" desiredCount=1 runningCount=1 serviceName=httpd-new-test
time="2018-01-22T16:44:08-08:00" level=info msg="(service httpd-new-test) has started 1 tasks: (task e052a733-2210-42bd-b834-d209b9e395cb)." timestamp=2018-01-23 00:44:03 +0000 UTC
time="2018-01-22T16:44:23-08:00" level=info msg="Service status" desiredCount=1 runningCount=2 serviceName=httpd-new-test
time="2018-01-22T16:44:38-08:00" level=info msg="Service status" desiredCount=1 runningCount=1 serviceName=httpd-new-test
time="2018-01-22T16:44:38-08:00" level=info msg="(service httpd-new-test) has stopped 1 running tasks: (task 6c7453c5-3714-449b-bf67-bded9384ccd2)." timestamp=2018-01-23 00:44:25 +0000 UTC
time="2018-01-22T16:44:38-08:00" level=info msg="ECS Service has reached a stable state" desiredCount=1 runningCount=1 serviceName=httpd-new-test
```

## Unit test output
#### existing service tests
```
$> go test -timeout=120s -v -cover ./ecs-cli/modules/cli/compose/entity/service
=== RUN   TestCreateWithDeploymentConfig
time="2018-01-22T16:08:17-08:00" level=info msg="Using ECS task definition" TaskDefinition=taskDefinitionId
--- PASS: TestCreateWithDeploymentConfig (0.00s)
=== RUN   TestCreateWithoutDeploymentConfig
time="2018-01-22T16:08:17-08:00" level=info msg="Using ECS task definition" TaskDefinition=taskDefinitionId
--- PASS: TestCreateWithoutDeploymentConfig (0.00s)
=== RUN   TestCreateWithNetworkConfig
time="2018-01-22T16:08:17-08:00" level=info msg="Using ECS task definition" TaskDefinition=taskDefinitionId
--- PASS: TestCreateWithNetworkConfig (0.00s)
=== RUN   TestCreateFargate
time="2018-01-22T16:08:17-08:00" level=info msg="Using ECS task definition" TaskDefinition=taskDefinitionId
--- PASS: TestCreateFargate (0.00s)
=== RUN   TestCreateFargateNetworkModeNotAWSVPC
time="2018-01-22T16:08:17-08:00" level=info msg="Using ECS task definition" TaskDefinition=taskDefinitionId
--- PASS: TestCreateFargateNetworkModeNotAWSVPC (0.00s)
=== RUN   TestCreateEC2Explicitly
time="2018-01-22T16:08:17-08:00" level=info msg="Using ECS task definition" TaskDefinition=taskDefinitionId
--- PASS: TestCreateEC2Explicitly (0.00s)
=== RUN   TestCreateWithALB
time="2018-01-22T16:08:17-08:00" level=info msg="Using ECS task definition" TaskDefinition=taskDefinitionId
--- PASS: TestCreateWithALB (0.00s)
=== RUN   TestCreateWithHealthCheckGracePeriodAndALB
time="2018-01-22T16:08:17-08:00" level=info msg="Using ECS task definition" TaskDefinition=taskDefinitionId
--- PASS: TestCreateWithHealthCheckGracePeriodAndALB (0.00s)
=== RUN   TestCreateWithELB
time="2018-01-22T16:08:17-08:00" level=info msg="Using ECS task definition" TaskDefinition=taskDefinitionId
--- PASS: TestCreateWithELB (0.00s)
=== RUN   TestCreateWithHealthCheckGracePeriodAndELB
time="2018-01-22T16:08:17-08:00" level=info msg="Using ECS task definition" TaskDefinition=taskDefinitionId
--- PASS: TestCreateWithHealthCheckGracePeriodAndELB (0.00s)
=== RUN   TestLoadContext
--- PASS: TestLoadContext (0.00s)
=== RUN   TestLoadContextForIncorrectInput
--- PASS: TestLoadContextForIncorrectInput (0.00s)
=== RUN   TestLoadContextForLoadBalancerInputError
--- PASS: TestLoadContextForLoadBalancerInputError (0.00s)
=== RUN   TestServiceInfo
--- PASS: TestServiceInfo (0.00s)
=== RUN   TestServiceRun
```
#### new service tests
```
=== RUN   TestUpdateExistingServiceWithForceFlag
time="2018-01-22T16:31:34-08:00" level=info msg="Using ECS task definition" TaskDefinition=test-task-def
time="2018-01-22T16:31:34-08:00" level=info msg="Updated ECS service successfully" desiredCount=1 force-deployment=true serviceName=test-service
time="2018-01-22T16:31:34-08:00" level=warning msg="Timeout was specified as zero. Your service deployment may not have completed yet."
time="2018-01-22T16:31:34-08:00" level=info msg="Using ECS task definition" TaskDefinition=newTaskDefinitionId
time="2018-01-22T16:31:34-08:00" level=info msg="Updated the ECS service with a new task definition. Old containers will be stopped automatically, and replaced with new ones" desiredCount=1 serviceName=test-se
rvice taskDefinition=newTaskDefinitionId
time="2018-01-22T16:31:34-08:00" level=warning msg="Timeout was specified as zero. Your service deployment may not have completed yet."
--- PASS: TestUpdateExistingServiceWithForceFlag (0.01s)
=== RUN   TestUpdateExistingServiceWithNewDeploymentConfig
time="2018-01-22T16:31:34-08:00" level=info msg="Using ECS task definition" TaskDefinition=test-task-def time="2018-01-22T16:31:34-08:00" level=info msg="Updated ECS service successfully" deployment-max-percent=200 deployment-min-healthy-percent=100 desiredCount=1 serviceName=test-service
time="2018-01-22T16:31:34-08:00" level=warning msg="Timeout was specified as zero. Your service deployment may not have completed yet." time="2018-01-22T16:31:34-08:00" level=info msg="Using ECS task definition" TaskDefinition=newTaskDefinitionId 
time="2018-01-22T16:31:34-08:00" level=info msg="Updated the ECS service with a new task definition. Old containers will be stopped automatically, and replaced with new ones" deployment-max-percent=200 deployment-min-healthy-percent=100 desiredCount=1 serviceName=test-service taskDefinition=newTaskDefinitionId
time="2018-01-22T16:31:34-08:00" level=warning msg="Timeout was specified as zero. Your service deployment may not have completed yet."
--- PASS: TestUpdateExistingServiceWithNewDeploymentConfig (0.01s)
=== RUN   TestUpdateExistingServiceWithNewHCGP
time="2018-01-22T16:31:34-08:00" level=info msg="Using ECS task definition" TaskDefinition=test-task-def time="2018-01-22T16:31:34-08:00" level=info msg="Updated ECS service successfully" desiredCount=1 health-check-grace-period=200 serviceName=test-service
time="2018-01-22T16:31:34-08:00" level=warning msg="Timeout was specified as zero. Your service deployment may not have completed yet." 
time="2018-01-22T16:31:34-08:00" level=info msg="Using ECS task definition" TaskDefinition=newTaskDefinitionId time="2018-01-22T16:31:34-08:00" level=info msg="Updated the ECS service with a new task definition. Old containers will be stopped automatically, and replaced with new ones" desiredCount=1 health-check-grace-period=200 serviceName=test-service taskDefinition=newTaskDefinitionId 
time="2018-01-22T16:31:34-08:00" level=warning msg="Timeout was specified as zero. Your service deployment may not have completed yet."
--- PASS: TestUpdateExistingServiceWithNewHCGP (0.00s)
=== RUN   TestUpdateExistingServiceWithDesiredCountOverOne
time="2018-01-22T16:31:34-08:00" level=info msg="Using ECS task definition" TaskDefinition=test-task-def time="2018-01-22T16:31:34-08:00" level=info msg="Updated ECS service successfully" desiredCount=2 serviceName=test-service
time="2018-01-22T16:31:34-08:00" level=warning msg="Timeout was specified as zero. Your service deployment may not have completed yet."
time="2018-01-22T16:31:34-08:00" level=info msg="Using ECS task definition" TaskDefinition=newTaskDefinitionId
time="2018-01-22T16:31:34-08:00" level=info msg="Updated the ECS service with a new task definition. Old containers will be stopped automatically, and replaced with new ones" desiredCount=2 serviceName=test-service taskDefinition=newTaskDefinitionId
time="2018-01-22T16:31:34-08:00" level=warning msg="Timeout was specified as zero. Your service deployment may not have completed yet."
--- PASS: TestUpdateExistingServiceWithDesiredCountOverOne (0.01s)
PASS
coverage: 56.7% of statements
ok      github.com/aws/amazon-ecs-cli/ecs-cli/modules/cli/compose/entity/service        1.066s
```