### PR TITLE
Make `make test` pass with Go 1.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,9 @@ os:
     - osx
 go_import_path: github.com/aws/amazon-ecs-cli
 go:
-    - 1.8
+    - 1.8.x
+    - 1.9.x
+    - 1.10.x
 script:
     - make test
     - make

--- a/ecs-cli/modules/cli/compose/container/container_test.go
+++ b/ecs-cli/modules/cli/compose/container/container_test.go
@@ -79,7 +79,7 @@ func TestStatus(t *testing.T) {
 	ecsCont.ExitCode = aws.Int64(int64(exitCode))
 	state = container.State()
 	if !strings.Contains(state, strconv.Itoa(exitCode)) {
-		t.Errorf("Expected state to contain [%s] but got [%s]", exitCode, state)
+		t.Errorf("Expected state to contain [%d] but got [%s]", exitCode, state)
 	}
 }
 

--- a/ecs-cli/modules/cli/compose/project/project_test.go
+++ b/ecs-cli/modules/cli/compose/project/project_test.go
@@ -111,7 +111,7 @@ redis:
 	project.context.ComposeBytes = composeBytes
 
 	if err := project.parseCompose(); err != nil {
-		t.Fatalf("Unexpected error parsing the compose string [%s]", composeFileString, err)
+		t.Fatalf("Unexpected error parsing the compose string [%s]: %v", composeFileString, err)
 	}
 
 	if testProjectName != project.context.ProjectName {
@@ -131,7 +131,7 @@ redis:
 		t.Fatalf("Expected [%s] as a service but got configs [%v]", "web", configs)
 	}
 	if cpuShares != int64(web.CPUShares) {
-		t.Errorf("Expected cpuShares to be [%s] but got [%s]", cpuShares, web.CPUShares)
+		t.Errorf("Expected cpuShares to be [%d] but got [%d]", cpuShares, web.CPUShares)
 	}
 	if len(web.Command) != 1 || !reflect.DeepEqual(command[0], web.Command[0]) {
 		t.Errorf("Expected command to be [%v] but got [%v]", command, web.Command)
@@ -175,16 +175,16 @@ redis:
 		t.Errorf("Expected logOpts to be [%v] but got [%v]", logOpts, web.Logging.Options)
 	}
 	if memLimit != int64(web.MemLimit) {
-		t.Errorf("Expected memLimit to be [%s] but got [%s]", memLimit, web.MemLimit)
+		t.Errorf("Expected memLimit to be [%d] but got [%d]", memLimit, web.MemLimit)
 	}
 	if !reflect.DeepEqual(ports, web.Ports) {
 		t.Errorf("Expected ports to be [%v] but got [%v]", ports, web.Ports)
 	}
 	if privileged != web.Privileged {
-		t.Errorf("Expected privileged to be [%s] but got [%s]", privileged, web.Privileged)
+		t.Errorf("Expected privileged to be [%t] but got [%t]", privileged, web.Privileged)
 	}
 	if readonly != web.ReadOnly {
-		t.Errorf("Expected readonly to be [%s] but got [%s]", readonly, web.ReadOnly)
+		t.Errorf("Expected readonly to be [%t] but got [%t]", readonly, web.ReadOnly)
 	}
 	if !reflect.DeepEqual(securityOpts, web.SecurityOpt) {
 		t.Errorf("Expected securityOpts to be [%v] but got [%v]", securityOpts, web.SecurityOpt)
@@ -226,7 +226,7 @@ services:
 	project.context.ComposeBytes = composeBytes
 
 	if err := project.parseCompose(); err != nil {
-		t.Fatalf("Unexpected error parsing the compose string [%s]", composeFileString, err)
+		t.Fatalf("Unexpected error parsing the compose string [%s]: %v", composeFileString, err)
 	}
 
 	configs := project.ServiceConfigs()
@@ -277,7 +277,7 @@ func TestParseComposeForVersion1WithEnvFile(t *testing.T) {
 	project.context.ComposeBytes = composeBytes
 
 	if err := project.parseCompose(); err != nil {
-		t.Fatalf("Unexpected error parsing the compose string [%s]", composeFileString, err)
+		t.Fatalf("Unexpected error parsing the compose string [%s]: %v", composeFileString, err)
 	}
 
 	configs := project.ServiceConfigs()
@@ -328,7 +328,7 @@ run_params:
 	assert.NoError(t, err, "Could not write data to ecs fields tempfile")
 
 	if err := project.parseECSParams(); err != nil {
-		t.Fatalf("Unexpected error parsing the ecs-params data: %v", ecsParamsString, err)
+		t.Fatalf("Unexpected error parsing the ecs-params data [%s]: %v", ecsParamsString, err)
 	}
 
 	ecsParams := project.context.ECSParams

--- a/ecs-cli/modules/cli/license/license_test.go
+++ b/ecs-cli/modules/cli/license/license_test.go
@@ -24,7 +24,7 @@ func TestVendorDirectoryStructure(t *testing.T) {
 
 	directories, _ := ioutil.ReadDir("./../../../vendor")
 	if len(directories) != expectedDirCount {
-		t.Errorf("Should have exactly 3 directories under vendor/. Found [%s] directories", len(directories))
+		t.Errorf("Should have exactly 3 directories under vendor/. Found [%d] directories", len(directories))
 	}
 	foundDirCount := 0
 	for _, dir := range directories {

--- a/ecs-cli/modules/config/config.go
+++ b/ecs-cli/modules/config/config.go
@@ -26,11 +26,11 @@ const (
 // This is to allow us to read old ini based config files
 // CliConfig has been updated to use the yaml annotations
 type iniCLIConfig struct {
-	*iniSectionKeys `ini:"ecs"`
+	*IniSectionKeys `ini:"ecs"`
 }
 
 // SectionKeys is the struct embedded in iniCLIConfig. It groups all the keys in the 'ecs' section in the ini file.
-type iniSectionKeys struct {
+type IniSectionKeys struct {
 	Cluster                  string `ini:"cluster"`
 	AwsProfile               string `ini:"aws_profile"`
 	Region                   string `ini:"region"`

--- a/ecs-cli/modules/config/readwriter.go
+++ b/ecs-cli/modules/config/readwriter.go
@@ -64,7 +64,7 @@ func NewINIReadWriter(dest *Destination) (*INIReadWriter, error) {
 func (rdwr *INIReadWriter) GetConfig(cliConfig *CLIConfig) error {
 
 	// read old ini formatted file
-	iniFormat := &iniCLIConfig{iniSectionKeys: new(iniSectionKeys)}
+	iniFormat := &iniCLIConfig{IniSectionKeys: &IniSectionKeys{}}
 	if err := rdwr.cfg.MapTo(iniFormat); err != nil {
 		return err
 	}

--- a/ecs-cli/modules/config/readwriter_v1.go
+++ b/ecs-cli/modules/config/readwriter_v1.go
@@ -40,7 +40,7 @@ type ReadWriter interface {
 	Get(string, string) (*CLIConfig, error)
 }
 
-// YAMLReadWriter implments the ReadWriter interfaces. It can be used to save and load
+// YAMLReadWriter implements the ReadWriter interfaces. It can be used to save and load
 // ecs-cli config. Sample ecs-cli config:
 // cluster: test
 // aws_profile:

--- a/ecs-cli/modules/utils/compose/convert_task_definition_test.go
+++ b/ecs-cli/modules/utils/compose/convert_task_definition_test.go
@@ -82,7 +82,7 @@ func TestConvertToTaskDefinition(t *testing.T) {
 		t.Errorf("Expected Name [%s] But was [%s]", name, aws.StringValue(containerDef.Name))
 	}
 	if cpu != aws.Int64Value(containerDef.Cpu) {
-		t.Errorf("Expected cpu [%s] But was [%s]", cpu, aws.Int64Value(containerDef.Cpu))
+		t.Errorf("Expected cpu [%d] But was [%d]", cpu, aws.Int64Value(containerDef.Cpu))
 	}
 	if len(containerDef.Command) != 1 || command != aws.StringValue(containerDef.Command[0]) {
 		t.Errorf("Expected command [%s] But was [%v]", command, containerDef.Command)
@@ -100,16 +100,16 @@ func TestConvertToTaskDefinition(t *testing.T) {
 		t.Errorf("Expected links [%v] But was [%v]", links, aws.StringValueSlice(containerDef.Links))
 	}
 	if memory != aws.Int64Value(containerDef.Memory) {
-		t.Errorf("Expected memory [%s] But was [%s]", memory, aws.Int64Value(containerDef.Memory))
+		t.Errorf("Expected memory [%d] But was [%d]", memory, aws.Int64Value(containerDef.Memory))
 	}
 
 	assert.Equal(t, memoryReservation, aws.Int64Value(containerDef.MemoryReservation), "Expected memoryReservation to match")
 
 	if privileged != aws.BoolValue(containerDef.Privileged) {
-		t.Errorf("Expected privileged [%s] But was [%s]", privileged, aws.BoolValue(containerDef.Privileged))
+		t.Errorf("Expected privileged [%t] But was [%t]", privileged, aws.BoolValue(containerDef.Privileged))
 	}
 	if readOnly != aws.BoolValue(containerDef.ReadonlyRootFilesystem) {
-		t.Errorf("Expected ReadonlyRootFilesystem [%s] But was [%s]", readOnly, aws.BoolValue(containerDef.ReadonlyRootFilesystem))
+		t.Errorf("Expected ReadonlyRootFilesystem [%t] But was [%t]", readOnly, aws.BoolValue(containerDef.ReadonlyRootFilesystem))
 	}
 	if user != aws.StringValue(containerDef.User) {
 		t.Errorf("Expected user [%s] But was [%s]", user, aws.StringValue(containerDef.User))
@@ -778,10 +778,10 @@ func verifyPortMapping(t *testing.T, output *ecs.PortMapping, hostPort, containe
 		t.Errorf("Expected protocol [%s] But was [%s]", protocol, *output.Protocol)
 	}
 	if hostPort != *output.HostPort {
-		t.Errorf("Expected hostPort [%s] But was [%s]", hostPort, *output.HostPort)
+		t.Errorf("Expected hostPort [%d] But was [%d]", hostPort, *output.HostPort)
 	}
 	if containerPort != *output.ContainerPort {
-		t.Errorf("Expected containerPort [%s] But was [%s]", containerPort, *output.ContainerPort)
+		t.Errorf("Expected containerPort [%d] But was [%d]", containerPort, *output.ContainerPort)
 	}
 }
 
@@ -934,10 +934,10 @@ func verifyUlimit(t *testing.T, output *ecs.Ulimit, name string, softLimit, hard
 		t.Errorf("Expected name [%s] But was [%s]", name, *output.Name)
 	}
 	if softLimit != *output.SoftLimit {
-		t.Errorf("Expected softLimit [%s] But was [%s]", softLimit, *output.SoftLimit)
+		t.Errorf("Expected softLimit [%d] But was [%d]", softLimit, *output.SoftLimit)
 	}
 	if hardLimit != *output.HardLimit {
-		t.Errorf("Expected hardLimit [%s] But was [%s]", hardLimit, *output.HardLimit)
+		t.Errorf("Expected hardLimit [%d] But was [%d]", hardLimit, *output.HardLimit)
 	}
 }
 
@@ -1067,7 +1067,7 @@ func TestIsZeroWhenConfigHasValues(t *testing.T) {
 		zeroValue := isZero(f)
 		_, hasValue := hasValues[fieldName]
 		if zeroValue == hasValue {
-			t.Errorf("Expected field [%s]: hasValues[%t] but found[%t]", ft.Name, hasValues, !zeroValue)
+			t.Errorf("Expected field [%s]: hasValues[%v] but found[%t]", ft.Name, hasValues, !zeroValue)
 		}
 	}
 }


### PR DESCRIPTION
Fixes #441 

Tests were failing for two reasons:

1. Incorrect verbs in `Errorf` and `Fatalf` (`go test` is a bit more strict about that now)
2. A change in behavior around reflection: Prior to Go 1.10, a reflection bug allowed embedded pointers to unexported struct types to be incorrectly accessible.  Go 1.10 fixed this bug, which broke the CLI's ability to set values in the unexported iniSectionKeys struct pointer embedded in the iniCLIConfig struct.  See https://golang.org/doc/go1.10#reflect.

I also added Travis support for Go 1.9 and 1.10 so we actually test with those versions too.