### PR TITLE
Pass local environment into parseV3, fixes #537

### DIFF
--- a/ecs-cli/modules/cli/compose/project/project_parseV3.go
+++ b/ecs-cli/modules/cli/compose/project/project_parseV3.go
@@ -2,8 +2,10 @@ package project
 
 import (
 	"io/ioutil"
+	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 
 	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/cli/compose/adapter"
 	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/cli/compose/logger"
@@ -69,10 +71,12 @@ func getV3Config(composeFiles []string) (*types.Config, error) {
 		return nil, err
 	}
 
+	localEnv := getEnvironment()
+
 	configDetails := types.ConfigDetails{
 		WorkingDir:  wrkDir,
 		ConfigFiles: configFiles,
-		Environment: nil,
+		Environment: localEnv,
 	}
 
 	// load config from config details
@@ -249,4 +253,14 @@ func logWarningForDeployFields(d types.DeployConfig, serviceName string) {
 			"service name": serviceName,
 		}).Warn("Skipping unsupported YAML option for service...")
 	}
+}
+
+func getEnvironment() map[string]string {
+	env := os.Environ()
+	envMap := make(map[string]string, len(env))
+	for _, s := range env {
+		varParts := strings.SplitN(s, "=", 2)
+		envMap[varParts[0]] = varParts[1]
+	}
+	return envMap
 }


### PR DESCRIPTION
Addresses issue #537

Pass map of local env vars into docker to be interpolated into compose project.

### Testing

docker-compose.yml:
```
version: '3'
services:
  test:
    image: "$MY_IMAGE"
    environment:
      - WEB_VAR1=myvar
      - PROC_REV=${PROCESSOR_REVISION}
```

"compose create" output:
```
$~\v3envVarsNoWork> ..\..\Documents\GO\src\github.com\aws\amazon-ecs-cli\bin\local\ecs-cli.exe compose create
INFO[0000] Using ECS task definition                     TaskDefinition="v3envVarsNoWork:12"
```

resulting task def:
```
{
    "containerDefinitions": [
        {
            "cpu": 0,
            "environment": [
                {
                    "name": "PROC_REV",
                    "value": "3d04"    // FROM ENV VAR
                },
                {
                    "name": "WEB_VAR1",
                    "value": "myvar"
                }
            ],
            "memory": 512,
            "image": "nginx",   // FROM ENV VAR
            "name": "test"
        }
    ],
    "family": "v3envVarsNoWork",
}
```

--
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
