### PR TITLE
Fix memory limit validation for compose 3

### DIFF
--- a/ecs-cli/modules/cli/compose/project/project_parseV1V2.go
+++ b/ecs-cli/modules/cli/compose/project/project_parseV1V2.go
@@ -75,6 +75,11 @@ func convertV1V2ToContainerConfig(context *project.Context, serviceName string, 
 	memory := adapter.ConvertToMemoryInMB(int64(service.MemLimit))
 	memoryReservation := adapter.ConvertToMemoryInMB(int64(service.MemReservation))
 
+	// Validate memory and memory reservation
+	if memory == 0 && memoryReservation != 0 {
+		memory = memoryReservation
+	}
+
 	mountPoints, err := adapter.ConvertToMountPoints(service.Volumes, volumes)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Previously, specifying memory reservation without memory limit would
cause a validation error. This fix allows either value to be specified
without the other, in either docker compose or ecs-params.

Fixes #546

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
