### PR TITLE
Convert v3 env vars to containerConfig Environment

### DIFF
--- a/ecs-cli/modules/cli/compose/project/project_parseV3.go
+++ b/ecs-cli/modules/cli/compose/project/project_parseV3.go
@@ -107,6 +107,15 @@ func convertToContainerConfig(serviceConfig types.ServiceConfig) (*containerconf
 		c.DockerLabels = labelsMap
 	}
 
+	envVars := []*ecs.KeyValuePair{}
+	for k, v := range serviceConfig.Environment {
+		env := ecs.KeyValuePair{}
+		env.SetName(k)
+		env.SetValue(*v)
+		envVars = append(envVars, &env)
+	}
+	c.Environment = envVars
+
 	extraHosts, err := utils.ConvertToExtraHosts(serviceConfig.ExtraHosts)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
`project` pkg test output:

```
PS C:\~\GO\src\github.com\aws\amazon-ecs-cli> go test -timeout=120s -v -cover ./ecs-cli/modules/cli/compose/project
=== RUN   TestParseV1V2_Version1_HappyPath
time="2018-05-16T13:50:19-07:00" level=warning msg="Ignoring the ip address while transforming it to task definition" container=web portMapping="127.0.0.1:8001:8001"
--- PASS: TestParseV1V2_Version1_HappyPath (0.01s)
=== RUN   TestParseV1V2_Version2Files
--- PASS: TestParseV1V2_Version2Files (0.00s)
=== RUN   TestParseV1V2_Version1_WithEnvFile
--- PASS: TestParseV1V2_Version1_WithEnvFile (0.00s)
=== RUN   TestParseV3WithOneFile
--- PASS: TestParseV3WithOneFile (0.01s)
=== RUN   TestParseV3WithMultipleFiles
--- PASS: TestParseV3WithMultipleFiles (0.01s)
=== RUN   TestThrowErrorOnBadYaml
--- PASS: TestThrowErrorOnBadYaml (0.00s)
=== RUN   TestThrowErrorIfFileDoesNotExist
--- PASS: TestThrowErrorIfFileDoesNotExist (0.00s)
=== RUN   TestParseV3WithEnvFile
--- PASS: TestParseV3WithEnvFile (0.01s)
=== RUN   TestParseCompose_V2
--- PASS: TestParseCompose_V2 (0.00s)
=== RUN   TestParseECSParams
--- PASS: TestParseECSParams (0.00s)
=== RUN   TestParseECSParams_NoFile
--- PASS: TestParseECSParams_NoFile (0.00s)
=== RUN   TestParseECSParams_WithFargateParams
--- PASS: TestParseECSParams_WithFargateParams (0.00s)
=== RUN   TestThrowErrorForUnsupportedComposeVersion
--- PASS: TestThrowErrorForUnsupportedComposeVersion (0.00s)
=== RUN   TestCheckComposeVersionForOneFile
--- PASS: TestCheckComposeVersionForOneFile (0.00s)
=== RUN   TestCheckComposeVersionForMultipleFiles
--- PASS: TestCheckComposeVersionForMultipleFiles (0.00s)
=== RUN   TestThrowErrorWhenComposeVersionsConflict
--- PASS: TestThrowErrorWhenComposeVersionsConflict (0.00s)
=== RUN   TestCheckComposeVersionWhenEmpty
--- PASS: TestCheckComposeVersionWhenEmpty (0.00s)
=== RUN   TestCheckComposeVersionWhenMissing
--- PASS: TestCheckComposeVersionWhenMissing (0.00s)
=== RUN   TestThrowErrorWhenVersionInDifferentFormats
--- PASS: TestThrowErrorWhenVersionInDifferentFormats (0.00s)
PASS
coverage: 64.7% of statements
ok      github.com/aws/amazon-ecs-cli/ecs-cli/modules/cli/compose/project       (cached)        coverage: 64.7% of statements
```