### PR TITLE
Service Discovery - Fix Override Warning Message

### DIFF
--- a/ecs-cli/modules/cli/servicediscovery/servicediscovery_helper.go
+++ b/ecs-cli/modules/cli/servicediscovery/servicediscovery_helper.go
@@ -65,8 +65,8 @@ func resolveIntPointerFieldOverride(c *cli.Context, flagName string, ecsParamsVa
 	}
 
 	if flagVal != nil && ecsParamsVal != nil {
-		paramsVal := string(*ecsParamsVal)
-		override := string(*flagVal)
+		paramsVal := strconv.FormatInt(*ecsParamsVal, 10)
+		override := strconv.FormatInt(*flagVal, 10)
 		showFieldOverrideMsg(paramsVal, override, field)
 	}
 	if flagVal != nil {


### PR DESCRIPTION
Int64 values weren't getting displayed properly

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
