### PR TITLE
Add support for custom user data with the ECS CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,6 +327,29 @@ ecs-cli up --cluster myCluster --empty
 
 This is equivalent to the [create-cluster command](https://docs.aws.amazon.com/cli/latest/reference/ecs/create-cluster.html), and will not create a CloudFormation stack associated with your cluster.
 
+#### User Data
+
+For the EC2 launch type, the ECS CLI always creates EC2 instances that include the following User Data:
+
+```
+#!/bin/bash
+echo ECS_CLUSTER={ clusterName } >> /etc/ecs/ecs.config
+```
+
+This user data directs the EC2 instance to join your ECS Cluster. You can optionally include extra user data with `--extra-user-data`; this flag takes a file name as its argument.  
+The flag can be used multiple times to specify multiple files. Extra user data can be shell scripts or cloud-init directives- see the [EC2 documentation](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/user-data.html) for more information.
+The ECS CLI takes all the User Data, and packs it into a MIME Multipart archive which can be used by cloud-init on the EC2 instance. The ECS CLI even allows existing MIME Multipart archives to be passed in with `--extra-user-data`.
+The CLI will unpack the existing archive, and then repack it into the final archive (preserving all header and content type information). Here is an example of specifying extra user data:
+
+```
+ecs-cli up \  
+  --capability-iam \  
+  --extra-user-data my-shellscript \  
+  --extra-user-data my-cloud-boot-hook \  
+  --extra-user-data my-mime-multipart-archive \  
+  --launch-type EC2
+```
+
 #### Creating a Fargate cluster
 
 ```

--- a/ecs-cli/modules/cli/cluster/userdata/user_data.go
+++ b/ecs-cli/modules/cli/cluster/userdata/user_data.go
@@ -1,0 +1,177 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package userdata
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"mime"
+	"mime/multipart"
+	"net/mail"
+	"net/textproto"
+	"strings"
+)
+
+// UserDataBuilder contains functionality to create user data scripts for Container Instances
+type UserDataBuilder interface {
+	AddFile(fileName string) error
+	Build() (string, error)
+}
+
+// Builder implements UserDataBuilder
+type Builder struct {
+	writer      *multipart.Writer
+	clusterName string
+	userdata    *bytes.Buffer
+}
+
+// NewBuilder creates a Builder object for a given clusterName
+func NewBuilder(clusterName string) UserDataBuilder {
+	buf := new(bytes.Buffer)
+	writer := multipart.NewWriter(buf)
+
+	builder := &Builder{
+		writer:      writer,
+		clusterName: clusterName,
+		userdata:    buf,
+	}
+
+	return builder
+}
+
+// AddFile adds new userdata from a file
+func (b *Builder) AddFile(fileName string) error {
+	data, err := ioutil.ReadFile(fileName)
+	if err != nil {
+		return err
+	}
+	extraUserData := string(data)
+
+	if ok, headers, body := isMultipart(extraUserData); ok { // extraUserData is multipart
+		if err = b.processExistingMultipart(headers, body); err != nil {
+			return err
+		}
+	} else { // extraUserData is not already multipart
+		if err = b.writeExtraUserDataMimePart(extraUserData); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Build the userdata for the given cluster
+// Build() is not idempotent and can only be called once
+func (b *Builder) Build() (string, error) {
+	// add user data for joining the ECS Cluster
+	if err := b.writeClusterUserDataMimePart(); err != nil {
+		return "", err
+	}
+	if err := b.writer.Close(); err != nil {
+		return "", err
+	}
+	header := fmt.Sprintf("Content-Type: multipart/mixed; boundary=\"%s\"\nMIME-Version: 1.0\n\n", b.writer.Boundary())
+	archive := append([]byte(header), b.userdata.Bytes()...)
+	return unixifyLineEndings(string(archive)), nil
+}
+
+func (b *Builder) writePart(header textproto.MIMEHeader, body []byte) error {
+	newPart, err := b.writer.CreatePart(header)
+	if err != nil {
+		return err
+	}
+	if _, err = newPart.Write(body); err != nil {
+		return err
+	}
+	return nil
+}
+
+// unpacks an existing multipart archive and writes it using `writer`
+func (b *Builder) processExistingMultipart(headers map[string]string, body io.Reader) error {
+	partReader := multipart.NewReader(body, headers["boundary"])
+	for {
+		part, err := partReader.NextPart()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return err
+		}
+		partBody, err := ioutil.ReadAll(part)
+		if err != nil {
+			return err
+		}
+		if err = b.writePart(part.Header, partBody); err != nil {
+			return err
+		}
+		if err = part.Close(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Determines if the given string is already a multipart archive
+// If it is, then it returns true, the multipart archive headers, and an io.Reader
+// which can read the body of the multipart archive
+func isMultipart(data string) (bool, map[string]string, io.Reader) {
+	msg, err := mail.ReadMessage(strings.NewReader(data))
+	if err != nil {
+		return false, nil, nil
+	}
+
+	mediaType, headers, err := mime.ParseMediaType(msg.Header.Get("Content-Type"))
+	if err != nil {
+		return false, nil, nil
+	}
+
+	if strings.HasPrefix(mediaType, "multipart/") {
+		return true, headers, msg.Body
+	}
+	return false, nil, nil
+}
+
+func (b *Builder) getClusterUserData() string {
+	joinClusterUserData := `
+#!/bin/bash
+echo ECS_CLUSTER=%s >> /etc/ecs/ecs.config
+`
+	return fmt.Sprintf(joinClusterUserData, b.clusterName)
+}
+
+// writes the user data script to join the ecs cluster to a multipart archive
+func (b *Builder) writeClusterUserDataMimePart() error {
+	header := make(textproto.MIMEHeader)
+	header.Add("Content-Type", "text/text/x-shellscript; charset=\"utf-8\"")
+	header.Add("MIME-Version", "1.0")
+
+	return b.writePart(header, []byte(b.getClusterUserData()))
+}
+
+// takes user inputted user data and writes it as one part in the mime multipart archive
+// `extraUserData` is any user data passed in by the user which is not already a multipart archive
+func (b *Builder) writeExtraUserDataMimePart(extraUserData string) error {
+	header := make(textproto.MIMEHeader)
+	// Setting the content type as text/plain is safe because Cloud Init will read its contents to determine its type
+	header.Add("Content-Type", "text/text/plain; charset=\"utf-8\"")
+	header.Add("MIME-Version", "1.0")
+
+	return b.writePart(header, []byte(extraUserData))
+}
+
+// replaces all "\r\n" with "\n"
+func unixifyLineEndings(s string) string {
+	return strings.Replace(s, "\r\n", "\n", -1)
+}

--- a/ecs-cli/modules/cli/cluster/userdata/user_data_test.go
+++ b/ecs-cli/modules/cli/cluster/userdata/user_data_test.go
@@ -1,0 +1,204 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package userdata
+
+import (
+	"bytes"
+	"io/ioutil"
+	"mime/multipart"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	testClusterName = "cluster"
+	testBoundary    = "========multipart-boundary=="
+)
+
+func newBuilderInTest(buf *bytes.Buffer, writer *multipart.Writer) *Builder {
+	builder := &Builder{
+		writer:      writer,
+		clusterName: testClusterName,
+		userdata:    buf,
+	}
+
+	return builder
+}
+
+var existingMultipartArchive = `Content-Type: multipart/mixed; boundary="b19714718818a0e648a502570ed78486f7358d7d3a4d42c3716e81102b56"
+MIME-Version: 1.0
+
+--b19714718818a0e648a502570ed78486f7358d7d3a4d42c3716e81102b56
+Content-Type: text/text/plain; charset="utf-8"
+Mime-Version: 1.0
+
+#!/bin/bash
+echo "Clyde spends the next year lonely and confused" >> $HOME/chapter3
+echo "He knows Pudding wasn't right for him, but he doesn't know how to move on" >> $HOME/chapter3
+echo "Meanwhile, Pudding and Tum Tum have the honeymoon of a lifetime" >> $HOME/chapter3
+echo "They spend 3 months travelling the world, visiting DogseyLand, the Temple of Doge in Japan, and much more" >> $HOME/chapter3
+echo "Tum Tum experiments with 10 different haircuts/stylings" >> $HOME/chapter3
+
+--b19714718818a0e648a502570ed78486f7358d7d3a4d42c3716e81102b56
+Content-Type: text/text/x-shellscript; charset="utf-8"
+Mime-Version: 1.0
+
+
+#!/bin/bash
+aws s3 cp s3://my-scripts/setupenv $HOME/setupenv
+source $HOME/setupenv
+
+
+--b19714718818a0e648a502570ed78486f7358d7d3a4d42c3716e81102b56--`
+
+var extraUserDataShellScript = `#!/bin/bash
+echo "Quickly, the honeymoon bliss wears off" >> $HOME/chapter4
+echo "The once happy couple, now fights over small things, like who gets to chew which toy" >> $HOME/chapter4
+echo "Pudding drags her bed to away from Tum Tum's, and hides a pile of toys underneath it" >> $HOME/chapter4`
+
+var extraUserDataCloudConfig = `#cloud-config
+
+# Install additional packages on first boot
+packages:
+ - pwgen
+ - pastebinit
+ - [libpython2.7, 2.7.3-0ubuntu3.1]
+ - gpg`
+
+var expectedMimeMultipart = `Content-Type: multipart/mixed; boundary="========multipart-boundary=="
+MIME-Version: 1.0
+
+--========multipart-boundary==
+Content-Type: text/text/plain; charset="utf-8"
+Mime-Version: 1.0
+
+#!/bin/bash
+echo "Clyde spends the next year lonely and confused" >> $HOME/chapter3
+echo "He knows Pudding wasn't right for him, but he doesn't know how to move on" >> $HOME/chapter3
+echo "Meanwhile, Pudding and Tum Tum have the honeymoon of a lifetime" >> $HOME/chapter3
+echo "They spend 3 months travelling the world, visiting DogseyLand, the Temple of Doge in Japan, and much more" >> $HOME/chapter3
+echo "Tum Tum experiments with 10 different haircuts/stylings" >> $HOME/chapter3
+
+--========multipart-boundary==
+Content-Type: text/text/x-shellscript; charset="utf-8"
+Mime-Version: 1.0
+
+
+#!/bin/bash
+aws s3 cp s3://my-scripts/setupenv $HOME/setupenv
+source $HOME/setupenv
+
+
+--========multipart-boundary==
+Content-Type: text/text/plain; charset="utf-8"
+Mime-Version: 1.0
+
+#!/bin/bash
+echo "Quickly, the honeymoon bliss wears off" >> $HOME/chapter4
+echo "The once happy couple, now fights over small things, like who gets to chew which toy" >> $HOME/chapter4
+echo "Pudding drags her bed to away from Tum Tum's, and hides a pile of toys underneath it" >> $HOME/chapter4
+--========multipart-boundary==
+Content-Type: text/text/plain; charset="utf-8"
+Mime-Version: 1.0
+
+#cloud-config
+
+# Install additional packages on first boot
+packages:
+ - pwgen
+ - pastebinit
+ - [libpython2.7, 2.7.3-0ubuntu3.1]
+ - gpg
+--========multipart-boundary==
+Content-Type: text/text/x-shellscript; charset="utf-8"
+Mime-Version: 1.0
+
+
+#!/bin/bash
+echo ECS_CLUSTER=cluster >> /etc/ecs/ecs.config
+
+--========multipart-boundary==--
+`
+
+func TestBuildUserDataWithExtraData(t *testing.T) {
+
+	multipartFilePath := writeTempFile(t, "existingMultipartArchive", existingMultipartArchive)
+	defer os.Remove(multipartFilePath)
+
+	shellScriptFilePath := writeTempFile(t, "extraUserDataShellScript", extraUserDataShellScript)
+	defer os.Remove(shellScriptFilePath)
+
+	cloudConfigFilePath := writeTempFile(t, "extraUserDataCloudConfig", extraUserDataCloudConfig)
+	defer os.Remove(cloudConfigFilePath)
+
+	buf := new(bytes.Buffer)
+	writer := multipart.NewWriter(buf)
+	// set the boundary between parts so that output is deterministic
+	writer.SetBoundary(testBoundary)
+	builder := newBuilderInTest(buf, writer)
+
+	err := builder.AddFile(multipartFilePath)
+	assert.NoError(t, err, "Unexpected error calling AddFile()")
+	err = builder.AddFile(shellScriptFilePath)
+	assert.NoError(t, err, "Unexpected error calling AddFile()")
+	err = builder.AddFile(cloudConfigFilePath)
+	assert.NoError(t, err, "Unexpected error calling AddFile()")
+
+	actual, err := builder.Build()
+	assert.NoError(t, err, "Unexpected error calling Build()")
+	expected := unixifyLineEndings(expectedMimeMultipart)
+	assert.Equal(t, expected, actual, "Expected resulting mime multipart archive to match")
+}
+
+func TestBuildUserDataNoExtraData(t *testing.T) {
+	var expectedUserData = `Content-Type: multipart/mixed; boundary="========multipart-boundary=="
+MIME-Version: 1.0
+
+--========multipart-boundary==
+Content-Type: text/text/x-shellscript; charset="utf-8"
+Mime-Version: 1.0
+
+
+#!/bin/bash
+echo ECS_CLUSTER=cluster >> /etc/ecs/ecs.config
+
+--========multipart-boundary==--
+`
+
+	buf := new(bytes.Buffer)
+	writer := multipart.NewWriter(buf)
+	// set the boundary between parts so that output is deterministic
+	writer.SetBoundary(testBoundary)
+	builder := newBuilderInTest(buf, writer)
+
+	actual, err := builder.Build()
+	assert.NoError(t, err, "Unexpected error calling Build()")
+	expected := unixifyLineEndings(expectedUserData)
+	assert.Equal(t, expected, actual, "Expected resulting mime multipart archive to match")
+}
+
+func writeTempFile(t *testing.T, name, content string) string {
+	tmpfile, err := ioutil.TempFile("", name)
+	assert.NoError(t, err, "Could not create tempfile")
+
+	_, err = tmpfile.Write([]byte(content))
+	assert.NoError(t, err, "Could not write data to ecs-params tempfile")
+
+	err = tmpfile.Close()
+	assert.NoError(t, err, "Could not close tempfile")
+
+	return tmpfile.Name()
+}

--- a/ecs-cli/modules/clients/aws/cloudformation/params.go
+++ b/ecs-cli/modules/clients/aws/cloudformation/params.go
@@ -37,6 +37,7 @@ const (
 	ParameterKeyAssociatePublicIPAddress = "AssociatePublicIpAddress"
 	ParameterKeyInstanceRole             = "InstanceRole"
 	ParameterKeyIsFargate                = "IsFargate"
+	ParameterKeyUserData                 = "UserData"
 )
 
 var ParameterNotFoundError = errors.New("Parameter not found")

--- a/ecs-cli/modules/clients/aws/cloudformation/template.go
+++ b/ecs-cli/modules/clients/aws/cloudformation/template.go
@@ -207,13 +207,18 @@ var template = `
       "Type": "String",
       "Description": "Optional - Whether to create resources only for running Fargate tasks.",
       "Default": "false"
+    },
+    "UserData" : {
+      "Type" : "String",
+      "Description" : "User data for EC2 instances. Required for EC2 launch type, ignored with Fargate",
+      "Default" : ""
     }
   },
   "Conditions": {
     "IsCNRegion": {
       "Fn::Or" : [
         {"Fn::Equals": [ { "Ref": "AWS::Region" }, "cn-north-1" ]},
-        {"Fn::Equals": [ { "Ref": "AWS::Region" }, "cn-northwest-1" ]},
+        {"Fn::Equals": [ { "Ref": "AWS::Region" }, "cn-northwest-1" ]}
       ]
     },
     "LaunchInstances": {
@@ -552,17 +557,7 @@ var template = `
         },
         "UserData": {
           "Fn::Base64": {
-            "Fn::Join": [
-              "",
-              [
-                "#!/bin/bash\n",
-                "echo ECS_CLUSTER=",
-                {
-                  "Ref": "EcsCluster"
-                },
-                " >> /etc/ecs/ecs.config\n"
-              ]
-            ]
+            "Ref": "UserData"
           }
         }
       }

--- a/ecs-cli/modules/commands/cluster/cluster_command.go
+++ b/ecs-cli/modules/commands/cluster/cluster_command.go
@@ -122,6 +122,11 @@ func clusterUpFlags() []cli.Flag {
 			Name:  flags.VpcIdFlag,
 			Usage: "[Optional] Specifies the ID of an existing VPC in which to launch your container instances. If you specify a VPC ID, you must specify a list of existing subnets in that VPC with the --subnets option. If you do not specify a VPC ID, a new VPC is created with two subnets.",
 		},
+		cli.StringSliceFlag{
+			Name:  flags.UserDataFlag,
+			Usage: "[Optional] Specifies additional User Data for your EC2 instances. Files can be shell scripts or cloud-init directives and are packaged into a MIME Multipart Archive along with ECS CLI provided User Data which directs instances to join your cluster.",
+			Value: &cli.StringSlice{},
+		},
 		cli.BoolFlag{
 			Name:  flags.ForceFlag + ", f",
 			Usage: "[Optional] Forces the recreation of any existing resources that match your current configuration. This option is useful for cleaning up stale resources from previous failed attempts.",

--- a/ecs-cli/modules/commands/flags/flags.go
+++ b/ecs-cli/modules/commands/flags/flags.go
@@ -84,6 +84,7 @@ const (
 	NoAutoAssignPublicIPAddressFlag = "no-associate-public-ip-address"
 	ForceFlag                       = "force"
 	EmptyFlag                       = "empty"
+	UserDataFlag                    = "extra-user-data"
 
 	// Image
 	RegistryIdFlag = "registry-id"


### PR DESCRIPTION
Features:
- multiple user data files can be specified with `--extra-user-data` (same as `--file` in Compose)
- all user data is concatenated into a single MIME Multipart archive, which includes a CLI generated shell script to join the ECS Cluster
- the passed in user data file can be a MIME Multipart archive; the CLI retains all header/content type information for each part in the archive.
- the CLI supports all user data formats (shell scripts and cloud-init directives)
  - in the final multipart archive, all files that didn't include content type declarations will be declared as `text/plain`. This is safe because cloud-init will interpret its type based upon its content (I've verified this through a good amount of real world testing and also by reading the cloud-init code). 

*Issue #, if available:*
#16 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
