### PR TITLE
support desired_count option when compose service create and up

### DIFF
--- a/ecs-cli/modules/commands/compose/service/compose_service_command.go
+++ b/ecs-cli/modules/commands/compose/service/compose_service_command.go
@@ -66,7 +66,7 @@ func createServiceCommand(factory composeFactory.ProjectFactory) cli.Command {
 		Name:         "create",
 		Usage:        "Creates an ECS service from your compose file. The service is created with a desired count of 0, so no containers are started by this command. Note that we do not recommend using plain text environment variables for sensitive information, such as credential data.",
 		Action:       compose.WithProject(factory, compose.ProjectCreate, true),
-		Flags:        flags.AppendFlags(deploymentConfigFlags(true), loadBalancerFlags(), flags.OptionalConfigFlags(), flags.OptionalLaunchTypeFlag(), flags.OptionalCreateLogsFlag(), serviceDiscoveryFlags()),
+		Flags:        flags.AppendFlags(deploymentConfigFlags(true), loadBalancerFlags(), flags.OptionalConfigFlags(), flags.OptionalLaunchTypeFlag(), flags.OptionalCreateLogsFlag(), serviceDiscoveryFlags(), DesiredCountFlag()),
 		OnUsageError: flags.UsageErrorFactory("create"),
 	}
 }
@@ -86,7 +86,7 @@ func upServiceCommand(factory composeFactory.ProjectFactory) cli.Command {
 		Name:         "up",
 		Usage:        "Creates a new ECS service or updates an existing one according to your compose file. For new services or existing services with a current desired count of 0, the desired count for the service is set to 1. For existing services with non-zero desired counts, a new task definition is created to reflect any changes to the compose file and the service is updated to use that task definition. In this case, the desired count does not change.",
 		Action:       compose.WithProject(factory, compose.ProjectUp, true),
-		Flags:        flags.AppendFlags(deploymentConfigFlags(true), loadBalancerFlags(), flags.OptionalConfigFlags(), ComposeServiceTimeoutFlag(), flags.OptionalLaunchTypeFlag(), flags.OptionalCreateLogsFlag(), ForceNewDeploymentFlag(), serviceDiscoveryFlags(), updateServiceDiscoveryFlags()),
+		Flags:        flags.AppendFlags(deploymentConfigFlags(true), loadBalancerFlags(), flags.OptionalConfigFlags(), ComposeServiceTimeoutFlag(), flags.OptionalLaunchTypeFlag(), flags.OptionalCreateLogsFlag(), ForceNewDeploymentFlag(), serviceDiscoveryFlags(), updateServiceDiscoveryFlags(), DesiredCountFlag()),
 		OnUsageError: flags.UsageErrorFactory("up"),
 	}
 }
@@ -275,4 +275,13 @@ func ForceNewDeploymentFlag() []cli.Flag {
 			Usage: "[Optional] Whether or not to force a new deployment of the service.",
 		},
 	}
+}
+
+func DesiredCountFlag() []cli.Flag {
+   return []cli.Flag{
+   		cli.Int64Flag{
+   			Name:  flags.DesiredCountFlag,
+   			Usage: "[Optional] Desired Count - Running per count task",
+   		},
+   }
 }

--- a/ecs-cli/modules/commands/flags/flags.go
+++ b/ecs-cli/modules/commands/flags/flags.go
@@ -128,6 +128,7 @@ const (
 	RoleFlag                                = "role"
 	ComposeServiceTimeOutFlag               = "timeout"
 	ForceDeploymentFlag                     = "force-deployment"
+	DesiredCountFlag                        = "desired-count"
 
 	// Registry Creds
 	UpdateExistingSecretsFlag = "update-existing-secrets"


### PR DESCRIPTION
*Description of changes:*

Currently, ecs-cli don't update desired count by service compose up/create.
This PR support `desired-count`  option, this can update desired count without scale command.
If provide option and already setting > 0 count in exists service , update desired count  by option.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
