### PR TITLE
Refactor convert_task_definition to use params struct

### DIFF
--- a/ecs-cli/modules/cli/compose/project/project.go
+++ b/ecs-cli/modules/cli/compose/project/project.go
@@ -186,14 +186,16 @@ func (p *ecsProject) transformTaskDefinition() error {
 	requiredCompatibilities := ecsContext.CommandConfig.LaunchType
 	taskDefinitionName := ecsContext.ProjectName
 
-	taskDefinition, err := utils.ConvertToTaskDefinition(
-		taskDefinitionName,
-		p.VolumeConfigs(),
-		p.ContainerConfigs(), // TODO Change to pointer on project?
-		taskRoleArn,
-		requiredCompatibilities,
-		ecsContext.ECSParams,
-	)
+	convertParams := utils.ConvertTaskDefParams{
+		TaskDefName:            taskDefinitionName,
+		TaskRoleArn:            taskRoleArn,
+		RequiredCompatibilites: requiredCompatibilities,
+		Volumes:                p.VolumeConfigs(),
+		ContainerConfigs:       p.ContainerConfigs(), // TODO Change to pointer on project?
+		ECSParams:              ecsContext.ECSParams,
+	}
+
+	taskDefinition, err := utils.ConvertToTaskDefinition(convertParams)
 
 	if err != nil {
 		return err

--- a/ecs-cli/modules/utils/compose/convert_task_definition_test.go
+++ b/ecs-cli/modules/utils/compose/convert_task_definition_test.go
@@ -1168,7 +1168,16 @@ func TestMemReservationHigherThanMemLimit(t *testing.T) {
 	volumeConfigs := adapter.NewVolumes()
 	containerConfigs := []adapter.ContainerConfig{containerConfig}
 
-	_, err := ConvertToTaskDefinition(projectName, volumeConfigs, containerConfigs, "", "", nil)
+	testParams := ConvertTaskDefParams{
+		TaskDefName:            projectName,
+		TaskRoleArn:            "",
+		RequiredCompatibilites: "",
+		Volumes:                volumeConfigs,
+		ContainerConfigs:       containerConfigs,
+		ECSParams:              nil,
+	}
+
+	_, err := ConvertToTaskDefinition(testParams)
 	assert.EqualError(t, err, "mem_limit must be greater than mem_reservation")
 }
 
@@ -1209,7 +1218,16 @@ func TestConvertToTaskDefinitionWithVolumes(t *testing.T) {
 		},
 	}
 
-	taskDefinition, err := ConvertToTaskDefinition(projectName, volumeConfigs, containerConfigs, "", "", nil)
+	testParams := ConvertTaskDefParams{
+		TaskDefName:            projectName,
+		TaskRoleArn:            "",
+		RequiredCompatibilites: "",
+		Volumes:                volumeConfigs,
+		ContainerConfigs:       containerConfigs,
+		ECSParams:              nil,
+	}
+
+	taskDefinition, err := ConvertToTaskDefinition(testParams)
 	assert.NoError(t, err, "Unexpected error converting Task Definition")
 
 	actualVolumes := taskDefinition.Volumes
@@ -1244,7 +1262,16 @@ func TestConvertToTaskDefinitionWithVolumesWithHostOnly(t *testing.T) {
 		},
 	}
 
-	taskDefinition, err := ConvertToTaskDefinition(projectName, volumeConfigs, containerConfigs, "", "", nil)
+	testParams := ConvertTaskDefParams{
+		TaskDefName:            projectName,
+		TaskRoleArn:            "",
+		RequiredCompatibilites: "",
+		Volumes:                volumeConfigs,
+		ContainerConfigs:       containerConfigs,
+		ECSParams:              nil,
+	}
+
+	taskDefinition, err := ConvertToTaskDefinition(testParams)
 	assert.NoError(t, err, "Unexpected error converting Task Definition")
 
 	actualVolumes := taskDefinition.Volumes
@@ -1295,7 +1322,16 @@ func TestConvertToTaskDefinitionWithECSParamsVolumeWithoutNameError(t *testing.T
 		},
 	}
 
-	_, err := ConvertToTaskDefinition(projectName, volumeConfigs, containerConfigs, "", "", ecsParams)
+	testParams := ConvertTaskDefParams{
+		TaskDefName:            projectName,
+		TaskRoleArn:            "",
+		RequiredCompatibilites: "",
+		Volumes:                volumeConfigs,
+		ContainerConfigs:       containerConfigs,
+		ECSParams:              ecsParams,
+	}
+
+	_, err := ConvertToTaskDefinition(testParams)
 	assert.Error(t, err, "Expected error converting Task Definition with ECS Params volume without name")
 }
 
@@ -1474,7 +1510,16 @@ func convertToTaskDefinitionInTest(t *testing.T, containerConfig *adapter.Contai
 	containerConfigs := []adapter.ContainerConfig{}
 	containerConfigs = append(containerConfigs, *containerConfig)
 
-	taskDefinition, err := ConvertToTaskDefinition(projectName, volumeConfigs, containerConfigs, taskRoleArn, launchType, nil)
+	testParams := ConvertTaskDefParams{
+		TaskDefName:            projectName,
+		TaskRoleArn:            taskRoleArn,
+		RequiredCompatibilites: launchType,
+		Volumes:                volumeConfigs,
+		ContainerConfigs:       containerConfigs,
+		ECSParams:              nil,
+	}
+
+	taskDefinition, err := ConvertToTaskDefinition(testParams)
 	if err != nil {
 		t.Errorf("Expected to convert [%v] containerConfigs without errors. But got [%v]", containerConfig, err)
 	}
@@ -1486,7 +1531,16 @@ func convertToTaskDefWithEcsParamsInTest(t *testing.T, containerConfigs []adapte
 		VolumeEmptyHost: []string{namedVolume},
 	}
 
-	taskDefinition, err := ConvertToTaskDefinition(projectName, volumeConfigs, containerConfigs, taskRoleArn, "", ecsParams)
+	testParams := ConvertTaskDefParams{
+		TaskDefName:            projectName,
+		TaskRoleArn:            taskRoleArn,
+		RequiredCompatibilites: "",
+		Volumes:                volumeConfigs,
+		ContainerConfigs:       containerConfigs,
+		ECSParams:              ecsParams,
+	}
+
+	taskDefinition, err := ConvertToTaskDefinition(testParams)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Previously, `convert_task_definition` was taking in 6 distinct parameters. Rather than continue to add on to these in the future, I refactored the function to take in a struct with all the "ingredients" necessary to convert compose inputs to a task def.

--
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
