### PR TITLE
Bug fix: catch errors from UserDataBuilder.AddFile

### DIFF
--- a/ecs-cli/modules/cli/cluster/cluster_app.go
+++ b/ecs-cli/modules/cli/cluster/cluster_app.go
@@ -511,7 +511,10 @@ func cliFlagsToCfnStackParams(context *cli.Context, cluster, launchType string) 
 		// handle extra user data, which is a string slice flag
 		if userDataFiles := context.StringSlice(flags.UserDataFlag); len(userDataFiles) > 0 {
 			for _, file := range userDataFiles {
-				builder.AddFile(file)
+				err := builder.AddFile(file)
+				if err != nil {
+					return nil, err
+				}
 			}
 		}
 		userData, err := builder.Build()


### PR DESCRIPTION
Fixes a minor bug: previously errors weren't caught on from the `AddFile` method for user data. This meant that something like this will erroneously succeed:

```
ecs-cli up --capability-iam --extra-user-data some_file_that_doesnt_exit
```

This PR fixes the issue by checking the error.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
