### PR TITLE
Add support for environment variables in ecs-params.yml - Issue #530

### DIFF
--- a/ecs-cli/modules/utils/compose/ecs_params_reader.go
+++ b/ecs-cli/modules/utils/compose/ecs_params_reader.go
@@ -115,7 +115,7 @@ func ReadECSParams(filename string) (*ECSParams, error) {
 	if err != nil {
 		return nil, errors.Wrapf(err, "Error reading file '%v'", filename)
 	}
-
+	ecsParamsData = []byte(os.ExpandEnv(string(ecsParamsData)))
 	ecsParams := &ECSParams{}
 
 	if err = yaml.Unmarshal([]byte(ecsParamsData), &ecsParams); err != nil {


### PR DESCRIPTION
This adds support and a test for environment variables in ecs-params.yml.
It is a basic set of support for variables in the `$VAR` and `${VAR}` format.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.