### PR TITLE
Wire up top-level Volumes for Compose 3

### DIFF
--- a/ecs-cli/modules/cli/compose/adapter/convert_test.go
+++ b/ecs-cli/modules/cli/compose/adapter/convert_test.go
@@ -344,6 +344,34 @@ func TestConvertToMountPointsWithNoCorrespondingNamedVolume(t *testing.T) {
 	assert.Error(t, err, "Expected error converting MountPoints")
 }
 
+func TestGetSourcePathAndUpdateVolumesWithEmptySourcePath(t *testing.T) {
+	expectedSourcePath := "volume-0"
+	volumes := &Volumes{
+		VolumeWithHost:  make(map[string]string),
+		VolumeEmptyHost: []string{}, // Top-level named volumes is empty
+	}
+
+	observedSourcePath, err := GetSourcePathAndUpdateVolumes("", volumes)
+
+	assert.NoError(t, err, "Unexpected error getting Mount Point source path")
+	assert.Equal(t, expectedSourcePath, observedSourcePath)
+	assert.Equal(t, expectedSourcePath, volumes.VolumeEmptyHost[0])
+}
+
+func TestGetSourcePathAndUpdateVolumesWithNamedVol(t *testing.T) {
+	namedSourcePath := "logging"
+	volumes := &Volumes{
+		VolumeWithHost:  make(map[string]string),
+		VolumeEmptyHost: []string{namedSourcePath},
+	}
+
+	observedSourcePath, err := GetSourcePathAndUpdateVolumes(namedSourcePath, volumes)
+
+	assert.NoError(t, err, "Unexpected error getting Mount Point source path")
+	assert.Equal(t, namedSourcePath, observedSourcePath)
+	assert.Equal(t, namedSourcePath, volumes.VolumeEmptyHost[0])
+}
+
 func TestConvertToExtraHosts(t *testing.T) {
 	hostname := "test.local"
 	ipAddress := "127.10.10.10"

--- a/ecs-cli/modules/cli/compose/project/project_parseV1V2.go
+++ b/ecs-cli/modules/cli/compose/project/project_parseV1V2.go
@@ -2,6 +2,7 @@ package project
 
 import (
 	"fmt"
+
 	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/cli/compose/adapter"
 	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/cli/compose/logger"
 	"github.com/aws/aws-sdk-go/aws"


### PR DESCRIPTION
`make` and `make test` pass

### Tests
docker-compose file:
```
version: '3'
services:
  wordpress:
    image: wordpress
    ports:
      - "80:80"
    links:
      - mysql
    logging:
      driver: awslogs
      options: 
        awslogs-group: multiservice-wordpress
        awslogs-region: us-east-1
        awslogs-stream-prefix: wordpress
  mysql:
    image: mysql
    environment:
      MYSQL_USER: test-user
    volumes:
     - /opt/data:/var/lib/mysql
     - test:/stuff/test:ro
    logging:
      driver: awslogs
      options: 
        awslogs-group: multiservice-mysql
        awslogs-region: us-east-1
        awslogs-stream-prefix: mysql
volumes:
  test:
```

ecs-params.yml:
```
version: 1
task_definition:
  services:
    wordpress:
      essential: true
      cpu_shares: 102
      mem_limit: 30g
      mem_reservation: 22m
```

resulting task definition:
```
{
    "containerDefinitions": [
        {
            "logConfiguration": {
                "logDriver": "awslogs",
                "options": {
                    "awslogs-group": "multiservice-wordpress",
                    "awslogs-region": "us-east-1",
                    "awslogs-stream-prefix": "wordpress"
                }
            },
            "portMappings": [
                {
                    "hostPort": 80,
                    "protocol": "tcp",
                    "containerPort": 80
                }
            ],
            "cpu": 102,
            "memory": 30720,
            "memoryReservation": 22,
            "image": "wordpress",
            "essential": true,
            "links": [
                "mysql"
            ],
            "privileged": false,
            "name": "wordpress"
        },
        {
            "logConfiguration": {
                "logDriver": "awslogs",
                "options": {
                    "awslogs-group": "multiservice-mysql",
                    "awslogs-region": "us-east-1",
                    "awslogs-stream-prefix": "mysql"
                }
            },
            "environment": [
                {
                    "name": "MYSQL_USER",
                    "value": "test-user"
                }
            ],
            "mountPoints": [
                {
                    "readOnly": false,
                    "containerPath": "/var/lib/mysql",
                    "sourceVolume": "volume-1"
                },
                {
                    "readOnly": true,
                    "containerPath": "/stuff/test",
                    "sourceVolume": "test"
                }
            ],
            "memory": 512,
            "name": "mysql"
        }
    ],
    "family": "multiService",
    "networkMode": null,
    "volumes": [
        {
            "name": "volume-1",
            "host": {
                "sourcePath": "/opt/data"
            }
        },
        {
            "name": "test",
            "host": {
                "sourcePath": null
            }
        }
    ]
}
```