### PR TITLE
 Integrate registry creds into 'compose'

### DIFF
--- a/ecs-cli/Gopkg.lock
+++ b/ecs-cli/Gopkg.lock
@@ -331,6 +331,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "ab13cb1375f62dd9180e1daabd3320c968208bc9bf17d64f9d95cafbe54136d7"
+  inputs-digest = "09cc6ede11a1723e900b53c27e98f3f8d462c0516dca8e5ce2f6a27bb01aba9c"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/ecs-cli/modules/cli/compose/project/project.go
+++ b/ecs-cli/modules/cli/compose/project/project.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/commands/flags"
 	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/utils/compose"
+	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/utils/regcredio"
 	"github.com/docker/libcompose/project"
 )
 
@@ -52,9 +53,10 @@ type Project interface {
 
 // ecsProject struct is an implementation of Project.
 type ecsProject struct {
-	containerConfigs []adapter.ContainerConfig
-	volumes          *adapter.Volumes
-	ecsContext       *context.ECSContext
+	containerConfigs       []adapter.ContainerConfig
+	volumes                *adapter.Volumes
+	ecsContext             *context.ECSContext
+	privateRegistryContext *regcredio.ECSRegistryCredsOutput // TODO: rename to 'ecsRegistryCreds'
 
 	// TODO: track a map of entities [taskDefinition -> Entity]
 	// 1 task definition for every disjoint set of containers in the compose file
@@ -124,6 +126,10 @@ func (p *ecsProject) Parse() error {
 		return err
 	}
 
+	if err := p.parsePrivateRegistryContext(); err != nil {
+		return err
+	}
+
 	return p.transformTaskDefinition()
 }
 
@@ -174,6 +180,19 @@ func (p *ecsProject) parseECSParams() error {
 	return nil
 }
 
+func (p *ecsProject) parsePrivateRegistryContext() error {
+	logrus.Debug("Parsing the ecs-registry-creds yaml...")
+	registryCredsFileName := p.ecsContext.CLIContext.GlobalString(flags.RegistryCredsFileNameFlag)
+	regCreds, err := regcredio.ReadCredsOutput(registryCredsFileName)
+	if err != nil {
+		return err
+	}
+
+	p.privateRegistryContext = regCreds
+
+	return nil
+}
+
 // transformTaskDefinition converts the compose yml and ecs-params yml into an
 // ECS task definition and loads it onto the project entity
 func (p *ecsProject) transformTaskDefinition() error {
@@ -193,6 +212,7 @@ func (p *ecsProject) transformTaskDefinition() error {
 		Volumes:                p.VolumeConfigs(),
 		ContainerConfigs:       p.ContainerConfigs(), // TODO Change to pointer on project?
 		ECSParams:              ecsContext.ECSParams,
+		PrivRegistryContext:    p.privateRegistryContext,
 	}
 
 	taskDefinition, err := utils.ConvertToTaskDefinition(convertParams)

--- a/ecs-cli/modules/cli/compose/project/project_test.go
+++ b/ecs-cli/modules/cli/compose/project/project_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/cli/compose/context"
 	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/commands/flags"
 	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/utils/compose"
+	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/utils/regcredio"
 	"github.com/stretchr/testify/assert"
 	"github.com/urfave/cli"
 )
@@ -295,6 +296,11 @@ func setupTestProject(t *testing.T) *ecsProject {
 }
 
 func setupTestProjectWithEcsParams(t *testing.T, ecsParamsFileName string) *ecsProject {
+	return setupTestProjectWithPrivateRegistryContext(t, ecsParamsFileName, "")
+}
+
+// TODO: refactor into all-purpose 'setupTestProject' func
+func setupTestProjectWithPrivateRegistryContext(t *testing.T, ecsParamsFileName, credFileName string) *ecsProject {
 	envLookup, err := utils.GetDefaultEnvironmentLookup()
 	assert.NoError(t, err, "Unexpected error setting up environment lookup")
 
@@ -304,6 +310,7 @@ func setupTestProjectWithEcsParams(t *testing.T, ecsParamsFileName string) *ecsP
 	flagSet := flag.NewFlagSet("ecs-cli", 0)
 	flagSet.String(flags.ProjectNameFlag, testProjectName, "")
 	flagSet.String(flags.ECSParamsFileNameFlag, ecsParamsFileName, "")
+	flagSet.String(flags.RegistryCredsFileNameFlag, credFileName, "")
 
 	parentContext := cli.NewContext(nil, flagSet, nil)
 	cliContext := cli.NewContext(nil, nil, parentContext)
@@ -316,5 +323,67 @@ func setupTestProjectWithEcsParams(t *testing.T, ecsParamsFileName string) *ecsP
 
 	return &ecsProject{
 		ecsContext: ecsContext,
+	}
+}
+
+func TestParsePrivateRegistryContext(t *testing.T) {
+	credsInputString := `version: "1"
+registry_credential_outputs:
+  task_execution_role: someTestRole
+  container_credentials:
+    my.example.registry.net:
+      credentials_parameter: arn:aws:secretsmanager::secret:amazon-ecs-cli-setup-my.example.registry.net
+      container_names:
+      - web
+    another.example.io:
+      credentials_parameter: arn:aws:secretsmanager::secret:amazon-ecs-cli-setup-another.example.io
+      kms_key_id: arn:aws:kms::key/some-key-57yrt
+      container_names:
+      - test`
+
+	content := []byte(credsInputString)
+
+	tmpfile, err := ioutil.TempFile("", regcredio.ECSCredFileBaseName)
+	assert.NoError(t, err, "Could not create ecs registry creds tempfile")
+
+	credFileName := tmpfile.Name()
+	defer os.Remove(credFileName)
+
+	project := setupTestProjectWithPrivateRegistryContext(t, "", credFileName)
+
+	_, err = tmpfile.Write(content)
+	assert.NoError(t, err, "Could not write data to ecs registry creds tempfile")
+
+	if err := project.parsePrivateRegistryContext(); err != nil {
+		t.Fatalf("Unexpected error parsing the "+regcredio.ECSCredFileBaseName+" data [%s]: %v", credsInputString, err)
+	}
+
+	ecsRegCreds := project.privateRegistryContext
+	assert.NotNil(t, ecsRegCreds, "Expected "+regcredio.ECSCredFileBaseName+" to be set on project")
+	assert.Equal(t, "1", ecsRegCreds.Version, "Expected Version to match")
+
+	credResources := ecsRegCreds.CredentialResources
+	assert.NotNil(t, credResources, "Expected credential resources to be non-nil")
+	assert.Equal(t, "someTestRole", credResources.TaskExecutionRole)
+	assert.NotNil(t, credResources.ContainerCredentials, "Expected ContainerCredentials to be non-nil")
+
+	firstOutputEntry := credResources.ContainerCredentials["my.example.registry.net"]
+	assert.NotEmpty(t, firstOutputEntry)
+	assert.Equal(t, "arn:aws:secretsmanager::secret:amazon-ecs-cli-setup-my.example.registry.net", firstOutputEntry.CredentialARN)
+	assert.Equal(t, "", firstOutputEntry.KMSKeyID)
+	assert.ElementsMatch(t, []string{"web"}, firstOutputEntry.ContainerNames)
+
+	secondOutputEntry := credResources.ContainerCredentials["another.example.io"]
+	assert.NotEmpty(t, secondOutputEntry)
+	assert.Equal(t, "arn:aws:secretsmanager::secret:amazon-ecs-cli-setup-another.example.io", secondOutputEntry.CredentialARN)
+	assert.Equal(t, "arn:aws:kms::key/some-key-57yrt", secondOutputEntry.KMSKeyID)
+	assert.ElementsMatch(t, []string{"test"}, secondOutputEntry.ContainerNames)
+}
+
+func TestParsePrivateRegistryContext_NoFile(t *testing.T) {
+	project := setupTestProject(t)
+	err := project.parsePrivateRegistryContext()
+	if assert.NoError(t, err) {
+		assert.Nil(t, project.privateRegistryContext)
 	}
 }

--- a/ecs-cli/modules/commands/compose/compose_command.go
+++ b/ecs-cli/modules/commands/compose/compose_command.go
@@ -103,6 +103,10 @@ func composeFlags() []cli.Flag {
 			Name:  flags.ECSParamsFileNameFlag,
 			Usage: "[Optional] Specifies ecs-params file to use. Defaults to " + ecsParamsFileNameDefaultValue + " file, if one exists.",
 		},
+		cli.StringFlag{
+			Name:  flags.RegistryCredsFileNameFlag,
+			Usage: "[Optional] Specifies the ecs-registry-creds file to use. Defaults to latest 'ecs-registry-creds' output file, if one exists.",
+		},
 	}
 }
 

--- a/ecs-cli/modules/commands/flags/flags.go
+++ b/ecs-cli/modules/commands/flags/flags.go
@@ -107,11 +107,12 @@ const (
 	UntaggedFlag   = "untagged"
 
 	// Compose
-	ProjectNameFlag       = "project-name"
-	ComposeFileNameFlag   = "file"
-	TaskRoleArnFlag       = "task-role-arn"
-	ECSParamsFileNameFlag = "ecs-params"
-	ForceUpdateFlag       = "force-update"
+	ProjectNameFlag           = "project-name"
+	ComposeFileNameFlag       = "file"
+	TaskRoleArnFlag           = "task-role-arn"
+	ECSParamsFileNameFlag     = "ecs-params"
+	ForceUpdateFlag           = "force-update"
+	RegistryCredsFileNameFlag = "registry-creds"
 
 	// Compose Service
 	CreateServiceCommandName                = "create"

--- a/ecs-cli/modules/utils/compose/convert_task_definition_test.go
+++ b/ecs-cli/modules/utils/compose/convert_task_definition_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/cli/compose/adapter"
+	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/utils/regcredio"
 	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/utils/value"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ecs"
@@ -43,7 +44,7 @@ var defaultNetwork = &yaml.Network{
 }
 
 // TODO Extract test docker file and use in test (to avoid gaps between parse and conversion unit tests)
-var testContainerConfig = &adapter.ContainerConfig{
+var testContainerConfig = adapter.ContainerConfig{
 	Name:    "mysql",
 	Command: []string{"cmd"},
 	CPU:     int64(131072),
@@ -230,7 +231,9 @@ func TestConvertToTaskDefinition(t *testing.T) {
 	// TODO add top-level volumes
 
 	// convert
-	taskDefinition := convertToTaskDefinitionInTest(t, testContainerConfig, taskRoleArn, "")
+	taskDefinition, err := convertToTaskDefinitionForTest(t, []adapter.ContainerConfig{testContainerConfig}, taskRoleArn, "", nil, nil)
+	assert.NoError(t, err, "Unexpected error converting Task Definition")
+
 	containerDef := *taskDefinition.ContainerDefinitions[0]
 
 	// verify task def fields
@@ -277,33 +280,39 @@ func TestConvertToTaskDefinition(t *testing.T) {
 }
 
 func TestConvertToTaskDefinitionWithNoSharedMemorySize(t *testing.T) {
-	containerConfig := &adapter.ContainerConfig{
+	containerConfig := adapter.ContainerConfig{
 		ShmSize: int64(0),
 	}
 
-	taskDefinition := convertToTaskDefinitionInTest(t, containerConfig, "", "")
+	taskDefinition, err := convertToTaskDefinitionForTest(t, []adapter.ContainerConfig{containerConfig}, "", "", nil, nil)
+	assert.NoError(t, err, "Unexpected error converting Task Definition")
+
 	containerDef := *taskDefinition.ContainerDefinitions[0]
 
 	assert.Nil(t, containerDef.LinuxParameters.SharedMemorySize, "Expected sharedMemorySize to be null")
 }
 
 func TestConvertToTaskDefinitionWithNoTmpfs(t *testing.T) {
-	containerConfig := &adapter.ContainerConfig{
+	containerConfig := adapter.ContainerConfig{
 		Tmpfs: nil,
 	}
 
-	taskDefinition := convertToTaskDefinitionInTest(t, containerConfig, "", "")
+	taskDefinition, err := convertToTaskDefinitionForTest(t, []adapter.ContainerConfig{containerConfig}, "", "", nil, nil)
+	assert.NoError(t, err, "Unexpected error converting Task Definition")
+
 	containerDef := *taskDefinition.ContainerDefinitions[0]
 
 	assert.Nil(t, containerDef.LinuxParameters.Tmpfs, "Expected Tmpfs to be null")
 }
 
 func TestConvertToTaskDefinitionWithBlankHostname(t *testing.T) {
-	containerConfig := &adapter.ContainerConfig{
+	containerConfig := adapter.ContainerConfig{
 		Hostname: "",
 	}
 
-	taskDefinition := convertToTaskDefinitionInTest(t, containerConfig, "", "")
+	taskDefinition, err := convertToTaskDefinitionForTest(t, []adapter.ContainerConfig{containerConfig}, "", "", nil, nil)
+	assert.NoError(t, err, "Unexpected error converting Task Definition")
+
 	containerDef := *taskDefinition.ContainerDefinitions[0]
 
 	assert.Nil(t, containerDef.Hostname, "Expected Hostname to be nil")
@@ -313,18 +322,21 @@ func TestConvertToTaskDefinitionWithBlankHostname(t *testing.T) {
 
 // Test Launch Types
 func TestConvertToTaskDefinitionLaunchTypeEmpty(t *testing.T) {
-	containerConfig := &adapter.ContainerConfig{}
+	containerConfig := adapter.ContainerConfig{}
 
-	taskDefinition := convertToTaskDefinitionInTest(t, containerConfig, "", "")
+	taskDefinition, err := convertToTaskDefinitionForTest(t, []adapter.ContainerConfig{containerConfig}, "", "", nil, nil)
+	assert.NoError(t, err, "Unexpected error converting Task Definition")
 	if len(taskDefinition.RequiresCompatibilities) > 0 {
 		t.Error("Did not expect RequiresCompatibilities to be set")
 	}
 }
 
 func TestConvertToTaskDefinitionLaunchTypeEC2(t *testing.T) {
-	containerConfig := &adapter.ContainerConfig{}
+	containerConfig := adapter.ContainerConfig{}
 
-	taskDefinition := convertToTaskDefinitionInTest(t, containerConfig, "", "EC2")
+	taskDefinition, err := convertToTaskDefinitionForTest(t, []adapter.ContainerConfig{containerConfig}, "", "EC2", nil, nil)
+	assert.NoError(t, err, "Unexpected error converting Task Definition")
+
 	if len(taskDefinition.RequiresCompatibilities) != 1 {
 		t.Error("Expected exactly one required compatibility to be set.")
 	}
@@ -332,9 +344,11 @@ func TestConvertToTaskDefinitionLaunchTypeEC2(t *testing.T) {
 }
 
 func TestConvertToTaskDefinitionLaunchTypeFargate(t *testing.T) {
-	containerConfig := &adapter.ContainerConfig{}
+	containerConfig := adapter.ContainerConfig{}
 
-	taskDefinition := convertToTaskDefinitionInTest(t, containerConfig, "", "FARGATE")
+	taskDefinition, err := convertToTaskDefinitionForTest(t, []adapter.ContainerConfig{containerConfig}, "", "FARGATE", nil, nil)
+	assert.NoError(t, err, "Unexpected error converting Task Definition")
+
 	if len(taskDefinition.RequiresCompatibilities) != 1 {
 		t.Error("Expected exactly one required compatibility to be set.")
 	}
@@ -376,7 +390,7 @@ task_definition:
 	assert.NoError(t, err, "Could not read ECS Params file")
 
 	containerConfigs := []adapter.ContainerConfig{*containerConfig}
-	_, err = convertToTaskDefWithEcsParamsInTest(t, containerConfigs, "", ecsParams)
+	_, err = convertToTaskDefinitionForTest(t, containerConfigs, "", "", ecsParams, nil)
 
 	assert.Error(t, err, "Expected error because memory reservation is greater than memory limit")
 }
@@ -415,7 +429,7 @@ task_definition:
 	ecsParams, err := ReadECSParams(ecsParamsFileName)
 	assert.NoError(t, err, "Could not read ECS Params file")
 
-	taskDefinition, err := convertToTaskDefWithEcsParamsInTest(t, containerConfigs, "", ecsParams)
+	taskDefinition, err := convertToTaskDefinitionForTest(t, containerConfigs, "", "", ecsParams, nil)
 
 	if assert.NoError(t, err) {
 		assert.Equal(t, "host", aws.StringValue(taskDefinition.NetworkMode), "Expected network mode to match")
@@ -461,7 +475,7 @@ task_definition:
 	ecsParams, err := ReadECSParams(ecsParamsFileName)
 	assert.NoError(t, err, "Could not read ECS Params file")
 
-	taskDefinition, err := convertToTaskDefWithEcsParamsInTest(t, containerConfigs, "", ecsParams)
+	taskDefinition, err := convertToTaskDefinitionForTest(t, containerConfigs, "", "", ecsParams, nil)
 
 	containerDefs := taskDefinition.ContainerDefinitions
 	mysql := findContainerByName("mysql", containerDefs)
@@ -504,7 +518,7 @@ task_definition:
 	ecsParams, err := ReadECSParams(ecsParamsFileName)
 	assert.NoError(t, err, "Could not read ECS Params file")
 
-	taskDefinition, err := convertToTaskDefWithEcsParamsInTest(t, containerConfigs, "", ecsParams)
+	taskDefinition, err := convertToTaskDefinitionForTest(t, containerConfigs, "", "", ecsParams, nil)
 
 	containerDefs := taskDefinition.ContainerDefinitions
 	mysql := findContainerByName("mysql", containerDefs)
@@ -543,7 +557,7 @@ task_definition:
 	ecsParams, err := ReadECSParams(ecsParamsFileName)
 	assert.NoError(t, err, "Could not read ECS Params file")
 
-	taskDefinition, err := convertToTaskDefWithEcsParamsInTest(t, containerConfigs, "", ecsParams)
+	taskDefinition, err := convertToTaskDefinitionForTest(t, containerConfigs, "", "", ecsParams, nil)
 
 	containerDefs := taskDefinition.ContainerDefinitions
 	mysql := findContainerByName("mysql", containerDefs)
@@ -582,7 +596,7 @@ task_definition:
 	ecsParams, err := ReadECSParams(ecsParamsFileName)
 	assert.NoError(t, err, "Could not read ECS Params file")
 
-	taskDefinition, err := convertToTaskDefWithEcsParamsInTest(t, containerConfigs, "", ecsParams)
+	taskDefinition, err := convertToTaskDefinitionForTest(t, containerConfigs, "", "", ecsParams, nil)
 
 	containerDefs := taskDefinition.ContainerDefinitions
 	mysql := findContainerByName("mysql", containerDefs)
@@ -620,7 +634,7 @@ task_definition:
 	ecsParams, err := ReadECSParams(ecsParamsFileName)
 	assert.NoError(t, err, "Could not read ECS Params file")
 
-	taskDefinition, err := convertToTaskDefWithEcsParamsInTest(t, containerConfigs, "", ecsParams)
+	taskDefinition, err := convertToTaskDefinitionForTest(t, containerConfigs, "", "", ecsParams, nil)
 
 	containerDefs := taskDefinition.ContainerDefinitions
 	mysql := findContainerByName("mysql", containerDefs)
@@ -659,7 +673,7 @@ task_definition:
 	ecsParams, err := ReadECSParams(ecsParamsFileName)
 	assert.NoError(t, err, "Could not read ECS Params file")
 
-	_, err = convertToTaskDefWithEcsParamsInTest(t, containerConfigs, "", ecsParams)
+	_, err = convertToTaskDefinitionForTest(t, containerConfigs, "", "", ecsParams, nil)
 
 	assert.Error(t, err, "Expected error if no containers are marked essential")
 }
@@ -691,7 +705,7 @@ task_definition:
 	ecsParams, err := ReadECSParams(ecsParamsFileName)
 	assert.NoError(t, err, "Could not read ECS Params file")
 
-	_, err = convertToTaskDefWithEcsParamsInTest(t, containerConfigs, "", ecsParams)
+	_, err = convertToTaskDefinitionForTest(t, containerConfigs, "", "", ecsParams, nil)
 
 	assert.Error(t, err, "Expected error if no containers are marked essential")
 }
@@ -720,7 +734,7 @@ task_definition:
 	ecsParams, err := ReadECSParams(ecsParamsFileName)
 	assert.NoError(t, err, "Could not read ECS Params file")
 
-	taskDefinition, err := convertToTaskDefWithEcsParamsInTest(t, containerConfigs, "", ecsParams)
+	taskDefinition, err := convertToTaskDefinitionForTest(t, containerConfigs, "", "", ecsParams, nil)
 	assert.NoError(t, err, "Unexpected error when no containers are marked essential")
 
 	mysql := findContainerByName("mysql", taskDefinition.ContainerDefinitions)
@@ -758,7 +772,7 @@ task_definition:
 	ecsParams, err := ReadECSParams(ecsParamsFileName)
 	assert.NoError(t, err, "Could not read ECS Params file")
 
-	taskDefinition, err := convertToTaskDefWithEcsParamsInTest(t, containerConfigs, "", ecsParams)
+	taskDefinition, err := convertToTaskDefinitionForTest(t, containerConfigs, "", "", ecsParams, nil)
 
 	assert.NoError(t, err, "Unexpected error when no containers are marked essential")
 	mysql := findContainerByName("mysql", taskDefinition.ContainerDefinitions)
@@ -793,7 +807,7 @@ task_definition:
 
 	taskRoleArn := "arn:aws:iam::123456789012:role/tweedledum"
 
-	taskDefinition, err := convertToTaskDefWithEcsParamsInTest(t, containerConfigs, taskRoleArn, ecsParams)
+	taskDefinition, err := convertToTaskDefinitionForTest(t, containerConfigs, taskRoleArn, "", ecsParams, nil)
 
 	if assert.NoError(t, err) {
 		assert.Equal(t, "host", aws.StringValue(taskDefinition.NetworkMode), "Expected network mode to match")
@@ -841,7 +855,7 @@ task_definition:
 	ecsParams, err := ReadECSParams(ecsParamsFileName)
 	assert.NoError(t, err, "Could not read ECS Params file")
 
-	taskDefinition, err := convertToTaskDefWithEcsParamsInTest(t, containerConfigs, "", ecsParams)
+	taskDefinition, err := convertToTaskDefinitionForTest(t, containerConfigs, "", "", ecsParams, nil)
 
 	containerDefs := taskDefinition.ContainerDefinitions
 	mysql := findContainerByName("mysql", containerDefs)
@@ -898,7 +912,7 @@ task_definition:
 	assert.NoError(t, err, "Could not read ECS Params file")
 
 	containerConfigs := []adapter.ContainerConfig{*containerConfig}
-	taskDefinition, err := convertToTaskDefWithEcsParamsInTest(t, containerConfigs, "", ecsParams)
+	taskDefinition, err := convertToTaskDefinitionForTest(t, containerConfigs, "", "", ecsParams, nil)
 
 	containerDefs := taskDefinition.ContainerDefinitions
 	web := findContainerByName("web", containerDefs)
@@ -943,7 +957,7 @@ task_definition:
 	assert.NoError(t, err, "Could not read ECS Params file")
 
 	containerConfigs := []adapter.ContainerConfig{*containerConfig}
-	taskDefinition, err := convertToTaskDefWithEcsParamsInTest(t, containerConfigs, "", ecsParams)
+	taskDefinition, err := convertToTaskDefinitionForTest(t, containerConfigs, "", "", ecsParams, nil)
 
 	containerDefs := taskDefinition.ContainerDefinitions
 	web := findContainerByName("web", containerDefs)
@@ -992,7 +1006,7 @@ task_definition:
 	assert.NoError(t, err, "Could not read ECS Params file")
 
 	containerConfigs := []adapter.ContainerConfig{*containerConfig}
-	taskDefinition, err := convertToTaskDefWithEcsParamsInTest(t, containerConfigs, "", ecsParams)
+	taskDefinition, err := convertToTaskDefinitionForTest(t, containerConfigs, "", "", ecsParams, nil)
 
 	containerDefs := taskDefinition.ContainerDefinitions
 	web := findContainerByName("web", containerDefs)
@@ -1035,7 +1049,7 @@ task_definition:
 	ecsParams, err := ReadECSParams(ecsParamsFileName)
 	assert.NoError(t, err, "Could not read ECS Params file")
 
-	taskDefinition, err := convertToTaskDefWithEcsParamsInTest(t, containerConfigs, "", ecsParams)
+	taskDefinition, err := convertToTaskDefinitionForTest(t, containerConfigs, "", "", ecsParams, nil)
 
 	containerDefs := taskDefinition.ContainerDefinitions
 	web := findContainerByName("web", containerDefs)
@@ -1075,7 +1089,7 @@ task_definition:
 	assert.NoError(t, err, "Could not read ECS Params file")
 
 	containerConfigs := []adapter.ContainerConfig{*containerConfig}
-	_, err = convertToTaskDefWithEcsParamsInTest(t, containerConfigs, "", ecsParams)
+	_, err = convertToTaskDefinitionForTest(t, containerConfigs, "", "", ecsParams, nil)
 
 	assert.Error(t, err, "Expected error if mem_reservation was more than mem_limit")
 }
@@ -1105,7 +1119,7 @@ task_definition:
 	ecsParams, err := ReadECSParams(ecsParamsFileName)
 	assert.NoError(t, err, "Could not read ECS Params file")
 
-	taskDefinition, err := convertToTaskDefWithEcsParamsInTest(t, containerConfigs, "", ecsParams)
+	taskDefinition, err := convertToTaskDefinitionForTest(t, containerConfigs, "", "", ecsParams, nil)
 
 	if assert.NoError(t, err) {
 		assert.Equal(t, "200", aws.StringValue(taskDefinition.Cpu), "Expected CPU to match")
@@ -1115,12 +1129,14 @@ task_definition:
 
 func TestConvertToTaskDefinition_MemLimitOnlyProvided(t *testing.T) {
 	webMem := int64(1048576)
-	containerConfig := &adapter.ContainerConfig{
+	containerConfig := adapter.ContainerConfig{
 		Name:   "web",
 		Memory: webMem,
 	}
 
-	taskDefinition := convertToTaskDefinitionInTest(t, containerConfig, "", "")
+	taskDefinition, err := convertToTaskDefinitionForTest(t, []adapter.ContainerConfig{containerConfig}, "", "", nil, nil)
+	assert.NoError(t, err, "Unexpected error converting Task Definition")
+
 	containerDefs := taskDefinition.ContainerDefinitions
 	web := findContainerByName("web", containerDefs)
 
@@ -1131,12 +1147,14 @@ func TestConvertToTaskDefinition_MemLimitOnlyProvided(t *testing.T) {
 
 func TestConvertToTaskDefinition_MemReservationOnlyProvided(t *testing.T) {
 	webMem := int64(1048576)
-	containerConfig := &adapter.ContainerConfig{
+	containerConfig := adapter.ContainerConfig{
 		Name:              "web",
 		MemoryReservation: webMem,
 	}
 
-	taskDefinition := convertToTaskDefinitionInTest(t, containerConfig, "", "")
+	taskDefinition, err := convertToTaskDefinitionForTest(t, []adapter.ContainerConfig{containerConfig}, "", "", nil, nil)
+	assert.NoError(t, err, "Unexpected error converting Task Definition")
+
 	containerDefs := taskDefinition.ContainerDefinitions
 	web := findContainerByName("web", containerDefs)
 
@@ -1146,11 +1164,13 @@ func TestConvertToTaskDefinition_MemReservationOnlyProvided(t *testing.T) {
 }
 
 func TestConvertToTaskDefinition_NoMemoryProvided(t *testing.T) {
-	containerConfig := &adapter.ContainerConfig{
+	containerConfig := adapter.ContainerConfig{
 		Name: "web",
 	}
 
-	taskDefinition := convertToTaskDefinitionInTest(t, containerConfig, "", "")
+	taskDefinition, err := convertToTaskDefinitionForTest(t, []adapter.ContainerConfig{containerConfig}, "", "", nil, nil)
+	assert.NoError(t, err, "Unexpected error converting Task Definition")
+
 	containerDefs := taskDefinition.ContainerDefinitions
 	web := findContainerByName("web", containerDefs)
 
@@ -1429,7 +1449,7 @@ task_definition:
 	assert.NoError(t, err, "Could not read ECS Params file")
 
 	containerConfigs := []adapter.ContainerConfig{*containerConfig}
-	taskDefinition, err := convertToTaskDefWithEcsParamsInTest(t, containerConfigs, "", ecsParams)
+	taskDefinition, err := convertToTaskDefinitionForTest(t, containerConfigs, "", "", ecsParams, nil)
 
 	containerDefs := taskDefinition.ContainerDefinitions
 	web := findContainerByName("web", containerDefs)
@@ -1485,7 +1505,7 @@ task_definition:
 	assert.NoError(t, err, "Could not read ECS Params file")
 
 	containerConfigs := []adapter.ContainerConfig{*containerConfig}
-	taskDefinition, err := convertToTaskDefWithEcsParamsInTest(t, containerConfigs, "", ecsParams)
+	taskDefinition, err := convertToTaskDefinitionForTest(t, containerConfigs, "", "", ecsParams, nil)
 
 	containerDefs := taskDefinition.ContainerDefinitions
 	web := findContainerByName("web", containerDefs)
@@ -1502,13 +1522,174 @@ task_definition:
 ///////////////////////
 // helper functions //
 //////////////////////
-func convertToTaskDefinitionInTest(t *testing.T, containerConfig *adapter.ContainerConfig, taskRoleArn string, launchType string) *ecs.TaskDefinition {
+
+func TestConvertToTaskDefinitionWithPrivRegContext(t *testing.T) {
+	containerConfigs := testContainerConfigs([]string{"mysql", "wordpress"})
+	credsFileString := `version: "1"
+registry_credential_outputs:
+  task_execution_role: someTestRole
+  container_credentials:
+    my.example.registry.net:
+      credentials_parameter: arn:aws:secretsmanager::secret:amazon-ecs-cli-setup-my.example.registry.net
+      container_names:
+      - mysql`
+
+	content := []byte(credsFileString)
+
+	tmpfile, err := ioutil.TempFile("", regcredio.ECSCredFileBaseName)
+	assert.NoError(t, err, "Could not create reg creds tempfile")
+
+	defer os.Remove(tmpfile.Name())
+
+	_, err = tmpfile.Write(content)
+	assert.NoError(t, err, "Could not write data to reg creds tempfile")
+
+	regCreds, err := regcredio.ReadCredsOutput(tmpfile.Name())
+	assert.NoError(t, err, "Could not read reg creds file")
+
+	taskDefinition, err := convertToTaskDefinitionForTest(t, containerConfigs, "", "", nil, regCreds)
+	assert.NoError(t, err, "Unexpected error when converting task definition")
+	assert.Equal(t, "someTestRole", aws.StringValue(taskDefinition.ExecutionRoleArn))
+
+	mysqlContainer := findContainerByName("mysql", taskDefinition.ContainerDefinitions)
+	assert.NotEmpty(t, mysqlContainer)
+	assert.NotEmpty(t, mysqlContainer.RepositoryCredentials)
+	assert.Equal(t, "arn:aws:secretsmanager::secret:amazon-ecs-cli-setup-my.example.registry.net", aws.StringValue(mysqlContainer.RepositoryCredentials.CredentialsParameter))
+}
+
+func TestConvertToTaskDefinitionWithPrivRegContext_EmptyContainerCredMap(t *testing.T) {
+	containerConfigs := testContainerConfigs([]string{"mysql", "wordpress"})
+	credsNoContainersFileString := `version: "1"
+registry_credential_outputs:
+  task_execution_role: someTestRole
+  container_credentials:
+    my.example.registry.net:
+      credentials_parameter: arn:aws:secretsmanager::secret:amazon-ecs-cli-setup-my.example.registry.net
+      container_names:`
+
+	content := []byte(credsNoContainersFileString)
+
+	tmpfile, err := ioutil.TempFile("", regcredio.ECSCredFileBaseName)
+	assert.NoError(t, err, "Could not create reg creds tempfile")
+
+	defer os.Remove(tmpfile.Name())
+
+	_, err = tmpfile.Write(content)
+	assert.NoError(t, err, "Could not write data to reg creds tempfile")
+
+	regCreds, err := regcredio.ReadCredsOutput(tmpfile.Name())
+	assert.NoError(t, err, "Could not read reg creds file")
+
+	taskDefinition, err := convertToTaskDefinitionForTest(t, containerConfigs, "", "", nil, regCreds)
+	assert.NoError(t, err, "Unexpected error when converting task definition")
+	assert.Equal(t, "someTestRole", aws.StringValue(taskDefinition.ExecutionRoleArn))
+
+	mysqlContainer := findContainerByName("mysql", taskDefinition.ContainerDefinitions)
+	assert.NotEmpty(t, mysqlContainer)
+	assert.Empty(t, mysqlContainer.RepositoryCredentials)
+}
+
+func TestConvertToTaskDefinitionWithPrivRegContext_OverrideECSParamsValues(t *testing.T) {
+	containerConfigs := testContainerConfigs([]string{"mysql", "wordpress"})
+
+	// set up reg cred file
+	credsFileString := `version: "1"
+registry_credential_outputs:
+  task_execution_role: someTestRole
+  container_credentials:
+    my.example.registry.net:
+      credentials_parameter: arn:aws:secretsmanager::secret:amazon-ecs-cli-setup-my.example.registry.net
+      container_names:
+      - mysql`
+
+	credsContent := []byte(credsFileString)
+
+	tmpfileCreds, err := ioutil.TempFile("", regcredio.ECSCredFileBaseName)
+	assert.NoError(t, err, "Could not create reg creds tempfile")
+
+	defer os.Remove(tmpfileCreds.Name())
+
+	_, err = tmpfileCreds.Write(credsContent)
+	assert.NoError(t, err, "Could not write data to reg creds tempfile")
+
+	regCreds, err := regcredio.ReadCredsOutput(tmpfileCreds.Name())
+	assert.NoError(t, err, "Could not read reg creds file")
+
+	// set up ecs-params
+	ecsParamsString := `version: 1
+task_definition:
+  ecs_network_mode: host
+  task_execution_role: arn:aws:iam::123456789012:role/my_role
+  services:
+    mysql:
+      essential: true
+      cpu_shares: 100
+      mem_limit: 524288000
+      repository_credentials:
+        credentials_parameter: arn:aws:secretsmanager:1234567890:secret:test-RT4iv`
+
+	contentECSParams := []byte(ecsParamsString)
+
+	tmpfileECSParams, err := ioutil.TempFile("", "ecs-params")
+	assert.NoError(t, err, "Could not create ecs-params tempfile")
+
+	ecsParamsFileName := tmpfileECSParams.Name()
+	defer os.Remove(tmpfileECSParams.Name())
+
+	_, err = tmpfileECSParams.Write(contentECSParams)
+	assert.NoError(t, err, "Could not write data to ecs-params tempfile")
+
+	err = tmpfileECSParams.Close()
+	assert.NoError(t, err, "Could not close ecs-params tempfile")
+
+	ecsParams, err := ReadECSParams(ecsParamsFileName)
+
+	taskDefinition, err := convertToTaskDefinitionForTest(t, containerConfigs, "", "", ecsParams, regCreds)
+	assert.NoError(t, err, "Unexpected error when converting task definition")
+	assert.Equal(t, "someTestRole", aws.StringValue(taskDefinition.ExecutionRoleArn))
+
+	mysqlContainer := findContainerByName("mysql", taskDefinition.ContainerDefinitions)
+	assert.NotEmpty(t, mysqlContainer)
+	assert.NotEmpty(t, mysqlContainer.RepositoryCredentials)
+	assert.Equal(t, "arn:aws:secretsmanager::secret:amazon-ecs-cli-setup-my.example.registry.net", aws.StringValue(mysqlContainer.RepositoryCredentials.CredentialsParameter))
+}
+
+func TestConvertToTaskDefinitionWithPrivRegContext_ErrorOnDuplicateContainers(t *testing.T) {
+	containerConfigs := testContainerConfigs([]string{"mysql", "wordpress"})
+	credsDuplicateContainersFileString := `version: "1"
+registry_credential_outputs:
+  task_execution_role: someTestRole
+  container_credentials:
+    my.example.registry.net:
+      credentials_parameter: arn:aws:secretsmanager::secret:amazon-ecs-cli-setup-my.example.registry.net
+      container_names:
+      - mysql
+    my.otherregistry.net:
+      credentials_parameter: arn:aws:secretsmanager::secret:amazon-ecs-cli-setup-my.otherregistry.net
+      container_names:
+      - mysql`
+
+	content := []byte(credsDuplicateContainersFileString)
+
+	tmpfile, err := ioutil.TempFile("", regcredio.ECSCredFileBaseName)
+	assert.NoError(t, err, "Could not create reg creds tempfile")
+
+	defer os.Remove(tmpfile.Name())
+
+	_, err = tmpfile.Write(content)
+	assert.NoError(t, err, "Could not write data to reg creds tempfile")
+
+	regCreds, err := regcredio.ReadCredsOutput(tmpfile.Name())
+	assert.NoError(t, err, "Could not read reg creds file")
+
+	_, err = convertToTaskDefinitionForTest(t, containerConfigs, "", "", nil, regCreds)
+	assert.Error(t, err, "Expected error when converting task definition")
+}
+
+func convertToTaskDefinitionForTest(t *testing.T, containerConfigs []adapter.ContainerConfig, taskRoleArn string, launchType string, ecsParams *ECSParams, ecsRegCreds *regcredio.ECSRegistryCredsOutput) (*ecs.TaskDefinition, error) {
 	volumeConfigs := &adapter.Volumes{
 		VolumeEmptyHost: []string{namedVolume},
 	}
-
-	containerConfigs := []adapter.ContainerConfig{}
-	containerConfigs = append(containerConfigs, *containerConfig)
 
 	testParams := ConvertTaskDefParams{
 		TaskDefName:            projectName,
@@ -1516,28 +1697,8 @@ func convertToTaskDefinitionInTest(t *testing.T, containerConfig *adapter.Contai
 		RequiredCompatibilites: launchType,
 		Volumes:                volumeConfigs,
 		ContainerConfigs:       containerConfigs,
-		ECSParams:              nil,
-	}
-
-	taskDefinition, err := ConvertToTaskDefinition(testParams)
-	if err != nil {
-		t.Errorf("Expected to convert [%v] containerConfigs without errors. But got [%v]", containerConfig, err)
-	}
-	return taskDefinition
-}
-
-func convertToTaskDefWithEcsParamsInTest(t *testing.T, containerConfigs []adapter.ContainerConfig, taskRoleArn string, ecsParams *ECSParams) (*ecs.TaskDefinition, error) {
-	volumeConfigs := &adapter.Volumes{
-		VolumeEmptyHost: []string{namedVolume},
-	}
-
-	testParams := ConvertTaskDefParams{
-		TaskDefName:            projectName,
-		TaskRoleArn:            taskRoleArn,
-		RequiredCompatibilites: "",
-		Volumes:                volumeConfigs,
-		ContainerConfigs:       containerConfigs,
 		ECSParams:              ecsParams,
+		PrivRegistryContext:    ecsRegCreds,
 	}
 
 	taskDefinition, err := ConvertToTaskDefinition(testParams)

--- a/ecs-cli/modules/utils/regcredio/creds_writers.go
+++ b/ecs-cli/modules/utils/regcredio/creds_writers.go
@@ -24,8 +24,9 @@ import (
 
 const (
 	// ECSCredFileTimeFmt is the timestamp format to use on 'registry-creds up' outputs
-	ECSCredFileTimeFmt  = "20060102T150405Z"
-	ecsCredFileBaseName = "ecs-registry-creds"
+	ECSCredFileTimeFmt = "20060102T150405Z"
+	// ECSCredFileBaseName is the base name of any private registry cred file produced or read by the ecs-cli
+	ECSCredFileBaseName = "ecs-registry-creds"
 )
 
 // GenerateCredsOutput marshals credential output JSON into YAML and outputs it to a file
@@ -58,7 +59,7 @@ func GenerateCredsOutput(creds map[string]CredsOutputEntry, roleName, outputDir 
 	}
 	timestampedSuffix := fmt.Sprintf("_%s.yml", timeStamp.Format(ECSCredFileTimeFmt))
 
-	file, err := os.Create(outputFileDir + string(os.PathSeparator) + ecsCredFileBaseName + timestampedSuffix)
+	file, err := os.Create(outputFileDir + string(os.PathSeparator) + ECSCredFileBaseName + timestampedSuffix)
 	if err != nil {
 		return err
 	}

--- a/ecs-cli/modules/utils/regcredio/creds_writers_test.go
+++ b/ecs-cli/modules/utils/regcredio/creds_writers_test.go
@@ -44,7 +44,7 @@ func TestGenerateCredsOutput(t *testing.T) {
 	assert.NoError(t, err, "Unexpected error when generating creds output")
 
 	// assert output file was produced, is legible
-	outputFile, err := filepath.Glob(testOutputDir + string(os.PathSeparator) + ecsCredFileBaseName + "*.yml")
+	outputFile, err := filepath.Glob(testOutputDir + string(os.PathSeparator) + ECSCredFileBaseName + "*.yml")
 	assert.NoError(t, err, "Unexpected error finding output file")
 
 	actualCredsOutput, err := ReadCredsOutput(outputFile[0])

--- a/ecs-cli/modules/utils/regcredio/types.go
+++ b/ecs-cli/modules/utils/regcredio/types.go
@@ -59,7 +59,7 @@ type CredResources struct {
 
 // CredsOutputEntry contains the credential ARN, key, and associated container names for a single registry
 type CredsOutputEntry struct {
-	CredentialARN  string   `yaml:"secret_manager_arn"`
+	CredentialARN  string   `yaml:"credentials_parameter"` //TODO: rename 'CredentialARN' to 'CredentialsParam' ?
 	KMSKeyID       string   `yaml:"kms_key_id,omitempty"`
 	ContainerNames []string `yaml:"container_names"`
 }


### PR DESCRIPTION
### Test output:

ecs-registry-creds_20181017T180501Z.yml:
```
version: "1"
registry_credential_outputs:
  task_execution_role: "myCredRole0"
  container_credentials:
    fakeregistry-2.net:
      credential_parameter: arn:aws:secretsmanager:us-west-2:#########:secret:amazon-ecs-cli-setup-fakeregistry-2.net-RKAB66
      container_names:
      - wordpress
    myacct.somemoarreg.io/someteam/mine:
      credential_parameter: arn:aws:secretsmanager:us-west-2:#########:secret:amazon-ecs-cli-setup-myacct.somemoarreg.io/someteam/mine-yarTSn
      kms_key_id: arn:aws:kms:us-west-2:#########:key/c58cf9b5-###-4657-8bee-a89f66d27c00
```

docker-compose.yml:
```
version: '3'
services:
  wordpress:
    image: fakeregistry-2.net-RKAB66/httpd
    ports:
      - "80:80"
```

ecs-params.yml:
```
version: 1
task_definition:
  task_execution_role: ecsTaskExecutionRole
  ecs_network_mode: bridge
  services:
    wordpress:
      repository_credentials:
        credentials_parameter: arn:aws:secretsmanager:us-west-2:##########:secret:some-test-secret-DZBDi3
      cpu_shares: 27
      mem_limit: 524288003
```

#### cmd output:
```
$~\credParamTest> ../../Documents/GO/src/github.com/aws/amazon-ecs-cli/bin/local/ecs-cli.exe compose create
INFO[0000] Found ecs-registry-creds file .\ecs-registry-creds_20181017T180501Z.yml
WARN[0000] No containers found for registry myacct.somemoarreg.io/someteam/mine
INFO[0000] Using ecs-registry-creds value as override (was arn:aws:secretsmanager:us-west-2:##########:secret:some-test-secret-DZBDi3 but is now arn:aws:secretsmanager:us-west-2:##########:secret:amazon-ecs-cli-setup-fakeregistry-2.net-RKAB66)  container name=wordpress option name=credentials_parameter
INFO[0000] Using ecs-registry-creds value as override (was ecsTaskExecutionRole but is now myCredRole0)  option name=task_execution_role
INFO[0000] Using ECS task definition                     TaskDefinition="credParamTest:4"
```

--
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
