### PR TITLE
make regex only accept 8 and 17 character hex

### DIFF
--- a/ecs-cli/modules/clients/aws/cloudformation/template.go
+++ b/ecs-cli/modules/clients/aws/cloudformation/template.go
@@ -155,7 +155,7 @@ var template = `
       "Type": "String",
       "Description": "Optional - VPC Id of existing VPC. Leave blank to have a new VPC created",
       "Default": "",
-      "AllowedPattern": "^(?:vpc-[0-9a-f]{8}|)$",
+      "AllowedPattern": "^(?:vpc-[0-9a-f]{8}|vpc-[0-9a-f]{17}|)$",
       "ConstraintDescription": "VPC Id must begin with 'vpc-' or leave blank to have a new VPC created"
     },
     "SubnetIds": {


### PR DESCRIPTION
make regex only accept 8 and 17 character hex for the VPC ID

new pull request for case #431 