### PR TITLE
Fail with an informative error message if cluster isn't set

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ bin/
 *.orig
 ecs-cli/vendor/pkg
 .vscode/*
+.idea/*


### PR DESCRIPTION
The CLI help indicates the cluster and region flags are optional.
However, this is only true if defaults are stored in .ecs/*

This commit checks for the presence of the 'cluster' flag, and
throws an error if not set. This way, we won't call the ECS API
and we present a clearer failure message.

### Examples:


#### Current (makes network call, unclear error)
```
➜  ecs-cli scale --capability-iam --size 0
FATA[0000] Error executing 'scale': InvalidParameterException: Clusters can not be blank.
	status code: 400, request id: b636f430-2ef5-11e8-bfed-5775413ad506
➜  ecs-cli ps
FATA[0000] Error executing 'ps InvalidParameterException: Clusters can not be blank.
	status code: 400, request id: 8e9625e2-2ef5-11e8-be00-2f76bba63d2b
```
#### New behavior (fails fast, reuses error from ecs-cli up)

```
➜  ecs-cli scale --capability-iam --size 0
FATA[0000] Error executing 'scale': Please configure a cluster using the configure command or the '--cluster' flag
➜  ecs-cli ps
FATA[0000] Error executing 'ps': Please configure a cluster using the configure command or the '--cluster' flag
```