### PR TITLE
Add support for EC2 Spot instances

### DIFF
--- a/ecs-cli/modules/cli/cluster/cluster_app.go
+++ b/ecs-cli/modules/cli/cluster/cluster_app.go
@@ -58,6 +58,7 @@ func init() {
 		flags.KeypairNameFlag:   cloudformation.ParameterKeyKeyPairName,
 		flags.ImageIdFlag:       cloudformation.ParameterKeyAmiId,
 		flags.InstanceRoleFlag:  cloudformation.ParameterKeyInstanceRole,
+		flags.SpotPriceFlag:	 cloudformation.ParameterKeySpotPrice,
 	}
 }
 

--- a/ecs-cli/modules/clients/aws/cloudformation/params.go
+++ b/ecs-cli/modules/clients/aws/cloudformation/params.go
@@ -38,6 +38,7 @@ const (
 	ParameterKeyInstanceRole             = "InstanceRole"
 	ParameterKeyIsFargate                = "IsFargate"
 	ParameterKeyUserData                 = "UserData"
+	ParameterKeySpotPrice                = "SpotPrice"
 )
 
 var ParameterNotFoundError = errors.New("Parameter not found")
@@ -72,6 +73,7 @@ func init() {
 		ParameterKeyCluster,
 		ParameterKeyAmiId,
 		ParameterKeyAssociatePublicIPAddress,
+		ParameterKeySpotPrice,
 	}
 }
 

--- a/ecs-cli/modules/clients/aws/cloudformation/template.go
+++ b/ecs-cli/modules/clients/aws/cloudformation/template.go
@@ -184,6 +184,11 @@ var template = `
       ],
       "ConstraintDescription": "must be a valid EC2 instance type."
     },
+    "SpotPrice": {
+      "Type": "Number",
+      "Description": "If greater than 0, then a EC2 Spot instance will be requested",
+      "Default": "0"
+    },
     "KeyName": {
       "Type": "String",
       "Description": "Optional - Name of an existing EC2 KeyPair to enable SSH access to the ECS instances",
@@ -339,6 +344,18 @@ var template = `
             ""
           ]
         }
+      ]
+    },
+    "UseSpotInstances": {
+      "Fn::Not": [
+      {
+        "Fn::Equals": [
+        {
+          "Ref": "SpotPrice"
+        },
+        0
+        ]
+      }
       ]
     }
   },
@@ -564,6 +581,17 @@ var template = `
         "ImageId": { "Ref" : "EcsAmiId" },
         "InstanceType": {
           "Ref": "EcsInstanceType"
+        },
+        "SpotPrice": {
+          "Fn::If": [
+            "UseSpotInstances",
+            {
+              "Ref": "SpotPrice"
+            },
+            {
+              "Ref": "AWS::NoValue"
+            }
+          ]
         },
         "AssociatePublicIpAddress": {
           "Ref": "AssociatePublicIpAddress"

--- a/ecs-cli/modules/commands/cluster/cluster_command.go
+++ b/ecs-cli/modules/commands/cluster/cluster_command.go
@@ -87,6 +87,10 @@ func clusterUpFlags() []cli.Flag {
 			Usage: "[Optional] Specifies the EC2 instance type for your container instances. Defaults to t2.micro. NOTE: Not applicable for launch type FARGATE.",
 		},
 		cli.StringFlag{
+			Name:  flags.SpotPriceFlag,
+			Usage: "[Optional] If filled and greater than 0, EC2 Spot instances will be requested.",
+		},
+		cli.StringFlag{
 			Name:  flags.ImageIdFlag,
 			Usage: "[Optional] Specify the AMI ID for your container instances. Defaults to amazon-ecs-optimized AMI. NOTE: Not applicable for launch type FARGATE.",
 		},

--- a/ecs-cli/modules/commands/flags/flags.go
+++ b/ecs-cli/modules/commands/flags/flags.go
@@ -77,6 +77,7 @@ const (
 	SubnetIdsFlag                   = "subnets"
 	VpcIdFlag                       = "vpc"
 	InstanceTypeFlag                = "instance-type"
+	SpotPriceFlag                   = "spot-price"
 	InstanceRoleFlag                = "instance-role"
 	ImageIdFlag                     = "image-id"
 	KeypairNameFlag                 = "keypair"
@@ -221,5 +222,6 @@ func CFNResourceFlags() []string {
 		InstanceRoleFlag,
 		ImageIdFlag,
 		KeypairNameFlag,
+		SpotPriceFlag,
 	}
 }


### PR DESCRIPTION
*Issue #396*

*Description of changes:*
This PR add support for EC2 Spot instances.

Main change is to update CloudFormation to add parameter `SpotPrice`.
If this parameter is greater than `0` then we specify a SpotPrice in LaunchConfiguration, resulting in creation of a Spot Request.

All the other changes, are 'plumbing' to get this option `spot-price` on command line when creating cluster

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
