### PR TITLE
Remove RunTaskWithOverrides from ECS Client

### DIFF
--- a/ecs-cli/modules/cli/compose/compose_app.go
+++ b/ecs-cli/modules/cli/compose/compose_app.go
@@ -89,6 +89,7 @@ func ProjectPs(p ecscompose.Project, c *cli.Context) {
 }
 
 // ProjectRun starts containers and executes one-time command against the container
+// TODO These only account for command overrides within a ContainerOverride: https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_ContainerOverride.html
 func ProjectRun(p ecscompose.Project, c *cli.Context) {
 	args := c.Args()
 	if len(args)%2 != 0 {

--- a/ecs-cli/modules/clients/aws/ecs/client.go
+++ b/ecs-cli/modules/clients/aws/ecs/client.go
@@ -55,7 +55,6 @@ type ECSClient interface {
 	// Tasks related
 	GetTasksPages(listTasksInput *ecs.ListTasksInput, fn ProcessTasksAction) error
 	RunTask(runTaskInput *ecs.RunTaskInput) (*ecs.RunTaskOutput, error)
-	RunTaskWithOverrides(taskDefinition, taskGroup string, count int, overrides map[string][]string) (*ecs.RunTaskOutput, error)
 	StopTask(taskID string) error
 	DescribeTasks(taskIds []*string) ([]*ecs.Task, error)
 
@@ -374,36 +373,6 @@ func (c *ecsClient) RunTask(input *ecs.RunTaskInput) (*ecs.RunTaskOutput, error)
 	if err != nil {
 		log.WithFields(log.Fields{
 			"task definition": input.TaskDefinition,
-			"error":           err,
-		}).Error("Error running tasks")
-	}
-	return resp, err
-}
-
-// RunTask issues a run task request for the input task definition
-func (c *ecsClient) RunTaskWithOverrides(taskDefinition, group string, count int, overrides map[string][]string) (*ecs.RunTaskOutput, error) {
-	commandOverrides := []*ecs.ContainerOverride{}
-	for cont, command := range overrides {
-		contOverride := &ecs.ContainerOverride{
-			Name:    aws.String(cont),
-			Command: aws.StringSlice(command),
-		}
-		commandOverrides = append(commandOverrides, contOverride)
-	}
-	ecsOverrides := &ecs.TaskOverride{
-		ContainerOverrides: commandOverrides,
-	}
-
-	resp, err := c.client.RunTask(&ecs.RunTaskInput{
-		Cluster:        aws.String(c.config.Cluster),
-		TaskDefinition: aws.String(taskDefinition),
-		Group:          aws.String(group),
-		Count:          aws.Int64(int64(count)),
-		Overrides:      ecsOverrides,
-	})
-	if err != nil {
-		log.WithFields(log.Fields{
-			"task definition": taskDefinition,
 			"error":           err,
 		}).Error("Error running tasks")
 	}

--- a/ecs-cli/modules/clients/aws/ecs/client_test.go
+++ b/ecs-cli/modules/clients/aws/ecs/client_test.go
@@ -459,6 +459,44 @@ func TestRunTask(t *testing.T) {
 	assert.NoError(t, err, "Unexpected error when calling RunTask")
 }
 
+func TestRunTaskWithOverrides(t *testing.T) {
+	mockEcs, _, client, ctrl := setupTestController(t, getDefaultCLIConfigParams(t))
+	defer ctrl.Finish()
+
+	td := "taskDef"
+	group := "taskGroup"
+	count := 5
+	containterOverride := &ecs.ContainerOverride{
+			Name:    aws.String("railsapp"),
+			Command: aws.StringSlice([]string{"bundle,exec,puma,-C,config/puma.rb"}),
+		}
+	taskOverride := &ecs.TaskOverride{
+		ContainerOverrides: []*ecs.ContainerOverride{containterOverride},
+	}
+
+	mockEcs.EXPECT().RunTask(gomock.Any()).Do(func(input interface{}) {
+		req := input.(*ecs.RunTaskInput)
+		assert.Equal(t, clusterName, aws.StringValue(req.Cluster), "Expected clusterName to match")
+		assert.Equal(t, td, aws.StringValue(req.TaskDefinition), "Expected taskDefinition to match")
+		assert.Equal(t, group, aws.StringValue(req.Group), "Expected group to match")
+		assert.Equal(t, taskOverride, req.Overrides, "Expected taskOverride to match")
+		assert.Equal(t, int64(count), aws.Int64Value(req.Count), "Expected count to match")
+		assert.Nil(t, req.NetworkConfiguration, "Expected Network Config to be nil.")
+		assert.Nil(t, req.LaunchType, "Expected Launch Type to be nil.")
+	}).Return(&ecs.RunTaskOutput{}, nil)
+
+	runTaskInput := &ecs.RunTaskInput{
+		Cluster:        aws.String(clusterName),
+		TaskDefinition: aws.String(td),
+		Group:          aws.String(group),
+		Count:          aws.Int64(int64(count)),
+		Overrides:      taskOverride,
+	}
+
+	_, err := client.RunTask(runTaskInput)
+	assert.NoError(t, err, "Unexpected error when calling RunTask")
+}
+
 func TestRunTaskWithLaunchTypeEC2(t *testing.T) {
 	mockEcs, _, client, ctrl := setupTestController(t, getCLIConfigParamsWithLaunchType(t, "EC2"))
 	defer ctrl.Finish()

--- a/ecs-cli/modules/clients/aws/ecs/mock/client.go
+++ b/ecs-cli/modules/clients/aws/ecs/mock/client.go
@@ -215,19 +215,6 @@ func (mr *MockECSClientMockRecorder) RunTask(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunTask", reflect.TypeOf((*MockECSClient)(nil).RunTask), arg0)
 }
 
-// RunTaskWithOverrides mocks base method
-func (m *MockECSClient) RunTaskWithOverrides(arg0, arg1 string, arg2 int, arg3 map[string][]string) (*ecs0.RunTaskOutput, error) {
-	ret := m.ctrl.Call(m, "RunTaskWithOverrides", arg0, arg1, arg2, arg3)
-	ret0, _ := ret[0].(*ecs0.RunTaskOutput)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// RunTaskWithOverrides indicates an expected call of RunTaskWithOverrides
-func (mr *MockECSClientMockRecorder) RunTaskWithOverrides(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunTaskWithOverrides", reflect.TypeOf((*MockECSClient)(nil).RunTaskWithOverrides), arg0, arg1, arg2, arg3)
-}
-
 // StopTask mocks base method
 func (m *MockECSClient) StopTask(arg0 string) error {
 	ret := m.ctrl.Call(m, "StopTask", arg0)


### PR DESCRIPTION
Command Overrides are still supported via `compose run`, but this simplifies some of the code in our ECSClient wrapper.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.