### PR TITLE
Service Discovery: Enable DNS in VPCs created by the ECS CLI

### DIFF
--- a/ecs-cli/modules/clients/aws/cloudformation/cluster_template.go
+++ b/ecs-cli/modules/clients/aws/cloudformation/cluster_template.go
@@ -304,6 +304,8 @@ var cluster_template = `
       "Condition": "CreateVpcResources",
       "Type": "AWS::EC2::VPC",
       "Properties": {
+        "EnableDnsSupport" : true,
+        "EnableDnsHostnames" : true,
         "CidrBlock": {
           "Fn::FindInMap": ["VpcCidrs", "vpc", "cidr"]
         }


### PR DESCRIPTION
*Description of changes:*
In order to [enable DNS](https://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/vpc-dns.html), the VPC level settings `EnableDNSSupport` and `EnableDNSHostnames` must both be set to true. Currently, VPCs created with ecs-cli up have `EnableDNSHostnames` set to false (`EnableDNSSupport` defaults to true). This change explicitly sets both fields to true. This change will also bring the ECS CLI in line with the ECS Console, which creates clusters with both settings set to true.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
