### PR TITLE
Support forward slash in image names

### DIFF
--- a/ecs-cli/modules/cli/image/image_app.go
+++ b/ecs-cli/modules/cli/image/image_app.go
@@ -21,7 +21,6 @@ import (
 	"text/tabwriter"
 	"time"
 
-	"github.com/sirupsen/logrus"
 	ecrclient "github.com/aws/amazon-ecs-cli/ecs-cli/modules/clients/aws/ecr"
 	stsclient "github.com/aws/amazon-ecs-cli/ecs-cli/modules/clients/aws/sts"
 	dockerclient "github.com/aws/amazon-ecs-cli/ecs-cli/modules/clients/docker"
@@ -31,6 +30,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/ecr"
 	units "github.com/docker/go-units"
 	docker "github.com/fsouza/go-dockerclient"
+	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 )
 
@@ -301,7 +301,7 @@ func splitImageName(image string, seperatorRegExp string,
 	format string) (registry string, repository string, tag string, err error) {
 
 	re := regexp.MustCompile(
-		`^(?:([0-9A-Za-z.\-]+)/)?` + // repository uri (Optional)
+		`^(?:((?:[a-zA-Z0-9][a-zA-Z0-9-_]*)\.dkr\.ecr\.[a-zA-Z0-9\-_]+\.amazonaws\.com(?:\.cn)?)/)?` + // repository uri (Optional)
 			`([0-9a-z\-_/]+)` + // repository
 			`(?:` + seperatorRegExp + `([0-9A-Za-z_.\-:]+))?$`) // tag (Optional)
 	matches := re.FindStringSubmatch(image)

--- a/ecs-cli/modules/cli/image/image_app_test.go
+++ b/ecs-cli/modules/cli/image/image_app_test.go
@@ -34,13 +34,14 @@ import (
 )
 
 const (
-	repository    = "repository"
-	tag           = "tag-v0.1.0"
-	image         = repository + ":" + tag
-	registry      = "registry"
-	registryID    = "123456789"
-	repositoryURI = registry + "/" + repository
-	clusterName   = "defaultCluster"
+	repository          = "repository"
+	repositoryWithSlash = "hi/repo"
+	tag                 = "tag-v0.1.0"
+	image               = repository + ":" + tag
+	registry            = "registry"
+	registryID          = "123456789"
+	repositoryURI       = registry + "/" + repository
+	clusterName         = "defaultCluster"
 )
 
 type mockReadWriter struct {
@@ -349,6 +350,71 @@ func TestSplitImageNameWithSha256(t *testing.T) {
 	assert.Empty(t, observedRegistryURI, "RegistryURI should be empty")
 	assert.Equal(t, repository, observedRepo, "Repository should match")
 	assert.Equal(t, sha, observedTag, "Tag should match")
+	assert.NoError(t, err, "Error splitting image name")
+}
+
+func TestSplitImageNameWithSlashInImageName(t *testing.T) {
+	expectedImage := repositoryWithSlash
+	observedRegistryURI, observedRepo, observedTag, err := splitImageName(expectedImage, "[:|@]", "format")
+
+	assert.Empty(t, observedRegistryURI, "RegistryURI should be empty")
+	assert.Equal(t, repositoryWithSlash, observedRepo, "Repository should match")
+	assert.Empty(t, observedTag, "Tag should be empty")
+	assert.NoError(t, err, "Error splitting image name")
+}
+
+func TestSplitImageNameWithSlashInImageNameAndSha256(t *testing.T) {
+	sha := "sha256:0b3787ac21ffb4edbd6710e0e60f991d5ded8d8a4f558209ef5987f73db4211a"
+	expectedImage := repositoryWithSlash + "@" + sha
+	observedRegistryURI, observedRepo, observedTag, err := splitImageName(expectedImage, "[:|@]", "format")
+
+	assert.Empty(t, observedRegistryURI, "RegistryURI should be empty")
+	assert.Equal(t, repositoryWithSlash, observedRepo, "Repository should match")
+	assert.Equal(t, sha, observedTag, "Tag should match")
+	assert.NoError(t, err, "Error splitting image name")
+}
+
+func TestSplitImageNameWithSlashInImageNameAndSha256AndURI(t *testing.T) {
+	sha := "sha256:0b3787ac21ffb4edbd6710e0e60f991d5ded8d8a4f558209ef5987f73db4211a"
+	uri := "012345678912.dkr.ecr.us-east-1.amazonaws.com"
+	expectedImage := uri + "/" + repositoryWithSlash + "@" + sha
+	observedRegistryURI, observedRepo, observedTag, err := splitImageName(expectedImage, "[:|@]", "format")
+
+	assert.Equal(t, uri, observedRegistryURI, "RegistryURI should match")
+	assert.Equal(t, repositoryWithSlash, observedRepo, "Repository should match")
+	assert.Equal(t, sha, observedTag, "Tag should match")
+	assert.NoError(t, err, "Error splitting image name")
+}
+
+func TestSplitImageNameWithSlashInImageNameAndTag(t *testing.T) {
+	expectedImage := repositoryWithSlash + ":" + tag
+	observedRegistryURI, observedRepo, observedTag, err := splitImageName(expectedImage, "[:|@]", "format")
+
+	assert.Empty(t, observedRegistryURI, "RegistryURI should be empty")
+	assert.Equal(t, repositoryWithSlash, observedRepo, "Repository should match")
+	assert.Equal(t, tag, observedTag, "Expected tag to match")
+	assert.NoError(t, err, "Error splitting image name")
+}
+
+func TestSplitImageNameWithSlashInImageNameAndURI(t *testing.T) {
+	uri := "012345678912.dkr.ecr.us-east-1.amazonaws.com"
+	expectedImage := uri + "/" + repositoryWithSlash
+	observedRegistryURI, observedRepo, observedTag, err := splitImageName(expectedImage, "[:|@]", "format")
+
+	assert.Equal(t, uri, observedRegistryURI, "RegistryURI should match")
+	assert.Equal(t, repositoryWithSlash, observedRepo, "Repository should match")
+	assert.Empty(t, observedTag, "Tag should be empty")
+	assert.NoError(t, err, "Error splitting image name")
+}
+
+func TestSplitImageNameWithSlashInImageNameAndURIAndTag(t *testing.T) {
+	uri := "012345678912.dkr.ecr.us-east-1.amazonaws.com"
+	expectedImage := uri + "/" + repositoryWithSlash + ":" + tag
+	observedRegistryURI, observedRepo, observedTag, err := splitImageName(expectedImage, "[:|@]", "format")
+
+	assert.Equal(t, uri, observedRegistryURI, "RegistryURI should match")
+	assert.Equal(t, repositoryWithSlash, observedRepo, "Repository should match")
+	assert.Equal(t, tag, observedTag, "Expected tag to match")
 	assert.NoError(t, err, "Error splitting image name")
 }
 


### PR DESCRIPTION
- Fixes bug #361. This simply required correcting the regex.