### PR TITLE
Adding --scheduling-strategy (REPLICA or DAEMON) option

### DIFF
--- a/ecs-cli/modules/commands/compose/service/compose_service_command.go
+++ b/ecs-cli/modules/commands/compose/service/compose_service_command.go
@@ -66,7 +66,7 @@ func createServiceCommand(factory composeFactory.ProjectFactory) cli.Command {
 		Name:         "create",
 		Usage:        "Creates an ECS service from your compose file. The service is created with a desired count of 0, so no containers are started by this command. Note that we do not recommend using plain text environment variables for sensitive information, such as credential data.",
 		Action:       compose.WithProject(factory, compose.ProjectCreate, true),
-		Flags:        flags.AppendFlags(deploymentConfigFlags(true), loadBalancerFlags(), flags.OptionalConfigFlags(), flags.OptionalLaunchTypeFlag(), flags.OptionalCreateLogsFlag(), serviceDiscoveryFlags()),
+		Flags:        flags.AppendFlags(deploymentConfigFlags(true), loadBalancerFlags(), flags.OptionalConfigFlags(), flags.OptionalLaunchTypeFlag(), flags.OptionalCreateLogsFlag(), serviceDiscoveryFlags(), flags.OptionalSchedulingStrategyFlag()),
 		OnUsageError: flags.UsageErrorFactory("create"),
 	}
 }
@@ -86,7 +86,7 @@ func upServiceCommand(factory composeFactory.ProjectFactory) cli.Command {
 		Name:         "up",
 		Usage:        "Creates a new ECS service or updates an existing one according to your compose file. For new services or existing services with a current desired count of 0, the desired count for the service is set to 1. For existing services with non-zero desired counts, a new task definition is created to reflect any changes to the compose file and the service is updated to use that task definition. In this case, the desired count does not change.",
 		Action:       compose.WithProject(factory, compose.ProjectUp, true),
-		Flags:        flags.AppendFlags(deploymentConfigFlags(true), loadBalancerFlags(), flags.OptionalConfigFlags(), ComposeServiceTimeoutFlag(), flags.OptionalLaunchTypeFlag(), flags.OptionalCreateLogsFlag(), ForceNewDeploymentFlag(), serviceDiscoveryFlags(), updateServiceDiscoveryFlags()),
+		Flags:        flags.AppendFlags(deploymentConfigFlags(true), loadBalancerFlags(), flags.OptionalConfigFlags(), ComposeServiceTimeoutFlag(), flags.OptionalLaunchTypeFlag(), flags.OptionalCreateLogsFlag(), ForceNewDeploymentFlag(), serviceDiscoveryFlags(), updateServiceDiscoveryFlags(), flags.OptionalSchedulingStrategyFlag()),
 		OnUsageError: flags.UsageErrorFactory("up"),
 	}
 }

--- a/ecs-cli/modules/commands/flags/flags.go
+++ b/ecs-cli/modules/commands/flags/flags.go
@@ -79,8 +79,9 @@ const (
 	CFNStackNameFlag                     = "cfn-stack-name"
 	CFNStackNamePrefixDefaultValue       = utils.ECSCLIResourcePrefix
 
-	LaunchTypeFlag        = "launch-type"
-	DefaultLaunchTypeFlag = "default-launch-type"
+	LaunchTypeFlag         = "launch-type"
+	DefaultLaunchTypeFlag  = "default-launch-type"
+	SchedulingStrategyFlag = "scheduling-strategy"
 
 	// Cluster
 	AsgMaxSizeFlag                  = "size"
@@ -195,6 +196,18 @@ func OptionalLaunchTypeFlag() []cli.Flag {
 			Name: LaunchTypeFlag,
 			Usage: fmt.Sprintf(
 				"[Optional] Specifies the launch type. Options: EC2 or FARGATE. Overrides the default launch type stored in your cluster configuration. Defaults to EC2 if a cluster configuration is not used.",
+			),
+		},
+	}
+}
+
+// OptionalSchedulingStrategyFlag allows users to specify the scheduling strategy for their task/service/cluster
+func OptionalSchedulingStrategyFlag() []cli.Flag {
+	return []cli.Flag{
+		cli.StringFlag{
+			Name: SchedulingStrategyFlag,
+			Usage: fmt.Sprintf(
+				"[Optional] Specifies the scheduling strategy type. Options: REPLICA (default) or DAEMON.",
 			),
 		},
 	}


### PR DESCRIPTION
This partially addresses #540 

Adding optional `--scheduling-strategy` flag  on `ecs-cli compose service create` and `ecs-cli compose service up` commands:

`--scheduling-strategy value                          [Optional] Specifies the scheduling strategy type. Options: REPLICA (default) or DAEMON.` 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
