### PR TITLE
Show container health check status in ps command

### DIFF
--- a/ecs-cli/modules/cli/compose/container/container.go
+++ b/ecs-cli/modules/cli/compose/container/container.go
@@ -28,9 +28,11 @@ const (
 	containerStateKey = "State"
 	containerPortsKey = "Ports"
 	taskDefinitionKey = "TaskDefinition"
+	healthKey         = "Health"
 )
 
-var ContainerInfoColumns = []string{containerNameKey, containerStateKey, containerPortsKey, taskDefinitionKey}
+// ContainerInfoColumns is the ordered list of info columns for the ps commands
+var ContainerInfoColumns = []string{containerNameKey, containerStateKey, containerPortsKey, taskDefinitionKey, healthKey}
 
 // Container is a wrapper around ecsContainer
 type Container struct {
@@ -59,8 +61,8 @@ func (c *Container) Id() string {
 // ECS doesn't have a describe container API so providing the task's UUID in the name enables users
 // to easily look up this container in the ecs world by invoking DescribeTask
 func (c *Container) Name() string {
-	taskId := utils.GetIdFromArn(aws.StringValue(c.task.TaskArn))
-	return utils.GetFormattedContainerName(taskId, aws.StringValue(c.ecsContainer.Name))
+	taskID := utils.GetIdFromArn(aws.StringValue(c.task.TaskArn))
+	return utils.GetFormattedContainerName(taskID, aws.StringValue(c.ecsContainer.Name))
 }
 
 // TaskDefinition returns the ECS task definition id which encompasses the container definition, with
@@ -112,6 +114,11 @@ func (c *Container) PortString() string {
 	return strings.Join(result, ", ")
 }
 
+// HealthStatus returns the container healthcheck status for the given container
+func (c *Container) HealthStatus() string {
+	return aws.StringValue(c.ecsContainer.HealthStatus)
+}
+
 // ConvertContainersToInfoSet transforms the list of containers into a formatted set of fields
 func ConvertContainersToInfoSet(containers []Container) project.InfoSet {
 	result := project.InfoSet{}
@@ -122,6 +129,7 @@ func ConvertContainersToInfoSet(containers []Container) project.InfoSet {
 			containerStateKey: cont.State(),
 			containerPortsKey: cont.PortString(),
 			taskDefinitionKey: cont.TaskDefinition(),
+			healthKey:         cont.HealthStatus(),
 		}
 		result = append(result, info)
 	}

--- a/ecs-cli/modules/cli/compose/container/container_test.go
+++ b/ecs-cli/modules/cli/compose/container/container_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ecs"
+	"github.com/stretchr/testify/assert"
 )
 
 const (
@@ -124,6 +125,15 @@ func TestPortString(t *testing.T) {
 	if !strings.Contains(portString, expectedBinding1WithoutEC2IpAddr) {
 		t.Errorf("Expected portString to contain [%s] but got [%s]", expectedBinding1WithoutEC2IpAddr, portString)
 	}
+}
+
+func TestHealthStatus(t *testing.T) {
+	containerHealth := ecs.HealthStatusHealthy
+	container := setupContainer()
+	container.ecsContainer.SetHealthStatus(containerHealth)
+
+	// container.HealthStatus() should simply report the value returned by the ECS API
+	assert.Equal(t, containerHealth, container.HealthStatus())
 }
 
 func setupContainer() Container {


### PR DESCRIPTION
*Description of changes:*
Show container health check status in ps command; simply returns the value returned by the ECS API (UNKNOWN if there isn't a health check, HEALTHY vs UNHEALTHY depending on the status).

```
$ ecs-cli ps --cluster compose3 --region eu-west-1
Name                                             State    Ports                      TaskDefinition       Health
afd7f8a0-3813-4e1a-9d9e-ca7e9d1fcfbb/wordpress   RUNNING  36.253.177.221:80->80/tcp  compose3:7           HEALTHY
dca67e02-68ca-4507-b194-a47239b5e7a9/wordpress   RUNNING  37.234.146.14:80->80/tcp   healthcheck:3        UNKNOWN
dca67e02-68ca-4507-b194-a47239b5e7a9/redis       RUNNING                             healthcheck:3        HEALTHY
feb6e10e-3385-4c9b-a6cb-787cc8e90dda/sample-app  RUNNING  54.229.211.206:80->80/tcp  tutorial-task-def:1  UNKNOWN
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
