### PR TITLE
Remove UpdateServiceCount() method from service, client

### DIFF
--- a/ecs-cli/modules/cli/compose/entity/service/service.go
+++ b/ecs-cli/modules/cli/compose/entity/service/service.go
@@ -243,9 +243,6 @@ func (s *Service) Up() error {
 		}).Warn("You cannot update the load balancer configuration on an existing service.")
 	}
 
-	oldTaskDefinitionId := entity.GetIdFromArn(ecsService.TaskDefinition)
-	newTaskDefinitionId := entity.GetIdFromArn(newTaskDefinition.TaskDefinitionArn)
-
 	oldCount := aws.Int64Value(ecsService.DesiredCount)
 	newCount := int64(1)
 	if oldCount != 0 {
@@ -253,6 +250,9 @@ func (s *Service) Up() error {
 	}
 
 	// if both the task definitions are the same, call update with the new count
+	oldTaskDefinitionId := entity.GetIdFromArn(ecsService.TaskDefinition)
+	newTaskDefinitionId := entity.GetIdFromArn(newTaskDefinition.TaskDefinitionArn)
+
 	if oldTaskDefinitionId == newTaskDefinitionId {
 		return s.updateService(newCount)
 	}
@@ -432,7 +432,7 @@ func (s *Service) updateService(count int64) error {
 		return err
 	}
 
-	if err = s.Context().ECSClient.UpdateServiceCount(serviceName, count, deploymentConfig, networkConfig, s.healthCheckGP, forceDeployment); err != nil {
+	if err = s.Context().ECSClient.UpdateService(serviceName, "", count, deploymentConfig, networkConfig, s.healthCheckGP, forceDeployment); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Removed UpdateServiceCount() client method and simplified Up() unit tests. 


### "compose service up" output (unchanged)
```
$> .\bin\local\ecs-cli.exe compose --file ...\httpd-new.yml --project-name httpd-new-test --ecs-params ...\ecs-params.yml service up --deployment-max-percent 251 --deployment-min-healthy-percent 53
time="2018-01-31T15:25:19-08:00" level=info msg="Using ECS task definition" TaskDefinition="httpd-new-test:7"
time="2018-01-31T15:25:20-08:00" level=info msg="Updated ECS service successfully" deployment-max-percent=251 deployment-min-healthy-percent=53 desiredCount=1 serviceName=httpd-new-test
time="2018-01-31T15:25:20-08:00" level=info msg="Service status" desiredCount=1 runningCount=1 serviceName=httpd-new-test
time="2018-01-31T15:25:20-08:00" level=info msg="ECS Service has reached a stable state" desiredCount=1 runningCount=1 serviceName=httpd-new-test
```

### service tests output
```
...
=== RUN   TestUpdateExistingServiceWithDesiredCountOverOne
time="2018-01-31T15:28:21-08:00" level=info msg="Using ECS task definition" TaskDefinition=test-task-def
time="2018-01-31T15:28:21-08:00" level=info msg="Updated ECS service successfully" desiredCount=2 serviceName=test-service
time="2018-01-31T15:28:21-08:00" level=warning msg="Timeout was specified as zero. Your service deployment may not have completed yet."
time="2018-01-31T15:28:21-08:00" level=info msg="Using ECS task definition" TaskDefinition=newTaskDefinitionId
time="2018-01-31T15:28:21-08:00" level=info msg="Updated the ECS service with a new task definition. Old containers will be stopped automatically, and replaced with new ones" desiredCount=2 serviceName=test-service taskDefinition=newTaskDefinitionId
time="2018-01-31T15:28:21-08:00" level=warning msg="Timeout was specified as zero. Your service deployment may not have completed yet."
--- PASS: TestUpdateExistingServiceWithDesiredCountOverOne (0.01s)
PASS
coverage: 56.7% of statements
ok      github.com/aws/amazon-ecs-cli/ecs-cli/modules/cli/compose/entity/service        0.533s
```

### client test output
```
...
=== RUN   TestGetEC2InstanceIDs
--- PASS: TestGetEC2InstanceIDs (0.00s)
=== RUN   TestGetEC2InstanceIDsWithEmptyArns
--- PASS: TestGetEC2InstanceIDsWithEmptyArns (0.00s)
=== RUN   TestGetEC2InstanceIDsWithNoEc2InstanceID
--- PASS: TestGetEC2InstanceIDsWithNoEc2InstanceID (0.00s)
=== RUN   TestGetEC2InstanceIDsErrorCase
time="2018-01-31T15:32:47-08:00" level=error msg="Error describing container instance" containerInstancesCount=1 error="something wrong"
--- PASS: TestGetEC2InstanceIDsErrorCase (0.00s)
PASS
coverage: 46.7% of statements
ok      github.com/aws/amazon-ecs-cli/ecs-cli/modules/clients/aws/ecs   0.678s
```