### PR TITLE
Add service cpu, memory, and memory_reservation fields to ecs-params

### DIFF
--- a/ecs-cli/modules/utils/compose/ecs_params_reader.go
+++ b/ecs-cli/modules/utils/compose/ecs_params_reader.go
@@ -16,14 +16,17 @@ package utils
 // ECS Params Reader is used to parse the ecs-params.yml file and marshal the data into the ECSParams struct
 
 import (
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/ecs"
-	"github.com/pkg/errors"
-	"gopkg.in/yaml.v2"
 	"io/ioutil"
 	"os"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ecs"
+	libYaml "github.com/docker/libcompose/yaml"
+	"github.com/pkg/errors"
+	"gopkg.in/yaml.v2"
 )
 
+// ECSParams contains the information parsed from the ecs-params.yml file
 type ECSParams struct {
 	Version        string
 	TaskDefinition EcsTaskDef `yaml:"task_definition"`
@@ -36,15 +39,23 @@ type EcsTaskDef struct {
 	TaskRoleArn          string        `yaml:"task_role_arn"`
 	ContainerDefinitions ContainerDefs `yaml:"services"`
 	ExecutionRole        string        `yaml:"task_execution_role"`
-	TaskSize             TaskSize      `yaml:"task_size"`           // Needed to run FARGATE tasks
+	TaskSize             TaskSize      `yaml:"task_size"` // Needed to run FARGATE tasks
 }
 
+// ContainerDefs is a map of ContainerDefs within a task definition
 type ContainerDefs map[string]ContainerDef
 
+// ContainerDef specifies settings for a specific container
 type ContainerDef struct {
 	Essential bool `yaml:"essential"`
+	// resource field yaml names correspond to equivalent docker-compose field
+	Cpu               int64                  `yaml:"cpu_shares"`
+	Memory            libYaml.MemStringorInt `yaml:"mem_limit"`
+	MemoryReservation libYaml.MemStringorInt `yaml:"mem_reservation"`
 }
 
+// TaskSize holds Cpu and Memory values needed for Fargate tasks
+// https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-cpu-memory-error.html
 type TaskSize struct {
 	Cpu    string `yaml:"cpu_limit"`
 	Memory string `yaml:"mem_limit"`
@@ -55,10 +66,14 @@ type RunParams struct {
 	NetworkConfiguration NetworkConfiguration `yaml:"network_configuration"`
 }
 
+// NetworkConfiguration specifies the network config for the task definition.
+// Supports values 'awsvpc' (required for Fargate), 'bridge', 'host' or 'none'
 type NetworkConfiguration struct {
 	AwsVpcConfiguration AwsVpcConfiguration `yaml:"awsvpc_configuration"`
 }
 
+// AwsVpcConfiguration specifies the networking resources available to
+// tasks running in 'awsvpc' networking mode
 type AwsVpcConfiguration struct {
 	Subnets        []string       `yaml:"subnets"`
 	SecurityGroups []string       `yaml:"security_groups"`

--- a/ecs-cli/modules/utils/compose/ecs_params_reader_test.go
+++ b/ecs-cli/modules/utils/compose/ecs_params_reader_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/docker/libcompose/yaml"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -77,6 +78,9 @@ task_definition:
   services:
     mysql:
       essential: false
+      cpu_shares: 100
+      mem_limit: 524288000
+      mem_reservation: 500mb
     wordpress:
       essential: true`
 
@@ -108,6 +112,9 @@ task_definition:
 		wordpress := containerDefs["wordpress"]
 
 		assert.False(t, mysql.Essential, "Expected container to not be essential")
+		assert.Equal(t, int64(100), mysql.Cpu)
+		assert.Equal(t, yaml.MemStringorInt(524288000), mysql.Memory)
+		assert.Equal(t, yaml.MemStringorInt(524288000), mysql.MemoryReservation)
 		assert.True(t, wordpress.Essential, "Expected container to be essential")
 	}
 }


### PR DESCRIPTION
compose output with new ECS service params logged out (error on creating task def expected ATM):

```
$> ..\..\Documents\GO\src\github.com\aws\amazon-ecs-cli\bin\local\ecs-cli.exe compose create
INFO[0000] ECS content: &{Version:1 TaskDefinition:{NetworkMode:bridge TaskRoleArn: ContainerDefinitions:map[web:{Essential:false CPUShares:2 Memory:10 MemoryReservation:8}] ExecutionRole: TaskSize:{Cpu: Memory:}} RunParams:{NetworkConfiguration:{AwsVpcConfiguration:{Subnets:[] SecurityGroups:[] AssignPublicIp:}}}}
ERRO[0000] Unable to open ECS Compose Project            error="cannot create a task definition with no containers; invalid service config"
FATA[0000] Unable to create and read ECS Compose Project  error="cannot create a task definition with no containers; invalid service config"
```

Also: Added comments for a few public structs that raised warnings re: style.