### PR TITLE
Fix stack timeout message to work for creation and deletion

### DIFF
--- a/ecs-cli/modules/clients/aws/cloudformation/client.go
+++ b/ecs-cli/modules/clients/aws/cloudformation/client.go
@@ -107,7 +107,7 @@ type cloudformationClient struct {
 }
 
 // NewCloudformationClient creates an instance of cloudFormationClient object.
-func NewCloudformationClient(config *config.CommandConfig) CloudformationClient  {
+func NewCloudformationClient(config *config.CommandConfig) CloudformationClient {
 	cfnClient := cloudformation.New(config.Session)
 	cfnClient.Handlers.Build.PushBackNamed(clients.CustomUserAgentHandler())
 
@@ -260,7 +260,7 @@ func (c *cloudformationClient) waitUntilComplete(stackName string, hasFailed fai
 		c.sleeper.Sleep(delayWait)
 	}
 
-	return fmt.Errorf("Timeout waiting for stack creation to complete")
+	return fmt.Errorf("Timeout waiting for stack operation to complete")
 }
 
 // latestStackEvent describes stack events and gets the latest event.


### PR DESCRIPTION
Test output:

```
$> ~\GO\src\github.com\aws\amazon-ecs-cli\bin\local\ecs-cli.exe down --force --cluster-config test
INFO[0001] Waiting for your cluster resources to be deleted...
INFO[0001] Cloudformation stack status                   stackStatus=DELETE_IN_PROGRESS
INFO[0063] Cloudformation stack status                   stackStatus=DELETE_IN_PROGRESS
INFO[0124] Cloudformation stack status                   stackStatus=DELETE_IN_PROGRESS
INFO[0186] Cloudformation stack status                   stackStatus=DELETE_IN_PROGRESS
INFO[0248] Cloudformation stack status                   stackStatus=DELETE_IN_PROGRESS
INFO[0309] Cloudformation stack status                   stackStatus=DELETE_IN_PROGRESS
INFO[0371] Cloudformation stack status                   stackStatus=DELETE_IN_PROGRESS
INFO[0433] Cloudformation stack status                   stackStatus=DELETE_IN_PROGRESS
INFO[0494] Cloudformation stack status                   stackStatus=DELETE_IN_PROGRESS
INFO[0556] Cloudformation stack status                   stackStatus=DELETE_IN_PROGRESS
INFO[0617] Cloudformation stack status                   stackStatus=DELETE_IN_PROGRESS
INFO[0679] Cloudformation stack status                   stackStatus=DELETE_IN_PROGRESS
INFO[0741] Cloudformation stack status                   stackStatus=DELETE_IN_PROGRESS
FATA[0771] Error executing 'down': Timeout waiting for stack operation to complete
```