### PR TITLE
Consistently set exit code to 1 for all CLI usage errors

### DIFF
--- a/ecs-cli/main.go
+++ b/ecs-cli/main.go
@@ -67,6 +67,6 @@ func main() {
 
 	err := app.Run(os.Args)
 	if err != nil {
-		logrus.Debug(err)
+		logrus.Fatal(err)
 	}
 }


### PR DESCRIPTION
Fixes #490 

Previously, I tried to fix this in https://github.com/aws/amazon-ecs-cli/pull/314  and https://github.com/aws/amazon-ecs-cli/pull/343. But that solution missed a few cases.

(The following cases were missed by the previous PRs)
```
$ ecs-cli --cat
Incorrect Usage. flag provided but not defined: -cat

NAME:
   ecs-cli - Command line interface for Amazon ECS

USAGE:
   ecs-cli [global options] command [command options] [arguments...]

VERSION:
   1.5.0 (*f650427)

AUTHOR:
   Amazon Web Services

COMMANDS:
     configure  Stores a single cluster configuration.
     up         Creates the ECS cluster (if it does not already exist) and the AWS resources required to set up the cluster.
     down       Deletes the CloudFormation stack that was created by ecs-cli up and the associated resources.
     scale      Modifies the number of container instances in your cluster. This command changes the desired and maximum instance count in the Auto Scaling group created by the ecs-cli up command. You can use this command to scale up (increase the number of instances) or scale down (decrease the number of instances) your cluster.
     ps         Lists all of the running containers in your ECS cluster
     push       Push an image to an Amazon ECR repository.
     pull       Pull an image from an Amazon ECR repository.
     images     List images an Amazon ECR repository.
     license    Prints the LICENSE files for the ECS CLI and its dependencies.
     compose    Executes docker-compose-style commands on an ECS cluster.
     logs       Retrieves container logs from CloudWatch logs. Assumes your Task Definition uses the awslogs driver and has a log stream prefix specified.
     help, h    Shows a list of commands or help for one command

GLOBAL OPTIONS:
   --endpoint value  Use a custom endpoint with the ECS CLI
   --help, -h        show help
   --version, -v     print the version
FATA[0000] flag provided but not defined: -cat          
$ echo $?
1
```

```
$ ecs-cli compose --cat
Incorrect Usage. flag provided but not defined: -cat

NAME:
   ecs-cli compose - Executes docker-compose-style commands on an ECS cluster.

USAGE:
   ecs-cli compose command [command options] [arguments...]

COMMANDS:
     create      Creates an ECS task definition from your compose file. Note that we do not recommend using plain text environment variables for sensitive information, such as credential data.
     ps, list    Lists all the containers in your cluster that were started by the compose project.
     run         Starts all containers overriding commands with the supplied one-off commands for the containers.
     scale       ecs-cli compose scale [count] - scales the number of running tasks to the specified count.
     start       Starts a single task from the task definition created from your compose file.
     stop, down  Stops all the running tasks created by the compose project.
     up          Creates an ECS task definition from your compose file (if it does not already exist) and runs one instance of that task on your cluster (a combination of create and start).
     service     Manage Amazon ECS services with docker-compose-style commands on an ECS cluster.

OPTIONS:
   --verbose, --debug              Increase the verbosity of command output to aid in diagnostics.
   --file value, -f value          Specifies one or more Docker compose files to use. Defaults to docker-compose.yml file, and an optional docker-compose.override.yml file. [$COMPOSE_FILE]
   --project-name value, -p value  Specifies the project name to use. Defaults to the current directory name. [$COMPOSE_PROJECT_NAME]
   --task-role-arn value           [Optional] Specifies the short name or full Amazon Resource Name (ARN) of the IAM role that containers in this task can assume. All containers in this task are granted the permissions that are specified in this role.
   --ecs-params value              [Optional] Specifies ecs-params file to use. Defaults to ecs-params.yml file, if one exists.
   --region value, -r value        [Optional] Specifies the AWS region to use. Defaults to the region configured using the configure command
   --cluster-config value          [Optional] Specifies the name of the ECS cluster configuration to use. Defaults to the default cluster configuration.
   --ecs-profile value             [Optional] Specifies the name of the ECS profile configuration to use. Defaults to the default profile configuration. [$ECS_PROFILE]
   --aws-profile value             [Optional] Use the AWS credentials from an existing named profile in ~/.aws/credentials. [$AWS_PROFILE]
   --cluster value, -c value       [Optional] Specifies the ECS cluster name to use. Defaults to the cluster configured using the configure command
   --help, -h                      show help
   
FATA[0000] flag provided but not defined: -cat          
$ echo $?
1
```