### PR TITLE
Move resource prefix to utils package

### DIFF
--- a/ecs-cli/modules/cli/configure/migrate.go
+++ b/ecs-cli/modules/cli/configure/migrate.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/config"
+	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/utils"
 )
 
 func maskSecret(secret string) (out string) {
@@ -122,7 +123,7 @@ credentials:
 [WARN] Please read the following changes carefully: http://docs.aws.amazon.com/AmazonECS/latest/developerguide/ECS_CLI_Configuration.html
 - The option --compose-project-name-prefix has been removed (name used for create task definition: <compose_project_name_prefix> + <project_name>). You can specify your desired name with the --project-name option.
 - The --compose-service-name-prefix option has been deprecated (name used for create service: <compose_service_name_prefix> + <project_name>). This field can still be configured; however, if it is not configured there is no longer a default value assigned.
-- The --cfn-stack-name-prefix option has been removed. To use an existing CloudFormation stack, please specify the full stack name using the --cfn-stack-name option; otherwise, the stack name defaults to amazon-ecs-cli-setup-<cluster_name>.
+- The --cfn-stack-name-prefix option has been removed. To use an existing CloudFormation stack, please specify the full stack name using the --cfn-stack-name option; otherwise, the stack name defaults to ` + utils.ECSCLIResourcePrefix + `<cluster_name>.
 - Storing an AWS Profile name in the config is no longer supported, please use the --aws-profile flag inline instead.
 
 Are you sure you want to migrate[y/n]?

--- a/ecs-cli/modules/commands/configure/configure_command.go
+++ b/ecs-cli/modules/commands/configure/configure_command.go
@@ -16,9 +16,10 @@ package configureCommand
 import (
 	"fmt"
 
-	"github.com/sirupsen/logrus"
 	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/cli/configure"
 	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/commands/flags"
+	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/utils"
+	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 )
 
@@ -186,7 +187,7 @@ func configureFlags() []cli.Flag {
 		cli.StringFlag{
 			Name: flags.CFNStackNameFlag,
 			Usage: fmt.Sprintf(
-				"[Optional] Specifies the name of AWS CloudFormation stack created on ecs-cli up. (default: \"amazon-ecs-cli-setup-<cluster-name>\")",
+				"[Optional] Specifies the name of AWS CloudFormation stack created on ecs-cli up. (default: \"" + utils.ECSCLIResourcePrefix + "<cluster-name>\")",
 			),
 		},
 		cli.StringFlag{

--- a/ecs-cli/modules/commands/flags/flags.go
+++ b/ecs-cli/modules/commands/flags/flags.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/utils"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 )
@@ -62,7 +63,7 @@ const (
 	ComposeServiceNamePrefixFlag         = "compose-service-name-prefix"
 	ComposeServiceNamePrefixDefaultValue = ComposeProjectNamePrefixDefaultValue + "service-"
 	CFNStackNameFlag                     = "cfn-stack-name"
-	CFNStackNamePrefixDefaultValue       = "amazon-ecs-cli-setup-"
+	CFNStackNamePrefixDefaultValue       = utils.ECSCLIResourcePrefix
 
 	LaunchTypeFlag        = "launch-type"
 	DefaultLaunchTypeFlag = "default-launch-type"

--- a/ecs-cli/modules/utils/utils.go
+++ b/ecs-cli/modules/utils/utils.go
@@ -19,6 +19,11 @@ import (
 	"os"
 )
 
+const (
+	// ECSCLIResourcePrefix is prepended to the names of resources created through the ecs-cli
+	ECSCLIResourcePrefix = "amazon-ecs-cli-setup-"
+)
+
 // InSlice checks if the given string exists in the given slice:
 func InSlice(str string, list []string) bool {
 	for _, s := range list {


### PR DESCRIPTION
Pull "amazon-ecs-cli-setup-" prefix out as a constant, reference where previously used as string value.

--
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
