### PR TITLE
Remove UpdateServiceCount from ecs client, regen mocks

### DIFF
--- a/ecs-cli/modules/clients/aws/ecs/client.go
+++ b/ecs-cli/modules/clients/aws/ecs/client.go
@@ -45,7 +45,6 @@ type ECSClient interface {
 
 	// Service related
 	CreateService(serviceName, taskDefName string, loadBalancer *ecs.LoadBalancer, role string, deploymentConfig *ecs.DeploymentConfiguration, networkConfig *ecs.NetworkConfiguration, launchType string, healthCheckGracePeriod *int64) error
-	UpdateServiceCount(serviceName string, count int64, deploymentConfig *ecs.DeploymentConfiguration, networkConfig *ecs.NetworkConfiguration, healthCheckGracePeriod *int64, force bool) error
 	UpdateService(serviceName, taskDefinitionName string, count int64, deploymentConfig *ecs.DeploymentConfiguration, networkConfig *ecs.NetworkConfiguration, healthCheckGracePeriod *int64, force bool) error
 	DescribeService(serviceName string) (*ecs.DescribeServicesOutput, error)
 	DeleteService(serviceName string) error
@@ -179,10 +178,6 @@ func (c *ecsClient) CreateService(serviceName, taskDefName string, loadBalancer 
 
 	log.WithFields(fields).Info("Created an ECS service")
 	return nil
-}
-
-func (c *ecsClient) UpdateServiceCount(serviceName string, count int64, deploymentConfig *ecs.DeploymentConfiguration, networkConfig *ecs.NetworkConfiguration, healthCheckGracePeriod *int64, force bool) error {
-	return c.UpdateService(serviceName, "", count, deploymentConfig, networkConfig, healthCheckGracePeriod, force)
 }
 
 func (c *ecsClient) UpdateService(serviceName, taskDefinition string, count int64, deploymentConfig *ecs.DeploymentConfiguration, networkConfig *ecs.NetworkConfiguration, healthCheckGracePeriod *int64, force bool) error {

--- a/ecs-cli/modules/clients/aws/ecs/mock/client.go
+++ b/ecs-cli/modules/clients/aws/ecs/mock/client.go
@@ -223,13 +223,3 @@ func (_m *MockECSClient) UpdateService(_param0 string, _param1 string, _param2 i
 func (_mr *_MockECSClientRecorder) UpdateService(arg0, arg1, arg2, arg3, arg4, arg5, arg6 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "UpdateService", arg0, arg1, arg2, arg3, arg4, arg5, arg6)
 }
-
-func (_m *MockECSClient) UpdateServiceCount(_param0 string, _param1 int64, _param2 *ecs.DeploymentConfiguration, _param3 *ecs.NetworkConfiguration, _param4 *int64, _param5 bool) error {
-	ret := _m.ctrl.Call(_m, "UpdateServiceCount", _param0, _param1, _param2, _param3, _param4, _param5)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-func (_mr *_MockECSClientRecorder) UpdateServiceCount(arg0, arg1, arg2, arg3, arg4, arg5 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "UpdateServiceCount", arg0, arg1, arg2, arg3, arg4, arg5)
-}


### PR DESCRIPTION
Client refactor & mock regen for https://github.com/aws/amazon-ecs-cli/pull/422

### test output
```
...
=== RUN   TestGetIdFromArn
--- PASS: TestGetIdFromArn (0.00s)
PASS
coverage: 85.6% of statements
ok  	github.com/aws/amazon-ecs-cli/ecs-cli/modules/utils/compose	0.012s	coverage: 85.6% of statements
?   	github.com/aws/amazon-ecs-cli/ecs-cli/modules/utils/logger	[no test files]
?   	github.com/aws/amazon-ecs-cli/ecs-cli/modules/utils/waiters	[no test files]
?   	github.com/aws/amazon-ecs-cli/ecs-cli/modules/version	[no test files]
?   	github.com/aws/amazon-ecs-cli/ecs-cli/modules/version/gen	[no test files]
```