### PR TITLE
Service Discovery - Update and Delete

### DIFF
--- a/ecs-cli/modules/cli/compose/entity/service/service_test.go
+++ b/ecs-cli/modules/cli/compose/entity/service/service_test.go
@@ -669,8 +669,10 @@ func TestCreateWithServiceDiscovery(t *testing.T) {
 	nonMockedServicediscoveryCreate := servicediscoveryCreate
 	defer func() { servicediscoveryCreate = nonMockedServicediscoveryCreate }()
 
-	servicediscoveryCreate = func(networkMode, serviceName string, c *context.ECSContext) (*string, error) {
-		return aws.String(sdsARN), nil
+	servicediscoveryCreate = func(networkMode, serviceName string, c *context.ECSContext) (*ecs.ServiceRegistry, error) {
+		return &ecs.ServiceRegistry{
+			RegistryArn: aws.String(sdsARN),
+		}, nil
 	}
 
 	createServiceTest(
@@ -692,15 +694,17 @@ func TestCreateWithServiceDiscoveryWithContainerNameAndPort(t *testing.T) {
 
 	flagSet := flag.NewFlagSet("ecs-cli-up", 0)
 	flagSet.Bool(flags.EnableServiceDiscoveryFlag, true, "")
-	flagSet.String(flags.ServiceDiscoveryContainerNameFlag, containerName, "")
-	flagSet.String(flags.ServiceDiscoveryContainerPortFlag, "80", "")
 
 	// Reset mockable function after test
 	nonMockedServicediscoveryCreate := servicediscoveryCreate
 	defer func() { servicediscoveryCreate = nonMockedServicediscoveryCreate }()
 
-	servicediscoveryCreate = func(networkMode, serviceName string, c *context.ECSContext) (*string, error) {
-		return aws.String(sdsARN), nil
+	servicediscoveryCreate = func(networkMode, serviceName string, c *context.ECSContext) (*ecs.ServiceRegistry, error) {
+		return &ecs.ServiceRegistry{
+			RegistryArn:   aws.String(sdsARN),
+			ContainerName: aws.String(containerName),
+			ContainerPort: aws.Int64(80),
+		}, nil
 	}
 
 	createServiceTest(

--- a/ecs-cli/modules/clients/aws/cloudformation/client.go
+++ b/ecs-cli/modules/clients/aws/cloudformation/client.go
@@ -419,7 +419,7 @@ func failureInDeleteEvent(event *cloudformation.StackEvent) bool {
 			"eventStatus": status,
 			"resource":    aws.StringValue(event.PhysicalResourceId),
 			"reason":      aws.StringValue(event.ResourceStatusReason),
-		}).Error("Error deleting cloudformation stack for cluster")
+		}).Error("Error deleting cloudformation stack")
 		return true
 	}
 

--- a/ecs-cli/modules/commands/compose/service/compose_service_command.go
+++ b/ecs-cli/modules/commands/compose/service/compose_service_command.go
@@ -86,7 +86,7 @@ func upServiceCommand(factory composeFactory.ProjectFactory) cli.Command {
 		Name:         "up",
 		Usage:        "Creates a new ECS service or updates an existing one according to your compose file. For new services or existing services with a current desired count of 0, the desired count for the service is set to 1. For existing services with non-zero desired counts, a new task definition is created to reflect any changes to the compose file and the service is updated to use that task definition. In this case, the desired count does not change.",
 		Action:       compose.WithProject(factory, compose.ProjectUp, true),
-		Flags:        flags.AppendFlags(deploymentConfigFlags(true), loadBalancerFlags(), flags.OptionalConfigFlags(), ComposeServiceTimeoutFlag(), flags.OptionalLaunchTypeFlag(), flags.OptionalCreateLogsFlag(), ForceNewDeploymentFlag(), serviceDiscoveryFlags()),
+		Flags:        flags.AppendFlags(deploymentConfigFlags(true), loadBalancerFlags(), flags.OptionalConfigFlags(), ComposeServiceTimeoutFlag(), flags.OptionalLaunchTypeFlag(), flags.OptionalCreateLogsFlag(), ForceNewDeploymentFlag(), serviceDiscoveryFlags(), updateServiceDiscoveryFlags()),
 		OnUsageError: flags.UsageErrorFactory("up"),
 	}
 }
@@ -128,7 +128,7 @@ func rmServiceCommand(factory composeFactory.ProjectFactory) cli.Command {
 		Aliases:      []string{"delete", "down"},
 		Usage:        "Updates the desired count of the service to 0 and then deletes the service.",
 		Action:       compose.WithProject(factory, compose.ProjectDown, true),
-		Flags:        flags.AppendFlags(flags.OptionalConfigFlags(), ComposeServiceTimeoutFlag()),
+		Flags:        flags.AppendFlags(flags.OptionalConfigFlags(), ComposeServiceTimeoutFlag(), deleteServiceDiscoveryFlags()),
 		OnUsageError: flags.UsageErrorFactory("rm"),
 	}
 }
@@ -137,7 +137,7 @@ func serviceDiscoveryFlags() []cli.Flag {
 	return []cli.Flag{
 		cli.BoolFlag{
 			Name:  flags.EnableServiceDiscoveryFlag,
-			Usage: "Enable or modify service discovery configuration",
+			Usage: "Enable Service Discovery for your ECS Service",
 		},
 		cli.StringFlag{
 			Name:  flags.VpcIdFlag,
@@ -178,6 +178,24 @@ func serviceDiscoveryFlags() []cli.Flag {
 		cli.StringFlag{
 			Name:  flags.HealthcheckCustomConfigFailureThresholdFlag,
 			Usage: "Service Discovery - The number of 30-second intervals that you want service discovery service to wait after receiving an UpdateInstanceCustomHealthStatus request before it changes the health status of a service instance",
+		},
+	}
+}
+
+func updateServiceDiscoveryFlags() []cli.Flag {
+	return []cli.Flag{
+		cli.BoolFlag{
+			Name:  flags.UpdateServiceDiscoveryFlag,
+			Usage: "[Optional] Service Discovery - Allows update of Service Discovery Service settings DNS TTL and Failure Threshold.",
+		},
+	}
+}
+
+func deleteServiceDiscoveryFlags() []cli.Flag {
+	return []cli.Flag{
+		cli.BoolFlag{
+			Name:  flags.DeletePrivateNamespaceFlag,
+			Usage: "[Optional] Service Discovery - Deletes the private namespace created by the ECS CLI",
 		},
 	}
 }

--- a/ecs-cli/modules/commands/flags/flags.go
+++ b/ecs-cli/modules/commands/flags/flags.go
@@ -69,6 +69,8 @@ const (
 	ServiceDiscoveryContainerNameFlag           = "sd-container-name"
 	ServiceDiscoveryContainerPortFlag           = "sd-container-port"
 	HealthcheckCustomConfigFailureThresholdFlag = "healthcheck-custom-config-failure-threshold"
+	DeletePrivateNamespaceFlag                  = "delete-namespace"
+	UpdateServiceDiscoveryFlag                  = "update-service-discovery"
 
 	ComposeProjectNamePrefixFlag         = "compose-project-name-prefix"
 	ComposeProjectNamePrefixDefaultValue = "ecscompose-"


### PR DESCRIPTION
Update and delete for Service Discovery. Only the SDS values DNS TTL and Failure Threshold can be updated, making update pretty boring.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
