### PR TITLE
Service Discovery - Set SDS Name from ECS Params

### DIFF
--- a/ecs-cli/modules/cli/servicediscovery/servicediscovery_app_test.go
+++ b/ecs-cli/modules/cli/servicediscovery/servicediscovery_app_test.go
@@ -37,7 +37,7 @@ import (
 const (
 	testClusterName        = "cluster"
 	testServiceName        = "service"
-	otherTestServiceName   = "some-other-name"
+	nonDefaultSDSName      = "some-custom-name"
 	testDescription        = "clyde loves pudding"
 	otherTestDescription   = "pudding plays hard to get"
 	testNamespaceStackName = "amazon-ecs-cli-setup-private-dns-namespace-cluster-service"
@@ -232,7 +232,7 @@ func TestCreateServiceDiscoveryWithECSParams(t *testing.T) {
 			Description: testDescription,
 		},
 		ServiceDiscoveryService: utils.ServiceDiscoveryService{
-			Name:        otherTestServiceName,
+			Name:        nonDefaultSDSName,
 			Description: testDescription,
 			DNSConfig: utils.DNSConfig{
 				TTL:  aws.Int64(60),
@@ -251,7 +251,7 @@ func TestCreateServiceDiscoveryWithECSParams(t *testing.T) {
 	}
 	var validateSDS validateSDSParamsFunc = func(t *testing.T, cfnParams *cloudformation.CfnStackParams) {
 		validateCFNParam(testNamespaceID, parameterKeyNamespaceID, cfnParams, t)
-		validateCFNParam(otherTestServiceName, parameterKeySDSName, cfnParams, t)
+		validateCFNParam(nonDefaultSDSName, parameterKeySDSName, cfnParams, t)
 		validateCFNParam(servicediscovery.RecordTypeSrv, parameterKeyDNSType, cfnParams, t)
 		validateCFNParam(testDescription, parameterKeySDSDescription, cfnParams, t)
 		validateCFNParam("60", parameterKeyDNSTTL, cfnParams, t)

--- a/ecs-cli/modules/cli/servicediscovery/servicediscovery_app_test.go
+++ b/ecs-cli/modules/cli/servicediscovery/servicediscovery_app_test.go
@@ -37,6 +37,7 @@ import (
 const (
 	testClusterName        = "cluster"
 	testServiceName        = "service"
+	otherTestServiceName   = "some-other-name"
 	testDescription        = "clyde loves pudding"
 	otherTestDescription   = "pudding plays hard to get"
 	testNamespaceStackName = "amazon-ecs-cli-setup-private-dns-namespace-cluster-service"
@@ -231,7 +232,7 @@ func TestCreateServiceDiscoveryWithECSParams(t *testing.T) {
 			Description: testDescription,
 		},
 		ServiceDiscoveryService: utils.ServiceDiscoveryService{
-			Name:        testServiceName,
+			Name:        otherTestServiceName,
 			Description: testDescription,
 			DNSConfig: utils.DNSConfig{
 				TTL:  aws.Int64(60),
@@ -250,7 +251,7 @@ func TestCreateServiceDiscoveryWithECSParams(t *testing.T) {
 	}
 	var validateSDS validateSDSParamsFunc = func(t *testing.T, cfnParams *cloudformation.CfnStackParams) {
 		validateCFNParam(testNamespaceID, parameterKeyNamespaceID, cfnParams, t)
-		validateCFNParam(testServiceName, parameterKeySDSName, cfnParams, t)
+		validateCFNParam(otherTestServiceName, parameterKeySDSName, cfnParams, t)
 		validateCFNParam(servicediscovery.RecordTypeSrv, parameterKeyDNSType, cfnParams, t)
 		validateCFNParam(testDescription, parameterKeySDSDescription, cfnParams, t)
 		validateCFNParam("60", parameterKeyDNSTTL, cfnParams, t)

--- a/ecs-cli/modules/cli/servicediscovery/servicediscovery_helper.go
+++ b/ecs-cli/modules/cli/servicediscovery/servicediscovery_helper.go
@@ -242,8 +242,13 @@ func truncate(s string, length int) string {
 	return s
 }
 
-func getSDSCFNParams(namespaceID, sdsName, networkMode string, input *utils.ServiceDiscovery) *cloudformation.CfnStackParams {
+func getSDSCFNParams(namespaceID, ecsServiceName, networkMode string, input *utils.ServiceDiscovery) *cloudformation.CfnStackParams {
 	cfnParams := cloudformation.NewCfnStackParams(requiredParamsSDS)
+
+	sdsName := input.ServiceDiscoveryService.Name
+	if sdsName == "" {
+		sdsName = ecsServiceName
+	}
 
 	cfnParams.Add(parameterKeyNamespaceID, namespaceID)
 	cfnParams.Add(parameterKeySDSName, sdsName)


### PR DESCRIPTION
Bug fix- set Service Discovery Service name from the ECS Params input (if it was specified). The previous incorrect behavior was that the default value (SDS name is the same as the ECS Service name) was always set no matter what.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
