### PR TITLE
Add top-level volumes to ecsProject

### DIFF
--- a/ecs-cli/modules/cli/compose/project/mock/project.go
+++ b/ecs-cli/modules/cli/compose/project/mock/project.go
@@ -186,3 +186,13 @@ func (_m *MockProject) Up() error {
 func (_mr *_MockProjectRecorder) Up() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Up")
 }
+
+func (_m *MockProject) VolumeConfigs() *adapter.Volumes {
+	ret := _m.ctrl.Call(_m, "VolumeConfigs")
+	ret0, _ := ret[0].(*adapter.Volumes)
+	return ret0
+}
+
+func (_mr *_MockProjectRecorder) VolumeConfigs() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "VolumeConfigs")
+}

--- a/ecs-cli/modules/cli/compose/project/project_parseV1V2.go
+++ b/ecs-cli/modules/cli/compose/project/project_parseV1V2.go
@@ -16,6 +16,8 @@ func (p *ecsProject) parseV1V2() (*[]adapter.ContainerConfig, error) {
 	// context. It sets up the name, the composefile and the composebytes
 	// (the composefile content). This is where libcompose ServiceConfigs
 	// and VolumeConfigs gets loaded.
+
+	// TODO instantiate the libcompose project here instead of in the factory
 	if err := p.Project.Parse(); err != nil {
 		return nil, err
 	}
@@ -25,6 +27,7 @@ func (p *ecsProject) parseV1V2() (*[]adapter.ContainerConfig, error) {
 	if err != nil {
 		return nil, err
 	}
+	p.volumes = volumes
 
 	context := &p.Context().Context
 	serviceConfigs := p.Project.ServiceConfigs

--- a/ecs-cli/modules/cli/compose/project/project_parseV1V2_test.go
+++ b/ecs-cli/modules/cli/compose/project/project_parseV1V2_test.go
@@ -213,19 +213,29 @@ func TestParseV1V2_Version2Files(t *testing.T) {
 	memory := int64(512)
 	mountPoints := []*ecs.MountPoint{
 		{
-			ContainerPath: aws.String("/tmp/cache"),
-			ReadOnly:      aws.Bool(false),
-			SourceVolume:  aws.String("banana"),
-		},
-		{
-			ContainerPath: aws.String("/tmp/cache"),
+			ContainerPath: aws.String("/var/lib/mysql"),
 			ReadOnly:      aws.Bool(false),
 			SourceVolume:  aws.String("volume-1"),
 		},
 		{
-			ContainerPath: aws.String("/tmp/cache"),
-			ReadOnly:      aws.Bool(true),
+			ContainerPath: aws.String("/var/lib/mysql"),
+			ReadOnly:      aws.Bool(false),
 			SourceVolume:  aws.String("volume-2"),
+		},
+		{
+			ContainerPath: aws.String("/tmp/cache"),
+			ReadOnly:      aws.Bool(false),
+			SourceVolume:  aws.String("volume-3"),
+		},
+		{
+			ContainerPath: aws.String("/etc/configs/"),
+			ReadOnly:      aws.Bool(true),
+			SourceVolume:  aws.String("volume-4"),
+		},
+		{
+			ContainerPath: aws.String("/var/lib/mysql"),
+			ReadOnly:      aws.Bool(false),
+			SourceVolume:  aws.String("datavolume"),
 		},
 	}
 	ports := []*ecs.PortMapping{
@@ -279,11 +289,13 @@ services:
   mysql:
     image: mysql
     volumes:
-      - banana:/tmp/cache
-      - :/tmp/cache
-      - ./cache:/tmp/cache:ro
+      - /var/lib/mysql
+      - /opt/data:/var/lib/mysql
+      - ./cache:/tmp/cache:rw
+      - ~/configs:/etc/configs/:ro
+      - datavolume:/var/lib/mysql
 volumes:
-  banana:`
+  datavolume:`
 
 	// Setup docker-compose file
 	tmpfile, err := ioutil.TempFile("", "test")
@@ -326,7 +338,7 @@ volumes:
 	assert.NoError(t, err, "Unexpected error retrieving wordpress config")
 
 	assert.Equal(t, mysqlImage, mysql.Image, "Expected mysql Image to match")
-	assert.Equal(t, mountPoints, mysql.MountPoints, "Expected MountPoints to match")
+	assert.ElementsMatch(t, mountPoints, mysql.MountPoints, "Expected MountPoints to match")
 }
 
 func TestParseV1V2_Version1_WithEnvFile(t *testing.T) {

--- a/ecs-cli/modules/utils/compose/convert_task_definition.go
+++ b/ecs-cli/modules/utils/compose/convert_task_definition.go
@@ -87,7 +87,7 @@ type TaskDefParams struct {
 
 // ConvertToTaskDefinition transforms the yaml configs to its ecs equivalent (task definition)
 // TODO container config a pointer to slice?
-func ConvertToTaskDefinition(context *project.Context, volumeConfigs map[string]*config.VolumeConfig,
+func ConvertToTaskDefinition(context *project.Context, volumes *adapter.Volumes,
 	containerConfigs []adapter.ContainerConfig, taskRoleArn string, requiredCompatibilites string, ecsParams *ECSParams) (*ecs.TaskDefinition, error) {
 	if len(containerConfigs) == 0 {
 		return nil, errors.New("cannot create a task definition with no containers; invalid service config")
@@ -106,12 +106,6 @@ func ConvertToTaskDefinition(context *project.Context, volumeConfigs map[string]
 	// The task-role-arn flag takes precedence over a taskRoleArn value specified in ecs-params file.
 	if taskRoleArn == "" {
 		taskRoleArn = taskDefParams.taskRoleArn
-	}
-
-	// TODO: Refactor when Volumes added to top level project
-	volumes, err := adapter.ConvertToVolumes(volumeConfigs)
-	if err != nil {
-		return nil, err
 	}
 
 	// Create containerDefinitions

--- a/ecs-cli/modules/utils/compose/convert_task_definition_test.go
+++ b/ecs-cli/modules/utils/compose/convert_task_definition_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/cli/compose/adapter"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ecs"
-	"github.com/docker/libcompose/config"
 	"github.com/docker/libcompose/project"
 	"github.com/docker/libcompose/yaml"
 	"github.com/stretchr/testify/assert"
@@ -203,7 +202,7 @@ func TestConvertToTaskDefinition(t *testing.T) {
 	// TODO add top-level volumes
 
 	// convert
-	taskDefinition := convertToTaskDefinitionInTest(t, nil, testContainerConfig, taskRoleArn, "")
+	taskDefinition := convertToTaskDefinitionInTest(t, testContainerConfig, taskRoleArn, "")
 	containerDef := *taskDefinition.ContainerDefinitions[0]
 
 	// verify task def fields
@@ -253,7 +252,7 @@ func TestConvertToTaskDefinitionWithNoSharedMemorySize(t *testing.T) {
 		ShmSize: int64(0),
 	}
 
-	taskDefinition := convertToTaskDefinitionInTest(t, nil, containerConfig, "", "")
+	taskDefinition := convertToTaskDefinitionInTest(t, containerConfig, "", "")
 	containerDef := *taskDefinition.ContainerDefinitions[0]
 
 	assert.Nil(t, containerDef.LinuxParameters.SharedMemorySize, "Expected sharedMemorySize to be null")
@@ -264,7 +263,7 @@ func TestConvertToTaskDefinitionWithNoTmpfs(t *testing.T) {
 		Tmpfs: nil,
 	}
 
-	taskDefinition := convertToTaskDefinitionInTest(t, nil, containerConfig, "", "")
+	taskDefinition := convertToTaskDefinitionInTest(t, containerConfig, "", "")
 	containerDef := *taskDefinition.ContainerDefinitions[0]
 
 	assert.Nil(t, containerDef.LinuxParameters.Tmpfs, "Expected Tmpfs to be null")
@@ -275,7 +274,7 @@ func TestConvertToTaskDefinitionWithBlankHostname(t *testing.T) {
 		Hostname: "",
 	}
 
-	taskDefinition := convertToTaskDefinitionInTest(t, nil, containerConfig, "", "")
+	taskDefinition := convertToTaskDefinitionInTest(t, containerConfig, "", "")
 	containerDef := *taskDefinition.ContainerDefinitions[0]
 
 	assert.Nil(t, containerDef.Hostname, "Expected Hostname to be nil")
@@ -287,7 +286,7 @@ func TestConvertToTaskDefinitionWithBlankHostname(t *testing.T) {
 func TestConvertToTaskDefinitionLaunchTypeEmpty(t *testing.T) {
 	containerConfig := &adapter.ContainerConfig{}
 
-	taskDefinition := convertToTaskDefinitionInTest(t, nil, containerConfig, "", "")
+	taskDefinition := convertToTaskDefinitionInTest(t, containerConfig, "", "")
 	if len(taskDefinition.RequiresCompatibilities) > 0 {
 		t.Error("Did not expect RequiresCompatibilities to be set")
 	}
@@ -296,7 +295,7 @@ func TestConvertToTaskDefinitionLaunchTypeEmpty(t *testing.T) {
 func TestConvertToTaskDefinitionLaunchTypeEC2(t *testing.T) {
 	containerConfig := &adapter.ContainerConfig{}
 
-	taskDefinition := convertToTaskDefinitionInTest(t, nil, containerConfig, "", "EC2")
+	taskDefinition := convertToTaskDefinitionInTest(t, containerConfig, "", "EC2")
 	if len(taskDefinition.RequiresCompatibilities) != 1 {
 		t.Error("Expected exactly one required compatibility to be set.")
 	}
@@ -306,7 +305,7 @@ func TestConvertToTaskDefinitionLaunchTypeEC2(t *testing.T) {
 func TestConvertToTaskDefinitionLaunchTypeFargate(t *testing.T) {
 	containerConfig := &adapter.ContainerConfig{}
 
-	taskDefinition := convertToTaskDefinitionInTest(t, nil, containerConfig, "", "FARGATE")
+	taskDefinition := convertToTaskDefinitionInTest(t, containerConfig, "", "FARGATE")
 	if len(taskDefinition.RequiresCompatibilities) != 1 {
 		t.Error("Expected exactly one required compatibility to be set.")
 	}
@@ -348,7 +347,7 @@ task_definition:
 	ecsParams, err := ReadECSParams(ecsParamsFileName)
 	assert.NoError(t, err, "Could not read ECS Params file")
 
-	taskDefinition, err := convertToTaskDefWithEcsParamsInTest(t, nil, containerConfigs, "", ecsParams)
+	taskDefinition, err := convertToTaskDefWithEcsParamsInTest(t, containerConfigs, "", ecsParams)
 
 	if assert.NoError(t, err) {
 		assert.Equal(t, "host", aws.StringValue(taskDefinition.NetworkMode), "Expected network mode to match")
@@ -392,7 +391,7 @@ task_definition:
 	ecsParams, err := ReadECSParams(ecsParamsFileName)
 	assert.NoError(t, err, "Could not read ECS Params file")
 
-	taskDefinition, err := convertToTaskDefWithEcsParamsInTest(t, nil, containerConfigs, "", ecsParams)
+	taskDefinition, err := convertToTaskDefWithEcsParamsInTest(t, containerConfigs, "", ecsParams)
 
 	containerDefs := taskDefinition.ContainerDefinitions
 	mysql := findContainerByName("mysql", containerDefs)
@@ -435,7 +434,7 @@ task_definition:
 	ecsParams, err := ReadECSParams(ecsParamsFileName)
 	assert.NoError(t, err, "Could not read ECS Params file")
 
-	taskDefinition, err := convertToTaskDefWithEcsParamsInTest(t, nil, containerConfigs, "", ecsParams)
+	taskDefinition, err := convertToTaskDefWithEcsParamsInTest(t, containerConfigs, "", ecsParams)
 
 	containerDefs := taskDefinition.ContainerDefinitions
 	mysql := findContainerByName("mysql", containerDefs)
@@ -474,7 +473,7 @@ task_definition:
 	ecsParams, err := ReadECSParams(ecsParamsFileName)
 	assert.NoError(t, err, "Could not read ECS Params file")
 
-	taskDefinition, err := convertToTaskDefWithEcsParamsInTest(t, nil, containerConfigs, "", ecsParams)
+	taskDefinition, err := convertToTaskDefWithEcsParamsInTest(t, containerConfigs, "", ecsParams)
 
 	containerDefs := taskDefinition.ContainerDefinitions
 	mysql := findContainerByName("mysql", containerDefs)
@@ -513,7 +512,7 @@ task_definition:
 	ecsParams, err := ReadECSParams(ecsParamsFileName)
 	assert.NoError(t, err, "Could not read ECS Params file")
 
-	taskDefinition, err := convertToTaskDefWithEcsParamsInTest(t, nil, containerConfigs, "", ecsParams)
+	taskDefinition, err := convertToTaskDefWithEcsParamsInTest(t, containerConfigs, "", ecsParams)
 
 	containerDefs := taskDefinition.ContainerDefinitions
 	mysql := findContainerByName("mysql", containerDefs)
@@ -551,7 +550,7 @@ task_definition:
 	ecsParams, err := ReadECSParams(ecsParamsFileName)
 	assert.NoError(t, err, "Could not read ECS Params file")
 
-	taskDefinition, err := convertToTaskDefWithEcsParamsInTest(t, nil, containerConfigs, "", ecsParams)
+	taskDefinition, err := convertToTaskDefWithEcsParamsInTest(t, containerConfigs, "", ecsParams)
 
 	containerDefs := taskDefinition.ContainerDefinitions
 	mysql := findContainerByName("mysql", containerDefs)
@@ -590,7 +589,7 @@ task_definition:
 	ecsParams, err := ReadECSParams(ecsParamsFileName)
 	assert.NoError(t, err, "Could not read ECS Params file")
 
-	_, err = convertToTaskDefWithEcsParamsInTest(t, nil, containerConfigs, "", ecsParams)
+	_, err = convertToTaskDefWithEcsParamsInTest(t, containerConfigs, "", ecsParams)
 
 	assert.Error(t, err, "Expected error if no containers are marked essential")
 }
@@ -622,7 +621,7 @@ task_definition:
 	ecsParams, err := ReadECSParams(ecsParamsFileName)
 	assert.NoError(t, err, "Could not read ECS Params file")
 
-	_, err = convertToTaskDefWithEcsParamsInTest(t, nil, containerConfigs, "", ecsParams)
+	_, err = convertToTaskDefWithEcsParamsInTest(t, containerConfigs, "", ecsParams)
 
 	assert.Error(t, err, "Expected error if no containers are marked essential")
 }
@@ -651,7 +650,7 @@ task_definition:
 	ecsParams, err := ReadECSParams(ecsParamsFileName)
 	assert.NoError(t, err, "Could not read ECS Params file")
 
-	taskDefinition, err := convertToTaskDefWithEcsParamsInTest(t, nil, containerConfigs, "", ecsParams)
+	taskDefinition, err := convertToTaskDefWithEcsParamsInTest(t, containerConfigs, "", ecsParams)
 	assert.NoError(t, err, "Unexpected error when no containers are marked essential")
 
 	mysql := findContainerByName("mysql", taskDefinition.ContainerDefinitions)
@@ -689,7 +688,7 @@ task_definition:
 	ecsParams, err := ReadECSParams(ecsParamsFileName)
 	assert.NoError(t, err, "Could not read ECS Params file")
 
-	taskDefinition, err := convertToTaskDefWithEcsParamsInTest(t, nil, containerConfigs, "", ecsParams)
+	taskDefinition, err := convertToTaskDefWithEcsParamsInTest(t, containerConfigs, "", ecsParams)
 
 	assert.NoError(t, err, "Unexpected error when no containers are marked essential")
 	mysql := findContainerByName("mysql", taskDefinition.ContainerDefinitions)
@@ -724,7 +723,7 @@ task_definition:
 
 	taskRoleArn := "arn:aws:iam::123456789012:role/tweedledum"
 
-	taskDefinition, err := convertToTaskDefWithEcsParamsInTest(t, nil, containerConfigs, taskRoleArn, ecsParams)
+	taskDefinition, err := convertToTaskDefWithEcsParamsInTest(t, containerConfigs, taskRoleArn, ecsParams)
 
 	if assert.NoError(t, err) {
 		assert.Equal(t, "host", aws.StringValue(taskDefinition.NetworkMode), "Expected network mode to match")
@@ -757,7 +756,7 @@ task_definition:
 	ecsParams, err := ReadECSParams(ecsParamsFileName)
 	assert.NoError(t, err, "Could not read ECS Params file")
 
-	taskDefinition, err := convertToTaskDefWithEcsParamsInTest(t, nil, containerConfigs, "", ecsParams)
+	taskDefinition, err := convertToTaskDefWithEcsParamsInTest(t, containerConfigs, "", ecsParams)
 
 	if assert.NoError(t, err) {
 		assert.Equal(t, "200", aws.StringValue(taskDefinition.Cpu), "Expected CPU to match")
@@ -789,149 +788,74 @@ func TestMemReservationHigherThanMemLimit(t *testing.T) {
 		WorkingDirectory:  workingDir,
 	}
 
-	volumeConfigs := make(map[string]*config.VolumeConfig)
-
+	volumeConfigs := &adapter.Volumes{}
 	containerConfigs := []adapter.ContainerConfig{containerConfig}
 
-	envLookup, err := GetDefaultEnvironmentLookup()
-	assert.NoError(t, err, "Unexpected error setting up environment lookup")
-	resourceLookup, err := GetDefaultResourceLookup()
-	assert.NoError(t, err, "Unexpected error setting up resource lookup")
-	context := &project.Context{
-		ProjectName:       "ProjectName",
-		Project:           &project.Project{},
-		EnvironmentLookup: envLookup,
-		ResourceLookup:    resourceLookup,
-	}
-	_, err = ConvertToTaskDefinition(context, volumeConfigs, containerConfigs, "", "", nil)
+	context := testContext(t)
+	_, err := ConvertToTaskDefinition(context, volumeConfigs, containerConfigs, "", "", nil)
 	assert.EqualError(t, err, "mem_limit must be greater than mem_reservation")
 }
 
-// TODO Modify test when top-level Volumes added
-// func TestConvertToTaskDefinitionWithVolumes(t *testing.T) {
-// 	volume := yaml.Volume{Source: hostPath, Destination: containerPath}
-// 	volumesFrom := []string{"container1"}
+func TestConvertToTaskDefinitionWithVolumes(t *testing.T) {
+	volumeConfigs := &adapter.Volumes{
+		VolumeWithHost: map[string]string{
+			hostPath: containerPath,
+		},
+		VolumeEmptyHost: []string{namedVolume},
+	}
 
-// 	containerConfig := &config.ServiceConfig{
-// 		Volumes:     &yaml.Volumes{Volumes: []*yaml.Volume{&volume}},
-// 		VolumesFrom: volumesFrom,
-// 	}
+	mountPoints := []*ecs.MountPoint{
+		{
+			ContainerPath: aws.String("/tmp/cache"),
+			ReadOnly:      aws.Bool(false),
+			SourceVolume:  aws.String("volume-3"),
+		},
+		{
+			ContainerPath: aws.String("/tmp/cache"),
+			ReadOnly:      aws.Bool(false),
+			SourceVolume:  aws.String("named_volume"),
+		},
+	}
+	containerConfig := adapter.ContainerConfig{
+		MountPoints: mountPoints,
+	}
 
-// 	taskDefinition := convertToTaskDefinitionInTest(t, nil, containerConfig, "", "")
-// 	containerDef := *taskDefinition.ContainerDefinitions[0]
+	containerConfigs := []adapter.ContainerConfig{containerConfig}
 
-// 	if len(volumesFrom) != len(containerDef.VolumesFrom) ||
-// 		volumesFrom[0] != aws.StringValue(containerDef.VolumesFrom[0].SourceContainer) {
-// 		t.Errorf("Expected volumesFrom [%v] But was [%v]", volumesFrom, containerDef.VolumesFrom)
-// 	}
-// 	volumeDef := *taskDefinition.Volumes[0]
-// 	mountPoint := *containerDef.MountPoints[0]
+	host := &ecs.HostVolumeProperties{SourcePath: aws.String(hostPath)}
+	expectedVolumes := []*ecs.Volume{
+		{
+			Host: host,
+			Name: aws.String(containerPath),
+		},
+		{
+			Name: aws.String(namedVolume),
+		},
+	}
 
-// 	if hostPath != aws.StringValue(volumeDef.Host.SourcePath) {
-// 		t.Errorf("Expected HostSourcePath [%s] But was [%s]", hostPath, aws.StringValue(volumeDef.Host.SourcePath))
-// 	}
-// 	if containerPath != aws.StringValue(mountPoint.ContainerPath) {
-// 		t.Errorf("Expected containerPath [%s] But was [%s]", containerPath, aws.StringValue(mountPoint.ContainerPath))
-// 	}
-// 	if aws.StringValue(volumeDef.Name) != aws.StringValue(mountPoint.SourceVolume) {
-// 		t.Errorf("Expected volume name to match. "+
-// 			"Got Volume.Name=[%s] And MountPoint.SourceVolume=[%s]",
-// 			aws.StringValue(volumeDef.Name), aws.StringValue(mountPoint.SourceVolume))
-// 	}
-// }
+	context := testContext(t)
+	taskDefinition, err := ConvertToTaskDefinition(context, volumeConfigs, containerConfigs, "", "", nil)
+	assert.NoError(t, err, "Unexpected error converting Task Definition")
 
-// TODO Modify test when top-level Volumes added
-// func TestConvertToTaskDefinitionWithNamedVolume(t *testing.T) {
-// 	volume := yaml.Volume{Source: namedVolume, Destination: containerPath}
+	actualVolumes := taskDefinition.Volumes
+	assert.ElementsMatch(t, expectedVolumes, actualVolumes, "Expected volumes to match")
+}
 
-// 	containerConfig := &config.ServiceConfig{
-// 		Volumes:  &yaml.Volumes{Volumes: []*yaml.Volume{&volume}},
-// 		Networks: &yaml.Networks{Networks: []*yaml.Network{defaultNetwork}},
-// 	}
-
-// 	taskDefinition := convertToTaskDefinitionInTest(t, "name", nil, containerConfig, "", "")
-// 	containerDef := *taskDefinition.ContainerDefinitions[0]
-
-// 	volumeDef := *taskDefinition.Volumes[0]
-// 	mountPoint := *containerDef.MountPoints[0]
-// 	if volumeDef.Host != nil {
-// 		t.Errorf("Expected volume host to be nil But was [%s]", volumeDef.Host)
-// 	}
-// 	if containerPath != aws.StringValue(mountPoint.ContainerPath) {
-// 		t.Errorf("Expected containerPath [%s] But was [%s]", containerPath, aws.StringValue(mountPoint.ContainerPath))
-// 	}
-// 	if aws.StringValue(volumeDef.Name) != aws.StringValue(mountPoint.SourceVolume) {
-// 		t.Errorf("Expected volume name to match. "+
-// 			"Got Volume.Name=[%s] And MountPoint.SourceVolume=[%s]",
-// 			aws.StringValue(volumeDef.Name), aws.StringValue(mountPoint.SourceVolume))
-// 	}
-// }
-
-////////////////////////////////
-// Convert individual fields //
-//////////////////////////////
-
-func convertToTaskDefinitionInTest(t *testing.T, volumeConfig *config.VolumeConfig, containerConfig *adapter.ContainerConfig, taskRoleArn string, launchType string) *ecs.TaskDefinition {
-	volumeConfigs := make(map[string]*config.VolumeConfig)
-	volumeConfigs[namedVolume] = volumeConfig
+func convertToTaskDefinitionInTest(t *testing.T, containerConfig *adapter.ContainerConfig, taskRoleArn string, launchType string) *ecs.TaskDefinition {
+	volumeConfigs := &adapter.Volumes{
+		VolumeEmptyHost: []string{namedVolume},
+	}
 
 	containerConfigs := []adapter.ContainerConfig{}
 	containerConfigs = append(containerConfigs, *containerConfig)
 
-	envLookup, err := GetDefaultEnvironmentLookup()
-	if err != nil {
-		t.Fatal("Unexpected error setting up environment lookup")
-	}
-	resourceLookup, err := GetDefaultResourceLookup()
-	if err != nil {
-		t.Fatal("Unexpected error setting up resource lookup")
-	}
-	context := &project.Context{
-		ProjectName:       "ProjectName",
-		Project:           &project.Project{},
-		EnvironmentLookup: envLookup,
-		ResourceLookup:    resourceLookup,
-	}
+	context := testContext(t)
+
 	taskDefinition, err := ConvertToTaskDefinition(context, volumeConfigs, containerConfigs, taskRoleArn, launchType, nil)
 	if err != nil {
 		t.Errorf("Expected to convert [%v] containerConfigs without errors. But got [%v]", containerConfig, err)
 	}
 	return taskDefinition
-}
-
-func convertToTaskDefWithEcsParamsInTest(t *testing.T, volumeConfig *config.VolumeConfig, containerConfigs []adapter.ContainerConfig, taskRoleArn string, ecsParams *ECSParams) (*ecs.TaskDefinition, error) {
-	volumeConfigs := make(map[string]*config.VolumeConfig)
-	if volumeConfig != nil {
-		volumeConfigs[namedVolume] = volumeConfig
-	}
-
-	envLookup, err := GetDefaultEnvironmentLookup()
-	assert.NoError(t, err, "Unexpected error setting up environment lookup")
-
-	resourceLookup, err := GetDefaultResourceLookup()
-	assert.NoError(t, err, "Unexpected error setting up resource lookup")
-
-	context := &project.Context{
-		ProjectName:       "ProjectName",
-		Project:           &project.Project{},
-		EnvironmentLookup: envLookup,
-		ResourceLookup:    resourceLookup,
-	}
-	taskDefinition, err := ConvertToTaskDefinition(context, volumeConfigs, containerConfigs, taskRoleArn, "", ecsParams)
-	if err != nil {
-		return nil, err
-	}
-
-	return taskDefinition, nil
-}
-
-func findContainerByName(name string, containerDefs []*ecs.ContainerDefinition) *ecs.ContainerDefinition {
-	for _, cd := range containerDefs {
-		if aws.StringValue(cd.Name) == name {
-			return cd
-		}
-	}
-	return nil
 }
 
 func TestIsZeroForEmptyConfig(t *testing.T) {
@@ -991,4 +915,46 @@ func TestIsZeroWhenConfigHasValues(t *testing.T) {
 		_, hasValue := hasValues[fieldName]
 		assert.NotEqual(t, zeroValue, hasValue)
 	}
+}
+
+// helper functions
+func convertToTaskDefWithEcsParamsInTest(t *testing.T, containerConfigs []adapter.ContainerConfig, taskRoleArn string, ecsParams *ECSParams) (*ecs.TaskDefinition, error) {
+	volumeConfigs := &adapter.Volumes{
+		VolumeEmptyHost: []string{namedVolume},
+	}
+
+	context := testContext(t)
+
+	taskDefinition, err := ConvertToTaskDefinition(context, volumeConfigs, containerConfigs, taskRoleArn, "", ecsParams)
+	if err != nil {
+		return nil, err
+	}
+
+	return taskDefinition, nil
+}
+
+func findContainerByName(name string, containerDefs []*ecs.ContainerDefinition) *ecs.ContainerDefinition {
+	for _, cd := range containerDefs {
+		if aws.StringValue(cd.Name) == name {
+			return cd
+		}
+	}
+	return nil
+}
+
+func testContext(t *testing.T) *project.Context {
+	envLookup, err := GetDefaultEnvironmentLookup()
+	assert.NoError(t, err, "Unexpected error setting up environment lookup")
+
+	resourceLookup, err := GetDefaultResourceLookup()
+	assert.NoError(t, err, "Unexpected error setting up resource lookup")
+
+	context := &project.Context{
+		ProjectName:       "ProjectName",
+		Project:           &project.Project{},
+		EnvironmentLookup: envLookup,
+		ResourceLookup:    resourceLookup,
+	}
+
+	return context
 }


### PR DESCRIPTION
Also changed tests for ConvertToMountPoints to better reflect actual
inputs for volumes in docker-compose, as well as to account for mutating
top-level volumes struct

TODO: set volumes on project in parseV3