### PR TITLE
Support container health check in Compose 3

### DIFF
--- a/ecs-cli/modules/cli/compose/adapter/containerconfig.go
+++ b/ecs-cli/modules/cli/compose/adapter/containerconfig.go
@@ -18,6 +18,7 @@ type ContainerConfig struct {
 	Entrypoint            []string
 	Environment           []*ecs.KeyValuePair
 	ExtraHosts            []*ecs.HostEntry
+	HealthCheck           *ecs.HealthCheck
 	Hostname              string
 	Image                 string
 	Links                 []string

--- a/ecs-cli/modules/cli/compose/logger/logger.go
+++ b/ecs-cli/modules/cli/compose/logger/logger.go
@@ -73,6 +73,7 @@ var supportedFieldsInV3 = map[string]bool{
 	"EnvFile":     true,
 	"ExtraHosts":  true,
 	"Hostname":    true,
+	"HealthCheck": true,
 	"Image":       true,
 	"Labels":      true,
 	"Links":       true,

--- a/ecs-cli/modules/cli/compose/project/project_parseV3.go
+++ b/ecs-cli/modules/cli/compose/project/project_parseV3.go
@@ -92,7 +92,6 @@ func convertToContainerConfig(serviceConfig types.ServiceConfig, serviceVols *ad
 	logger.LogUnsupportedV3ServiceConfigFields(serviceConfig)
 	logWarningForDeployFields(serviceConfig.Deploy, serviceConfig.Name)
 
-	//TODO: Add Healthcheck, Devices to ContainerConfig
 	c := &adapter.ContainerConfig{
 		CapAdd:                serviceConfig.CapAdd,
 		CapDrop:               serviceConfig.CapDrop,
@@ -114,6 +113,10 @@ func convertToContainerConfig(serviceConfig types.ServiceConfig, serviceVols *ad
 		return nil, err
 	}
 	c.Devices = devices
+
+	if serviceConfig.HealthCheck != nil && !serviceConfig.HealthCheck.Disable {
+		c.HealthCheck = adapter.ConvertToHealthCheck(serviceConfig.HealthCheck)
+	}
 
 	if serviceConfig.DNS != nil {
 		c.DNSServers = serviceConfig.DNS

--- a/ecs-cli/modules/utils/compose/convert_task_definition.go
+++ b/ecs-cli/modules/utils/compose/convert_task_definition.go
@@ -116,6 +116,7 @@ func convertToContainerDef(inputCfg *adapter.ContainerConfig, ecsContainerDef *C
 	if inputCfg.Hostname != "" {
 		outputContDef.SetHostname(inputCfg.Hostname)
 	}
+	outputContDef.SetHealthCheck(inputCfg.HealthCheck)
 	outputContDef.SetImage(inputCfg.Image)
 	outputContDef.SetLinks(aws.StringSlice(inputCfg.Links)) // TODO, read from external links
 	outputContDef.SetLogConfiguration(inputCfg.LogConfiguration)


### PR DESCRIPTION
*Issue #, if available:*
#472 

*Description of changes:*
Support the `healthcheck` field in Docker Compose v3. Note that `start_period` is not supported as this field was adding compose 3.4, and the ECS CLI does not support minor versions of compose.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
