### PR TITLE
Add cn-northwest-1 to CFN template

### DIFF
--- a/ecs-cli/modules/clients/aws/cloudformation/template.go
+++ b/ecs-cli/modules/clients/aws/cloudformation/template.go
@@ -211,7 +211,10 @@ var template = `
   },
   "Conditions": {
     "IsCNRegion": {
-      "Fn::Equals": [ { "Ref": "AWS::Region" }, "cn-north-1" ]
+      "Fn::Or" : [
+        {"Fn::Equals": [ { "Ref": "AWS::Region" }, "cn-north-1" ]},
+        {"Fn::Equals": [ { "Ref": "AWS::Region" }, "cn-northwest-1" ]},
+      ]
     },
     "LaunchInstances": {
       "Fn::Equals": [ { "Ref": "IsFargate" }, "false" ]


### PR DESCRIPTION
Previously, cluster up would fail in cn-northwest-1 because the service
principal was not resolving correctly. This adds that region to the CFN
template.

Fixes #552

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
