### PR TITLE
Service Discovery: Full Create Workflow

### DIFF
--- a/ecs-cli/modules/cli/compose/entity/service/service_test.go
+++ b/ecs-cli/modules/cli/compose/entity/service/service_test.go
@@ -606,7 +606,7 @@ func TestCreateWithServiceDiscovery(t *testing.T) {
 	nonMockedServicediscoveryCreate := servicediscoveryCreate
 	defer func() { servicediscoveryCreate = nonMockedServicediscoveryCreate }()
 
-	servicediscoveryCreate = func(c *cli.Context, networkMode, serviceName, clusterName string) (*string, error) {
+	servicediscoveryCreate = func(networkMode, serviceName string, c *context.ECSContext) (*string, error) {
 		return aws.String(sdsARN), nil
 	}
 
@@ -636,7 +636,7 @@ func TestCreateWithServiceDiscoveryWithContainerNameAndPort(t *testing.T) {
 	nonMockedServicediscoveryCreate := servicediscoveryCreate
 	defer func() { servicediscoveryCreate = nonMockedServicediscoveryCreate }()
 
-	servicediscoveryCreate = func(c *cli.Context, networkMode, serviceName, clusterName string) (*string, error) {
+	servicediscoveryCreate = func(networkMode, serviceName string, c *context.ECSContext) (*string, error) {
 		return aws.String(sdsARN), nil
 	}
 

--- a/ecs-cli/modules/cli/servicediscovery/servicediscovery_app.go
+++ b/ecs-cli/modules/cli/servicediscovery/servicediscovery_app.go
@@ -16,11 +16,12 @@ package servicediscovery
 import (
 	"fmt"
 
+	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/cli/compose/context"
 	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/clients/aws/cloudformation"
 	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/commands/flags"
 	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/config"
+	utils "github.com/aws/amazon-ecs-cli/ecs-cli/modules/utils/compose"
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/ecs"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 )
@@ -30,55 +31,66 @@ const (
 	serviceDiscoveryServiceStackNameFormat = "amazon-ecs-cli-setup-%s-%s-service-discovery-service"
 )
 
-// CloudFormation template parameters
 const (
-	parameterKeyNamespaceDescription = "NamespaceDescription"
-	parameterKeyVPCID                = "VPCID"
-	parameterKeyNamespaceName        = "NamespaceName"
+	cfnTemplateOutputPrivateNamespaceID = "PrivateDNSNamespaceID"
+	cfnTemplateOutputSDSARN             = "ServiceDiscoveryServiceARN"
 )
 
-const (
-	parameterKeySDSDescription                          = "SDSDescription"
-	parameterKeySDSName                                 = "SDSName"
-	parameterKeyNamespaceID                             = "NamespaceID"
-	parameterKeyDNSType                                 = "DNSType"
-	parameterKeyDNSTTL                                  = "DNSTTL"
-	parameterKeyHealthCheckCustomConfigFailureThreshold = "FailureThreshold"
-)
+// Create creates a DNS namespace (or uses an existing one) and creates a Service Discovery Service
+// The Service Discovery ARN is returned so that it can be used to enable ECS Service Discovery
+func Create(networkMode, serviceName string, c *context.ECSContext) (*string, error) {
+	cfnClient := cloudformation.NewCloudformationClient(c.CommandConfig)
 
-const (
-	CFNTemplateOutputPrivateNamespaceID = "PrivateDNSNamespaceID"
-	CFNTemplateOutputSDSARN             = "ServiceDiscoveryServiceARN"
-)
-
-const (
-	dnsRecordTypeA   = "A"
-	dnsRecordTypeSRV = "SRV"
-)
-
-var requiredParamsSDS = []string{parameterKeyNamespaceID, parameterKeySDSName, parameterKeyDNSType}
-var requiredParamsNamespace = []string{parameterKeyVPCID, parameterKeyNamespaceName}
-
-// Create creates resources for service discovery and returns the ID of the Service Discovery Service
-func Create(c *cli.Context, networkMode, serviceName, clusterName string) (*string, error) {
-	rdwr, err := config.NewReadWriter()
-	if err != nil {
-		return nil, err
+	var ecsParamsSD *utils.ServiceDiscovery
+	if c.ECSParams != nil {
+		ecsParamsSD = &c.ECSParams.RunParams.ServiceDiscovery
+	} else {
+		ecsParamsSD = &utils.ServiceDiscovery{}
 	}
 
-	commandConfig, err := config.NewCommandConfig(c, rdwr)
-	if err != nil {
-		return nil, err
-	}
-
-	cfnClient := cloudformation.NewCloudformationClient(commandConfig)
-
-	return create(c, networkMode, serviceName, clusterName, cfnClient)
+	return create(c.CLIContext, networkMode, serviceName, cfnClient, ecsParamsSD, c.CommandConfig)
 }
 
-func create(c *cli.Context, networkMode, serviceName, clusterName string, cfnClient cloudformation.CloudformationClient) (*string, error) {
-	// create namespace
-	namespaceParams := namespaceCFNParams(c)
+func create(c *cli.Context, networkMode, serviceName string, cfnClient cloudformation.CloudformationClient, ecsParamsSD *utils.ServiceDiscovery, config *config.CommandConfig) (*string, error) {
+	err := validateNameAndIdExclusive(c, ecsParamsSD)
+	if err != nil {
+		return nil, err
+	}
+	input, err := mergeSDFlagsAndInput(c, ecsParamsSD)
+	if err != nil {
+		return nil, err
+	}
+	err = validateMergedSDInputFields(input, networkMode)
+	if err != nil {
+		return nil, err
+	}
+	namespaceWarningsWhenIDSpecified(input)
+
+	namespaceID, err := getOrCreateNamespace(c, networkMode, serviceName, cfnClient, input, config)
+	if err != nil {
+		return nil, err
+	}
+
+	// create SDS
+	sdsParams := getSDSCFNParams(aws.StringValue(namespaceID), serviceName, networkMode, input)
+	if err := sdsParams.Validate(); err != nil {
+		return nil, err
+	}
+
+	sdsStackName := cfnStackName(serviceDiscoveryServiceStackNameFormat, config.Cluster, serviceName)
+	if _, err := cfnClient.CreateStack(cloudformation.GetSDSTemplate(), sdsStackName, false, sdsParams); err != nil {
+		return nil, err
+	}
+
+	logrus.Info("Waiting for the Service Discovery Service to be created...")
+	cfnClient.WaitUntilCreateComplete(sdsStackName)
+
+	// Return the ID of the SDS we just created
+	return getOutputIDFromStack(cfnClient, sdsStackName, cfnTemplateOutputSDSARN)
+}
+
+func createNamespace(c *cli.Context, networkMode, serviceName, clusterName string, cfnClient cloudformation.CloudformationClient, input *utils.ServiceDiscovery) (*string, error) {
+	namespaceParams := getNamespaceCFNParams(input)
 	if err := namespaceParams.Validate(); err != nil {
 		return nil, err
 	}
@@ -89,79 +101,90 @@ func create(c *cli.Context, networkMode, serviceName, clusterName string, cfnCli
 	}
 
 	logrus.Info("Waiting for the private DNS namespace to be created...")
-	// Wait for stack creation
 	cfnClient.WaitUntilCreateComplete(namespaceStackName)
 
 	// Get the ID of the namespace we just created
-	namespaceID, err := getOutputIDFromStack(cfnClient, namespaceStackName, CFNTemplateOutputPrivateNamespaceID)
+	return getOutputIDFromStack(cfnClient, namespaceStackName, cfnTemplateOutputPrivateNamespaceID)
+}
+
+func getOrCreateNamespace(c *cli.Context, networkMode, serviceName string, cfnClient cloudformation.CloudformationClient, input *utils.ServiceDiscovery, config *config.CommandConfig) (*string, error) {
+	namespace, err := getExistingNamespace(input, config)
 	if err != nil {
 		return nil, err
 	}
-
-	// create SDS
-	sdsParams := sdsCFNParams(aws.StringValue(namespaceID), serviceName, networkMode)
-	if err := sdsParams.Validate(); err != nil {
-		return nil, err
+	if namespace == nil {
+		namespace, err = createNamespace(c, networkMode, serviceName, config.Cluster, cfnClient, input)
+	} else {
+		logrus.Infof("Using existing namespace %s", *namespace)
 	}
-
-	sdsStackName := cfnStackName(serviceDiscoveryServiceStackNameFormat, clusterName, serviceName)
-	if _, err := cfnClient.CreateStack(cloudformation.GetSDSTemplate(), sdsStackName, false, sdsParams); err != nil {
-		return nil, err
-	}
-
-	logrus.Info("Waiting for the Service Discovery Service to be created...")
-	// Wait for stack creation
-	cfnClient.WaitUntilCreateComplete(sdsStackName)
-
-	// Return the ID of the SDS we just created
-	return getOutputIDFromStack(cfnClient, sdsStackName, CFNTemplateOutputSDSARN)
+	return namespace, err
 }
 
-func getOutputIDFromStack(cfnClient cloudformation.CloudformationClient, stackName, outputKey string) (*string, error) {
-	response, err := cfnClient.DescribeStacks(stackName)
+func getExistingNamespace(input *utils.ServiceDiscovery, config *config.CommandConfig) (*string, error) {
+	switch {
+	case input.PrivateDNSNamespace.ID != "":
+		return aws.String(input.PrivateDNSNamespace.ID), nil
+	case input.PublicDNSNamespace.ID != "":
+		return aws.String(input.PublicDNSNamespace.ID), nil
+	case input.PrivateDNSNamespace.Name != "":
+		return findPrivateNamespace(input.PrivateDNSNamespace.Name, input.PrivateDNSNamespace.VPC, config)
+	case input.PublicDNSNamespace.Name != "":
+		return getPublicNamespaceSpecifiedByName(input.PublicDNSNamespace.Name, config)
+	default:
+		return nil, nil
+	}
+}
+
+func getPublicNamespaceSpecifiedByName(name string, config *config.CommandConfig) (*string, error) {
+	namespace, err := findPublicNamespace(name, config)
 	if err != nil {
 		return nil, err
 	}
-	if len(response.Stacks) == 0 {
-		return nil, fmt.Errorf("Could not find CloudFormation stack: %s", stackName)
+	if namespace == nil {
+		// we do not create public namespaces, so failing to find it is in an error case
+		return nil, fmt.Errorf("Failed to find public namespace %s", name)
 	}
-
-	for _, output := range response.Stacks[0].Outputs {
-		if aws.StringValue(output.OutputKey) == outputKey {
-			return output.OutputValue, nil
-		}
-	}
-	return nil, fmt.Errorf("Failed to find output %s in stack %s", outputKey, stackName)
-
+	return namespace, err
 }
 
-func cfnStackName(stackName, cluster, service string) string {
-	return fmt.Sprintf(stackName, cluster, service)
-}
+// Flags override the values specified in ECS Params
+// Merges fields for Namespace and SDS
+// This function just merges fields; it doesn't validate them
+func mergeSDFlagsAndInput(c *cli.Context, ecsParamsSD *utils.ServiceDiscovery) (*utils.ServiceDiscovery, error) {
+	// Private DNS Namespace fields
+	privNamespace := ecsParamsSD.PrivateDNSNamespace
+	privNamespace.Namespace = resolveNamespaceOverride(c.String(flags.PrivateDNSNamespaceNameFlag), c.String(flags.PrivateDNSNamespaceIDFlag), "private", privNamespace.Namespace)
+	privNamespace.VPC = resolveStringFieldOverride(c, flags.VpcIdFlag, privNamespace.VPC, "private_dns_namespace.vpc")
+	ecsParamsSD.PrivateDNSNamespace = privNamespace
 
-func sdsCFNParams(namespaceID, sdsName, networkMode string) *cloudformation.CfnStackParams {
-	cfnParams := cloudformation.NewCfnStackParams(requiredParamsSDS)
+	// Public DNS Namespace fields
+	pubNamespace := ecsParamsSD.PublicDNSNamespace
+	pubNamespace.Namespace = resolveNamespaceOverride(c.String(flags.PublicDNSNamespaceNameFlag), c.String(flags.PublicDNSNamespaceIDFlag), "public", pubNamespace.Namespace)
+	ecsParamsSD.PublicDNSNamespace = pubNamespace
 
-	cfnParams.Add(parameterKeyNamespaceID, namespaceID)
-	cfnParams.Add(parameterKeySDSName, sdsName)
-
-	dnsType := dnsRecordTypeSRV
-	if networkMode == ecs.NetworkModeAwsvpc {
-		dnsType = dnsRecordTypeA
+	// SDS fields
+	sds := ecsParamsSD.ServiceDiscoveryService
+	sds.DNSConfig.Type = resolveStringFieldOverride(c, flags.DNSTypeFlag, sds.DNSConfig.Type, "dns_config.type")
+	ttl, err := resolveIntPointerFieldOverride(c, flags.DNSTTLFlag, sds.DNSConfig.TTL, "dns_config.ttl")
+	if err != nil {
+		return nil, err
 	}
-	cfnParams.Add(parameterKeyDNSType, dnsType)
+	sds.DNSConfig.TTL = ttl
+	threshold, err := resolveIntPointerFieldOverride(c, flags.HealthcheckCustomConfigFailureThresholdFlag, sds.HealthCheckCustomConfig.FailureThreshold, "failure_threshold")
+	if err != nil {
+		return nil, err
+	}
+	sds.HealthCheckCustomConfig.FailureThreshold = threshold
+	ecsParamsSD.ServiceDiscoveryService = sds
 
-	return cfnParams
-}
+	// top level fields
+	// these container fields aren't used when creating Route53 resources in this package, but we aggregate them here so that we can do error checking- SRV records require these.
+	ecsParamsSD.ContainerName = resolveStringFieldOverride(c, flags.ServiceDiscoveryContainerNameFlag, ecsParamsSD.ContainerName, "container_name")
+	port, err := resolveIntPointerFieldOverride(c, flags.ServiceDiscoveryContainerPortFlag, ecsParamsSD.ContainerPort, "container_port")
+	if err != nil {
+		return nil, err
+	}
+	ecsParamsSD.ContainerPort = port
 
-func namespaceCFNParams(context *cli.Context) *cloudformation.CfnStackParams {
-	cfnParams := cloudformation.NewCfnStackParams(requiredParamsNamespace)
-
-	namespaceName := context.String(flags.PrivateDNSNamespaceNameFlag)
-	cfnParams.Add(parameterKeyNamespaceName, namespaceName)
-
-	vpcID := context.String(flags.VpcIdFlag)
-	cfnParams.Add(parameterKeyVPCID, vpcID)
-
-	return cfnParams
+	return ecsParamsSD, nil
 }

--- a/ecs-cli/modules/cli/servicediscovery/servicediscovery_app_test.go
+++ b/ecs-cli/modules/cli/servicediscovery/servicediscovery_app_test.go
@@ -15,13 +15,17 @@ package servicediscovery
 
 import (
 	"flag"
+	"fmt"
 	"testing"
 
 	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/clients/aws/cloudformation"
 	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/clients/aws/cloudformation/mock"
 	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/commands/flags"
+	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/config"
+	utils "github.com/aws/amazon-ecs-cli/ecs-cli/modules/utils/compose"
 	"github.com/aws/aws-sdk-go/aws"
 	sdk "github.com/aws/aws-sdk-go/service/cloudformation"
+	"github.com/aws/aws-sdk-go/service/servicediscovery"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/urfave/cli"
@@ -30,27 +34,362 @@ import (
 const (
 	testClusterName        = "cluster"
 	testServiceName        = "service"
+	testDescription        = "clyde loves pudding"
+	otherTestDescription   = "pudding plays hard to get"
 	testNamespaceStackName = "amazon-ecs-cli-setup-cluster-service-private-dns-namespace"
 	testSDSStackName       = "amazon-ecs-cli-setup-cluster-service-service-discovery-service"
 	testNamespaceName      = "corp"
+	otherTestNamespaceName = "dumpling"
 	testVPCID              = "vpc-8BAADF00D"
+	otherTestVPCID         = "vpc-F33DFAC3"
 	testNamespaceID        = "ns-CA15CA15CA15CA15"
+	otherTestNamespaceID   = "ns-D0G5D0G5D0G5D0G5D0G5"
+	testPublicNamespaceID  = "ns-PUBL1C"
 	testSDSARN             = "arn:aws:servicediscovery:eu-west-1:11111111111:service/srv-clydelovespudding"
+	testContainerName      = "my-container"
+	otherTestContainerName = "my-other-container"
 )
 
+type validateSDSParamsFunc func(*testing.T, *cloudformation.CfnStackParams)
+type validateNamespaceParamsFunc func(*testing.T, *cloudformation.CfnStackParams)
+
 func TestCreateServiceDiscoveryAWSVPC(t *testing.T) {
-	testCreateServiceDiscovery(t, "awsvpc", dnsRecordTypeA)
+	var validateNamespace validateNamespaceParamsFunc = func(t *testing.T, cfnParams *cloudformation.CfnStackParams) {
+		validateCFNParam(testNamespaceName, parameterKeyNamespaceName, cfnParams, t)
+		validateCFNParam(testVPCID, parameterKeyVPCID, cfnParams, t)
+	}
+	var validateSDS validateSDSParamsFunc = func(t *testing.T, cfnParams *cloudformation.CfnStackParams) {
+		validateCFNParam(testNamespaceID, parameterKeyNamespaceID, cfnParams, t)
+		validateCFNParam(testServiceName, parameterKeySDSName, cfnParams, t)
+		validateCFNParam(servicediscovery.RecordTypeA, parameterKeyDNSType, cfnParams, t)
+	}
+
+	oldFindPrivateNamespace := findPrivateNamespace
+	defer func() { findPrivateNamespace = oldFindPrivateNamespace }()
+	findPrivateNamespace = func(name, vpc string, config *config.CommandConfig) (*string, error) {
+		// In this test the namespace does pre-exist
+		return nil, nil
+	}
+
+	testCreateServiceDiscovery(t, "awsvpc", &utils.ServiceDiscovery{}, simpleWorkflowContext(), validateNamespace, validateSDS, true)
 }
 
 func TestCreateServiceDiscoveryBridge(t *testing.T) {
-	testCreateServiceDiscovery(t, "bridge", dnsRecordTypeSRV)
+	input := &utils.ServiceDiscovery{
+		ContainerName: testContainerName,
+		ContainerPort: aws.Int64(80),
+	}
+	var validateNamespace validateNamespaceParamsFunc = func(t *testing.T, cfnParams *cloudformation.CfnStackParams) {
+		validateCFNParam(testNamespaceName, parameterKeyNamespaceName, cfnParams, t)
+		validateCFNParam(testVPCID, parameterKeyVPCID, cfnParams, t)
+	}
+	var validateSDS validateSDSParamsFunc = func(t *testing.T, cfnParams *cloudformation.CfnStackParams) {
+		validateCFNParam(testNamespaceID, parameterKeyNamespaceID, cfnParams, t)
+		validateCFNParam(testServiceName, parameterKeySDSName, cfnParams, t)
+		validateCFNParam(servicediscovery.RecordTypeSrv, parameterKeyDNSType, cfnParams, t)
+	}
+
+	oldFindPrivateNamespace := findPrivateNamespace
+	defer func() { findPrivateNamespace = oldFindPrivateNamespace }()
+	findPrivateNamespace = func(name, vpc string, config *config.CommandConfig) (*string, error) {
+		// In this test the namespace does not pre-exist
+		return nil, nil
+	}
+
+	testCreateServiceDiscovery(t, "bridge", input, simpleWorkflowContext(), validateNamespace, validateSDS, true)
 }
 
 func TestCreateServiceDiscoveryHost(t *testing.T) {
-	testCreateServiceDiscovery(t, "host", dnsRecordTypeSRV)
+	input := &utils.ServiceDiscovery{
+		ContainerName: testContainerName,
+		ContainerPort: aws.Int64(80),
+	}
+	var validateNamespace validateNamespaceParamsFunc = func(t *testing.T, cfnParams *cloudformation.CfnStackParams) {
+		validateCFNParam(testNamespaceName, parameterKeyNamespaceName, cfnParams, t)
+		validateCFNParam(testVPCID, parameterKeyVPCID, cfnParams, t)
+	}
+	var validateSDS validateSDSParamsFunc = func(t *testing.T, cfnParams *cloudformation.CfnStackParams) {
+		validateCFNParam(testNamespaceID, parameterKeyNamespaceID, cfnParams, t)
+		validateCFNParam(testServiceName, parameterKeySDSName, cfnParams, t)
+		validateCFNParam(servicediscovery.RecordTypeSrv, parameterKeyDNSType, cfnParams, t)
+	}
+
+	oldFindPrivateNamespace := findPrivateNamespace
+	defer func() { findPrivateNamespace = oldFindPrivateNamespace }()
+	findPrivateNamespace = func(name, vpc string, config *config.CommandConfig) (*string, error) {
+		// In this test the namespace does not pre-exist
+		return nil, nil
+	}
+
+	testCreateServiceDiscovery(t, "host", input, simpleWorkflowContext(), validateNamespace, validateSDS, true)
 }
 
-func testCreateServiceDiscovery(t *testing.T, networkMode, expectedDNSType string) {
+func TestCreateServiceDiscoveryWithECSParams(t *testing.T) {
+	input := &utils.ServiceDiscovery{
+		ContainerName: testContainerName,
+		ContainerPort: aws.Int64(80),
+		PrivateDNSNamespace: utils.PrivateDNSNamespace{
+			Namespace: utils.Namespace{
+				Name: testNamespaceName,
+			},
+			VPC:         testVPCID,
+			Description: testDescription,
+		},
+		ServiceDiscoveryService: utils.ServiceDiscoveryService{
+			Name:        testServiceName,
+			Description: testDescription,
+			DNSConfig: utils.DNSConfig{
+				TTL:  aws.Int64(60),
+				Type: servicediscovery.RecordTypeSrv,
+			},
+			HealthCheckCustomConfig: utils.HealthCheckCustomConfig{
+				FailureThreshold: aws.Int64(2),
+			},
+		},
+	}
+
+	var validateNamespace validateNamespaceParamsFunc = func(t *testing.T, cfnParams *cloudformation.CfnStackParams) {
+		validateCFNParam(testNamespaceName, parameterKeyNamespaceName, cfnParams, t)
+		validateCFNParam(testVPCID, parameterKeyVPCID, cfnParams, t)
+		validateCFNParam(testDescription, parameterKeyNamespaceDescription, cfnParams, t)
+	}
+	var validateSDS validateSDSParamsFunc = func(t *testing.T, cfnParams *cloudformation.CfnStackParams) {
+		validateCFNParam(testNamespaceID, parameterKeyNamespaceID, cfnParams, t)
+		validateCFNParam(testServiceName, parameterKeySDSName, cfnParams, t)
+		validateCFNParam(servicediscovery.RecordTypeSrv, parameterKeyDNSType, cfnParams, t)
+		validateCFNParam(testDescription, parameterKeySDSDescription, cfnParams, t)
+		validateCFNParam("60", parameterKeyDNSTTL, cfnParams, t)
+		validateCFNParam("2", parameterKeyHealthCheckCustomConfigFailureThreshold, cfnParams, t)
+	}
+
+	oldFindPrivateNamespace := findPrivateNamespace
+	defer func() { findPrivateNamespace = oldFindPrivateNamespace }()
+	findPrivateNamespace = func(name, vpc string, config *config.CommandConfig) (*string, error) {
+		// In this test the namespace does not pre-exist
+		return nil, nil
+	}
+
+	testCreateServiceDiscovery(t, "awsvpc", input, emptyContext(), validateNamespace, validateSDS, true)
+}
+
+func TestCreateServiceDiscoveryWithECSParamsOverriddenByFlags(t *testing.T) {
+	input := &utils.ServiceDiscovery{
+		ContainerName: testContainerName,
+		ContainerPort: aws.Int64(80),
+		PrivateDNSNamespace: utils.PrivateDNSNamespace{
+			Namespace: utils.Namespace{
+				Name: testNamespaceName,
+			},
+			VPC:         testVPCID,
+			Description: testDescription,
+		},
+		ServiceDiscoveryService: utils.ServiceDiscoveryService{
+			Name:        testServiceName,
+			Description: testDescription,
+			DNSConfig: utils.DNSConfig{
+				TTL:  aws.Int64(60),
+				Type: servicediscovery.RecordTypeSrv,
+			},
+			HealthCheckCustomConfig: utils.HealthCheckCustomConfig{
+				FailureThreshold: aws.Int64(2),
+			},
+		},
+	}
+
+	flagDNSTTL := "120"
+	flagContPort := "22"
+	flagHealthThreshold := "3"
+	flagSet := flag.NewFlagSet("create-sd", 0)
+	flagSet.String(flags.PrivateDNSNamespaceNameFlag, otherTestNamespaceName, "")
+	flagSet.String(flags.VpcIdFlag, otherTestVPCID, "")
+	flagSet.String(flags.DNSTTLFlag, flagDNSTTL, "")
+	flagSet.String(flags.DNSTypeFlag, servicediscovery.RecordTypeA, "")
+	flagSet.String(flags.ServiceDiscoveryContainerNameFlag, otherTestContainerName, "")
+	flagSet.String(flags.ServiceDiscoveryContainerPortFlag, flagContPort, "")
+	flagSet.String(flags.HealthcheckCustomConfigFailureThresholdFlag, flagHealthThreshold, "")
+	flagSet.Bool(flags.ForceFlag, true, "")
+
+	overrides := cli.NewContext(nil, flagSet, nil)
+
+	var validateNamespace validateNamespaceParamsFunc = func(t *testing.T, cfnParams *cloudformation.CfnStackParams) {
+		validateCFNParam(otherTestNamespaceName, parameterKeyNamespaceName, cfnParams, t)
+		validateCFNParam(otherTestVPCID, parameterKeyVPCID, cfnParams, t)
+		validateCFNParam(testDescription, parameterKeyNamespaceDescription, cfnParams, t)
+	}
+	var validateSDS validateSDSParamsFunc = func(t *testing.T, cfnParams *cloudformation.CfnStackParams) {
+		validateCFNParam(testServiceName, parameterKeySDSName, cfnParams, t)
+		validateCFNParam(servicediscovery.RecordTypeA, parameterKeyDNSType, cfnParams, t)
+		validateCFNParam(testDescription, parameterKeySDSDescription, cfnParams, t)
+		validateCFNParam(flagDNSTTL, parameterKeyDNSTTL, cfnParams, t)
+		validateCFNParam(flagHealthThreshold, parameterKeyHealthCheckCustomConfigFailureThreshold, cfnParams, t)
+	}
+
+	oldFindPrivateNamespace := findPrivateNamespace
+	defer func() { findPrivateNamespace = oldFindPrivateNamespace }()
+	findPrivateNamespace = func(name, vpc string, config *config.CommandConfig) (*string, error) {
+		// In this test the namespace does not pre-exist
+		return nil, nil
+	}
+
+	testCreateServiceDiscovery(t, "awsvpc", input, overrides, validateNamespace, validateSDS, true)
+}
+
+func TestCreateServiceDiscoveryWithECSParamsExistingPrivateNamespaceByID(t *testing.T) {
+	input := &utils.ServiceDiscovery{
+		ContainerName: testContainerName,
+		ContainerPort: aws.Int64(80),
+		PrivateDNSNamespace: utils.PrivateDNSNamespace{
+			Namespace: utils.Namespace{
+				ID: otherTestNamespaceID,
+			},
+		},
+		ServiceDiscoveryService: utils.ServiceDiscoveryService{
+			Name:        testServiceName,
+			Description: testDescription,
+			DNSConfig: utils.DNSConfig{
+				TTL:  aws.Int64(60),
+				Type: servicediscovery.RecordTypeSrv,
+			},
+			HealthCheckCustomConfig: utils.HealthCheckCustomConfig{
+				FailureThreshold: aws.Int64(2),
+			},
+		},
+	}
+
+	var validateNamespace validateNamespaceParamsFunc = func(t *testing.T, cfnParams *cloudformation.CfnStackParams) {}
+	var validateSDS validateSDSParamsFunc = func(t *testing.T, cfnParams *cloudformation.CfnStackParams) {
+		validateCFNParam(otherTestNamespaceID, parameterKeyNamespaceID, cfnParams, t)
+		validateCFNParam(testServiceName, parameterKeySDSName, cfnParams, t)
+		validateCFNParam(servicediscovery.RecordTypeSrv, parameterKeyDNSType, cfnParams, t)
+		validateCFNParam(testDescription, parameterKeySDSDescription, cfnParams, t)
+		validateCFNParam("60", parameterKeyDNSTTL, cfnParams, t)
+		validateCFNParam("2", parameterKeyHealthCheckCustomConfigFailureThreshold, cfnParams, t)
+	}
+
+	testCreateServiceDiscovery(t, "awsvpc", input, emptyContext(), validateNamespace, validateSDS, false)
+}
+
+func TestCreateServiceDiscoveryWithECSParamsExistingPrivateNamespaceByName(t *testing.T) {
+	input := &utils.ServiceDiscovery{
+		ContainerName: testContainerName,
+		ContainerPort: aws.Int64(80),
+		PrivateDNSNamespace: utils.PrivateDNSNamespace{
+			Namespace: utils.Namespace{
+				Name: otherTestNamespaceName,
+			},
+			VPC: otherTestVPCID,
+		},
+		ServiceDiscoveryService: utils.ServiceDiscoveryService{
+			Name:        testServiceName,
+			Description: testDescription,
+			DNSConfig: utils.DNSConfig{
+				TTL:  aws.Int64(60),
+				Type: servicediscovery.RecordTypeSrv,
+			},
+			HealthCheckCustomConfig: utils.HealthCheckCustomConfig{
+				FailureThreshold: aws.Int64(2),
+			},
+		},
+	}
+
+	var validateNamespace validateNamespaceParamsFunc = func(t *testing.T, cfnParams *cloudformation.CfnStackParams) {}
+	var validateSDS validateSDSParamsFunc = func(t *testing.T, cfnParams *cloudformation.CfnStackParams) {
+		validateCFNParam(otherTestNamespaceID, parameterKeyNamespaceID, cfnParams, t)
+		validateCFNParam(testServiceName, parameterKeySDSName, cfnParams, t)
+		validateCFNParam(servicediscovery.RecordTypeSrv, parameterKeyDNSType, cfnParams, t)
+		validateCFNParam(testDescription, parameterKeySDSDescription, cfnParams, t)
+		validateCFNParam("60", parameterKeyDNSTTL, cfnParams, t)
+		validateCFNParam("2", parameterKeyHealthCheckCustomConfigFailureThreshold, cfnParams, t)
+	}
+
+	oldFindPrivateNamespace := findPrivateNamespace
+	defer func() { findPrivateNamespace = oldFindPrivateNamespace }()
+	findPrivateNamespace = func(name, vpc string, config *config.CommandConfig) (*string, error) {
+		// In this test the namespace does pre-exist and we search for it
+		return aws.String(otherTestNamespaceID), nil
+	}
+
+	testCreateServiceDiscovery(t, "awsvpc", input, emptyContext(), validateNamespace, validateSDS, false)
+}
+
+func TestCreateServiceDiscoveryWithECSParamsExistingPublicNamespaceByID(t *testing.T) {
+	input := &utils.ServiceDiscovery{
+		ContainerName: testContainerName,
+		ContainerPort: aws.Int64(80),
+		PublicDNSNamespace: utils.PublicDNSNamespace{
+			Namespace: utils.Namespace{
+				ID: otherTestNamespaceID,
+			},
+		},
+		ServiceDiscoveryService: utils.ServiceDiscoveryService{
+			Name:        testServiceName,
+			Description: testDescription,
+			DNSConfig: utils.DNSConfig{
+				TTL:  aws.Int64(60),
+				Type: servicediscovery.RecordTypeSrv,
+			},
+			HealthCheckCustomConfig: utils.HealthCheckCustomConfig{
+				FailureThreshold: aws.Int64(2),
+			},
+		},
+	}
+
+	var validateNamespace validateNamespaceParamsFunc = func(t *testing.T, cfnParams *cloudformation.CfnStackParams) {}
+	var validateSDS validateSDSParamsFunc = func(t *testing.T, cfnParams *cloudformation.CfnStackParams) {
+		validateCFNParam(otherTestNamespaceID, parameterKeyNamespaceID, cfnParams, t)
+		validateCFNParam(testServiceName, parameterKeySDSName, cfnParams, t)
+		validateCFNParam(servicediscovery.RecordTypeSrv, parameterKeyDNSType, cfnParams, t)
+		validateCFNParam(testDescription, parameterKeySDSDescription, cfnParams, t)
+		validateCFNParam("60", parameterKeyDNSTTL, cfnParams, t)
+		validateCFNParam("2", parameterKeyHealthCheckCustomConfigFailureThreshold, cfnParams, t)
+	}
+
+	testCreateServiceDiscovery(t, "awsvpc", input, emptyContext(), validateNamespace, validateSDS, false)
+}
+
+func TestCreateServiceDiscoveryWithECSParamsExistingPublicNamespaceByName(t *testing.T) {
+	input := &utils.ServiceDiscovery{
+		ContainerName: testContainerName,
+		ContainerPort: aws.Int64(80),
+		PublicDNSNamespace: utils.PublicDNSNamespace{
+			Namespace: utils.Namespace{
+				Name: otherTestNamespaceName,
+			},
+		},
+		ServiceDiscoveryService: utils.ServiceDiscoveryService{
+			Name:        testServiceName,
+			Description: testDescription,
+			DNSConfig: utils.DNSConfig{
+				TTL:  aws.Int64(60),
+				Type: servicediscovery.RecordTypeSrv,
+			},
+			HealthCheckCustomConfig: utils.HealthCheckCustomConfig{
+				FailureThreshold: aws.Int64(2),
+			},
+		},
+	}
+
+	var validateNamespace validateNamespaceParamsFunc = func(t *testing.T, cfnParams *cloudformation.CfnStackParams) {}
+	var validateSDS validateSDSParamsFunc = func(t *testing.T, cfnParams *cloudformation.CfnStackParams) {
+		validateCFNParam(otherTestNamespaceID, parameterKeyNamespaceID, cfnParams, t)
+		validateCFNParam(testServiceName, parameterKeySDSName, cfnParams, t)
+		validateCFNParam(servicediscovery.RecordTypeSrv, parameterKeyDNSType, cfnParams, t)
+		validateCFNParam(testDescription, parameterKeySDSDescription, cfnParams, t)
+		validateCFNParam("60", parameterKeyDNSTTL, cfnParams, t)
+		validateCFNParam("2", parameterKeyHealthCheckCustomConfigFailureThreshold, cfnParams, t)
+	}
+
+	oldFindPublicNamespace := findPublicNamespace
+	defer func() { findPublicNamespace = oldFindPublicNamespace }()
+	findPublicNamespace = func(name string, config *config.CommandConfig) (*string, error) {
+		// In this test the namespace does pre-exist and we search for it
+		return aws.String(otherTestNamespaceID), nil
+	}
+
+	testCreateServiceDiscovery(t, "awsvpc", input, emptyContext(), validateNamespace, validateSDS, false)
+}
+
+func testCreateServiceDiscovery(t *testing.T, networkMode string, ecsParamsSD *utils.ServiceDiscovery, c *cli.Context, validateNamespace validateNamespaceParamsFunc, validateSDS validateSDSParamsFunc, createNamespace bool) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -59,7 +398,7 @@ func testCreateServiceDiscovery(t *testing.T, networkMode, expectedDNSType strin
 			&sdk.Stack{
 				Outputs: []*sdk.Output{
 					&sdk.Output{
-						OutputKey:   aws.String(CFNTemplateOutputPrivateNamespaceID),
+						OutputKey:   aws.String(cfnTemplateOutputPrivateNamespaceID),
 						OutputValue: aws.String(testNamespaceID),
 					},
 				},
@@ -72,7 +411,7 @@ func testCreateServiceDiscovery(t *testing.T, networkMode, expectedDNSType strin
 			&sdk.Stack{
 				Outputs: []*sdk.Output{
 					&sdk.Output{
-						OutputKey:   aws.String(CFNTemplateOutputSDSARN),
+						OutputKey:   aws.String(cfnTemplateOutputSDSARN),
 						OutputValue: aws.String(testSDSARN),
 					},
 				},
@@ -81,48 +420,65 @@ func testCreateServiceDiscovery(t *testing.T, networkMode, expectedDNSType strin
 	}
 
 	mockCloudformation := mock_cloudformation.NewMockCloudformationClient(ctrl)
-	gomock.InOrder(
-		mockCloudformation.EXPECT().CreateStack(gomock.Any(), testNamespaceStackName, false, gomock.Any()).Do(func(x, y, w, z interface{}) {
-			stackName := y.(string)
-			capabilityIAM := w.(bool)
-			cfnParams := z.(*cloudformation.CfnStackParams)
-			validateCFNParam(testNamespaceName, parameterKeyNamespaceName, cfnParams, t)
-			validateCFNParam(testVPCID, parameterKeyVPCID, cfnParams, t)
-			assert.False(t, capabilityIAM, "Expected capability capabilityIAM to be false")
-			assert.Equal(t, testNamespaceStackName, stackName, "Expected stack name to match")
-		}).Return("", nil),
-		mockCloudformation.EXPECT().WaitUntilCreateComplete(testNamespaceStackName).Return(nil),
-		mockCloudformation.EXPECT().DescribeStacks(testNamespaceStackName).Return(describeNamespaceStackResponse, nil),
+
+	// Create a list of expected calls for gomock.InOrder
+	// The expected calls differ depending upon whether or not we are going to create a namespace or not
+	var expectedCFNCalls []*gomock.Call
+	if createNamespace {
+		expectedCFNCalls = append(expectedCFNCalls, []*gomock.Call{
+			mockCloudformation.EXPECT().CreateStack(gomock.Any(), testNamespaceStackName, false, gomock.Any()).Do(func(x, y, w, z interface{}) {
+				stackName := y.(string)
+				capabilityIAM := w.(bool)
+				cfnParams := z.(*cloudformation.CfnStackParams)
+				validateNamespace(t, cfnParams)
+				assert.False(t, capabilityIAM, "Expected capability capabilityIAM to be false")
+				assert.Equal(t, testNamespaceStackName, stackName, "Expected stack name to match")
+			}).Return("", nil),
+			mockCloudformation.EXPECT().WaitUntilCreateComplete(testNamespaceStackName).Return(nil),
+			mockCloudformation.EXPECT().DescribeStacks(testNamespaceStackName).Return(describeNamespaceStackResponse, nil),
+		}...)
+	}
+	expectedCFNCalls = append(expectedCFNCalls, []*gomock.Call{
 		mockCloudformation.EXPECT().CreateStack(gomock.Any(), testSDSStackName, false, gomock.Any()).Do(func(x, y, w, z interface{}) {
 			stackName := y.(string)
 			capabilityIAM := w.(bool)
 			cfnParams := z.(*cloudformation.CfnStackParams)
-			validateCFNParam(testNamespaceID, parameterKeyNamespaceID, cfnParams, t)
-			validateCFNParam(testServiceName, parameterKeySDSName, cfnParams, t)
-			validateCFNParam(expectedDNSType, parameterKeyDNSType, cfnParams, t)
+			validateSDS(t, cfnParams)
 			assert.False(t, capabilityIAM, "Expected capability capabilityIAM to be false")
 			assert.Equal(t, testSDSStackName, stackName, "Expected stack name to match")
 		}).Return("", nil),
 		mockCloudformation.EXPECT().WaitUntilCreateComplete(testSDSStackName).Return(nil),
 		mockCloudformation.EXPECT().DescribeStacks(testSDSStackName).Return(describeSDSStackResponse, nil),
-	)
+	}...)
 
-	flagSet := flag.NewFlagSet("create-sd", 0)
-	flagSet.String(flags.PrivateDNSNamespaceNameFlag, testNamespaceName, "")
-	flagSet.String(flags.VpcIdFlag, testVPCID, "")
-	flagSet.Bool(flags.ForceFlag, true, "")
+	gomock.InOrder(expectedCFNCalls...)
 
-	context := cli.NewContext(nil, flagSet, nil)
+	config := &config.CommandConfig{
+		Cluster: testClusterName,
+	}
 
-	sdsARN, err := create(context, networkMode, testServiceName, testClusterName, mockCloudformation)
+	sdsARN, err := create(c, networkMode, testServiceName, mockCloudformation, ecsParamsSD, config)
 
 	assert.NoError(t, err, "Unexpected Error calling create")
 	assert.Equal(t, testSDSARN, aws.StringValue(sdsARN), "Expected SDS ARN to match")
 
 }
 
+func emptyContext() *cli.Context {
+	flagSet := flag.NewFlagSet("create-sd", 0)
+	return cli.NewContext(nil, flagSet, nil)
+}
+
+func simpleWorkflowContext() *cli.Context {
+	flagSet := flag.NewFlagSet("create-sd", 0)
+	flagSet.String(flags.PrivateDNSNamespaceNameFlag, testNamespaceName, "")
+	flagSet.String(flags.VpcIdFlag, testVPCID, "")
+
+	return cli.NewContext(nil, flagSet, nil)
+}
+
 func validateCFNParam(expectedValue, paramKey string, cfnParams *cloudformation.CfnStackParams, t *testing.T) {
 	observedValue, err := cfnParams.GetParameter(paramKey)
 	assert.NoError(t, err, "Unexpected error getting cfn parameter")
-	assert.Equal(t, expectedValue, aws.StringValue(observedValue.ParameterValue))
+	assert.Equal(t, expectedValue, aws.StringValue(observedValue.ParameterValue), fmt.Sprintf("Expected %s to be %s", paramKey, expectedValue))
 }

--- a/ecs-cli/modules/clients/aws/route53/servicediscovery_client.go
+++ b/ecs-cli/modules/clients/aws/route53/servicediscovery_client.go
@@ -23,6 +23,14 @@ import (
 	"github.com/aws/aws-sdk-go/service/servicediscovery"
 )
 
+// FindPrivateNamespaceFunc is the interface/signature for FindPrivateNamespace
+// This helps when writing code in other packages that need to mock this function
+type FindPrivateNamespaceFunc func(name, vpc string, config *config.CommandConfig) (*string, error)
+
+// FindPublicNamespaceFunc is the interface/signature for FindPublicNamespace
+// This allows other packages to mock it
+type FindPublicNamespaceFunc func(name string, config *config.CommandConfig) (*string, error)
+
 // FindPrivateNamespace returns the ID(s) of the private namespace with the given name and vpc
 func FindPrivateNamespace(name, vpc string, config *config.CommandConfig) (*string, error) {
 	r53Client := newRoute53Client(config)

--- a/ecs-cli/modules/commands/compose/service/compose_service_command.go
+++ b/ecs-cli/modules/commands/compose/service/compose_service_command.go
@@ -148,12 +148,36 @@ func serviceDiscoveryFlags() []cli.Flag {
 			Usage: "Service Discovery - The name of the private DNS namespace to use with Service Discovery. The CLI creates the namespace if it doesn't already exist. For example, if the name is 'corp' than a service 'foo' will be reachable via DNS at 'foo.corp'",
 		},
 		cli.StringFlag{
+			Name:  flags.PrivateDNSNamespaceIDFlag,
+			Usage: "Service Discovery - The ID of an existing private DNS namespace to use with Service Discovery.",
+		},
+		cli.StringFlag{
+			Name:  flags.PublicDNSNamespaceIDFlag,
+			Usage: "Service Discovery - The ID of an existing public DNS namespace to use with Service Discovery.",
+		},
+		cli.StringFlag{
+			Name:  flags.PublicDNSNamespaceNameFlag,
+			Usage: "Service Discovery - The name of an existing public DNS namespace to use with Service Discovery. For example, if the name is 'corp' than a service 'foo' will be reachable via DNS at 'foo.corp'",
+		},
+		cli.StringFlag{
 			Name:  flags.ServiceDiscoveryContainerNameFlag,
 			Usage: "Service Discovery - The name of the container (service name in compose) that will use Service Discovery",
 		},
 		cli.StringFlag{
 			Name:  flags.ServiceDiscoveryContainerPortFlag,
 			Usage: "Service Discovery - The port on the container used for Service Discovery",
+		},
+		cli.StringFlag{
+			Name:  flags.DNSTTLFlag,
+			Usage: "Service Discovery - The TTL of the DNS Records used with the Route53 Service Discovery Resource",
+		},
+		cli.StringFlag{
+			Name:  flags.DNSTypeFlag,
+			Usage: "Service Discovery - The TTL of the DNS Records used with the Route53 Service Discovery Resource. Note that SRV records require container name and container port",
+		},
+		cli.StringFlag{
+			Name:  flags.HealthcheckCustomConfigFailureThresholdFlag,
+			Usage: "Service Discovery - The number of 30-second intervals that you want service discovery service to wait after receiving an UpdateInstanceCustomHealthStatus request before it changes the health status of a service instance",
 		},
 	}
 }

--- a/ecs-cli/modules/commands/flags/flags.go
+++ b/ecs-cli/modules/commands/flags/flags.go
@@ -58,12 +58,16 @@ const (
 	CreateLogsFlag     = "create-log-groups"
 
 	// Service Discovery
-	PrivateDNSNamespaceNameFlag       = "private-dns-namespace"
-	PrivateDNSNamespaceIDFlag         = "private-dns-namespace-id"
-	PublicDNSNamespaceIDFlag          = "public-dns-namespace-id"
-	EnableServiceDiscoveryFlag        = "with-service-discovery"
-	ServiceDiscoveryContainerNameFlag = "sd-container-name"
-	ServiceDiscoveryContainerPortFlag = "sd-container-port"
+	PrivateDNSNamespaceNameFlag                 = "private-dns-namespace"
+	PrivateDNSNamespaceIDFlag                   = "private-dns-namespace-id"
+	PublicDNSNamespaceIDFlag                    = "public-dns-namespace-id"
+	PublicDNSNamespaceNameFlag                  = "public-dns-namespace"
+	EnableServiceDiscoveryFlag                  = "enable-service-discovery"
+	DNSTypeFlag                                 = "dns-type"
+	DNSTTLFlag                                  = "dns-ttl"
+	ServiceDiscoveryContainerNameFlag           = "sd-container-name"
+	ServiceDiscoveryContainerPortFlag           = "sd-container-port"
+	HealthcheckCustomConfigFailureThresholdFlag = "healthcheck-custom-config-failure-threshold"
 
 	ComposeProjectNamePrefixFlag         = "compose-project-name-prefix"
 	ComposeProjectNamePrefixDefaultValue = "ecscompose-"

--- a/ecs-cli/modules/utils/compose/ecs_params_reader.go
+++ b/ecs-cli/modules/utils/compose/ecs_params_reader.go
@@ -114,18 +114,22 @@ type ServiceDiscovery struct {
 	ServiceDiscoveryService ServiceDiscoveryService `yaml:"service_discovery_service"`
 }
 
+// Namespace holds the basic information for any type of namespace
+type Namespace struct {
+	ID   string `yaml:"id"`
+	Name string `yaml:"name"`
+}
+
 // PrivateDNSNamespace holds information related to Route53 private DNS namespaces
 type PrivateDNSNamespace struct {
+	Namespace   `yaml:",inline"`
 	VPC         string `yaml:"vpc"`
-	ID          string `yaml:"id"`
-	Name        string `yaml:"name"`
 	Description string `yaml:"description"`
 }
 
 // PublicDNSNamespace holds information related to Route53 public DNS namespaces
 type PublicDNSNamespace struct {
-	ID   string `yaml:"id"`
-	Name string `yaml:"name"`
+	Namespace `yaml:",inline"`
 }
 
 // ServiceDiscoveryService holds information related to Route53 Service Discovery Services
@@ -133,7 +137,6 @@ type ServiceDiscoveryService struct {
 	Name                    string                  `yaml:"name"`
 	Description             string                  `yaml:"description"`
 	DNSConfig               DNSConfig               `yaml:"dns_config"`
-	RoutingPolicy           string                  `yaml:"routing_policy"`
 	HealthCheckCustomConfig HealthCheckCustomConfig `yaml:"healthcheck_custom_config"`
 }
 

--- a/ecs-cli/modules/utils/compose/ecs_params_reader_test.go
+++ b/ecs-cli/modules/utils/compose/ecs_params_reader_test.go
@@ -532,7 +532,6 @@ run_params:
       dns_config:
         type: A
         ttl: 60
-      routing_policy: MULTIVALUE
       healthcheck_custom_config:
         failure_threshold: 1`
 
@@ -567,7 +566,6 @@ run_params:
 		assert.Equal(t, "This is an SDS", sds.Description, "Expected SDS Description to match")
 		assert.Equal(t, "A", sds.DNSConfig.Type, "Expected SDS DNSConfig Type to match")
 		assert.Equal(t, aws.Int64(60), sds.DNSConfig.TTL, "Expected SDS DNSConfig TTL to match")
-		assert.Equal(t, "MULTIVALUE", sds.RoutingPolicy, "Expected SDS RoutingPolicy to match")
 		assert.Equal(t, aws.Int64(1), sds.HealthCheckCustomConfig.FailureThreshold, "Expected SDS HealthCheckCustomConfig FailureThreshold to match")
 	}
 }


### PR DESCRIPTION
Ties everything together from previous PRs:
- read all ECS Params and flags input for SD creation
- merge all inputs together and validate
- find existing namespace ID if possible

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
