### PR TITLE
Add secret creation to 'registry-creds up' cmd

### DIFF
--- a/ecs-cli/modules/cli/regcreds/regcreds_app.go
+++ b/ecs-cli/modules/cli/regcreds/regcreds_app.go
@@ -14,10 +14,25 @@
 package regcreds
 
 import (
+	"fmt"
+
+	secretsClient "github.com/aws/amazon-ecs-cli/ecs-cli/modules/clients/aws/secretsmanager"
+	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/commands/flags"
+	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/config"
 	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/utils/regcreds"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/secretsmanager"
+	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 )
+
+// CredsOutputEntry contains the credential ARN and associated container names
+// TODO: use & move to output_reader once implemented?
+type CredsOutputEntry struct {
+	CredentialARN  string
+	ContainerNames []string
+}
 
 // Up creates or updates registry credential secrets and an ECS task execution role needed to use them in a task def
 func Up(c *cli.Context) {
@@ -31,7 +46,172 @@ func Up(c *cli.Context) {
 	if err != nil {
 		log.Fatal("Error executing 'up': ", err)
 	}
-	log.Infof("Read creds input: %+v", credsInput) // remove after SDK calls added
 
-	//TODO: create secrets, create role, produce output
+	err = validateCredsInput(*credsInput)
+	if err != nil {
+		log.Fatal("Error executing 'up': ", err)
+	}
+
+	commandConfig := getNewCommandConfig(c)
+
+	_, err = getOrCreateRegistryCredentials(credsInput.RegistryCredentials, commandConfig, c)
+	if err != nil {
+		log.Fatal("Error executing 'up': ", err)
+	}
+
+	//TODO: create role, produce output
+}
+
+func getOrCreateRegistryCredentials(entryMap readers.RegistryCreds, cmdConfig *config.CommandConfig, c *cli.Context) (*map[string]CredsOutputEntry, error) {
+	registryResults := make(map[string]CredsOutputEntry)
+	updateAllowed := c.Bool(flags.UpdateExistingSecretsFlag)
+
+	smClient := secretsClient.NewSecretsManagerClient(cmdConfig)
+
+	for registryName, credentialEntry := range entryMap {
+		hasCredPair := hasCredPair(credentialEntry)
+		hasSecretARN := false
+		if credentialEntry.SecretManagerARN != "" {
+			hasSecretARN = true
+		}
+
+		log.Infof("Processing credentials for registry %s...", registryName)
+
+		if hasCredPair && hasSecretARN {
+			arn, err := updateOrWarnForExistingSecret(credentialEntry, updateAllowed, smClient)
+			if err != nil {
+				return nil, err
+			}
+			registryResults[registryName] = buildOutputEntry(arn, credentialEntry.ContainerNames)
+
+		} else if hasSecretARN {
+			registryResults[registryName] = buildOutputEntry(credentialEntry.SecretManagerARN, credentialEntry.ContainerNames)
+			log.Infof("Using existing secret %s.", registryName)
+
+		} else {
+			arn, err := createNewRegistrySecret(registryName, credentialEntry, smClient)
+			if err != nil {
+				return nil, err
+			}
+			registryResults[registryName] = buildOutputEntry(arn, credentialEntry.ContainerNames)
+		}
+	}
+
+	log.Infof("\n up results: %v", registryResults)
+
+	return &registryResults, nil
+}
+
+func createNewRegistrySecret(registryName string, credEntry readers.RegistryCredEntry, smClient secretsClient.SMClient) (string, error) {
+
+	secretName := generateSecretName(registryName)
+
+	existingSecret, _ := smClient.DescribeSecret(secretName)
+	if existingSecret != nil {
+		log.Infof("Existing credential secret found, using %s", *existingSecret.ARN)
+
+		return *existingSecret.ARN, nil
+	}
+
+	secretString := generateSecretString(credEntry.Username, credEntry.Password)
+
+	createSecretRequest := secretsmanager.CreateSecretInput{
+		Name:         aws.String(secretName),
+		SecretString: aws.String(secretString),
+		Description:  aws.String(fmt.Sprintf("Created with the ECS CLI for use with registry %s", registryName)),
+	}
+	if credEntry.KmsKeyID != "" {
+		createSecretRequest.SetKmsKeyId(credEntry.KmsKeyID)
+	}
+
+	output, err := smClient.CreateSecret(createSecretRequest)
+	if err != nil {
+		return "", err
+	}
+	log.Infof("New credential secret created: %s", *output.ARN)
+
+	return *output.ARN, nil
+}
+
+func updateOrWarnForExistingSecret(credEntry readers.RegistryCredEntry, updateAllowed bool, smClient secretsClient.SMClient) (string, error) {
+	secretArn := credEntry.SecretManagerARN
+
+	if updateAllowed {
+		updatedSecretString := generateSecretString(credEntry.Username, credEntry.Password)
+		putSecretValueRequest := secretsmanager.PutSecretValueInput{
+			SecretId:     aws.String(secretArn),
+			SecretString: aws.String(updatedSecretString),
+		}
+
+		_, err := smClient.PutSecretValue(putSecretValueRequest)
+		if err != nil {
+			return "", err
+		}
+
+		log.Infof("Updated existing secret %s with new value", secretArn)
+
+	} else {
+		log.Warnf("'username' and 'password' found but ignored for existing secret %s. To update existing secrets with new values, use '--update-existing-secrets' flag.", secretArn)
+	}
+
+	return secretArn, nil
+}
+
+func validateCredsInput(input readers.ECSRegCredsInput) error {
+	// TODO: validate version?
+
+	inputRegCreds := input.RegistryCredentials
+
+	if len(inputRegCreds) == 0 {
+		return errors.New("provided credentials must contain at least one registry")
+	}
+
+	for registryName, credentialEntry := range inputRegCreds {
+		if !hasRequiredFields(credentialEntry) {
+			return fmt.Errorf("missing required field(s) for registry %s; registry credentials should contain existing secret ARN or username + password", registryName)
+		}
+	}
+	return nil
+}
+
+func hasRequiredFields(entry readers.RegistryCredEntry) bool {
+	if (entry.SecretManagerARN != "") || hasCredPair(entry) {
+		return true
+	}
+	return false
+}
+
+func hasCredPair(entry readers.RegistryCredEntry) bool {
+	if entry.Username != "" && entry.Password != "" {
+		return true
+	}
+	return false
+}
+
+func getNewCommandConfig(c *cli.Context) *config.CommandConfig {
+	rdwr, err := config.NewReadWriter()
+	if err != nil {
+		log.Fatal("Error executing 'up': ", err)
+	}
+	commandConfig, err := config.NewCommandConfig(c, rdwr)
+	if err != nil {
+		log.Fatal("Error executing 'up': ", err)
+	}
+
+	return commandConfig
+}
+
+func generateSecretName(regName string) string {
+	return "amazon-ecs-cli-setup-" + regName
+}
+
+func generateSecretString(username, password string) string {
+	return `{"username":"` + username + `"},{"password":"` + password + `"}`
+}
+
+func buildOutputEntry(arn string, containers []string) CredsOutputEntry {
+	return CredsOutputEntry{
+		CredentialARN:  arn,
+		ContainerNames: containers,
+	}
 }

--- a/ecs-cli/modules/cli/regcreds/regcreds_app_test.go
+++ b/ecs-cli/modules/cli/regcreds/regcreds_app_test.go
@@ -1,0 +1,68 @@
+// Copyright 2015-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package regcreds
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/utils/regcreds"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRegCregsUp(t *testing.T) {
+	testFileString := `version: 1
+registry_credentials:
+  myrepo.someregistry.io:
+    username: some_user_name
+    password: myl337p4$$w0rd!<bz*
+    container_names:
+      - test`
+
+	tmpfile, err := ioutil.TempFile("", "test")
+	assert.NoError(t, err, "Unexpected error in creating test file")
+	defer os.Remove(tmpfile.Name())
+
+	_, err = tmpfile.Write([]byte(testFileString))
+	assert.NoError(t, err, "Unexpected error writing file")
+	err = tmpfile.Close()
+	assert.NoError(t, err, "Unexpected error closing file")
+
+	//todo: add client and call mocks when added
+}
+
+func TestValidateCredsInput_ErrorEmptyCreds(t *testing.T) {
+	emptyCredMap := make(map[string]readers.RegistryCredEntry)
+	emptyCredsInput := readers.ECSRegCredsInput{
+		Version:             "1",
+		RegistryCredentials: emptyCredMap,
+	}
+
+	err := validateCredsInput(emptyCredsInput)
+	assert.Error(t, err, "Expected empty creds to return error")
+}
+
+func TestValidateCredsInput_ErrorOnMissingReqFields(t *testing.T) {
+	mapWithEmptyCredEntry := make(map[string]readers.RegistryCredEntry)
+	mapWithEmptyCredEntry["example.com"] = readers.RegistryCredEntry{}
+
+	testCredsInput := readers.ECSRegCredsInput{
+		Version:             "1",
+		RegistryCredentials: mapWithEmptyCredEntry,
+	}
+
+	err := validateCredsInput(testCredsInput)
+	assert.Error(t, err, "Expected creds with empty entry to return error")
+}

--- a/ecs-cli/modules/clients/aws/secretsmanager/client.go
+++ b/ecs-cli/modules/clients/aws/secretsmanager/client.go
@@ -23,7 +23,9 @@ import (
 // SMClient defines methods for interacting with the SecretsManagerAPI interface
 type SMClient interface {
 	CreateSecret(secretsmanager.CreateSecretInput) (*secretsmanager.CreateSecretOutput, error)
+	DescribeSecret(secretID string) (*secretsmanager.DescribeSecretOutput, error)
 	ListSecrets(*string) (*secretsmanager.ListSecretsOutput, error)
+	PutSecretValue(input secretsmanager.PutSecretValueInput) (*secretsmanager.PutSecretValueOutput, error)
 }
 
 type secretsManagerClient struct {
@@ -54,11 +56,33 @@ func (c *secretsManagerClient) CreateSecret(input secretsmanager.CreateSecretInp
 	return output, nil
 }
 
+func (c *secretsManagerClient) DescribeSecret(secretID string) (*secretsmanager.DescribeSecretOutput, error) {
+	request := secretsmanager.DescribeSecretInput{}
+	request.SetSecretId(secretID)
+
+	output, err := c.client.DescribeSecret(&request)
+	if err != nil {
+		return nil, err
+	}
+
+	return output, nil
+}
+
 func (c *secretsManagerClient) ListSecrets(nextToken *string) (*secretsmanager.ListSecretsOutput, error) {
 	request := secretsmanager.ListSecretsInput{
 		NextToken: nextToken,
 	}
 	output, err := c.client.ListSecrets(&request)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return output, nil
+}
+
+func (c *secretsManagerClient) PutSecretValue(input secretsmanager.PutSecretValueInput) (*secretsmanager.PutSecretValueOutput, error) {
+	output, err := c.client.PutSecretValue(&input)
 
 	if err != nil {
 		return nil, err

--- a/ecs-cli/modules/clients/aws/secretsmanager/mock/client.go
+++ b/ecs-cli/modules/clients/aws/secretsmanager/mock/client.go
@@ -60,6 +60,19 @@ func (mr *MockSMClientMockRecorder) CreateSecret(arg0 interface{}) *gomock.Call 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateSecret", reflect.TypeOf((*MockSMClient)(nil).CreateSecret), arg0)
 }
 
+// DescribeSecret mocks base method
+func (m *MockSMClient) DescribeSecret(arg0 string) (*secretsmanager.DescribeSecretOutput, error) {
+	ret := m.ctrl.Call(m, "DescribeSecret", arg0)
+	ret0, _ := ret[0].(*secretsmanager.DescribeSecretOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DescribeSecret indicates an expected call of DescribeSecret
+func (mr *MockSMClientMockRecorder) DescribeSecret(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeSecret", reflect.TypeOf((*MockSMClient)(nil).DescribeSecret), arg0)
+}
+
 // ListSecrets mocks base method
 func (m *MockSMClient) ListSecrets(arg0 *string) (*secretsmanager.ListSecretsOutput, error) {
 	ret := m.ctrl.Call(m, "ListSecrets", arg0)
@@ -71,4 +84,17 @@ func (m *MockSMClient) ListSecrets(arg0 *string) (*secretsmanager.ListSecretsOut
 // ListSecrets indicates an expected call of ListSecrets
 func (mr *MockSMClientMockRecorder) ListSecrets(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSecrets", reflect.TypeOf((*MockSMClient)(nil).ListSecrets), arg0)
+}
+
+// PutSecretValue mocks base method
+func (m *MockSMClient) PutSecretValue(arg0 secretsmanager.PutSecretValueInput) (*secretsmanager.PutSecretValueOutput, error) {
+	ret := m.ctrl.Call(m, "PutSecretValue", arg0)
+	ret0, _ := ret[0].(*secretsmanager.PutSecretValueOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// PutSecretValue indicates an expected call of PutSecretValue
+func (mr *MockSMClientMockRecorder) PutSecretValue(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutSecretValue", reflect.TypeOf((*MockSMClient)(nil).PutSecretValue), arg0)
 }

--- a/ecs-cli/modules/commands/flags/flags.go
+++ b/ecs-cli/modules/commands/flags/flags.go
@@ -110,6 +110,9 @@ const (
 	RoleFlag                                = "role"
 	ComposeServiceTimeOutFlag               = "timeout"
 	ForceDeploymentFlag                     = "force-deployment"
+
+	// Registry Creds
+	UpdateExistingSecretsFlag = "update-existing-secrets"
 )
 
 // OptionalRegionAndProfileFlags provides these flags:

--- a/ecs-cli/modules/commands/regcreds/regcreds_command.go
+++ b/ecs-cli/modules/commands/regcreds/regcreds_command.go
@@ -38,7 +38,16 @@ func upCommand() cli.Command {
 		Name:         "up",
 		Usage:        "Generates AWS Secrets Manager secrets and an IAM Task Execution Role for use in an ECS Task Definition.",
 		Action:       regcreds.Up,
-		Flags:        nil, //TODO: add flags as funtionality is implemented
+		Flags:        regcredsUpFlags(),
 		OnUsageError: flags.UsageErrorFactory("up"),
+	}
+}
+
+func regcredsUpFlags() []cli.Flag {
+	return []cli.Flag{
+		cli.BoolFlag{
+			Name:  flags.UpdateExistingSecretsFlag,
+			Usage: "[Optional] Specifies whether existing secrets should be updated with new credential input.",
+		},
 	}
 }

--- a/ecs-cli/modules/utils/regcreds/creds_input_reader.go
+++ b/ecs-cli/modules/utils/regcreds/creds_input_reader.go
@@ -40,6 +40,16 @@ type RegistryCredEntry struct {
 	ContainerNames   []string `yaml:"container_names"`
 }
 
+// HasRequiredFields indicates whether the entry has the fields required to create or use registry credentials
+func (e RegistryCredEntry) HasRequiredFields() bool {
+	return e.SecretManagerARN != "" || e.HasCredPair()
+}
+
+// HasCredPair indicates whether the entry contains a username + password
+func (e RegistryCredEntry) HasCredPair() bool {
+	return e.Username != "" && e.Password != ""
+}
+
 // ReadCredsInput parses 'registry-creds up' input into an ECSRegCredsInput struct
 func ReadCredsInput(filename string) (*ECSRegCredsInput, error) {
 

--- a/ecs-cli/modules/utils/regcreds/creds_input_reader.go
+++ b/ecs-cli/modules/utils/regcreds/creds_input_reader.go
@@ -36,7 +36,7 @@ type RegistryCredEntry struct {
 	SecretManagerARN string   `yaml:"secret_manager_arn"`
 	Username         string   `yaml:"username"`
 	Password         string   `yaml:"password"`
-	KmdKeyID         string   `yaml:"kms_key_id"`
+	KmsKeyID         string   `yaml:"kms_key_id"`
 	ContainerNames   []string `yaml:"container_names"`
 }
 
@@ -69,14 +69,14 @@ func expandCredEntry(credEntry RegistryCredEntry) RegistryCredEntry {
 	expandedSecretARN := getValueOrEnvVar(credEntry.SecretManagerARN)
 	expandedUsername := getValueOrEnvVar(credEntry.Username)
 	expandedPassword := getValueOrEnvVar(credEntry.Password)
-	expandedKmsKeyID := getValueOrEnvVar(credEntry.KmdKeyID)
+	expandedKmsKeyID := getValueOrEnvVar(credEntry.KmsKeyID)
 	//TODO: look for env vars in container names?
 
 	expandedCredEntry := RegistryCredEntry{
 		SecretManagerARN: expandedSecretARN,
 		Username:         expandedUsername,
 		Password:         expandedPassword,
-		KmdKeyID:         expandedKmsKeyID,
+		KmsKeyID:         expandedKmsKeyID,
 		ContainerNames:   credEntry.ContainerNames,
 	}
 	return expandedCredEntry

--- a/ecs-cli/modules/utils/regcreds/creds_input_reader_test.go
+++ b/ecs-cli/modules/utils/regcreds/creds_input_reader_test.go
@@ -56,7 +56,7 @@ registry_credentials:
 	assert.NotEmpty(t, firstRegResult)
 	assert.Equal(t, "some_user_name", firstRegResult.Username)
 	assert.Equal(t, "myl337p4$$w0rd!<bz*", firstRegResult.Password)
-	assert.Equal(t, "aws:arn:kms:key/iuytre-jhgfd", firstRegResult.KmdKeyID)
+	assert.Equal(t, "aws:arn:kms:key/iuytre-jhgfd", firstRegResult.KmsKeyID)
 	assert.Equal(t, 2, len(firstRegResult.ContainerNames))
 
 	otherRegResult := credsResult.RegistryCredentials["other-registry.net"]
@@ -120,7 +120,7 @@ registry_credentials:
 	assert.NotEmpty(t, credEntry)
 	assert.Equal(t, usrnameEnvVal, credEntry.Username)
 	assert.Equal(t, passwrdEnvVal, credEntry.Password)
-	assert.Equal(t, kmsEnvVal, credEntry.KmdKeyID)
+	assert.Equal(t, kmsEnvVal, credEntry.KmsKeyID)
 	assert.Equal(t, secretEnvVal, credEntry.SecretManagerARN)
 	assert.Equal(t, 1, len(credEntry.ContainerNames))
 }


### PR DESCRIPTION
Create or update secrets for registry credentials on `registry-creds up`.
`make` and `make test` pass.

### Test output (`registry-creds up`)

createTest2.yml:
```yml
version: 1
registry_credentials:
  fakeregistry-1.net:  # new reg credentials
    username: ${USERNAME}
    password: ${PASSWORD}
    kms_key_id: arn:aws:kms:[REDACTED]
    container_names:
      - web-app
  fakeregistry-2.net: # existing registry secret
    secret_manager_arn: arn:aws:secretsmanager:[REDACTED]:secret:amazon-ecs-cli-setup-fakeregistry-2.net-RKAB66
    container_names:
      - metrics
  somemoarreg.io: # existing registry secret, recreation attempt (arn not named; will be found via lookup)
    username: ${USERNAME}
    password: ${PASSWORD2}
    container_names:
      - test
      - logging
```

cmd output (NOTE order of credential entries not retained):
```
$~\Documents\GO\src\github.com\aws\amazon-ecs-cli> ./bin/local/ecs-cli.exe registry-creds up ./createTest2.yml
?[36mINFO?[0m[0000] Processing credentials for registry somemoarreg.io...
?[36mINFO?[0m[0000] Existing credential secret found, using arn:aws:secretsmanager:[REDACTED]:secret:amazon-ecs-cli-setup-somemoarreg.io-yD5DYF
?[36mINFO?[0m[0000] Processing credentials for registry fakeregistry-1.net...
?[36mINFO?[0m[0000] New credential secret created: arn:aws:secretsmanager:[REDACTED]:secret:amazon-ecs-cli-setup-fakeregistry-1.net-SLHARv
?[36mINFO?[0m[0000] Processing credentials for registry fakeregistry-2.net...
?[36mINFO?[0m[0000] Using existing secret arn:aws:secretsmanager:[REDACTED]:secret:amazon-ecs-cli-setup-fakeregistry-2.net-RKAB66.
```



### Test output (`registry-creds up --update-existing-secrets`)

updateTest.yml:
```yml
version: 1
registry_credentials:
  somemoarreg.io:
    secret_manager_arn: arn:aws:secretsmanager:[REDACTED]:secret:amazon-ecs-cli-setup-somemoarreg.io-yD5DYF
    username: ${USERNAME}
    password: ${PASSWORD2}
    container_names:
      - nginx-custom
      - logging
```

cmd output:
```
$~Documents\GO\src\github.com\aws\amazon-ecs-cli> ./bin/local/ecs-cli.exe registry-creds up ./updateTest.yml --update-existing-secrets
?[36mINFO?[0m[0000] Processing credentials for registry somemoarreg.io...
?[36mINFO?[0m[0000] Updated existing secret arn:aws:secretsmanager:[REDACTED]:secret:amazon-ecs-cli-setup-somemoarreg.io-yD5DYF with new value
```

--
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
