### PR TITLE
complete maximumPercent and minimumHealthyPercent if these parameters…

### DIFF
--- a/ecs-cli/modules/clients/aws/ecs/client.go
+++ b/ecs-cli/modules/clients/aws/ecs/client.go
@@ -132,6 +132,14 @@ func (c *ecsClient) DeleteService(serviceName string) error {
 }
 
 func (c *ecsClient) CreateService(serviceName string, createServiceInput *ecs.CreateServiceInput) error {
+  if createServiceInput.DeploymentConfiguration == nil || createServiceInput.DeploymentConfiguration.MaximumPercent == nil {
+    input.DeploymentConfiguration.MaximumPercent = aws.Int64(200)
+  }
+
+  if createServiceInput.DeploymentConfiguration != nil && createServiceInput.DeploymentConfiguration.MinimumHealthyPercent != nil {
+    input.DeploymentConfiguration.MinimumHealthyPercent = aws.Int64(100)
+  }
+
 	if _, err := c.client.CreateService(createServiceInput); err != nil {
 		log.WithFields(log.Fields{
 			"service": serviceName,
@@ -163,6 +171,15 @@ func (c *ecsClient) UpdateService(serviceName, taskDefinition string, count int6
 	if taskDefinition != "" {
 		input.TaskDefinition = aws.String(taskDefinition)
 	}
+
+  if deploymentConfig == nil || deploymentConfig.MaximumPercent == nil {
+    input.DeploymentConfiguration.MaximumPercent = aws.Int64(200)
+	}
+
+  if deploymentConfig != nil && deploymentConfig.MinimumHealthyPercent != nil {
+    input.DeploymentConfiguration.MinimumHealthyPercent = aws.Int64(100)
+  }
+
 	_, err := c.client.UpdateService(input)
 	if err != nil {
 		log.WithFields(log.Fields{

--- a/ecs-cli/modules/clients/aws/ecs/client.go
+++ b/ecs-cli/modules/clients/aws/ecs/client.go
@@ -136,7 +136,7 @@ func (c *ecsClient) CreateService(serviceName string, createServiceInput *ecs.Cr
     createServiceInput.DeploymentConfiguration.MaximumPercent = aws.Int64(200)
   }
 
-  if createServiceInput.DeploymentConfiguration != nil && createServiceInput.DeploymentConfiguration.MinimumHealthyPercent != nil {
+  if createServiceInput.DeploymentConfiguration == nil || createServiceInput.DeploymentConfiguration.MinimumHealthyPercent == nil {
     createServiceInput.DeploymentConfiguration.MinimumHealthyPercent = aws.Int64(100)
   }
 

--- a/ecs-cli/modules/clients/aws/ecs/client.go
+++ b/ecs-cli/modules/clients/aws/ecs/client.go
@@ -133,11 +133,11 @@ func (c *ecsClient) DeleteService(serviceName string) error {
 
 func (c *ecsClient) CreateService(serviceName string, createServiceInput *ecs.CreateServiceInput) error {
   if createServiceInput.DeploymentConfiguration == nil || createServiceInput.DeploymentConfiguration.MaximumPercent == nil {
-    input.DeploymentConfiguration.MaximumPercent = aws.Int64(200)
+    createServiceInput.DeploymentConfiguration.MaximumPercent = aws.Int64(200)
   }
 
   if createServiceInput.DeploymentConfiguration != nil && createServiceInput.DeploymentConfiguration.MinimumHealthyPercent != nil {
-    input.DeploymentConfiguration.MinimumHealthyPercent = aws.Int64(100)
+    createServiceInput.DeploymentConfiguration.MinimumHealthyPercent = aws.Int64(100)
   }
 
 	if _, err := c.client.CreateService(createServiceInput); err != nil {


### PR DESCRIPTION
… did not exist

*Issue #616 , if available:*

*Description of changes:*
In client.go, It does completion to maximumPercent and minimumHealthPercent when deployconfiguration does not specfied.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
