### PR TITLE
Service Discovery: Refactor CFN Client and add SD CFN templates

### DIFF
--- a/ecs-cli/modules/cli/cluster/cluster_app_test.go
+++ b/ecs-cli/modules/cli/cluster/cluster_app_test.go
@@ -132,7 +132,7 @@ func TestClusterUpWithForce(t *testing.T) {
 		mockCloudformation.EXPECT().ValidateStackExists(stackName).Return(nil),
 		mockCloudformation.EXPECT().DeleteStack(stackName).Return(nil),
 		mockCloudformation.EXPECT().WaitUntilDeleteComplete(stackName).Return(nil),
-		mockCloudformation.EXPECT().CreateStack(gomock.Any(), stackName, gomock.Any()).Return("", nil),
+		mockCloudformation.EXPECT().CreateStack(gomock.Any(), stackName, true, gomock.Any()).Return("", nil),
 		mockCloudformation.EXPECT().WaitUntilCreateComplete(stackName).Return(nil),
 	)
 
@@ -165,11 +165,13 @@ func TestClusterUpWithoutPublicIP(t *testing.T) {
 
 	gomock.InOrder(
 		mockCloudformation.EXPECT().ValidateStackExists(stackName).Return(errors.New("error")),
-		mockCloudformation.EXPECT().CreateStack(gomock.Any(), stackName, gomock.Any()).Do(func(x, y, z interface{}) {
+		mockCloudformation.EXPECT().CreateStack(gomock.Any(), stackName, true, gomock.Any()).Do(func(x, y, w, z interface{}) {
+			capabilityIAM := w.(bool)
 			cfnParams := z.(*cloudformation.CfnStackParams)
-			associateIPAddress, err := cfnParams.GetParameter(cloudformation.ParameterKeyAssociatePublicIPAddress)
+			associateIPAddress, err := cfnParams.GetParameter(ParameterKeyAssociatePublicIPAddress)
 			assert.NoError(t, err, "Unexpected error getting cfn parameter")
 			assert.Equal(t, "false", aws.StringValue(associateIPAddress.ParameterValue), "Should not associate public IP address")
+			assert.True(t, capabilityIAM, "Expected capability capabilityIAM to be true")
 		}).Return("", nil),
 		mockCloudformation.EXPECT().WaitUntilCreateComplete(stackName).Return(nil),
 	)
@@ -510,14 +512,14 @@ func TestCliFlagsToCfnStackParams(t *testing.T) {
 	context := cli.NewContext(nil, flagSet, nil)
 	params := cliFlagsToCfnStackParams(context)
 
-	_, err := params.GetParameter(cloudformation.ParameterKeyAsgMaxSize)
+	_, err := params.GetParameter(ParameterKeyAsgMaxSize)
 	assert.Error(t, err, "Expected error for parameter ParameterKeyAsgMaxSize")
 	assert.Equal(t, cloudformation.ParameterNotFoundError, err, "Expect error to be ParameterNotFoundError")
 
 	flagSet.String(flags.AsgMaxSizeFlag, "2", "")
 	context = cli.NewContext(nil, flagSet, nil)
 	params = cliFlagsToCfnStackParams(context)
-	_, err = params.GetParameter(cloudformation.ParameterKeyAsgMaxSize)
+	_, err = params.GetParameter(ParameterKeyAsgMaxSize)
 	assert.NoError(t, err, "Unexpected error getting parameter ParameterKeyAsgMaxSize")
 }
 
@@ -538,11 +540,13 @@ func TestClusterUpForImageIdInput(t *testing.T) {
 
 	gomock.InOrder(
 		mockCloudformation.EXPECT().ValidateStackExists(stackName).Return(errors.New("error")),
-		mockCloudformation.EXPECT().CreateStack(gomock.Any(), stackName, gomock.Any()).Do(func(x, y, z interface{}) {
+		mockCloudformation.EXPECT().CreateStack(gomock.Any(), stackName, true, gomock.Any()).Do(func(x, y, w, z interface{}) {
+			capabilityIAM := w.(bool)
 			cfnStackParams := z.(*cloudformation.CfnStackParams)
-			param, err := cfnStackParams.GetParameter(cloudformation.ParameterKeyAmiId)
+			param, err := cfnStackParams.GetParameter(ParameterKeyAmiId)
 			assert.NoError(t, err, "Expected image id params to be present")
 			assert.Equal(t, imageID, aws.StringValue(param.ParameterValue), "Expected image id to match")
+			assert.True(t, capabilityIAM, "Expected capability capabilityIAM to be true")
 		}).Return("", nil),
 		mockCloudformation.EXPECT().WaitUntilCreateComplete(stackName).Return(nil),
 	)
@@ -607,9 +611,9 @@ func TestClusterUpWithFargateLaunchTypeFlag(t *testing.T) {
 	)
 	gomock.InOrder(
 		mockCloudformation.EXPECT().ValidateStackExists(stackName).Return(errors.New("error")),
-		mockCloudformation.EXPECT().CreateStack(gomock.Any(), stackName, gomock.Any()).Do(func(x, y, z interface{}) {
+		mockCloudformation.EXPECT().CreateStack(gomock.Any(), stackName, true, gomock.Any()).Do(func(x, y, w, z interface{}) {
 			cfnParams := z.(*cloudformation.CfnStackParams)
-			isFargate, err := cfnParams.GetParameter(cloudformation.ParameterKeyIsFargate)
+			isFargate, err := cfnParams.GetParameter(ParameterKeyIsFargate)
 			assert.NoError(t, err, "Unexpected error getting cfn parameter")
 			assert.Equal(t, "true", aws.StringValue(isFargate.ParameterValue), "Should have Fargate launch type.")
 		}).Return("", nil),
@@ -648,11 +652,13 @@ func TestClusterUpWithFargateDefaultLaunchTypeConfig(t *testing.T) {
 	)
 	gomock.InOrder(
 		mockCloudformation.EXPECT().ValidateStackExists(stackName).Return(errors.New("error")),
-		mockCloudformation.EXPECT().CreateStack(gomock.Any(), stackName, gomock.Any()).Do(func(x, y, z interface{}) {
+		mockCloudformation.EXPECT().CreateStack(gomock.Any(), stackName, true, gomock.Any()).Do(func(x, y, w, z interface{}) {
+			capabilityIAM := w.(bool)
 			cfnParams := z.(*cloudformation.CfnStackParams)
-			isFargate, err := cfnParams.GetParameter(cloudformation.ParameterKeyIsFargate)
+			isFargate, err := cfnParams.GetParameter(ParameterKeyIsFargate)
 			assert.NoError(t, err, "Unexpected error getting cfn parameter")
 			assert.Equal(t, "true", aws.StringValue(isFargate.ParameterValue), "Should have Fargate launch type.")
+			assert.True(t, capabilityIAM, "Expected capability capabilityIAM to be true")
 		}).Return("", nil),
 		mockCloudformation.EXPECT().WaitUntilCreateComplete(stackName).Return(nil),
 		mockCloudformation.EXPECT().DescribeNetworkResources(stackName).Return(nil),
@@ -691,11 +697,13 @@ func TestClusterUpWithFargateLaunchTypeFlagOverride(t *testing.T) {
 	)
 	gomock.InOrder(
 		mockCloudformation.EXPECT().ValidateStackExists(stackName).Return(errors.New("error")),
-		mockCloudformation.EXPECT().CreateStack(gomock.Any(), stackName, gomock.Any()).Do(func(x, y, z interface{}) {
+		mockCloudformation.EXPECT().CreateStack(gomock.Any(), stackName, true, gomock.Any()).Do(func(x, y, w, z interface{}) {
+			capabilityIAM := w.(bool)
 			cfnParams := z.(*cloudformation.CfnStackParams)
-			isFargate, err := cfnParams.GetParameter(cloudformation.ParameterKeyIsFargate)
+			isFargate, err := cfnParams.GetParameter(ParameterKeyIsFargate)
 			assert.NoError(t, err, "Unexpected error getting cfn parameter")
 			assert.Equal(t, "true", aws.StringValue(isFargate.ParameterValue), "Should have Fargate launch type.")
+			assert.True(t, capabilityIAM, "Expected capability capabilityIAM to be true")
 		}).Return("", nil),
 		mockCloudformation.EXPECT().WaitUntilCreateComplete(stackName).Return(nil),
 		mockCloudformation.EXPECT().DescribeNetworkResources(stackName).Return(nil),
@@ -734,7 +742,7 @@ func TestClusterUpWithEC2LaunchTypeFlagOverride(t *testing.T) {
 	)
 	gomock.InOrder(
 		mockCloudformation.EXPECT().ValidateStackExists(stackName).Return(errors.New("error")),
-		mockCloudformation.EXPECT().CreateStack(gomock.Any(), stackName, gomock.Any()).Return("", nil),
+		mockCloudformation.EXPECT().CreateStack(gomock.Any(), stackName, true, gomock.Any()).Return("", nil),
 		mockCloudformation.EXPECT().WaitUntilCreateComplete(stackName).Return(nil),
 	)
 	globalSet := flag.NewFlagSet("ecs-cli", 0)
@@ -768,7 +776,7 @@ func TestClusterUpWithBlankDefaultLaunchTypeConfig(t *testing.T) {
 	)
 	gomock.InOrder(
 		mockCloudformation.EXPECT().ValidateStackExists(stackName).Return(errors.New("error")),
-		mockCloudformation.EXPECT().CreateStack(gomock.Any(), stackName, gomock.Any()).Return("", nil),
+		mockCloudformation.EXPECT().CreateStack(gomock.Any(), stackName, true, gomock.Any()).Return("", nil),
 		mockCloudformation.EXPECT().WaitUntilCreateComplete(stackName).Return(nil),
 	)
 	globalSet := flag.NewFlagSet("ecs-cli", 0)
@@ -943,7 +951,7 @@ func TestClusterScale(t *testing.T) {
 		assert.NoError(t, err, "Unexpected error on scale.")
 		_, err = cfnParams.GetParameter("SomeParam2")
 		assert.NoError(t, err, "Unexpected error on scale.")
-		param, err := cfnParams.GetParameter(cloudformation.ParameterKeyAsgMaxSize)
+		param, err := cfnParams.GetParameter(ParameterKeyAsgMaxSize)
 		assert.NoError(t, err, "Unexpected error on scale.")
 		assert.Equal(t, "1", aws.StringValue(param.ParameterValue))
 	}).Return("", nil)
@@ -1046,7 +1054,7 @@ func mocksForSuccessfulClusterUp(mockECS *mock_ecs.MockECSClient, mockCloudforma
 	)
 	gomock.InOrder(
 		mockCloudformation.EXPECT().ValidateStackExists(stackName).Return(errors.New("error")),
-		mockCloudformation.EXPECT().CreateStack(gomock.Any(), stackName, gomock.Any()).Return("", nil),
+		mockCloudformation.EXPECT().CreateStack(gomock.Any(), stackName, true, gomock.Any()).Return("", nil),
 		mockCloudformation.EXPECT().WaitUntilCreateComplete(stackName).Return(nil),
 	)
 }

--- a/ecs-cli/modules/clients/aws/cloudformation/client.go
+++ b/ecs-cli/modules/clients/aws/cloudformation/client.go
@@ -88,7 +88,7 @@ func init() {
 
 // CloudformationClient defines methods to interact the with the CloudFormationAPI interface.
 type CloudformationClient interface {
-	CreateStack(string, string, *CfnStackParams) (string, error)
+	CreateStack(string, string, bool, *CfnStackParams) (string, error)
 	WaitUntilCreateComplete(string) error
 	DeleteStack(string) error
 	WaitUntilDeleteComplete(string) error
@@ -123,13 +123,16 @@ func newClient(config *config.CommandConfig, client cloudformationiface.CloudFor
 }
 
 // CreateStack creates the cloudformation stack by invoking the sdk's CreateStack API and returns the stack id.
-func (c *cloudformationClient) CreateStack(template string, stackName string, params *CfnStackParams) (string, error) {
-	output, err := c.client.CreateStack(&cloudformation.CreateStackInput{
+func (c *cloudformationClient) CreateStack(template, stackName string, capabilityIAM bool, params *CfnStackParams) (string, error) {
+	input := &cloudformation.CreateStackInput{
 		TemplateBody: aws.String(template),
-		Capabilities: aws.StringSlice([]string{cloudformation.CapabilityCapabilityIam}),
 		StackName:    aws.String(stackName),
 		Parameters:   params.Get(),
-	})
+	}
+	if capabilityIAM {
+		input.Capabilities = aws.StringSlice([]string{cloudformation.CapabilityCapabilityIam})
+	}
+	output, err := c.client.CreateStack(input)
 
 	if err != nil {
 		return "", err

--- a/ecs-cli/modules/clients/aws/cloudformation/cluster_template.go
+++ b/ecs-cli/modules/clients/aws/cloudformation/cluster_template.go
@@ -13,8 +13,8 @@
 
 package cloudformation
 
-func GetTemplate() string {
-	return template
+func GetClusterTemplate() string {
+	return cluster_template
 }
 
 // TODO: Improvements:
@@ -32,7 +32,7 @@ const (
 	SecurityGroupLogicalResourceId = "EcsSecurityGroup"
 )
 
-var template = `
+var cluster_template = `
 {
   "AWSTemplateFormatVersion": "2010-09-09",
   "Description": "AWS CloudFormation template to create resources required to run tasks on an ECS cluster.",

--- a/ecs-cli/modules/clients/aws/cloudformation/mock/client.go
+++ b/ecs-cli/modules/clients/aws/cloudformation/mock/client.go
@@ -43,15 +43,15 @@ func (_m *MockCloudformationClient) EXPECT() *_MockCloudformationClientRecorder 
 	return _m.recorder
 }
 
-func (_m *MockCloudformationClient) CreateStack(_param0 string, _param1 string, _param2 *cloudformation.CfnStackParams) (string, error) {
-	ret := _m.ctrl.Call(_m, "CreateStack", _param0, _param1, _param2)
+func (_m *MockCloudformationClient) CreateStack(_param0 string, _param1 string, _param2 bool, _param3 *cloudformation.CfnStackParams) (string, error) {
+	ret := _m.ctrl.Call(_m, "CreateStack", _param0, _param1, _param2, _param3)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockCloudformationClientRecorder) CreateStack(arg0, arg1, arg2 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateStack", arg0, arg1, arg2)
+func (_mr *_MockCloudformationClientRecorder) CreateStack(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateStack", arg0, arg1, arg2, arg3)
 }
 
 func (_m *MockCloudformationClient) DeleteStack(_param0 string) error {

--- a/ecs-cli/modules/clients/aws/cloudformation/params_test.go
+++ b/ecs-cli/modules/clients/aws/cloudformation/params_test.go
@@ -21,8 +21,14 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+const (
+	parameterKeyAsgMaxSize = "AsgMaxSize"
+	parameterKeyCluster    = "EcsCluster"
+	parameterKeyAmiId      = "EcsAmiId"
+)
+
 func TestAddAndValidate(t *testing.T) {
-	cfnParams := NewCfnStackParams()
+	cfnParams := NewCfnStackParams([]string{parameterKeyCluster})
 
 	err := cfnParams.Validate()
 	if err == nil {
@@ -30,26 +36,26 @@ func TestAddAndValidate(t *testing.T) {
 	}
 
 	// Add AMI ID
-	err = cfnParams.Add(ParameterKeyAmiId, "ami-12345")
+	err = cfnParams.Add(parameterKeyAmiId, "ami-12345")
 	if err != nil {
 		t.Error("Error adding parameter: ", err)
 	}
 	err = cfnParams.Validate()
 	if err == nil {
-		t.Errorf("Expected validation error when %s is not specified", ParameterKeyCluster)
+		t.Errorf("Expected validation error when %s is not specified", parameterKeyCluster)
 	}
 
 	// Add Cluster
-	err = cfnParams.Add(ParameterKeyCluster, "")
+	err = cfnParams.Add(parameterKeyCluster, "")
 	if err != nil {
 		t.Error("Error adding parameter: ", err)
 	}
 	err = cfnParams.Validate()
 	if err == nil {
-		t.Errorf("Expected validation error when %s is empty", ParameterKeyCluster)
+		t.Errorf("Expected validation error when %s is empty", parameterKeyCluster)
 	}
 
-	err = cfnParams.Add(ParameterKeyCluster, "default")
+	err = cfnParams.Add(parameterKeyCluster, "default")
 	if err != nil {
 		t.Error("Error adding parameter: ", err)
 	}
@@ -63,9 +69,9 @@ func TestAddAndValidate(t *testing.T) {
 		t.Errorf("Mismatch in number of keys in params map. Expected 2, found: %d", len(paramsMap))
 	}
 
-	clusterValue, exists := cfnParams.nameToKeys[ParameterKeyCluster]
+	clusterValue, exists := cfnParams.nameToKeys[parameterKeyCluster]
 	if !exists {
-		t.Errorf("Expected key %s does not exist", ParameterKeyCluster)
+		t.Errorf("Expected key %s does not exist", parameterKeyCluster)
 	}
 
 	if "default" != clusterValue {
@@ -82,7 +88,7 @@ func TestAddWithUsePreviousValue(t *testing.T) {
 			ParameterKey: aws.String("SomeParam2"),
 		},
 	}
-	cfnParams, err := NewCfnStackParamsForUpdate(existingParameters)
+	cfnParams, err := NewCfnStackParamsForUpdate([]string{parameterKeyCluster}, existingParameters)
 	assert.NoError(t, err, "Unexpected error getting New CFN Stack Params")
 
 	params := cfnParams.Get()
@@ -102,28 +108,28 @@ func TestAddWithUsePreviousValue(t *testing.T) {
 		}
 	}
 
-	err = cfnParams.AddWithUsePreviousValue(ParameterKeyAsgMaxSize, false)
+	err = cfnParams.AddWithUsePreviousValue(parameterKeyAsgMaxSize, false)
 	if err != nil {
-		t.Errorf("Error adding parameter with use previous value '%s': '%v'", ParameterKeyAsgMaxSize, err)
+		t.Errorf("Error adding parameter with use previous value '%s': '%v'", parameterKeyAsgMaxSize, err)
 	}
 
 	size := "3"
-	err = cfnParams.Add(ParameterKeyAsgMaxSize, size)
+	err = cfnParams.Add(parameterKeyAsgMaxSize, size)
 	if err != nil {
-		t.Errorf("Error adding parameter '%s': %v", ParameterKeyAsgMaxSize, err)
+		t.Errorf("Error adding parameter '%s': %v", parameterKeyAsgMaxSize, err)
 	}
 
-	param, err := cfnParams.GetParameter(ParameterKeyAsgMaxSize)
+	param, err := cfnParams.GetParameter(parameterKeyAsgMaxSize)
 	if err != nil {
-		t.Errorf("Error getting parameter '%s': %v", ParameterKeyAsgMaxSize, err)
+		t.Errorf("Error getting parameter '%s': %v", parameterKeyAsgMaxSize, err)
 	}
 	usePrevious := param.UsePreviousValue
 	if usePrevious == nil {
-		t.Fatalf("usePrevious is not set for '%s' in params map", ParameterKeyAsgMaxSize)
+		t.Fatalf("usePrevious is not set for '%s' in params map", parameterKeyAsgMaxSize)
 	}
 
 	if aws.BoolValue(usePrevious) {
-		t.Errorf("usePrevious value is true for '%s', expected false", ParameterKeyAsgMaxSize)
+		t.Errorf("usePrevious value is true for '%s', expected false", parameterKeyAsgMaxSize)
 	}
 
 }

--- a/ecs-cli/modules/clients/aws/cloudformation/private_namespace_template.go
+++ b/ecs-cli/modules/clients/aws/cloudformation/private_namespace_template.go
@@ -1,0 +1,58 @@
+// Copyright 2015-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//  http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package cloudformation
+
+func GetPrivateNamespaceTemplate() string {
+	return private_namespace_template
+}
+
+var private_namespace_template = `
+{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Description": "AWS CloudFormation template to create a private DNS namespace to enable ECS Service Discovery.",
+  "Parameters": {
+    "NamespaceDescription": {
+      "Type": "String",
+      "Description": "Optional - The description of the private DNS namespace",
+      "Default": "Created by the Amazon ECS CLI"
+    },
+    "VPCID": {
+      "Type": "String",
+      "Description": "The VPC attached to the DNS private namespace",
+      "Default": ""
+    },
+    "NamespaceName": {
+      "Type": "String",
+      "Description": "The name of the namespace",
+      "Default": ""
+    },
+  },
+  "Resources": {
+    "PrivateDNSNamespace": {
+      "Type" : "AWS::ServiceDiscovery::PrivateDnsNamespace",
+      "Properties" : {
+        "Description" : { "Ref" : "NamespaceDescription" },
+        "Vpc" : { "Ref" : "VPCID" },
+        "Name" : { "Ref" : "NamespaceName" }
+      }
+    }
+  }
+  "Outputs" : {
+    "PrivateDNSNamespaceID" : {
+      "Description": "The ID of the private DNS namespace.",
+      "Value" : { "Fn::GetAtt" : [ "PrivateDNSNamespace", "Id" ]}
+    }
+  }
+}
+`

--- a/ecs-cli/modules/clients/aws/cloudformation/sds_template.go
+++ b/ecs-cli/modules/clients/aws/cloudformation/sds_template.go
@@ -1,0 +1,82 @@
+// Copyright 2015-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//  http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package cloudformation
+
+func GetSDSTemplate() string {
+	return sds_template
+}
+
+var sds_template = `
+{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Description": "AWS CloudFormation template to create a private DNS namespace to enable ECS Service Discovery.",
+  "Parameters": {
+    "SDSDescription": {
+      "Type": "String",
+      "Description": "Optional - The description of the private DNS namespace",
+      "Default": "Created by the Amazon ECS CLI"
+    },
+    "SDSName": {
+      "Type": "String",
+      "Description": "The name of the Service Discovery Service",
+      "Default": ""
+    },
+    "NamespaceID": {
+      "Type": "String",
+      "Description": "The ID of the namespace that you want to use for DNS configuration",
+      "Default": ""
+    },
+    "DNSType": {
+      "Type": "String",
+      "Description": "The DNS type of the record that you want Route 53 to create.",
+      "Default": ""
+    },
+    "DNSTTL": {
+      "Type": "String",
+      "Description": "The amount of time, in seconds, that you want DNS resolvers to cache the settings for this record.",
+      "Default": "60"
+    },
+    "FailureThreshold": {
+      "Type": "Double",
+      "Description": "The number of 30-second intervals that you want service discovery to wait after receiving an UpdateInstanceCustomHealthStatus request before it changes the health status of a service instance.",
+      "Default": 1
+    },
+  },
+  "Resources": {
+    "ServiceDiscoveryService": {
+      "Type" : "AWS::ServiceDiscovery::Service",
+      "Properties" : {
+        "Description" : { "Ref" : "SDSDescription" },
+        "DnsConfig" : {
+          "DnsRecords" : [ {
+            "Type" : { "Ref" : "DNSType" },
+            "TTL" : { "Ref" : "DNSTTL" }
+          } ],
+          "NamespaceId" : { "Ref" : "NamespaceID" }
+        },
+        "HealthCheckCustomConfig" : {
+          "FailureThreshold" : { "Ref" : "FailureThreshold" }
+        },
+        "Name" : { "Ref" : "SDSName" }
+      }
+    }
+  }
+  "Outputs" : {
+    "ServiceDiscoveryServiceID" : {
+      "Description": "The ID of the Service Discovery Service which can be used when launching an ECS Service.",
+      "Value" : { "Fn::GetAtt" : [ "ServiceDiscoveryService", "Id" ]}
+    }
+  }
+}
+`


### PR DESCRIPTION
*Description of changes:*
Refactored CloudFormation client and params to be generic so that they can be used by the service discovery implementation- previously they were specific to the cluster up workflow. Also added the CFN templates for private dns namespace and service discovery service.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
