### PR TITLE
Add registry-creds cmd and creds_input_reader, tests

### DIFF
--- a/ecs-cli/main.go
+++ b/ecs-cli/main.go
@@ -24,6 +24,7 @@ import (
 	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/commands/image"
 	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/commands/license"
 	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/commands/log"
+	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/commands/regcreds"
 	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/utils/logger"
 	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/version"
 	"github.com/cihub/seelog"
@@ -56,6 +57,7 @@ func main() {
 		licenseCommand.LicenseCommand(),
 		composeCommand.ComposeCommand(composeFactory),
 		logsCommand.LogCommand(),
+		regcredsCommand.RegistryCredsCommand(),
 	}
 
 	app.Flags = []cli.Flag{

--- a/ecs-cli/modules/cli/regcreds/regcreds_app.go
+++ b/ecs-cli/modules/cli/regcreds/regcreds_app.go
@@ -14,7 +14,6 @@
 package regcreds
 
 import (
-	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/commands/flags"
 	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/utils/regcreds"
 	log "github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
@@ -22,10 +21,13 @@ import (
 
 // Up creates or updates registry credential secrets and an ECS task execution role needed to use them in a task def
 func Up(c *cli.Context) {
+	args := c.Args()
 
-	ecsCredsInputFile := c.String(flags.ComposeFileNameFlag)
+	if len(args) != 1 {
+		log.Fatal("Exactly 1 credential file is required. Found: ", len(args))
+	}
 
-	credsInput, err := readers.ReadCredsInput(ecsCredsInputFile)
+	credsInput, err := readers.ReadCredsInput(args[0])
 	if err != nil {
 		log.Fatal("Error executing 'up': ", err)
 	}

--- a/ecs-cli/modules/cli/regcreds/regcreds_app.go
+++ b/ecs-cli/modules/cli/regcreds/regcreds_app.go
@@ -1,0 +1,35 @@
+// Copyright 2015-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package regcreds
+
+import (
+	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/commands/flags"
+	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/utils/regcreds"
+	log "github.com/sirupsen/logrus"
+	"github.com/urfave/cli"
+)
+
+// Up creates or updates registry credential secrets and an ECS task execution role needed to use them in a task def
+func Up(c *cli.Context) {
+
+	ecsCredsInputFile := c.String(flags.ComposeFileNameFlag)
+
+	credsInput, err := readers.ReadCredsInput(ecsCredsInputFile)
+	if err != nil {
+		log.Fatal("Error executing 'up': ", err)
+	}
+	log.Infof("Read creds input: %+v", credsInput) // remove after SDK calls added
+
+	//TODO: create secrets, create role, produce output
+}

--- a/ecs-cli/modules/commands/flags/flags.go
+++ b/ecs-cli/modules/commands/flags/flags.go
@@ -110,9 +110,6 @@ const (
 	RoleFlag                                = "role"
 	ComposeServiceTimeOutFlag               = "timeout"
 	ForceDeploymentFlag                     = "force-deployment"
-
-	// RegCreds
-	InputFileFlag = "file"
 )
 
 // OptionalRegionAndProfileFlags provides these flags:

--- a/ecs-cli/modules/commands/flags/flags.go
+++ b/ecs-cli/modules/commands/flags/flags.go
@@ -110,6 +110,9 @@ const (
 	RoleFlag                                = "role"
 	ComposeServiceTimeOutFlag               = "timeout"
 	ForceDeploymentFlag                     = "force-deployment"
+
+	// RegCreds
+	InputFileFlag = "file"
 )
 
 // OptionalRegionAndProfileFlags provides these flags:

--- a/ecs-cli/modules/commands/regcreds/regcreds_command.go
+++ b/ecs-cli/modules/commands/regcreds/regcreds_command.go
@@ -1,0 +1,54 @@
+// Copyright 2015-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package regcredsCommand
+
+import (
+	ecscli "github.com/aws/amazon-ecs-cli/ecs-cli/modules"
+	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/cli/regcreds"
+	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/commands/flags"
+	"github.com/urfave/cli"
+)
+
+// RegistryCredsCommand provides a list of commands that facilitate use of private registry credentials with ECS.
+func RegistryCredsCommand() cli.Command {
+	return cli.Command{
+		Name:   "registry-creds",
+		Usage:  "Facilitates the creation and use of private registry credentials within ECS.",
+		Before: ecscli.BeforeApp,
+		Flags:  flags.OptionalRegionAndProfileFlags(),
+		Subcommands: []cli.Command{
+			upCommand(),
+		},
+	}
+}
+
+func upCommand() cli.Command {
+	return cli.Command{
+		Name:         "up",
+		Usage:        "Generates AWS Secrets Manager secrets and an IAM Task Execution Role for use in an ECS Task Definition.",
+		Action:       regcreds.Up,
+		Flags:        regcredsUpFlags(),
+		OnUsageError: flags.UsageErrorFactory("up"),
+	}
+}
+
+// TODO: add rest of flags as functionality implemented
+func regcredsUpFlags() []cli.Flag {
+	return []cli.Flag{
+		cli.StringFlag{
+			Name:  flags.InputFileFlag,
+			Usage: "Specifies the name of the file containing registry credentials.",
+		},
+	}
+}

--- a/ecs-cli/modules/commands/regcreds/regcreds_command.go
+++ b/ecs-cli/modules/commands/regcreds/regcreds_command.go
@@ -38,17 +38,7 @@ func upCommand() cli.Command {
 		Name:         "up",
 		Usage:        "Generates AWS Secrets Manager secrets and an IAM Task Execution Role for use in an ECS Task Definition.",
 		Action:       regcreds.Up,
-		Flags:        regcredsUpFlags(),
+		Flags:        nil, //TODO: add flags as funtionality is implemented
 		OnUsageError: flags.UsageErrorFactory("up"),
-	}
-}
-
-// TODO: add rest of flags as functionality implemented
-func regcredsUpFlags() []cli.Flag {
-	return []cli.Flag{
-		cli.StringFlag{
-			Name:  flags.InputFileFlag,
-			Usage: "Specifies the name of the file containing registry credentials.",
-		},
 	}
 }

--- a/ecs-cli/modules/utils/regcreds/creds_input_reader.go
+++ b/ecs-cli/modules/utils/regcreds/creds_input_reader.go
@@ -1,0 +1,95 @@
+// Copyright 2015-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package readers
+
+import (
+	"io/ioutil"
+	"os"
+	"strings"
+
+	"github.com/pkg/errors"
+	"gopkg.in/yaml.v2"
+)
+
+// ECSRegCredsInput contains registry cred entries for creation and/or use in a task execution role
+type ECSRegCredsInput struct {
+	Version             string
+	RegistryCredentials RegistryCreds `yaml:"registry_credentials"`
+}
+
+// RegistryCreds is a map of registry names to RegCredEntry structs
+type RegistryCreds map[string]RegistryCredEntry
+
+// RegistryCredEntry contains info needed to create an AWS Secrets Manager secret and match it to an ECS container(s)
+type RegistryCredEntry struct {
+	SecretManagerARN string   `yaml:"secret_manager_arn"`
+	Username         string   `yaml:"username"`
+	Password         string   `yaml:"password"`
+	KmdKeyID         string   `yaml:"kms_key_id"`
+	ContainerNames   []string `yaml:"container_names"`
+}
+
+// ReadCredsInput parses 'registry-creds up' input into an ECSRegCredsInput struct
+func ReadCredsInput(filename string) (*ECSRegCredsInput, error) {
+	if filename == "" {
+		return nil, errors.New("file is required")
+	}
+
+	rawCredsInput, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return nil, errors.Wrapf(err, "Error reading file '%v'", filename)
+	}
+	credsInput := &ECSRegCredsInput{}
+
+	if err = yaml.Unmarshal([]byte(rawCredsInput), &credsInput); err != nil {
+		return nil, errors.Wrapf(err, "Error unmarshalling yaml data from credential input file: %s", filename)
+	}
+
+	expandedCredsInput := RegistryCreds{}
+	for regName, credEntry := range credsInput.RegistryCredentials {
+		expandedCredEntry := expandCredEntry(credEntry)
+		expandedCredsInput[regName] = expandedCredEntry
+	}
+
+	credsInput.RegistryCredentials = expandedCredsInput
+
+	return credsInput, nil
+}
+
+// expandCredEntry checks if individual fields are env vars and if so, retrieves & sets that value
+func expandCredEntry(credEntry RegistryCredEntry) RegistryCredEntry {
+	expandedSecretARN := getValueOrEnvVar(credEntry.SecretManagerARN)
+	expandedUsername := getValueOrEnvVar(credEntry.Username)
+	expandedPassword := getValueOrEnvVar(credEntry.Password)
+	expandedKmsKeyID := getValueOrEnvVar(credEntry.KmdKeyID)
+	//TODO: look for env vars in container names?
+
+	expandedCredEntry := RegistryCredEntry{
+		SecretManagerARN: expandedSecretARN,
+		Username:         expandedUsername,
+		Password:         expandedPassword,
+		KmdKeyID:         expandedKmsKeyID,
+		ContainerNames:   credEntry.ContainerNames,
+	}
+	return expandedCredEntry
+}
+
+// selectively runs ExpandEnv() to avoid indescriminant replacement of substrings with '$'
+// e.g., password='c00l$tuff2018' -> return same; password='${MY_PASSWORD}' -> return env value.
+func getValueOrEnvVar(s string) string {
+	if strings.HasPrefix(s, "${") && strings.HasSuffix(s, "}") {
+		return os.ExpandEnv(s)
+	}
+	return s
+}

--- a/ecs-cli/modules/utils/regcreds/creds_input_reader.go
+++ b/ecs-cli/modules/utils/regcreds/creds_input_reader.go
@@ -42,9 +42,6 @@ type RegistryCredEntry struct {
 
 // ReadCredsInput parses 'registry-creds up' input into an ECSRegCredsInput struct
 func ReadCredsInput(filename string) (*ECSRegCredsInput, error) {
-	if filename == "" {
-		return nil, errors.New("file is required")
-	}
 
 	rawCredsInput, err := ioutil.ReadFile(filename)
 	if err != nil {

--- a/ecs-cli/modules/utils/regcreds/creds_input_reader_test.go
+++ b/ecs-cli/modules/utils/regcreds/creds_input_reader_test.go
@@ -1,0 +1,153 @@
+// Copyright 2015-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package readers
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestReadCredsInput(t *testing.T) {
+	credsInputString := `version: 1
+registry_credentials:
+  registry.io:
+    username: some_user_name
+    password: myl337p4$$w0rd!<bz*
+    kms_key_id: aws:arn:kms:key/iuytre-jhgfd
+    container_names:
+      - nginx-custom
+      - logging
+  other-registry.net:
+    secret_manager_arn: aws:arn:secretsmanager:secret/repocreds-776ytg
+    container_names:
+      - metrics`
+
+	tmpfile, err := ioutil.TempFile("", "test")
+	assert.NoError(t, err, "Unexpected error in creating test file")
+	defer os.Remove(tmpfile.Name())
+
+	_, err = tmpfile.Write([]byte(credsInputString))
+	assert.NoError(t, err, "Unexpected error writing file")
+	err = tmpfile.Close()
+	assert.NoError(t, err, "Unexpected error closing file")
+
+	credsResult, err := ReadCredsInput(tmpfile.Name())
+	assert.NoError(t, err, "Unexpected error reading file")
+
+	// assert expected values match
+	assert.Equal(t, "1", credsResult.Version)
+	assert.Equal(t, 2, len(credsResult.RegistryCredentials))
+
+	firstRegResult := credsResult.RegistryCredentials["registry.io"]
+	assert.NotEmpty(t, firstRegResult)
+	assert.Equal(t, "some_user_name", firstRegResult.Username)
+	assert.Equal(t, "myl337p4$$w0rd!<bz*", firstRegResult.Password)
+	assert.Equal(t, "aws:arn:kms:key/iuytre-jhgfd", firstRegResult.KmdKeyID)
+	assert.Equal(t, 2, len(firstRegResult.ContainerNames))
+
+	otherRegResult := credsResult.RegistryCredentials["other-registry.net"]
+	assert.NotEmpty(t, otherRegResult)
+	assert.Equal(t, "aws:arn:secretsmanager:secret/repocreds-776ytg", otherRegResult.SecretManagerARN)
+	assert.Equal(t, 1, len(otherRegResult.ContainerNames))
+}
+
+func TestReadCredsInputWithEnvVarsFromShell(t *testing.T) {
+	// setup test env vars
+	secretEnvKey := "MY_SECRET_ARN"
+	secretEnvVal := "aws:arn:secretmanager:secret/regsecret-1"
+
+	usrnameEnvKey := "MY_REG_USRNAME"
+	usrnameEnvVal := "myname@example.net"
+
+	passwrdEnvKey := "MY_REG_PASSWORD"
+	passwrdEnvVal := "ne4t04905e867uyrdtoilfgkj"
+
+	kmsEnvKey := "MY_KEY_ARN"
+	kmsEnvVal := "aws:arn:kms:key/iuytre-yhe4"
+
+	os.Setenv(usrnameEnvKey, usrnameEnvVal)
+	os.Setenv(passwrdEnvKey, passwrdEnvVal)
+	os.Setenv(kmsEnvKey, kmsEnvVal)
+	os.Setenv(secretEnvKey, secretEnvVal)
+	defer func() {
+		os.Unsetenv(usrnameEnvKey)
+		os.Unsetenv(passwrdEnvKey)
+		os.Unsetenv(kmsEnvKey)
+		os.Unsetenv(secretEnvKey)
+	}()
+
+	inputFileString := `version: 1
+registry_credentials:
+  myrepo.someregistry.io:
+    secret_manager_arn: ${MY_SECRET_ARN}
+    username: ${MY_REG_USRNAME}
+    password: ${MY_REG_PASSWORD}
+    kms_key_id: ${MY_KEY_ARN}
+    container_names:
+      - test`
+
+	tmpfile, err := ioutil.TempFile("", "test")
+	assert.NoError(t, err, "Unexpected error in creating test file")
+	defer os.Remove(tmpfile.Name())
+
+	_, err = tmpfile.Write([]byte(inputFileString))
+	assert.NoError(t, err, "Unexpected error writing file")
+	err = tmpfile.Close()
+	assert.NoError(t, err, "Unexpected error closing file")
+
+	credsResult, err := ReadCredsInput(tmpfile.Name())
+	assert.NoError(t, err, "Unexpected error reading file")
+
+	// assert expected values match
+	assert.Equal(t, "1", credsResult.Version)
+	assert.Equal(t, 1, len(credsResult.RegistryCredentials))
+
+	credEntry := credsResult.RegistryCredentials["myrepo.someregistry.io"]
+	assert.NotEmpty(t, credEntry)
+	assert.Equal(t, usrnameEnvVal, credEntry.Username)
+	assert.Equal(t, passwrdEnvVal, credEntry.Password)
+	assert.Equal(t, kmsEnvVal, credEntry.KmdKeyID)
+	assert.Equal(t, secretEnvVal, credEntry.SecretManagerARN)
+	assert.Equal(t, 1, len(credEntry.ContainerNames))
+}
+
+func TestReadCredsInput_ErrorFileNotFound(t *testing.T) {
+	var fakeFileName = "/missingFile"
+	_, err := ReadCredsInput(fakeFileName)
+	assert.Error(t, err, "Expected error on missing file")
+}
+
+func TestReadCredsInput_ErrorBadYaml(t *testing.T) {
+	badCredEntryFileString := `version: 1
+registry_credentials:
+  myrepo.someregistry.io:
+  secret_manager_arn: arn:aws:secretmanager:some-secret
+  container_names:
+	  - test`
+
+	tmpfile, err := ioutil.TempFile("", "test")
+	assert.NoError(t, err, "Unexpected error in creating test file")
+	defer os.Remove(tmpfile.Name())
+
+	_, err = tmpfile.Write([]byte(badCredEntryFileString))
+	assert.NoError(t, err, "Unexpected error writing file")
+	err = tmpfile.Close()
+	assert.NoError(t, err, "Unexpected error closing file")
+
+	_, err = ReadCredsInput(tmpfile.Name())
+	assert.Error(t, err, "Expected error on bad file YAML")
+}


### PR DESCRIPTION
Add new "registry-creds" cmd and read in file input.

Test output:

inputFile.yml:
```
version: 1
registry_credentials:
  quay.io:
    secret_manager_arn: aws:arn:secretsmanager:secret/repocreds-776ytg
    username: ${USERNAME}
    password: myl337p4$$w0rd!
    kms_key_id: aws:arn:kms:key/iuytre-jhgfd
    container_names:
      - nginx-custom
      - logging
```

CMD output:
```
$~\GO\src\github.com\aws\amazon-ecs-cli> ./bin/local/ecs-cli.exe registry-creds up --file inputFile.yml
?[36mINFO?[0m[0000] Read creds input: &{Version:1 RegistryCredentials:map[quay.io:{SecretManagerARN:aws:arn:secretsmanager:secret/repocreds-776ytg Username:[REDACTED] Password:myl337p4$$w0rd!<bz* KmdKeyID:aws:arn:kms:key/iuytre-jhgfd ContainerNames:[nginx-custom logging]}]}
```


--
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
