### PR TITLE
Refactor parseV3 tests

### DIFF
--- a/ecs-cli/modules/cli/compose/project/project_parseV3_test.go
+++ b/ecs-cli/modules/cli/compose/project/project_parseV3_test.go
@@ -3,7 +3,7 @@ package project
 import (
 	"io/ioutil"
 	"os"
-	"strings"
+	"reflect"
 	"testing"
 
 	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/cli/compose/adapter"
@@ -11,12 +11,92 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ecs"
 	"github.com/stretchr/testify/assert"
-
-	"github.com/docker/cli/cli/compose/types"
-	"github.com/docker/libcompose/yaml"
 )
 
 func TestParseV3WithOneFile(t *testing.T) {
+	// set up expected ContainerConfig values
+	wordpressCon := adapter.ContainerConfig{}
+	wordpressCon.Name = "wordpress"
+	wordpressCon.CapAdd = []string{"ALL"}
+	wordpressCon.CapDrop = []string{"NET_ADMIN"}
+	wordpressCon.Command = []string{"echo \"hello world\""}
+	wordpressCon.Image = "wordpress"
+	wordpressCon.Entrypoint = []string{"/wordpress/entry"}
+	wordpressCon.PortMappings = []*ecs.PortMapping{
+		{
+			ContainerPort: aws.Int64(80),
+			HostPort:      aws.Int64(80),
+			Protocol:      aws.String("tcp"),
+		},
+	}
+	wordpressCon.DNSServers = []string{"2.2.2.2"}
+	wordpressCon.DNSSearchDomains = []string{"wrd.search.com", "wrd.search2.com"}
+	wordpressCon.Environment = []*ecs.KeyValuePair{
+		{
+			Name:  aws.String("wordpress_env"),
+			Value: aws.String("val1"),
+		},
+	}
+	wordpressCon.DockerLabels = map[string]*string{
+		"com.example.wordpress": aws.String("wordpress label"),
+	}
+	wordpressCon.Hostname = "wrdhost"
+	wordpressCon.Links = []string{"mysql"}
+	wordLogDriver := aws.String("awslogs")
+	wordLogOpts := map[string]*string{
+		"awslogs-group":         aws.String("mywrdprs-logs"),
+		"awslogs-region":        aws.String("us-west-2"),
+		"awslogs-stream-prefix": aws.String("wordpress"),
+	}
+	wordpressCon.LogConfiguration = &ecs.LogConfiguration{
+		LogDriver: wordLogDriver,
+		Options:   wordLogOpts,
+	}
+	wordTmpfsOpt := []string{"rw"}
+	wordpressCon.Tmpfs = []*ecs.Tmpfs{
+		{
+			ContainerPath: aws.String("/run"),
+			MountOptions:  aws.StringSlice(wordTmpfsOpt),
+			Size:          aws.Int64(1024),
+		},
+	}
+	wordpressCon.Privileged = true
+	wordpressCon.ReadOnly = true
+	wordpressCon.DockerSecurityOptions = []string{"label:role:ROLE", "label:user:USER"}
+	wordpressCon.Ulimits = []*ecs.Ulimit{
+		{
+			Name:      aws.String("rss"),
+			HardLimit: aws.Int64(65535),
+			SoftLimit: aws.Int64(65535),
+		},
+		{
+			Name:      aws.String("nofile"),
+			HardLimit: aws.Int64(4000),
+			SoftLimit: aws.Int64(2000),
+		},
+		{
+			Name:      aws.String("nice"),
+			HardLimit: aws.Int64(500),
+			SoftLimit: aws.Int64(300),
+		},
+	}
+	wordpressCon.WorkingDirectory = "/wrdprsdir"
+
+	mysqlCon := adapter.ContainerConfig{}
+	mysqlCon.Name = "mysql"
+	mysqlCon.Image = "mysql"
+	mysqlCon.DockerLabels = map[string]*string{
+		"com.example.mysql":  aws.String("mysqllabel"),
+		"com.example.mysql2": aws.String("anothermysql label"),
+	}
+	mysqlCon.User = "mysqluser"
+	mysqlCon.ExtraHosts = []*ecs.HostEntry{
+		{
+			Hostname:  aws.String("mysqlexhost"),
+			IpAddress: aws.String("10.0.0.0"),
+		},
+	}
+
 	// set up file
 	composeFileString := `version: '3'
 services:
@@ -25,7 +105,8 @@ services:
       - ALL
     cap_drop:
       - NET_ADMIN
-    command: echo "hello world"
+    command: 
+      - echo "hello world"
     image: wordpress
     entrypoint: /wordpress/entry
     ports: ["80:80"]
@@ -49,6 +130,12 @@ services:
     tmpfs:
       - "/run:rw,size=1gb"
     read_only: true
+    hostname: wrdhost
+    security_opt:
+      - label:role:ROLE
+      - label:user:USER
+    working_dir: /wrdprsdir
+    privileged: true
     ulimits:
       rss: 65535
       nofile:
@@ -63,12 +150,6 @@ services:
       - "com.example.mysql=mysqllabel"
       - "com.example.mysql2=anothermysql label"
     user: mysqluser
-    hostname: mysqlhost
-    security_opt:
-      - label:role:ROLE
-      - label:user:USER
-    working_dir: /mysqltestdir
-    privileged: true
     extra_hosts:
       - "mysqlexhost:10.0.0.0"`
 
@@ -87,20 +168,64 @@ services:
 	project := setupTestProject(t)
 	project.ecsContext.ComposeFiles = append(project.ecsContext.ComposeFiles, tmpfile.Name())
 
-	// get map of docker-parsed ServiceConfigs
-	expectedConfigs := getServiceConfigMap(t, project.ecsContext.ComposeFiles)
-
-	// assert # and content of container configs matches expected services
+	// assert # and content of container configs matches expected
 	actualConfigs, err := project.parseV3()
 	assert.NoError(t, err, "Unexpected error parsing file")
 
-	assert.Equal(t, len(expectedConfigs), len(*actualConfigs))
-	for _, containerConfig := range *actualConfigs {
-		verifyConvertToContainerConfigOutput(t, expectedConfigs[containerConfig.Name], containerConfig)
-	}
+	assert.Equal(t, 2, len(*actualConfigs))
+
+	wp, err := getContainerConfigByName(wordpressCon.Name, actualConfigs)
+	assert.NoError(t, err, "Unexpected error retrieving wordpress config")
+	verifyContainerConfig(t, wordpressCon, *wp)
+
+	mysql, err := getContainerConfigByName(mysqlCon.Name, actualConfigs)
+	assert.NoError(t, err, "Unexpected error retrieving mysql config")
+	verifyContainerConfig(t, mysqlCon, *mysql)
 }
 
 func TestParseV3WithMultipleFiles(t *testing.T) {
+	// set up expected ContainerConfig values
+	wordpressCon := adapter.ContainerConfig{}
+	wordpressCon.Name = "wordpress"
+	wordpressCon.Image = "wordpress"
+	wordpressCon.PortMappings = []*ecs.PortMapping{
+		{
+			ContainerPort: aws.Int64(80),
+			HostPort:      aws.Int64(80),
+			Protocol:      aws.String("tcp"),
+		},
+		{
+			ContainerPort: aws.Int64(777),
+			HostPort:      aws.Int64(0),
+			Protocol:      aws.String("tcp"),
+		},
+	}
+	wordpressCon.Environment = []*ecs.KeyValuePair{
+		{
+			Name:  aws.String("WRDPRS1"),
+			Value: aws.String("val1"),
+		},
+		{
+			Name:  aws.String("WRDPRS2"),
+			Value: aws.String("val2"),
+		},
+	}
+
+	mysqlCon := adapter.ContainerConfig{}
+	mysqlCon.Name = "mysql"
+	mysqlCon.Image = "mysql"
+
+	redisCon := adapter.ContainerConfig{}
+	redisCon.Name = "redis"
+	redisCon.Image = "redis"
+	redisCon.PortMappings = []*ecs.PortMapping{
+		{
+			ContainerPort: aws.Int64(90),
+			HostPort:      aws.Int64(90),
+			Protocol:      aws.String("tcp"),
+		},
+	}
+
 	// set up files
 	fileString1 := `version: '3'
 services:
@@ -148,52 +273,88 @@ services:
 	project.ecsContext.ComposeFiles = append(project.ecsContext.ComposeFiles, tmpfile1.Name())
 	project.ecsContext.ComposeFiles = append(project.ecsContext.ComposeFiles, tmpfile2.Name())
 
-	// get map of docker-parsed ServiceConfigs
-	expectedConfigs := getServiceConfigMap(t, project.ecsContext.ComposeFiles)
-
-	// assert # and content of container configs matches expected services
+	// assert # and content of container configs matches expected
 	actualConfigs, err := project.parseV3()
-	if err != nil {
-		t.Fatal("Unexpected error parsing file: ", err)
-	}
-	assert.Equal(t, len(expectedConfigs), len(*actualConfigs))
-	for _, containerConfig := range *actualConfigs {
-		verifyConvertToContainerConfigOutput(t, expectedConfigs[containerConfig.Name], containerConfig)
-	}
+	assert.NoError(t, err, "Unexpected error parsing file")
+
+	assert.Equal(t, 3, len(*actualConfigs))
+
+	wp, err := getContainerConfigByName(wordpressCon.Name, actualConfigs)
+	assert.NoError(t, err, "Unexpected error retrieving wordpress config")
+	verifyContainerConfig(t, wordpressCon, *wp)
+
+	mysql, err := getContainerConfigByName(mysqlCon.Name, actualConfigs)
+	assert.NoError(t, err, "Unexpected error retrieving mysql config")
+	verifyContainerConfig(t, mysqlCon, *mysql)
+
+	redis, err := getContainerConfigByName(redisCon.Name, actualConfigs)
+	assert.NoError(t, err, "Unexpected error retrieving redis config")
+	verifyContainerConfig(t, redisCon, *redis)
 }
 
 func TestParseV3WithTopLevelVolume(t *testing.T) {
+	// set up expected ContainerConfig values
+	wordpressCon := adapter.ContainerConfig{}
+	wordpressCon.Name = "wordpress"
+	wordpressCon.Image = "wordpress"
+	wordpressCon.CapAdd = []string{"ALL"}
+	wordpressCon.PortMappings = []*ecs.PortMapping{
+		{
+			ContainerPort: aws.Int64(80),
+			HostPort:      aws.Int64(80),
+			Protocol:      aws.String("tcp"),
+		},
+	}
+	wordpressCon.Links = []string{"mysql"}
+	wordpressCon.ReadOnly = true
+
+	mysqlCon := adapter.ContainerConfig{}
+	mysqlCon.Name = "mysql"
+	mysqlCon.Image = "mysql"
+	mysqlCon.DockerLabels = map[string]*string{
+		"com.example.mysql":  aws.String("mysqllabel"),
+		"com.example.mysql2": aws.String("anothermysql label"),
+	}
+	mysqlCon.Privileged = true
+	mysqlCon.MountPoints = []*ecs.MountPoint{
+		{
+			ContainerPath: aws.String("/var/lib/mysql"),
+			ReadOnly:      aws.Bool(false),
+			SourceVolume:  aws.String("volume-1"),
+		},
+		{
+			ContainerPath: aws.String("/test/place"),
+			ReadOnly:      aws.Bool(true),
+			SourceVolume:  aws.String("logging"),
+		},
+		{
+			ContainerPath: aws.String("/var/lib/mysql"),
+			ReadOnly:      aws.Bool(false),
+			SourceVolume:  aws.String("volume-2"),
+		},
+	}
+
 	// set up file
 	composeFileString := `version: '3'
 services:
   wordpress:
     cap_add:
       - ALL
-    cap_drop:
-      - NET_ADMIN
-    command: echo "hello world"
     image: wordpress
-    entrypoint: /wordpress/entry
     ports: ["80:80"]
     links:
       - mysql
-    tmpfs:
-      - "/run:rw,size=1gb"
     read_only: true
   mysql:
     image: mysql
     labels:
       - "com.example.mysql=mysqllabel"
       - "com.example.mysql2=anothermysql label"
-    user: mysqluser
-    working_dir: /mysqltestdir
     privileged: true
     volumes:
      - /opt/data:/var/lib/mysql
      - logging:/test/place:ro
      - /var/lib/mysql
-    extra_hosts:
-      - "mysqlexhost:10.0.0.0"
 volumes:
   logging:`
 
@@ -212,17 +373,19 @@ volumes:
 	project := setupTestProject(t)
 	project.ecsContext.ComposeFiles = append(project.ecsContext.ComposeFiles, tmpfile.Name())
 
-	// get map of docker-parsed ServiceConfigs
-	expectedConfigs := getServiceConfigMap(t, project.ecsContext.ComposeFiles)
-
 	// assert # and content of container configs matches expected services
 	actualConfigs, err := project.parseV3()
 	assert.NoError(t, err, "Unexpected error parsing file")
 
-	assert.Equal(t, len(expectedConfigs), len(*actualConfigs))
-	for _, containerConfig := range *actualConfigs {
-		verifyConvertToContainerConfigOutput(t, expectedConfigs[containerConfig.Name], containerConfig)
-	}
+	assert.Equal(t, 2, len(*actualConfigs))
+
+	wp, err := getContainerConfigByName(wordpressCon.Name, actualConfigs)
+	assert.NoError(t, err, "Unexpected error retrieving wordpress config")
+	verifyContainerConfig(t, wordpressCon, *wp)
+
+	mysql, err := getContainerConfigByName(mysqlCon.Name, actualConfigs)
+	assert.NoError(t, err, "Unexpected error retrieving mysql config")
+	verifyContainerConfig(t, mysqlCon, *mysql)
 }
 
 func TestParseV3_ErrorWithExternalVolume(t *testing.T) {
@@ -343,10 +506,6 @@ services:
 	project := setupTestProject(t)
 	project.ecsContext.ComposeFiles = append(project.ecsContext.ComposeFiles, tmpfile.Name())
 
-	// get map of docker-parsed ServiceConfigs
-	expectedConfigs := getServiceConfigMap(t, project.ecsContext.ComposeFiles)
-	expectedConfig := expectedConfigs[serviceName]
-
 	// assert # and content of container configs matches expected services
 	actualConfigs, err := project.parseV3()
 	assert.NoError(t, err, "Unexpected error parsing file")
@@ -355,141 +514,31 @@ services:
 
 	assert.Equal(t, 1, len(*actualConfigs))
 	assert.Equal(t, expectedEnv, actualConfig.Environment)
-	verifyConvertToContainerConfigOutput(t, expectedConfig, *actualConfig)
 }
 
-func verifyConvertToContainerConfigOutput(t *testing.T, expected types.ServiceConfig, actual adapter.ContainerConfig) {
-
-	// verify equivalent fields
-	assert.Equal(t, expected.CapAdd, actual.CapAdd, "Expected CapAdd to match")
-	assert.Equal(t, expected.CapDrop, actual.CapDrop, "Expected CapDrop to match")
-	assert.Equal(t, expected.SecurityOpt, actual.DockerSecurityOptions, "Expected SecurityOpt and DockerSecuirtyOptions to match")
-	assert.Equal(t, []string(expected.Entrypoint), actual.Entrypoint, "Expected EntryPoint to match")
-	assert.Equal(t, expected.Name, actual.Name, "Expected Name to match")
+// TODO: add check for fields not used by V3, use to also check V1V2 ContainerConfigs?
+func verifyContainerConfig(t *testing.T, expected, actual adapter.ContainerConfig) {
+	assert.ElementsMatch(t, expected.CapAdd, actual.CapAdd, "Expected CapAdd to match")
+	assert.ElementsMatch(t, expected.CapDrop, actual.CapDrop, "Expected CapDrop to match")
+	assert.ElementsMatch(t, expected.Command, actual.Command, "Expected Command to match")
+	assert.ElementsMatch(t, expected.DNSSearchDomains, actual.DNSSearchDomains, "Expected DNSSearchDomains to match")
+	assert.ElementsMatch(t, expected.DNSServers, actual.DNSServers, "Expected DNSServers to match")
+	dockerLabelsEqual := reflect.DeepEqual(expected.DockerLabels, actual.DockerLabels)
+	assert.True(t, dockerLabelsEqual, "Expected DockerLabels to match")
+	assert.ElementsMatch(t, expected.DockerSecurityOptions, actual.DockerSecurityOptions, "Expected DockerSecurityOptions to match")
+	assert.ElementsMatch(t, expected.Entrypoint, actual.Entrypoint, "Expected Entrypoint to match")
+	assert.ElementsMatch(t, expected.Environment, actual.Environment, "Expected Environment to match")
+	assert.ElementsMatch(t, expected.ExtraHosts, actual.ExtraHosts, "Expected ExtraHosts to match")
+	assert.Equal(t, expected.Hostname, actual.Hostname, "Expected Hostname to match")
 	assert.Equal(t, expected.Image, actual.Image, "Expected Image to match")
-	assert.Equal(t, expected.Hostname, actual.Hostname, "Expected HostName to match")
-	assert.Equal(t, expected.Links, actual.Links, "Expected Links to match")
+	assert.ElementsMatch(t, expected.Links, actual.Links, "Expected Links to match")
+	assert.Equal(t, expected.LogConfiguration, actual.LogConfiguration, "Expected LogConfiguration to match")
+	assert.ElementsMatch(t, expected.MountPoints, actual.MountPoints, "Expected MountPoints to match")
+	assert.ElementsMatch(t, expected.PortMappings, actual.PortMappings, "Expected PortMappings to match")
 	assert.Equal(t, expected.Privileged, actual.Privileged, "Expected Privileged to match")
 	assert.Equal(t, expected.ReadOnly, actual.ReadOnly, "Expected ReadOnly to match")
-	assert.Equal(t, []string(expected.Command), actual.Command, "Expected Command to match")
+	assert.ElementsMatch(t, expected.Tmpfs, actual.Tmpfs, "Expected Tmpfs to match")
+	assert.ElementsMatch(t, expected.Ulimits, actual.Ulimits, "Expected Ulimits to match")
 	assert.Equal(t, expected.User, actual.User, "Expected User to match")
-	assert.Equal(t, expected.WorkingDir, actual.WorkingDirectory, "Expected WorkingDirectory to match")
-
-	// verify nil-able lists
-	if expected.DNSSearch != nil {
-		assert.Equal(t, []string(expected.DNSSearch), actual.DNSSearchDomains, "Expected DNSSearch and DNSSearchDomains to match")
-	} else {
-		assert.Empty(t, actual.DNSSearchDomains)
-	}
-	if expected.DNS != nil {
-		assert.Equal(t, []string(expected.DNS), actual.DNSServers, "Expected DNS and DNSServers to match")
-	} else {
-		assert.Empty(t, actual.DNSServers)
-	}
-
-	// verify custom conversions
-	expectedHosts, err := adapter.ConvertToExtraHosts(expected.ExtraHosts)
-	assert.NoError(t, err, "Unexpected error converting extra hosts")
-	assert.Equal(t, expectedHosts, actual.ExtraHosts, "Expected ExtraHosts to match")
-
-	if expected.Tmpfs != nil {
-		expectedTmpfs, err := adapter.ConvertToTmpfs(yaml.Stringorslice(expected.Tmpfs))
-		assert.NoError(t, err, "Unexpected error converting Tmpfs")
-		assert.Equal(t, expectedTmpfs, actual.Tmpfs, "Expected Tmpfs to match")
-	} else {
-		assert.Empty(t, actual.Tmpfs)
-	}
-
-	if expected.Logging != nil {
-		assert.Equal(t, expected.Logging.Driver, *actual.LogConfiguration.LogDriver, "Expected LogDriver to match")
-		logOptsMap := aws.StringMap(expected.Logging.Options)
-		assert.Equal(t, logOptsMap, actual.LogConfiguration.Options, "Expected Log Options to match")
-	} else {
-		assert.Empty(t, actual.LogConfiguration)
-	}
-
-	if expected.Labels != nil {
-		labelsMap := aws.StringMap(expected.Labels)
-		assert.Equal(t, labelsMap, actual.DockerLabels, "Expected Labels and DockerLabels to match")
-	} else {
-		assert.Empty(t, actual.DockerLabels)
-	}
-
-	if len(expected.Ports) > 0 {
-		var exPorts []*ecs.PortMapping
-		for _, portConfig := range expected.Ports {
-			mapping := convertPortConfigToECSMapping(portConfig)
-			exPorts = append(exPorts, mapping)
-		}
-		assert.Equal(t, exPorts, actual.PortMappings, "Expected PortMappings to match")
-	} else {
-		assert.Empty(t, actual.PortMappings)
-	}
-
-	if len(expected.Ulimits) > 0 {
-		assert.Equal(t, len(expected.Ulimits), len(actual.Ulimits), "Expected number of Ulimits to match")
-
-		for _, lim := range actual.Ulimits {
-			matchingServUlimit := expected.Ulimits[*lim.Name]
-
-			assert.NotNil(t, matchingServUlimit, "Expected ContainerConfig ulimit to have corresponding serviceConfig ulimit")
-			verifyUlimit(t, *matchingServUlimit, *lim)
-		}
-	} else {
-		assert.Empty(t, actual.Ulimits)
-	}
-
-	if len(expected.Volumes) > 0 {
-		for i, vol := range expected.Volumes {
-			if vol.Type == "volume" {
-				verifyMountPoint(t, vol, *actual.MountPoints[i])
-			}
-		}
-	} else {
-		assert.Empty(t, actual.MountPoints)
-	}
-
-	if len(expected.Environment) > 0 {
-		for _, env := range actual.Environment {
-			assert.Equal(t, *expected.Environment[*env.Name], *env.Value)
-		}
-	} else {
-		assert.Empty(t, actual.Environment)
-	}
-}
-
-func verifyUlimit(t *testing.T, servUlimit types.UlimitsConfig, containerUlimit ecs.Ulimit) {
-	var soft int64
-	var hard int64
-	if servUlimit.Single > 0 {
-		soft = int64(servUlimit.Single)
-		hard = int64(servUlimit.Single)
-	} else {
-		soft = int64(servUlimit.Soft)
-		hard = int64(servUlimit.Hard)
-	}
-	assert.Equal(t, soft, *containerUlimit.SoftLimit, "Expected soft limit to match")
-	assert.Equal(t, hard, *containerUlimit.HardLimit, "Expected hard limit to match")
-}
-
-func verifyMountPoint(t *testing.T, servVolume types.ServiceVolumeConfig, mountPoint ecs.MountPoint) {
-	if servVolume.Source == "" {
-		assert.True(t, strings.HasPrefix(*mountPoint.SourceVolume, "volume-"), "Expected volume Source to being with 'volume-'")
-	} else {
-		assert.Equal(t, servVolume.Source, *mountPoint.SourceVolume, "Expected volume Source and mount point SourceVolume to match")
-	}
-	assert.Equal(t, servVolume.Target, *mountPoint.ContainerPath, "Expected volume Target and mount point ContainerPath to match")
-	assert.Equal(t, servVolume.ReadOnly, *mountPoint.ReadOnly, "Expected volume and mount point readOnly to match")
-}
-
-func getServiceConfigMap(t *testing.T, composeFiles []string) map[string]types.ServiceConfig {
-	// confirm files can be parsed by docker
-	expectedDockerConfig, err := getV3Config(composeFiles)
-	assert.NoError(t, err, "Unexpected error parsing v3 files")
-
-	servMap := make(map[string]types.ServiceConfig)
-	for _, service := range expectedDockerConfig.Services {
-		servMap[service.Name] = service
-	}
-	return servMap
+	assert.Equal(t, expected.WorkingDirectory, actual.WorkingDirectory, "Expected WorkingDirectory to match")
 }


### PR DESCRIPTION
Refactor parseV3_test to not rely on docker/cli abstractions or conversion helper methods.

--
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
