### PR TITLE
Bug fix: log client creation doesn't change region in session

### DIFF
--- a/ecs-cli/modules/clients/aws/cloudwatchlogs/client.go
+++ b/ecs-cli/modules/clients/aws/cloudwatchlogs/client.go
@@ -16,6 +16,7 @@ package cloudwatchlogs
 import (
 	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/clients"
 	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/config"
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
 	"github.com/aws/aws-sdk-go/service/cloudwatchlogs/cloudwatchlogsiface"
 )
@@ -33,9 +34,8 @@ type cwLogsClient struct {
 
 // NewCloudWatchLogsClient creates an instance of ec2Client object.
 func NewCloudWatchLogsClient(params *config.CommandConfig, logRegion string) Client {
-	session := params.Session
-	session.Config = session.Config.WithRegion(logRegion)
-	client := cloudwatchlogs.New(session)
+	newSession := params.Session.Copy(&aws.Config{Region: aws.String(logRegion)})
+	client := cloudwatchlogs.New(newSession)
 	client.Handlers.Build.PushBackNamed(clients.CustomUserAgentHandler())
 	return &cwLogsClient{
 		client: client,

--- a/ecs-cli/modules/clients/aws/cloudwatchlogs/client_test.go
+++ b/ecs-cli/modules/clients/aws/cloudwatchlogs/client_test.go
@@ -1,0 +1,40 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package cloudwatchlogs
+
+import (
+	"testing"
+
+	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/config"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewCloudWatchLogsClientLeavesRegionIntact(t *testing.T) {
+	// Test that it doesn't mess up command config session and re-set the region
+	correctRegion := "eu-west-1"
+	sess, err := session.NewSession(&aws.Config{
+		Region: aws.String(correctRegion),
+	})
+	assert.NoError(t, err)
+	params := &config.CommandConfig{
+		Session: sess,
+	}
+
+	NewCloudWatchLogsClient(params, "us-east-2")
+
+	assert.Equal(t, correctRegion, aws.StringValue(params.Session.Config.Region), "Expected configured region to remain unchanged after call to NewCloudWatchLogsClient()")
+
+}


### PR DESCRIPTION
Fixes #644, see issue for description of the issue.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
