### PR TITLE
Ensure git hash in ecs-cli --version is always 7 characters

### DIFF
--- a/ecs-cli/modules/version/gen/version-gen.go
+++ b/ecs-cli/modules/version/gen/version-gen.go
@@ -72,7 +72,7 @@ func gitDirty() bool {
 }
 
 func gitHash() string {
-	cmd := exec.Command("git", "rev-parse", "--short", "HEAD")
+	cmd := exec.Command("git", "rev-parse", "--short=7", "HEAD")
 	hash, err := cmd.Output()
 	if err != nil {
 		return "UNKNOWN"


### PR DESCRIPTION

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
