### PR TITLE
Add waiter for service creation - Fix for issue 79

### DIFF
--- a/ecs-cli/modules/cli/compose/entity/service/service.go
+++ b/ecs-cli/modules/cli/compose/entity/service/service.go
@@ -235,6 +235,10 @@ func (s *Service) Up() error {
 		if err != nil {
 			return err
 		}
+		err = waitForServiceDescribable(s)
+		if err != nil {
+			return err
+		}
 		return s.Start()
 	}
 


### PR DESCRIPTION
*Issue #, if available:* #79 

*Description of changes:* Insert a `waitForServiceDescribable()` in `Up()`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
