### PR TITLE
Log warning for unsupported v3 compose options

### DIFF
--- a/ecs-cli/modules/cli/compose/adapter/convert.go
+++ b/ecs-cli/modules/cli/compose/adapter/convert.go
@@ -440,3 +440,20 @@ func SortedGoString(v interface{}) (string, error) {
 	}
 	return string(b), nil
 }
+
+// ConvertCamelCaseToUnderScore returns an underscore-separated name for a given camelcased string
+// e.g., "NetworkMode" -> "network_mode"
+func ConvertCamelCaseToUnderScore(s string) string {
+	camelRegex := regexp.MustCompile("(^[^A-Z]*|[A-Z]*)([A-Z][^A-Z]+|$)")
+
+	var chars []string
+	for _, sub := range camelRegex.FindAllStringSubmatch(s, -1) {
+		if sub[1] != "" {
+			chars = append(chars, sub[1])
+		}
+		if sub[2] != "" {
+			chars = append(chars, sub[2])
+		}
+	}
+	return strings.ToLower(strings.Join(chars, "_"))
+}

--- a/ecs-cli/modules/cli/compose/adapter/convert_test.go
+++ b/ecs-cli/modules/cli/compose/adapter/convert_test.go
@@ -548,3 +548,22 @@ func TestSortedGoString(t *testing.T) {
 
 	assert.Equal(t, strA, strB, "Sorted inputs should match")
 }
+
+func TestConvertCamelCaseToUnderScore(t *testing.T) {
+	testCases := []struct {
+		input    string
+		expected string
+	}{
+		{"CamelCaseString", "camel_case_string"},
+		{"lowercase", "lowercase"},
+		{"UPPERCASE", "uppercase"},
+		{"CamelWithACRONYM", "camel_with_acronym"},
+		{"Uppercase", "uppercase"},
+	}
+	for _, test := range testCases {
+		t.Run(fmt.Sprintf("%s should be %s", test.input, test.expected), func(t *testing.T) {
+			output := ConvertCamelCaseToUnderScore(test.input)
+			assert.Equal(t, test.expected, output, "Expected output to match")
+		})
+	}
+}

--- a/ecs-cli/modules/cli/compose/project/project_parseV1V2.go
+++ b/ecs-cli/modules/cli/compose/project/project_parseV1V2.go
@@ -53,7 +53,7 @@ func (p *ecsProject) parseV1V2() (*[]adapter.ContainerConfig, error) {
 }
 
 func convertV1V2ToContainerConfig(context *project.Context, serviceName string, volumes *adapter.Volumes, service *config.ServiceConfig) (*adapter.ContainerConfig, error) {
-	logger.LogUnsupportedServiceConfigFields(serviceName, service)
+	logger.LogUnsupportedV1V2ServiceConfigFields(serviceName, service)
 
 	environment := adapter.ConvertToKeyValuePairs(context, service.Environment, serviceName)
 

--- a/ecs-cli/modules/cli/compose/project/project_parseV3.go
+++ b/ecs-cli/modules/cli/compose/project/project_parseV3.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 
 	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/cli/compose/adapter"
+	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/cli/compose/logger"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ecs"
 	"github.com/pkg/errors"
@@ -84,6 +85,9 @@ func getV3Config(composeFiles []string) (*types.Config, error) {
 }
 
 func convertToContainerConfig(serviceConfig types.ServiceConfig, serviceVols *adapter.Volumes) (*adapter.ContainerConfig, error) {
+	logger.LogUnsupportedV3ServiceConfigFields(serviceConfig)
+	logWarningForDeployFields(serviceConfig.Deploy, serviceConfig.Name)
+
 	//TODO: Add Healthcheck, Devices to ContainerConfig
 	c := &adapter.ContainerConfig{
 		CapAdd:                serviceConfig.CapAdd,
@@ -185,9 +189,6 @@ func convertToContainerConfig(serviceConfig types.ServiceConfig, serviceVols *ad
 		c.MountPoints = mountPoints
 	}
 
-	logWarningForDeployFields(serviceConfig.Deploy, serviceConfig.Name)
-
-	// TODO: log out unsupported fields
 	return c, nil
 }
 


### PR DESCRIPTION
`make` and `make test` succeed

## Tests

example v3 docker-compose.yml:
```
version: '3'
services:
  web:
    image: httpd
    command: echo "hello world"
    devices:  # unsupported
      - "/dev/test"
    pid: "wont-work" # unsupported
    dns:
      - 8.8.8.8
      - 9.9.9.9
    ports:
      - "80:80"
    ulimits:
      nice: 6505
      rss:
        soft: 2000
        hard: 4000
```

ecs-cli compose result:
```
$~\testUnsupported> ..\..\Documents\GO\src\github.com\aws\amazon-ecs-cli\bin\local\ecs-cli.exe compose create
WARN[0000] Skipping unsupported YAML option for service...  option name=devices service name=web
WARN[0000] Skipping unsupported YAML option for service...  option name=pid service name=web
INFO[0000] Using ECS task definition                     TaskDefinition="testUnsupported:5"
```

example v2 docker-compose.yml:
```
version: '2'
services:
  web:
    image: httpd
    command: echo "hello world"
    devices:  # unsupported
      - "/dev/test"
    pid: "wont-work" # unsupported
    dns:
      - 8.8.8.8
      - 9.9.9.9
    ports:
      - "80:80"
    ulimits:
      nice: 6505
      rss:
        soft: 2000
        hard: 4000
```

ecs-cli compose result:
```
$~\testUnsupported> ..\..\Documents\GO\src\github.com\aws\amazon-ecs-cli\bin\local\ecs-cli.exe compose create
WARN[0000] Skipping unsupported YAML option for service...  option name=devices service name=web
WARN[0000] Skipping unsupported YAML option for service...  option name=pid service name=web
INFO[0000] Using ECS task definition                     TaskDefinition="testUnsupported:6"
```