### PR TITLE
Add support for credentials_parameter

### DIFF
--- a/ecs-cli/modules/utils/compose/convert_task_definition.go
+++ b/ecs-cli/modules/utils/compose/convert_task_definition.go
@@ -175,7 +175,15 @@ func convertToContainerDef(inputCfg *adapter.ContainerConfig, ecsContainerDef *C
 		mem = resolveIntResourceOverride(inputCfg.Name, mem, ecsMemInMB, "MemoryLimit")
 
 		ecsMemResInMB := adapter.ConvertToMemoryInMB(int64(ecsContainerDef.MemoryReservation))
+
 		memRes = resolveIntResourceOverride(inputCfg.Name, memRes, ecsMemResInMB, "MemoryReservation")
+
+		credParam := ecsContainerDef.RepositoryCredentials.CredentialsParameter
+
+		if credParam != "" {
+			outputContDef.RepositoryCredentials = &ecs.RepositoryCredentials{}
+			outputContDef.RepositoryCredentials.SetCredentialsParameter(credParam)
+		}
 
 		var err error
 		healthCheck, err = resolveHealthCheck(inputCfg.Name, healthCheck, ecsContainerDef.HealthCheck)

--- a/ecs-cli/modules/utils/compose/convert_task_definition_test.go
+++ b/ecs-cli/modules/utils/compose/convert_task_definition_test.go
@@ -436,6 +436,8 @@ task_definition:
   services:
     mysql:
       essential: false
+      repository_credentials:
+        credentials_parameter: arn:aws:secretsmanager:1234567890:secret:test-secret
   task_size:
     mem_limit: 5Gb
     cpu_limit: 256`
@@ -471,7 +473,7 @@ task_definition:
 		assert.Equal(t, "256", aws.StringValue(taskDefinition.Cpu), "Expected CPU to match")
 		assert.Equal(t, "5Gb", aws.StringValue(taskDefinition.Memory), "Expected CPU to match")
 		assert.True(t, aws.BoolValue(wordpress.Essential), "Expected container with name: '%v' to be true", *wordpress.Name)
-
+		assert.Equal(t, "arn:aws:secretsmanager:1234567890:secret:test-secret", aws.StringValue(mysql.RepositoryCredentials.CredentialsParameter), "Expected CredentialsParameter to match")
 	}
 }
 

--- a/ecs-cli/modules/utils/compose/ecs_params_reader.go
+++ b/ecs-cli/modules/utils/compose/ecs_params_reader.go
@@ -27,6 +27,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/ecs"
 	libYaml "github.com/docker/libcompose/yaml"
 	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v2"
 )
 
@@ -51,7 +52,8 @@ type ContainerDefs map[string]ContainerDef
 
 // ContainerDef holds fields for an ECS Container Definition that are not supplied by docker-compose
 type ContainerDef struct {
-	Essential bool `yaml:"essential"`
+	Essential             bool                  `yaml:"essential"`
+	RepositoryCredentials RepositoryCredentials `yaml:"repository_credentials"`
 	// resource field yaml names correspond to equivalent docker-compose field
 	Cpu               int64                  `yaml:"cpu_shares"`
 	Memory            libYaml.MemStringorInt `yaml:"mem_limit"`
@@ -68,6 +70,11 @@ type HealthCheck struct {
 	Interval    string `yaml:"interval,omitempty"`
 	Retries     int64  `yaml:"retries,omitempty"`
 	StartPeriod string `yaml:"start_period,omitempty"`
+}
+
+// RepositoryCredentials holds CredentialParameters for a ContainerDef
+type RepositoryCredentials struct {
+	CredentialsParameter string `yaml:"credentials_param"`
 }
 
 // TaskSize holds Cpu and Memory values needed for Fargate tasks
@@ -201,6 +208,8 @@ func ReadECSParams(filename string) (*ECSParams, error) {
 	if err = yaml.Unmarshal([]byte(ecsParamsData), &ecsParams); err != nil {
 		return nil, errors.Wrapf(err, "Error unmarshalling yaml data from ECS params file: %v", filename)
 	}
+
+	log.Infof("ECS params: %+v", ecsParams) // remove me!
 
 	return ecsParams, nil
 }

--- a/ecs-cli/modules/utils/compose/ecs_params_reader.go
+++ b/ecs-cli/modules/utils/compose/ecs_params_reader.go
@@ -27,7 +27,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/ecs"
 	libYaml "github.com/docker/libcompose/yaml"
 	"github.com/pkg/errors"
-	log "github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v2"
 )
 
@@ -74,7 +73,7 @@ type HealthCheck struct {
 
 // RepositoryCredentials holds CredentialParameters for a ContainerDef
 type RepositoryCredentials struct {
-	CredentialsParameter string `yaml:"credentials_param"`
+	CredentialsParameter string `yaml:"credentials_parameter"`
 }
 
 // TaskSize holds Cpu and Memory values needed for Fargate tasks
@@ -208,8 +207,6 @@ func ReadECSParams(filename string) (*ECSParams, error) {
 	if err = yaml.Unmarshal([]byte(ecsParamsData), &ecsParams); err != nil {
 		return nil, errors.Wrapf(err, "Error unmarshalling yaml data from ECS params file: %v", filename)
 	}
-
-	log.Infof("ECS params: %+v", ecsParams) // remove me!
 
 	return ecsParams, nil
 }

--- a/ecs-cli/modules/utils/compose/ecs_params_reader_test.go
+++ b/ecs-cli/modules/utils/compose/ecs_params_reader_test.go
@@ -85,7 +85,7 @@ task_definition:
     wordpress:
       essential: true
       repository_credentials:
-        credentials_param: arn:aws:secretsmanager:1234567890:secret:test-RT4iv`
+        credentials_parameter: arn:aws:secretsmanager:1234567890:secret:test-RT4iv`
 
 	content := []byte(ecsParamsString)
 
@@ -119,7 +119,7 @@ task_definition:
 		assert.Equal(t, yaml.MemStringorInt(524288000), mysql.Memory)
 		assert.Equal(t, yaml.MemStringorInt(524288000), mysql.MemoryReservation)
 		assert.True(t, wordpress.Essential, "Expected container to be essential")
-		assert.Equal(t, wordpress.RepositoryCredentials.CredentialsParameter, "arn:aws:secretsmanager:1234567890:secret:test-RT4iv")
+		assert.Equal(t, "arn:aws:secretsmanager:1234567890:secret:test-RT4iv", wordpress.RepositoryCredentials.CredentialsParameter, "Expected CredentialsParameter to match")
 	}
 }
 

--- a/ecs-cli/modules/utils/compose/ecs_params_reader_test.go
+++ b/ecs-cli/modules/utils/compose/ecs_params_reader_test.go
@@ -83,7 +83,9 @@ task_definition:
       mem_limit: 524288000
       mem_reservation: 500mb
     wordpress:
-      essential: true`
+      essential: true
+      repository_credentials:
+        credentials_param: arn:aws:secretsmanager:1234567890:secret:test-RT4iv`
 
 	content := []byte(ecsParamsString)
 
@@ -117,6 +119,7 @@ task_definition:
 		assert.Equal(t, yaml.MemStringorInt(524288000), mysql.Memory)
 		assert.Equal(t, yaml.MemStringorInt(524288000), mysql.MemoryReservation)
 		assert.True(t, wordpress.Essential, "Expected container to be essential")
+		assert.Equal(t, wordpress.RepositoryCredentials.CredentialsParameter, "arn:aws:secretsmanager:1234567890:secret:test-RT4iv")
 	}
 }
 


### PR DESCRIPTION
Add support for `RepositoryCredentials.CredentialsParameter` to ecs-params.yml

### Test output:

docker-compose.yml:
```
version: '3'
services:
  wordpress:
    image: httpd
    ports:
      - "80:80"
```
ecs-params.yml:
```
version: 1
task_definition:
  task_execution_role: ecsTaskExecutionRole
  services:
    wordpress:
      repository_credentials:
        credentials_parameter: arn:aws:secretsmanager:XXXXXXXXXX:secret:XXXXXXXX
      cpu_shares: 27
      mem_limit: 524288003
```
CMD output:
```
$~\credParamTest> ..\..\Documents\GO\src\github.com\aws\amazon-ecs-cli\bin\local\ecs-cli.exe compose create
INFO[0000] Using ECS task definition                     TaskDefinition="credParamTest:5"
```

Created task def:
```
{
    "executionRoleArn": "arn:aws:iam::XXXXXXXXX:role/ecsTaskExecutionRole",
    "containerDefinitions": [
        {
            "portMappings": [
                {
                    "hostPort": 80,
                    "protocol": "tcp",
                    "containerPort": 80
                }
            ],
            "cpu": 27,
            "repositoryCredentials": {
                "credentialsParameter": "arn:aws:secretsmanager:XXXXXXXXXX:secret:XXXXXXXX"
            },
            "memory": 500,
            "image": "httpd",
            "essential": true,
            "name": "wordpress"
        }
    ],
    "family": "credParamTest",
}
```

--
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.