### PR TITLE
Improve messaging and validation for registry creds

### DIFF
--- a/ecs-cli/modules/cli/compose/project/project_test.go
+++ b/ecs-cli/modules/cli/compose/project/project_test.go
@@ -296,11 +296,11 @@ func setupTestProject(t *testing.T) *ecsProject {
 }
 
 func setupTestProjectWithEcsParams(t *testing.T, ecsParamsFileName string) *ecsProject {
-	return setupTestProjectWithPrivateRegistryContext(t, ecsParamsFileName, "")
+	return setupTestProjectWithECSRegistryCreds(t, ecsParamsFileName, "")
 }
 
 // TODO: refactor into all-purpose 'setupTestProject' func
-func setupTestProjectWithPrivateRegistryContext(t *testing.T, ecsParamsFileName, credFileName string) *ecsProject {
+func setupTestProjectWithECSRegistryCreds(t *testing.T, ecsParamsFileName, credFileName string) *ecsProject {
 	envLookup, err := utils.GetDefaultEnvironmentLookup()
 	assert.NoError(t, err, "Unexpected error setting up environment lookup")
 
@@ -326,7 +326,7 @@ func setupTestProjectWithPrivateRegistryContext(t *testing.T, ecsParamsFileName,
 	}
 }
 
-func TestParsePrivateRegistryContext(t *testing.T) {
+func TestParseECSRegistryCreds(t *testing.T) {
 	credsInputString := `version: "1"
 registry_credential_outputs:
   task_execution_role: someTestRole
@@ -349,16 +349,16 @@ registry_credential_outputs:
 	credFileName := tmpfile.Name()
 	defer os.Remove(credFileName)
 
-	project := setupTestProjectWithPrivateRegistryContext(t, "", credFileName)
+	project := setupTestProjectWithECSRegistryCreds(t, "", credFileName)
 
 	_, err = tmpfile.Write(content)
 	assert.NoError(t, err, "Could not write data to ecs registry creds tempfile")
 
-	if err := project.parsePrivateRegistryContext(); err != nil {
+	if err := project.parseECSRegistryCreds(); err != nil {
 		t.Fatalf("Unexpected error parsing the "+regcredio.ECSCredFileBaseName+" data [%s]: %v", credsInputString, err)
 	}
 
-	ecsRegCreds := project.privateRegistryContext
+	ecsRegCreds := project.ecsRegistryCreds
 	assert.NotNil(t, ecsRegCreds, "Expected "+regcredio.ECSCredFileBaseName+" to be set on project")
 	assert.Equal(t, "1", ecsRegCreds.Version, "Expected Version to match")
 
@@ -380,10 +380,10 @@ registry_credential_outputs:
 	assert.ElementsMatch(t, []string{"test"}, secondOutputEntry.ContainerNames)
 }
 
-func TestParsePrivateRegistryContext_NoFile(t *testing.T) {
+func TestParseECSRegistryCreds_NoFile(t *testing.T) {
 	project := setupTestProject(t)
-	err := project.parsePrivateRegistryContext()
+	err := project.parseECSRegistryCreds()
 	if assert.NoError(t, err) {
-		assert.Nil(t, project.privateRegistryContext)
+		assert.Nil(t, project.ecsRegistryCreds)
 	}
 }

--- a/ecs-cli/modules/commands/regcreds/regcreds_command.go
+++ b/ecs-cli/modules/commands/regcreds/regcreds_command.go
@@ -36,9 +36,9 @@ func RegistryCredsCommand() cli.Command {
 func upCommand() cli.Command {
 	return cli.Command{
 		Name:         "up",
-		Usage:        "Generates AWS Secrets Manager secrets and an IAM Task Execution Role for use in an ECS Task Definition.",
+		Usage:        "Uses a YAML input file to generate AWS Secrets Manager secrets and an IAM Task Execution Role for use in an ECS Task Definition.",
 		Action:       regcreds.Up,
-		Flags:        regcredsUpFlags(),
+		Flags:        flags.AppendFlags(flags.OptionalRegionAndProfileFlags(), regcredsUpFlags()),
 		OnUsageError: flags.UsageErrorFactory("up"),
 	}
 }

--- a/ecs-cli/modules/utils/compose/convert_task_definition_test.go
+++ b/ecs-cli/modules/utils/compose/convert_task_definition_test.go
@@ -1523,7 +1523,7 @@ task_definition:
 // helper functions //
 //////////////////////
 
-func TestConvertToTaskDefinitionWithPrivRegContext(t *testing.T) {
+func TestConvertToTaskDefinitionWithECSRegistryCreds(t *testing.T) {
 	containerConfigs := testContainerConfigs([]string{"mysql", "wordpress"})
 	credsFileString := `version: "1"
 registry_credential_outputs:
@@ -1557,7 +1557,7 @@ registry_credential_outputs:
 	assert.Equal(t, "arn:aws:secretsmanager::secret:amazon-ecs-cli-setup-my.example.registry.net", aws.StringValue(mysqlContainer.RepositoryCredentials.CredentialsParameter))
 }
 
-func TestConvertToTaskDefinitionWithPrivRegContext_EmptyContainerCredMap(t *testing.T) {
+func TestConvertToTaskDefinitionWithECSRegistryCreds_EmptyContainerCredMap(t *testing.T) {
 	containerConfigs := testContainerConfigs([]string{"mysql", "wordpress"})
 	credsNoContainersFileString := `version: "1"
 registry_credential_outputs:
@@ -1589,7 +1589,7 @@ registry_credential_outputs:
 	assert.Empty(t, mysqlContainer.RepositoryCredentials)
 }
 
-func TestConvertToTaskDefinitionWithPrivRegContext_OverrideECSParamsValues(t *testing.T) {
+func TestConvertToTaskDefinitionWithECSRegistryCreds_OverrideECSParamsValues(t *testing.T) {
 	containerConfigs := testContainerConfigs([]string{"mysql", "wordpress"})
 
 	// set up reg cred file
@@ -1654,7 +1654,7 @@ task_definition:
 	assert.Equal(t, "arn:aws:secretsmanager::secret:amazon-ecs-cli-setup-my.example.registry.net", aws.StringValue(mysqlContainer.RepositoryCredentials.CredentialsParameter))
 }
 
-func TestConvertToTaskDefinitionWithPrivRegContext_ErrorOnDuplicateContainers(t *testing.T) {
+func TestConvertToTaskDefinitionWithECSRegistryCreds_ErrorOnDuplicateContainers(t *testing.T) {
 	containerConfigs := testContainerConfigs([]string{"mysql", "wordpress"})
 	credsDuplicateContainersFileString := `version: "1"
 registry_credential_outputs:
@@ -1698,7 +1698,7 @@ func convertToTaskDefinitionForTest(t *testing.T, containerConfigs []adapter.Con
 		Volumes:                volumeConfigs,
 		ContainerConfigs:       containerConfigs,
 		ECSParams:              ecsParams,
-		PrivRegistryContext:    ecsRegCreds,
+		ECSRegistryCreds:       ecsRegCreds,
 	}
 
 	taskDefinition, err := ConvertToTaskDefinition(testParams)

--- a/ecs-cli/modules/utils/regcredio/creds_readers_test.go
+++ b/ecs-cli/modules/utils/regcredio/creds_readers_test.go
@@ -32,7 +32,7 @@ registry_credentials:
       - nginx-custom
       - logging
   other-registry.net:
-    secret_manager_arn: aws:arn:secretsmanager:secret/repocreds-776ytg
+    secrets_manager_arn: aws:arn:secretsmanager:secret/repocreds-776ytg
     container_names:
       - metrics`
 
@@ -93,7 +93,7 @@ func TestReadCredsInputWithEnvVarsFromShell(t *testing.T) {
 	inputFileString := `version: 1
 registry_credentials:
   myrepo.someregistry.io:
-    secret_manager_arn: ${MY_SECRET_ARN}
+    secrets_manager_arn: ${MY_SECRET_ARN}
     username: ${MY_REG_USRNAME}
     password: ${MY_REG_PASSWORD}
     kms_key_id: ${MY_KEY_ARN}
@@ -135,7 +135,7 @@ func TestReadCredsInput_ErrorBadYaml(t *testing.T) {
 	badCredEntryFileString := `version: 1
 registry_credentials:
   myrepo.someregistry.io:
-  secret_manager_arn: arn:aws:secretmanager:some-secret
+  secrets_manager_arn: arn:aws:secretmanager:some-secret
   container_names:
 	  - test`
 

--- a/ecs-cli/modules/utils/regcredio/types.go
+++ b/ecs-cli/modules/utils/regcredio/types.go
@@ -26,7 +26,7 @@ type RegistryCreds map[string]RegistryCredEntry
 
 // RegistryCredEntry contains info needed to create an AWS Secrets Manager secret and match it to an ECS container(s)
 type RegistryCredEntry struct {
-	SecretManagerARN string   `yaml:"secret_manager_arn"`
+	SecretManagerARN string   `yaml:"secrets_manager_arn"`
 	Username         string   `yaml:"username"`
 	Password         string   `yaml:"password"`
 	KmsKeyID         string   `yaml:"kms_key_id"`


### PR DESCRIPTION
* Add optional region & profile flags to `registry-creds up`
* Add a warning when regcred containers present but not used with `compose`
* Add a warning re: no container names to `registry-creds up`
* Add messaging re: deleting sensitive input file
* Rename some things
* Cap max # of regcred entries to 10 on `registry-creds up`


### Examples:

warning on unused regcred containers with `compose`:
```
$~\regCredTest> ../../Documents/GO/src/github.com/aws/amazon-ecs-cli/bin/local/ecs-cli.exe compose create
INFO[0000] Found ecs-registry-creds file .\ecs-registry-creds_20181024T175954Z.yml
INFO[0000] Using ecs-registry-creds value arn:aws:secretsmanager:ap-northeast-1:##########:secret:amazon-ecs-cli-setup-dockerhub-YXVBuX  container name=web option name=credentials_parameter
WARN[0000] Containers listed with registry credentials but not used: [booooo metrics]
INFO[0000] Using ecs-registry-creds value nrtCreds       option name=task_execution_role
INFO[0001] Using ECS task definition                     TaskDefinition="regCredTest:4"
```

msg re: deleting input file after `registry-creds up` completes AND using `--region` flag:
```
$~> ./bin/local/ecs-cli.exe registry-creds up ./creds_input.yml --role-name nrtCreds --region ap-northeast-1
?[36mINFO?[0m[0000] Processing credentials for registry some-other-repo.net...
...
?[36mINFO?[0m[0003] Writing registry credential output to new file .\ecs-registry-creds_20181024T193417Z.yml
?[36mINFO?[0m[0003]
If your input file contains sensitive information, make sure that you delete it after use.
```

error when regcred entries > 10:
```
$~> ./bin/local/ecs-cli.exe registry-creds up ./creds_input.yml --role-name nrtCreds --region ap-northeast-1
?[31mFATA?[0m[0000] Error executing 'up': a max of 10 registry credential entries can be created at one time
```

warning re: no container names:
```
$~> ./bin/local/ecs-cli.exe registry-creds up ./creds_input.yml --role-name nrtCreds --region ap-northeast-1
?[33mWARN?[0m[0000] No container names given for registry 'some-other-repo.net1'; output cannot be incorporated into a task definition when running 'compose' command
?[36mINFO?[0m[0000] Processing credentials for registry dockerhub...
...
```

--
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
