### PR TITLE
Set default for essential to be true on ContainerDef

### DIFF
--- a/ecs-cli/modules/utils/compose/ecs_params_reader.go
+++ b/ecs-cli/modules/utils/compose/ecs_params_reader.go
@@ -87,6 +87,17 @@ const (
 	Disabled AssignPublicIp = "DISABLED"
 )
 
+func (cd *ContainerDef) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	type rawContainerDef ContainerDef
+	raw := rawContainerDef{Essential: true} //  If essential is not specified, we want it to be true
+	if err := unmarshal(&raw); err != nil {
+		return err
+	}
+
+	*cd = ContainerDef(raw)
+	return nil
+}
+
 // ReadECSParams parses the ecs-params.yml file and puts it into an ECSParams struct.
 func ReadECSParams(filename string) (*ECSParams, error) {
 	if filename == "" {


### PR DESCRIPTION
Previously, the only field on a service in ecs-params.yml was essential.
The desired behavior is that if essential is not specified, the default
is true. However, the yaml unmarshaller by default sets any unspecified
field in the yaml to the zero value, which in the case of a boolean is
false. Since we did not expect customers to specify the 'services' field
at all in the past unless they wished to specify essential to be false,
this worked. However, with the addition of other fields (CPU, Memory) on
container definitions, we need to ensure that the default for essential
is still true even when not specified.