### PR TITLE
Expose "placementStrategy" setting through a new ecs-cli flag

### DIFF
--- a/ecs-cli/modules/cli/compose/entity/service/service.go
+++ b/ecs-cli/modules/cli/compose/entity/service/service.go
@@ -413,7 +413,7 @@ func (s *Service) createService() error {
 		return fmt.Errorf("--%v is only valid for services configured to use load balancers", flags.HealthCheckGracePeriodFlag)
 	}
 
-	err = s.Context().ECSClient.CreateService(serviceName, taskDefinitionID, s.loadBalancer, placementStrategy, s.role, s.DeploymentConfig(), networkConfig, launchType, s.healthCheckGP)
+	err = s.Context().ECSClient.CreateService(serviceName, taskDefinitionID, s.loadBalancer, s.role, s.DeploymentConfig(), networkConfig, launchType, s.healthCheckGP, placementStrategy)
 	if err != nil {
 		return err
 	}

--- a/ecs-cli/modules/cli/compose/entity/service/service.go
+++ b/ecs-cli/modules/cli/compose/entity/service/service.go
@@ -35,15 +35,18 @@ import (
 // Service type is placeholder for a single task definition and its cache
 // and it performs operations on ECS Service level
 type Service struct {
-	taskDef          *ecs.TaskDefinition
-	cache            cache.Cache
-	ecsContext       *context.ECSContext
-	timeSleeper      *utils.TimeSleeper
-	deploymentConfig *ecs.DeploymentConfiguration
-	loadBalancer     *ecs.LoadBalancer
-	role             string
-	healthCheckGP    *int64
+	taskDef           *ecs.TaskDefinition
+	cache             cache.Cache
+	ecsContext        *context.ECSContext
+	timeSleeper       *utils.TimeSleeper
+	deploymentConfig  *ecs.DeploymentConfiguration
+	loadBalancer      *ecs.LoadBalancer
+	placementStrategy []ecs.PlacementStrategy
+	role              string
+	healthCheckGP     *int64
 }
+
+//var placementStrategy []ecs.PlacementStrategy
 
 const (
 	ecsActiveResourceCode  = "ACTIVE"
@@ -57,6 +60,36 @@ func NewService(ecsContext *context.ECSContext) entity.ProjectEntity {
 		ecsContext:  ecsContext,
 		timeSleeper: &utils.TimeSleeper{},
 	}
+}
+
+// createPlacementStrategy returns a placement strategy
+//func (placementStrategy []ecs.PlacementStrategy) createPlacementStrategy(ps String) {
+func createPlacementStrategy(config string) []*ecs.PlacementStrategy {
+	psDefaultType := ecs.PlacementStrategyTypeRandom
+	psDefaultField := ""
+	defaultPlacementStrategy := ecs.PlacementStrategy{Field: &psDefaultField, Type: &psDefaultType}
+
+	var placementStrategy []*ecs.PlacementStrategy
+
+	if len(config) > 0 {
+		args := strings.Split(config, ",")
+
+		for _, element := range args {
+			kv := strings.Split(element, "/")
+			if element == psDefaultType {
+				placementStrategy = append(placementStrategy, &defaultPlacementStrategy)
+			} else {
+
+				t, f := kv[0], kv[1]
+				newPair := ecs.PlacementStrategy{Field: &f, Type: &t}
+				placementStrategy = append(placementStrategy, &newPair)
+			}
+		}
+
+	} else {
+		placementStrategy = append(placementStrategy, &defaultPlacementStrategy)
+	}
+	return placementStrategy
 }
 
 // LoadContext reads the ECS context set in NewService and loads DeploymentConfiguration and LoadBalancer
@@ -364,6 +397,12 @@ func (s *Service) createService() error {
 	launchType := s.Context().CommandConfig.LaunchType
 
 	networkConfig, err := composeutils.ConvertToECSNetworkConfiguration(s.ecsContext.ECSParams)
+
+	var placementStrategy []*ecs.PlacementStrategy
+	ps := s.Context().CLIContext.String(flags.PlacementStrategy)
+
+	placementStrategy = createPlacementStrategy(ps)
+
 	if err != nil {
 		return err
 	}
@@ -374,7 +413,7 @@ func (s *Service) createService() error {
 		return fmt.Errorf("--%v is only valid for services configured to use load balancers", flags.HealthCheckGracePeriodFlag)
 	}
 
-	err = s.Context().ECSClient.CreateService(serviceName, taskDefinitionID, s.loadBalancer, s.role, s.DeploymentConfig(), networkConfig, launchType, s.healthCheckGP)
+	err = s.Context().ECSClient.CreateService(serviceName, taskDefinitionID, s.loadBalancer, placementStrategy, s.role, s.DeploymentConfig(), networkConfig, launchType, s.healthCheckGP)
 	if err != nil {
 		return err
 	}

--- a/ecs-cli/modules/cli/compose/entity/service/service_test.go
+++ b/ecs-cli/modules/cli/compose/entity/service/service_test.go
@@ -224,10 +224,10 @@ func TestCreateFargateNetworkModeNotAWSVPC(t *testing.T) {
 	cliContext := cli.NewContext(nil, flagSet, nil)
 
 	context := &context.ECSContext{
-		ECSClient:  mockEcs,
-		CommandConfig:  &config.CommandConfig{LaunchType: "FARGATE"},
-		CLIContext: cliContext,
-		ECSParams:  &utils.ECSParams{},
+		ECSClient:     mockEcs,
+		CommandConfig: &config.CommandConfig{LaunchType: "FARGATE"},
+		CLIContext:    cliContext,
+		ECSParams:     &utils.ECSParams{},
 	}
 
 	service := NewService(context)
@@ -622,10 +622,10 @@ func createServiceWithHealthCheckGPTest(t *testing.T,
 	)
 
 	context := &context.ECSContext{
-		ECSClient:  mockEcs,
-		CommandConfig:  commandConfig,
-		CLIContext: cliContext,
-		ECSParams:  ecsParams,
+		ECSClient:     mockEcs,
+		CommandConfig: commandConfig,
+		CLIContext:    cliContext,
+		ECSParams:     ecsParams,
 	}
 
 	service := NewService(context)
@@ -905,10 +905,10 @@ func upServiceWithCurrentTaskDefTest(t *testing.T,
 	mockEcs := getUpdateServiceMockClient(t, ctrl, describeServiceResponse, taskDefinition, registerTaskDefResponse, expectedInput)
 
 	ecsContext := &context.ECSContext{
-		ECSClient:  mockEcs,
-		CommandConfig:  commandConfig,
-		CLIContext: cliContext,
-		ECSParams:  ecsParams,
+		ECSClient:     mockEcs,
+		CommandConfig: commandConfig,
+		CLIContext:    cliContext,
+		ECSParams:     ecsParams,
 	}
 	// if taskDef is unchanged, serviceName is taken from current context
 	if existingService != nil {
@@ -949,10 +949,10 @@ func upServiceWithNewTaskDefTest(t *testing.T,
 	mockEcs := getUpdateServiceMockClient(t, ctrl, describeServiceResponse, taskDefinition, registerTaskDefResponse, expectedInput)
 
 	ecsContext := &context.ECSContext{
-		ECSClient:  mockEcs,
-		CommandConfig:  commandConfig,
-		CLIContext: cliContext,
-		ECSParams:  ecsParams,
+		ECSClient:     mockEcs,
+		CommandConfig: commandConfig,
+		CLIContext:    cliContext,
+		ECSParams:     ecsParams,
 	}
 	service := NewService(ecsContext)
 	err := service.LoadContext()

--- a/ecs-cli/modules/clients/aws/ecs/client.go
+++ b/ecs-cli/modules/clients/aws/ecs/client.go
@@ -44,7 +44,7 @@ type ECSClient interface {
 	IsActiveCluster(clusterName string) (bool, error)
 
 	// Service related
-	CreateService(serviceName, taskDefName string, loadBalancer *ecs.LoadBalancer, role string, deploymentConfig *ecs.DeploymentConfiguration, networkConfig *ecs.NetworkConfiguration, launchType string, healthCheckGracePeriod *int64) error
+	CreateService(serviceName, taskDefName string, loadBalancer *ecs.LoadBalancer, placementStrategy []*ecs.PlacementStrategy, role string, deploymentConfig *ecs.DeploymentConfiguration, networkConfig *ecs.NetworkConfiguration, launchType string, healthCheckGracePeriod *int64) error
 	UpdateService(serviceName, taskDefinitionName string, count int64, deploymentConfig *ecs.DeploymentConfiguration, networkConfig *ecs.NetworkConfiguration, healthCheckGracePeriod *int64, force bool) error
 	DescribeService(serviceName string) (*ecs.DescribeServicesOutput, error)
 	DeleteService(serviceName string) error
@@ -131,9 +131,17 @@ func (c *ecsClient) DeleteService(serviceName string) error {
 	return nil
 }
 
-func (c *ecsClient) CreateService(serviceName, taskDefName string, loadBalancer *ecs.LoadBalancer, role string, deploymentConfig *ecs.DeploymentConfiguration, networkConfig *ecs.NetworkConfiguration, launchType string, healthCheckGracePeriod *int64) error {
+func (c *ecsClient) CreateService(serviceName, taskDefName string, loadBalancer *ecs.LoadBalancer, placementStrategy []*ecs.PlacementStrategy, role string, deploymentConfig *ecs.DeploymentConfiguration, networkConfig *ecs.NetworkConfiguration, launchType string, healthCheckGracePeriod *int64) error {
+
+	//var f = "attribute:ecs.availability-zone"
+	//var t = ecs.PlacementStrategyTypeSpread
+	////var t = "spread"
+	//var ps = ecs.PlacementStrategy{Field: &f, Type: &t}
+
 	createServiceInput := &ecs.CreateServiceInput{
 		DesiredCount:            aws.Int64(0),            // Required
+		//PlacementStrategy:		 []*ecs.PlacementStrategy{&ps},
+		PlacementStrategy:       placementStrategy,
 		ServiceName:             aws.String(serviceName), // Required
 		TaskDefinition:          aws.String(taskDefName), // Required
 		Cluster:                 aws.String(c.config.Cluster),
@@ -529,3 +537,4 @@ func (c *ecsClient) IsActiveCluster(clusterName string) (bool, error) {
 	log.WithFields(log.Fields{"cluster": clusterName, "status": status}).Debug("cluster status")
 	return false, nil
 }
+

--- a/ecs-cli/modules/clients/aws/ecs/client.go
+++ b/ecs-cli/modules/clients/aws/ecs/client.go
@@ -133,14 +133,8 @@ func (c *ecsClient) DeleteService(serviceName string) error {
 
 func (c *ecsClient) CreateService(serviceName, taskDefName string, loadBalancer *ecs.LoadBalancer, role string, deploymentConfig *ecs.DeploymentConfiguration, networkConfig *ecs.NetworkConfiguration, launchType string, healthCheckGracePeriod *int64, placementStrategy []*ecs.PlacementStrategy) error {
 
-	//var f = "attribute:ecs.availability-zone"
-	//var t = ecs.PlacementStrategyTypeSpread
-	////var t = "spread"
-	//var ps = ecs.PlacementStrategy{Field: &f, Type: &t}
-
 	createServiceInput := &ecs.CreateServiceInput{
 		DesiredCount: aws.Int64(0), // Required
-		//PlacementStrategy:		 []*ecs.PlacementStrategy{&ps},
 		PlacementStrategy:       placementStrategy,
 		ServiceName:             aws.String(serviceName), // Required
 		TaskDefinition:          aws.String(taskDefName), // Required

--- a/ecs-cli/modules/clients/aws/ecs/client.go
+++ b/ecs-cli/modules/clients/aws/ecs/client.go
@@ -44,7 +44,7 @@ type ECSClient interface {
 	IsActiveCluster(clusterName string) (bool, error)
 
 	// Service related
-	CreateService(serviceName, taskDefName string, loadBalancer *ecs.LoadBalancer, placementStrategy []*ecs.PlacementStrategy, role string, deploymentConfig *ecs.DeploymentConfiguration, networkConfig *ecs.NetworkConfiguration, launchType string, healthCheckGracePeriod *int64) error
+	CreateService(serviceName, taskDefName string, loadBalancer *ecs.LoadBalancer, role string, deploymentConfig *ecs.DeploymentConfiguration, networkConfig *ecs.NetworkConfiguration, launchType string, healthCheckGracePeriod *int64, placementStrategy []*ecs.PlacementStrategy) error
 	UpdateService(serviceName, taskDefinitionName string, count int64, deploymentConfig *ecs.DeploymentConfiguration, networkConfig *ecs.NetworkConfiguration, healthCheckGracePeriod *int64, force bool) error
 	DescribeService(serviceName string) (*ecs.DescribeServicesOutput, error)
 	DeleteService(serviceName string) error
@@ -131,7 +131,7 @@ func (c *ecsClient) DeleteService(serviceName string) error {
 	return nil
 }
 
-func (c *ecsClient) CreateService(serviceName, taskDefName string, loadBalancer *ecs.LoadBalancer, placementStrategy []*ecs.PlacementStrategy, role string, deploymentConfig *ecs.DeploymentConfiguration, networkConfig *ecs.NetworkConfiguration, launchType string, healthCheckGracePeriod *int64) error {
+func (c *ecsClient) CreateService(serviceName, taskDefName string, loadBalancer *ecs.LoadBalancer, role string, deploymentConfig *ecs.DeploymentConfiguration, networkConfig *ecs.NetworkConfiguration, launchType string, healthCheckGracePeriod *int64, placementStrategy []*ecs.PlacementStrategy) error {
 
 	//var f = "attribute:ecs.availability-zone"
 	//var t = ecs.PlacementStrategyTypeSpread

--- a/ecs-cli/modules/clients/aws/ecs/client.go
+++ b/ecs-cli/modules/clients/aws/ecs/client.go
@@ -139,7 +139,7 @@ func (c *ecsClient) CreateService(serviceName, taskDefName string, loadBalancer 
 	//var ps = ecs.PlacementStrategy{Field: &f, Type: &t}
 
 	createServiceInput := &ecs.CreateServiceInput{
-		DesiredCount:            aws.Int64(0),            // Required
+		DesiredCount: aws.Int64(0), // Required
 		//PlacementStrategy:		 []*ecs.PlacementStrategy{&ps},
 		PlacementStrategy:       placementStrategy,
 		ServiceName:             aws.String(serviceName), // Required
@@ -537,4 +537,3 @@ func (c *ecsClient) IsActiveCluster(clusterName string) (bool, error) {
 	log.WithFields(log.Fields{"cluster": clusterName, "status": status}).Debug("cluster status")
 	return false, nil
 }
-

--- a/ecs-cli/modules/clients/aws/ecs/mock/client.go
+++ b/ecs-cli/modules/clients/aws/ecs/mock/client.go
@@ -56,7 +56,7 @@ func (_mr *_MockECSClientRecorder) CreateCluster(arg0 interface{}) *gomock.Call 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateCluster", arg0)
 }
 
-func (_m *MockECSClient) CreateService(_param0 string, _param1 string, _param2 *ecs.LoadBalancer, _param3 string, _param4 *ecs.DeploymentConfiguration, _param5 *ecs.NetworkConfiguration, _param6 string, _param7 *int64,  _param8 []*ecs.PlacementStrategy) error {
+func (_m *MockECSClient) CreateService(_param0 string, _param1 string, _param2 *ecs.LoadBalancer, _param3 string, _param4 *ecs.DeploymentConfiguration, _param5 *ecs.NetworkConfiguration, _param6 string, _param7 *int64, _param8 []*ecs.PlacementStrategy) error {
 	ret := _m.ctrl.Call(_m, "CreateService", _param0, _param1, _param2, _param3, _param4, _param5, _param6, _param7, _param8)
 	ret0, _ := ret[0].(error)
 	return ret0

--- a/ecs-cli/modules/clients/aws/ecs/mock/client.go
+++ b/ecs-cli/modules/clients/aws/ecs/mock/client.go
@@ -56,14 +56,14 @@ func (_mr *_MockECSClientRecorder) CreateCluster(arg0 interface{}) *gomock.Call 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateCluster", arg0)
 }
 
-func (_m *MockECSClient) CreateService(_param0 string, _param1 string, _param2 *ecs.LoadBalancer, _param3 string, _param4 *ecs.DeploymentConfiguration, _param5 *ecs.NetworkConfiguration, _param6 string, _param7 *int64) error {
-	ret := _m.ctrl.Call(_m, "CreateService", _param0, _param1, _param2, _param3, _param4, _param5, _param6, _param7)
+func (_m *MockECSClient) CreateService(_param0 string, _param1 string, _param2 *ecs.LoadBalancer, _param3 []*ecs.PlacementStrategy, _param4 string, _param5 *ecs.DeploymentConfiguration, _param6 *ecs.NetworkConfiguration, _param7 string, _param8 *int64) error {
+	ret := _m.ctrl.Call(_m, "CreateService", _param0, _param1, _param2, _param3, _param4, _param5, _param6, _param7, _param8)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-func (_mr *_MockECSClientRecorder) CreateService(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateService", arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7)
+func (_mr *_MockECSClientRecorder) CreateService(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateService", arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)
 }
 
 func (_m *MockECSClient) DeleteCluster(_param0 string) (string, error) {

--- a/ecs-cli/modules/clients/aws/ecs/mock/client.go
+++ b/ecs-cli/modules/clients/aws/ecs/mock/client.go
@@ -56,7 +56,7 @@ func (_mr *_MockECSClientRecorder) CreateCluster(arg0 interface{}) *gomock.Call 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateCluster", arg0)
 }
 
-func (_m *MockECSClient) CreateService(_param0 string, _param1 string, _param2 *ecs.LoadBalancer, _param3 []*ecs.PlacementStrategy, _param4 string, _param5 *ecs.DeploymentConfiguration, _param6 *ecs.NetworkConfiguration, _param7 string, _param8 *int64) error {
+func (_m *MockECSClient) CreateService(_param0 string, _param1 string, _param2 *ecs.LoadBalancer, _param3 string, _param4 *ecs.DeploymentConfiguration, _param5 *ecs.NetworkConfiguration, _param6 string, _param7 *int64,  _param8 []*ecs.PlacementStrategy) error {
 	ret := _m.ctrl.Call(_m, "CreateService", _param0, _param1, _param2, _param3, _param4, _param5, _param6, _param7, _param8)
 	ret0, _ := ret[0].(error)
 	return ret0

--- a/ecs-cli/modules/commands/compose/service/compose_service_command.go
+++ b/ecs-cli/modules/commands/compose/service/compose_service_command.go
@@ -86,7 +86,7 @@ func upServiceCommand(factory composeFactory.ProjectFactory) cli.Command {
 		Name:         "up",
 		Usage:        "Creates a new ECS service or updates an existing one according to your compose file. For new services or existing services with a current desired count of 0, the desired count for the service is set to 1. For existing services with non-zero desired counts, a new task definition is created to reflect any changes to the compose file and the service is updated to use that task definition. In this case, the desired count does not change.",
 		Action:       compose.WithProject(factory, compose.ProjectUp, true),
-		Flags:        append(append(append(append(deploymentConfigFlags(true), append(loadBalancerFlags(), flags.OptionalConfigFlags()...)...), ComposeServiceTimeoutFlag()), flags.OptionalLaunchTypeFlag(), flags.OptionalCreateLogsFlag()), ForceNewDeploymentFlag()),
+		Flags:        append(append(append(append(deploymentConfigFlags(true), append(loadBalancerFlags(), flags.OptionalConfigFlags()...)...), ComposeServiceTimeoutFlag()), flags.OptionalLaunchTypeFlag(), flags.OptionalCreateLogsFlag()), ForceNewDeploymentFlag(), flags.OptionalPlacementStrategy()),
 		OnUsageError: flags.UsageErrorFactory("up"),
 	}
 }

--- a/ecs-cli/modules/commands/flags/flags.go
+++ b/ecs-cli/modules/commands/flags/flags.go
@@ -100,16 +100,16 @@ const (
 	DeploymentMaxPercentDefaultValue        = 200
 	DeploymentMaxPercentFlag                = "deployment-max-percent"
 	DeploymentMinHealthyPercentDefaultValue = 100
-	DeploymentMinHealthyPercentFlag = "deployment-min-healthy-percent"
-	TargetGroupArnFlag              = "target-group-arn"
-	ContainerNameFlag               = "container-name"
-	ContainerPortFlag               = "container-port"
-	LoadBalancerNameFlag            = "load-balancer-name"
-	HealthCheckGracePeriodFlag      = "health-check-grace-period"
-	RoleFlag                        = "role"
-	ComposeServiceTimeOutFlag       = "timeout"
-	ForceDeploymentFlag             = "force-deployment"
-	PlacementStrategy               = "placement-strategy"
+	DeploymentMinHealthyPercentFlag         = "deployment-min-healthy-percent"
+	TargetGroupArnFlag                      = "target-group-arn"
+	ContainerNameFlag                       = "container-name"
+	ContainerPortFlag                       = "container-port"
+	LoadBalancerNameFlag                    = "load-balancer-name"
+	HealthCheckGracePeriodFlag              = "health-check-grace-period"
+	RoleFlag                                = "role"
+	ComposeServiceTimeOutFlag               = "timeout"
+	ForceDeploymentFlag                     = "force-deployment"
+	PlacementStrategy                       = "placement-strategy"
 )
 
 // OptionalRegionAndProfileFlags provides these flags:

--- a/ecs-cli/modules/commands/flags/flags.go
+++ b/ecs-cli/modules/commands/flags/flags.go
@@ -100,15 +100,16 @@ const (
 	DeploymentMaxPercentDefaultValue        = 200
 	DeploymentMaxPercentFlag                = "deployment-max-percent"
 	DeploymentMinHealthyPercentDefaultValue = 100
-	DeploymentMinHealthyPercentFlag         = "deployment-min-healthy-percent"
-	TargetGroupArnFlag                      = "target-group-arn"
-	ContainerNameFlag                       = "container-name"
-	ContainerPortFlag                       = "container-port"
-	LoadBalancerNameFlag                    = "load-balancer-name"
-	HealthCheckGracePeriodFlag              = "health-check-grace-period"
-	RoleFlag                                = "role"
-	ComposeServiceTimeOutFlag               = "timeout"
-	ForceDeploymentFlag                     = "force-deployment"
+	DeploymentMinHealthyPercentFlag = "deployment-min-healthy-percent"
+	TargetGroupArnFlag              = "target-group-arn"
+	ContainerNameFlag               = "container-name"
+	ContainerPortFlag               = "container-port"
+	LoadBalancerNameFlag            = "load-balancer-name"
+	HealthCheckGracePeriodFlag      = "health-check-grace-period"
+	RoleFlag                        = "role"
+	ComposeServiceTimeOutFlag       = "timeout"
+	ForceDeploymentFlag             = "force-deployment"
+	PlacementStrategy               = "placement-strategy"
 )
 
 // OptionalRegionAndProfileFlags provides these flags:
@@ -178,6 +179,16 @@ func OptionalCreateLogsFlag() cli.Flag {
 		Name: CreateLogsFlag,
 		Usage: fmt.Sprintf(
 			"[Optional] Create the CloudWatch log groups specified in your compose file(s).",
+		),
+	}
+}
+
+// OptionalPlacementStrategy allows users to specify how containers will be distributed
+func OptionalPlacementStrategy() cli.Flag {
+	return cli.StringFlag{
+		Name: PlacementStrategy,
+		Usage: fmt.Sprintf(
+			"[Optional] Specify an optional placement strategy(s).",
 		),
 	}
 }


### PR DESCRIPTION
Expose "placementStrategy" setting through a new ecs-cli flag

New flag "--placement-strategy" can be used to alter default behavior of "random" distribution of containers. Random distribution does not provide "production" grade support of application because multiple containers can be placed in the same availability zone.

This new flag will allow setting the placement strategy so that containers can be distributed across AZ's, or optimized for CPU/Memory oriented use cases also.

placementStrategy can be set via a command line flag (string) with the following format:

"Type/Field,Type/Field"

(comma separated pairs; and forward slash separated "Type/Field" values)

Where:
"Type" == "random|spread|binpack"
&&
"Field" == "instanceId| host|attribute:ecs.availability-zone"

This PR will only set the placement strategy upon creating a new service & will not update existing tasks. 

