### PR TITLE
Add `extends` to supportedComposeV1V2YamlOptions

### DIFF
--- a/ecs-cli/modules/cli/compose/logger/logger.go
+++ b/ecs-cli/modules/cli/compose/logger/logger.go
@@ -37,6 +37,7 @@ var supportedComposeV1V2YamlOptions = []string{
 	"entrypoint",
 	"env_file",
 	"environment",
+	"extends",
 	"extra_hosts",
 	"hostname",
 	"image",


### PR DESCRIPTION
Currently, ecs-cli reports warnings about `extends` field.

```yaml
version: '2'
services:
  web:
    extends:
      file: base.yml
      service: base
    command: bundle exec unicorn -p 3000 -c ./config/unicorn.rb
    ports:
      - "3000"
```

```
$ ecs-cli compose --cluster app --ecs-params ecs/ecs-params.yml -f ecs/web.yml -p web service up --deployment-max-percent=200 --deployment-min-healthy-percent=100
time="2018-12-04T02:58:18Z" level=warning msg="Skipping unsupported YAML option for service..." option name=extends service name=web
```

However, the `extends` field seems to be supported by ecs-cli.