### PR TITLE
In hashing task definitions, also sort containers by Name

### DIFF
--- a/ecs-cli/modules/cli/compose/adapter/convert.go
+++ b/ecs-cli/modules/cli/compose/adapter/convert.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"reflect"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -502,6 +503,17 @@ func SortedGoString(v interface{}) (string, error) {
 		return "", err
 	}
 	return string(b), nil
+}
+
+// Necessary in conjunction with SortedGoString to avoid spurious tdcache misses
+func SortedContainerDefinitionsByName(request *ecs.RegisterTaskDefinitionInput) ecs.RegisterTaskDefinitionInput {
+	cdefs := request.ContainerDefinitions
+	sort.Slice(cdefs, func(i, j int) bool {
+		return *cdefs[i].Name < *cdefs[j].Name
+	})
+	sorted := *request
+	sorted.ContainerDefinitions = cdefs
+	return sorted
 }
 
 // ConvertCamelCaseToUnderScore returns an underscore-separated name for a given camelcased string

--- a/ecs-cli/modules/clients/aws/ecs/client.go
+++ b/ecs-cli/modules/clients/aws/ecs/client.go
@@ -310,7 +310,7 @@ func (c *ecsClient) constructTaskDefinitionCacheHash(taskDefinition *ecs.TaskDef
 	// Get the region from the ecsClient configuration
 	region := aws.StringValue(c.config.Session.Config.Region)
 	awsUserAccountId := utils.GetAwsAccountIdFromArn(aws.StringValue(taskDefinition.TaskDefinitionArn))
-	sortedRequestString, err := adapter.SortedGoString(request)
+	sortedRequestString, err := adapter.SortedGoString(adapter.SortedContainerDefinitionsByName(request))
 	if err != nil {
 		log.WithFields(log.Fields{
 			"error": err,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* [Range over map](https://github.com/aws/amazon-ecs-cli/blob/c7335b0259cc1fe526b751d7bc540730e09df2c7/ecs-cli/modules/compose/ecs/utils/convert_task_definition.go#L48) produces a nondeterministic ordering of container defs, thereby requiring task definition cache keys (the "tdcache") to sort on them (lest the cli mistakenly believe them to be changed, which remains relatively innocuous). 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.