### PR TITLE
Resource Tagging in `ecs-cli up`

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Line Interface](http://aws.amazon.com/cli/) product detail page.
 	- [Viewing Container Logs](#viewing-container-logs)
 	- [Using FIPS Endpoints](#using-fips-endpoints)
 	- [Using Private Registry Authentication](#using-private-registry-authentication)
+	- [Tagging Resources](#tagging-resources)
 - [Amazon ECS CLI Commands](#amazon-ecs-cli-commands)
 - [Contributing to the CLI](#contributing-to-the-cli)
 - [License](#license)
@@ -1007,6 +1008,22 @@ INFO[0018] Started container... container=bf35a813-dd76-4fe0-b5a2-c1334c2331f4/l
  * to use an ecs-registry-creds output file from outside the current directory, you can specify it in with the `--registry-creds <value>` flag
 
  For more information about using private registries with ECS, see [Private Registry Authentication for Tasks](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/private-auth.html).
+
+### Tagging Resources
+
+ECS CLI Commmands support a `--tags` flag which allows you to specify AWS Resource Tags in the format `key=value,key2=value2,key3=value3`. Resource tags can be used for cost allocation, automation, access control, and more. See [AWS Tagging Strategies](https://aws.amazon.com/answers/account-management/aws-tagging-strategies/) for a discussion of use cases.
+
+#### ecs-cli up command
+
+ The ECS Cluster, and CloudFormation template with EC2 resources can be tagged. In addition, the ECS CLI will add tags to the following resources which are created by the CloudFormation template:
+ * VPC
+ * Subnets
+ * Internet Gateway
+ * Route Tables
+ * Security Group
+ * Autoscaling Group
+
+ For the autoscaling group, the ECS CLI will add a `Name` tag whose value will be `ECS Instance - <CloudFormation stack name>`, which will be propagated to your EC2 instances. You can override this behavior by specifying your own `Name` tag.
 
 ## Amazon ECS CLI Commands
 

--- a/ecs-cli/modules/cli/servicediscovery/servicediscovery_app.go
+++ b/ecs-cli/modules/cli/servicediscovery/servicediscovery_app.go
@@ -185,7 +185,7 @@ func create(c *cli.Context, networkMode, serviceName string, cfnClient cloudform
 		return nil, errors.Wrapf(err, "A Service Discovery Service CloudFormation stack for %s already exists, failed to delete existing stack", serviceName)
 	}
 
-	if _, err := cfnClient.CreateStack(cloudformation.GetSDSTemplate(), sdsStackName, false, sdsParams); err != nil {
+	if _, err := cfnClient.CreateStack(cloudformation.GetSDSTemplate(), sdsStackName, false, sdsParams, nil); err != nil {
 		return nil, err
 	}
 
@@ -221,7 +221,7 @@ func createNamespace(c *cli.Context, networkMode, serviceName, clusterName strin
 		return nil, errors.Wrapf(err, "A Private DNS Namespace CloudFormation stack for %s already exists, failed to delete existing stack: %s", serviceName, err)
 	}
 
-	if _, err := cfnClient.CreateStack(cloudformation.GetPrivateNamespaceTemplate(), namespaceStackName, false, namespaceParams); err != nil {
+	if _, err := cfnClient.CreateStack(cloudformation.GetPrivateNamespaceTemplate(), namespaceStackName, false, namespaceParams, nil); err != nil {
 		return nil, err
 	}
 

--- a/ecs-cli/modules/cli/servicediscovery/servicediscovery_app_test.go
+++ b/ecs-cli/modules/cli/servicediscovery/servicediscovery_app_test.go
@@ -182,10 +182,10 @@ func TestCreateServiceDiscoveryForceRecreate(t *testing.T) {
 		// validate that existing SDS stack is deleted
 		mockCloudformation.EXPECT().DeleteStack(testNamespaceStackName).Return(nil),
 		mockCloudformation.EXPECT().WaitUntilDeleteComplete(testNamespaceStackName).Return(nil),
-		mockCloudformation.EXPECT().CreateStack(gomock.Any(), testNamespaceStackName, false, gomock.Any()).Do(func(x, y, w, z interface{}) {
-			stackName := y.(string)
-			capabilityIAM := w.(bool)
-			cfnParams := z.(*cloudformation.CfnStackParams)
+		mockCloudformation.EXPECT().CreateStack(gomock.Any(), testNamespaceStackName, false, gomock.Any(), gomock.Any()).Do(func(v, w, x, y, z interface{}) {
+			stackName := w.(string)
+			capabilityIAM := x.(bool)
+			cfnParams := y.(*cloudformation.CfnStackParams)
 			validateCFNParam(testNamespaceName, parameterKeyNamespaceName, cfnParams, t)
 			validateCFNParam(testVPCID, parameterKeyVPCID, cfnParams, t)
 			assert.False(t, capabilityIAM, "Expected capability capabilityIAM to be false")
@@ -197,10 +197,10 @@ func TestCreateServiceDiscoveryForceRecreate(t *testing.T) {
 		// Validate that existing Namespace stack is deleted
 		mockCloudformation.EXPECT().DeleteStack(testSDSStackName).Return(nil),
 		mockCloudformation.EXPECT().WaitUntilDeleteComplete(testSDSStackName).Return(nil),
-		mockCloudformation.EXPECT().CreateStack(gomock.Any(), testSDSStackName, false, gomock.Any()).Do(func(x, y, w, z interface{}) {
-			stackName := y.(string)
-			capabilityIAM := w.(bool)
-			cfnParams := z.(*cloudformation.CfnStackParams)
+		mockCloudformation.EXPECT().CreateStack(gomock.Any(), testSDSStackName, false, gomock.Any(), gomock.Any()).Do(func(v, w, x, y, z interface{}) {
+			stackName := w.(string)
+			capabilityIAM := x.(bool)
+			cfnParams := y.(*cloudformation.CfnStackParams)
 			validateCFNParam(testNamespaceID, parameterKeyNamespaceID, cfnParams, t)
 			validateCFNParam(testServiceName, parameterKeySDSName, cfnParams, t)
 			validateCFNParam(servicediscovery.RecordTypeA, parameterKeyDNSType, cfnParams, t)
@@ -798,10 +798,10 @@ func testCreateServiceDiscovery(t *testing.T, networkMode string, ecsParamsSD *u
 	if createNamespace {
 		expectedCFNCalls = append(expectedCFNCalls, []*gomock.Call{
 			mockCloudformation.EXPECT().ValidateStackExists(testNamespaceStackName).Return(fmt.Errorf("Stack Not Found")),
-			mockCloudformation.EXPECT().CreateStack(gomock.Any(), testNamespaceStackName, false, gomock.Any()).Do(func(x, y, w, z interface{}) {
-				stackName := y.(string)
-				capabilityIAM := w.(bool)
-				cfnParams := z.(*cloudformation.CfnStackParams)
+			mockCloudformation.EXPECT().CreateStack(gomock.Any(), testNamespaceStackName, false, gomock.Any(), gomock.Any()).Do(func(v, w, x, y, z interface{}) {
+				stackName := w.(string)
+				capabilityIAM := x.(bool)
+				cfnParams := y.(*cloudformation.CfnStackParams)
 				validateNamespace(t, cfnParams)
 				assert.False(t, capabilityIAM, "Expected capability capabilityIAM to be false")
 				assert.Equal(t, testNamespaceStackName, stackName, "Expected stack name to match")
@@ -812,10 +812,10 @@ func testCreateServiceDiscovery(t *testing.T, networkMode string, ecsParamsSD *u
 	}
 	expectedCFNCalls = append(expectedCFNCalls, []*gomock.Call{
 		mockCloudformation.EXPECT().ValidateStackExists(testSDSStackName).Return(fmt.Errorf("Stack Not Found")),
-		mockCloudformation.EXPECT().CreateStack(gomock.Any(), testSDSStackName, false, gomock.Any()).Do(func(x, y, w, z interface{}) {
-			stackName := y.(string)
-			capabilityIAM := w.(bool)
-			cfnParams := z.(*cloudformation.CfnStackParams)
+		mockCloudformation.EXPECT().CreateStack(gomock.Any(), testSDSStackName, false, gomock.Any(), gomock.Any()).Do(func(v, w, x, y, z interface{}) {
+			stackName := w.(string)
+			capabilityIAM := x.(bool)
+			cfnParams := y.(*cloudformation.CfnStackParams)
 			validateSDS(t, cfnParams)
 			assert.False(t, capabilityIAM, "Expected capability capabilityIAM to be false")
 			assert.Equal(t, testSDSStackName, stackName, "Expected stack name to match")

--- a/ecs-cli/modules/clients/aws/cloudformation/client.go
+++ b/ecs-cli/modules/clients/aws/cloudformation/client.go
@@ -88,7 +88,7 @@ func init() {
 
 // CloudformationClient defines methods to interact the with the CloudFormationAPI interface.
 type CloudformationClient interface {
-	CreateStack(string, string, bool, *CfnStackParams) (string, error)
+	CreateStack(string, string, bool, *CfnStackParams, []*cloudformation.Tag) (string, error)
 	WaitUntilCreateComplete(string) error
 	DeleteStack(string) error
 	DescribeStacks(string) (*cloudformation.DescribeStacksOutput, error)
@@ -124,7 +124,7 @@ func newClient(config *config.CommandConfig, client cloudformationiface.CloudFor
 }
 
 // CreateStack creates the cloudformation stack by invoking the sdk's CreateStack API and returns the stack id.
-func (c *cloudformationClient) CreateStack(template, stackName string, capabilityIAM bool, params *CfnStackParams) (string, error) {
+func (c *cloudformationClient) CreateStack(template, stackName string, capabilityIAM bool, params *CfnStackParams, tags []*cloudformation.Tag) (string, error) {
 	input := &cloudformation.CreateStackInput{
 		TemplateBody: aws.String(template),
 		StackName:    aws.String(stackName),
@@ -132,6 +132,9 @@ func (c *cloudformationClient) CreateStack(template, stackName string, capabilit
 	}
 	if capabilityIAM {
 		input.Capabilities = aws.StringSlice([]string{cloudformation.CapabilityCapabilityIam})
+	}
+	if len(tags) > 0 {
+		input.Tags = tags
 	}
 	output, err := c.client.CreateStack(input)
 

--- a/ecs-cli/modules/clients/aws/cloudformation/mock/client.go
+++ b/ecs-cli/modules/clients/aws/cloudformation/mock/client.go
@@ -49,16 +49,16 @@ func (m *MockCloudformationClient) EXPECT() *MockCloudformationClientMockRecorde
 }
 
 // CreateStack mocks base method
-func (m *MockCloudformationClient) CreateStack(arg0, arg1 string, arg2 bool, arg3 *cloudformation.CfnStackParams) (string, error) {
-	ret := m.ctrl.Call(m, "CreateStack", arg0, arg1, arg2, arg3)
+func (m *MockCloudformationClient) CreateStack(arg0, arg1 string, arg2 bool, arg3 *cloudformation.CfnStackParams, arg4 []*cloudformation0.Tag) (string, error) {
+	ret := m.ctrl.Call(m, "CreateStack", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CreateStack indicates an expected call of CreateStack
-func (mr *MockCloudformationClientMockRecorder) CreateStack(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateStack", reflect.TypeOf((*MockCloudformationClient)(nil).CreateStack), arg0, arg1, arg2, arg3)
+func (mr *MockCloudformationClientMockRecorder) CreateStack(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateStack", reflect.TypeOf((*MockCloudformationClient)(nil).CreateStack), arg0, arg1, arg2, arg3, arg4)
 }
 
 // DeleteStack mocks base method

--- a/ecs-cli/modules/clients/aws/ecs/client.go
+++ b/ecs-cli/modules/clients/aws/ecs/client.go
@@ -37,7 +37,7 @@ type ProcessTasksAction func(tasks []*ecs.Task) error
 // ECSClient is an interface that specifies only the methods used from the sdk interface. Intended to make mocking and testing easier.
 type ECSClient interface {
 	// Cluster related
-	CreateCluster(clusterName string) (string, error)
+	CreateCluster(clusterName string, tags []*ecs.Tag) (string, error)
 	DeleteCluster(clusterName string) (string, error)
 	IsActiveCluster(clusterName string) (bool, error)
 
@@ -83,8 +83,15 @@ func newClient(config *config.CommandConfig, client ecsiface.ECSAPI) ECSClient {
 	}
 }
 
-func (c *ecsClient) CreateCluster(clusterName string) (string, error) {
-	resp, err := c.client.CreateCluster(&ecs.CreateClusterInput{ClusterName: &clusterName})
+func (c *ecsClient) CreateCluster(clusterName string, tags []*ecs.Tag) (string, error) {
+	input := &ecs.CreateClusterInput{
+		ClusterName: &clusterName,
+	}
+	if len(tags) > 0 {
+		input.Tags = tags
+	}
+	resp, err := c.client.CreateCluster(input)
+
 	if err != nil {
 		log.WithFields(log.Fields{
 			"cluster": clusterName,

--- a/ecs-cli/modules/clients/aws/ecs/mock/client.go
+++ b/ecs-cli/modules/clients/aws/ecs/mock/client.go
@@ -50,16 +50,16 @@ func (m *MockECSClient) EXPECT() *MockECSClientMockRecorder {
 }
 
 // CreateCluster mocks base method
-func (m *MockECSClient) CreateCluster(arg0 string) (string, error) {
-	ret := m.ctrl.Call(m, "CreateCluster", arg0)
+func (m *MockECSClient) CreateCluster(arg0 string, arg1 []*ecs0.Tag) (string, error) {
+	ret := m.ctrl.Call(m, "CreateCluster", arg0, arg1)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CreateCluster indicates an expected call of CreateCluster
-func (mr *MockECSClientMockRecorder) CreateCluster(arg0 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateCluster", reflect.TypeOf((*MockECSClient)(nil).CreateCluster), arg0)
+func (mr *MockECSClientMockRecorder) CreateCluster(arg0, arg1 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateCluster", reflect.TypeOf((*MockECSClient)(nil).CreateCluster), arg0, arg1)
 }
 
 // CreateService mocks base method

--- a/ecs-cli/modules/commands/cluster/cluster_command.go
+++ b/ecs-cli/modules/commands/cluster/cluster_command.go
@@ -132,6 +132,10 @@ func clusterUpFlags() []cli.Flag {
 			Name:  flags.ForceFlag + ", f",
 			Usage: "[Optional] Forces the recreation of any existing resources that match your current configuration. This option is useful for cleaning up stale resources from previous failed attempts.",
 		},
+		cli.StringFlag{
+			Name:  flags.ResourceTagsFlag,
+			Usage: "[Optional] Specify tags which will be added to AWS Resources created for your cluster. Specify in the format 'key1=value1,key2=value2,key3=value3'",
+		},
 	}
 }
 

--- a/ecs-cli/modules/commands/flags/flags.go
+++ b/ecs-cli/modules/commands/flags/flags.go
@@ -140,6 +140,8 @@ const (
 	OutputDirFlag             = "output-dir"
 
 	DesiredTaskStatus = "desired-status"
+
+	ResourceTagsFlag = "tags"
 )
 
 // OptionalRegionAndProfileFlags provides these flags:
@@ -251,7 +253,7 @@ func DebugFlag() []cli.Flag {
 func FipsEndpointFlag() []cli.Flag {
 	return []cli.Flag{
 		cli.BoolFlag{
-			Name: UseFIPSFlag + ",fips",
+			Name:  UseFIPSFlag + ",fips",
 			Usage: "[Optional] Routes calls to AWS services through FIPS endpoints.",
 		},
 	}

--- a/ecs-cli/modules/utils/utils.go
+++ b/ecs-cli/modules/utils/utils.go
@@ -17,8 +17,11 @@ package utils
 import (
 	"fmt"
 	"os"
+	"strings"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/ecs"
 )
 
 const (
@@ -57,4 +60,21 @@ func EntityAlreadyExists(err error) bool {
 		return awsErr.Code() == "EntityAlreadyExists"
 	}
 	return false
+}
+
+// GetTags parses AWS Resource tags from the flag value
+// users specify tags in this format: key1=value1,key2=value2,key3=value3
+func GetTags(flagValue string, tags []*ecs.Tag) ([]*ecs.Tag, error) {
+	keyValPairs := strings.Split(flagValue, ",")
+	for _, pair := range keyValPairs {
+		split := strings.Split(pair, "=")
+		if len(split) != 2 {
+			return nil, fmt.Errorf("Tag input not formatted correctly: %s", pair)
+		}
+		tags = append(tags, &ecs.Tag{
+			Key:   aws.String(split[0]),
+			Value: aws.String(split[1]),
+		})
+	}
+	return tags, nil
 }

--- a/ecs-cli/modules/utils/utils.go
+++ b/ecs-cli/modules/utils/utils.go
@@ -66,14 +66,14 @@ func EntityAlreadyExists(err error) bool {
 // users specify tags in this format: key1=value1,key2=value2,key3=value3
 func GetTags(flagValue string, tags []*ecs.Tag) ([]*ecs.Tag, error) {
 	keyValPairs := strings.Split(flagValue, ",")
-	for _, pair := range keyValPairs {
-		split := strings.Split(pair, "=")
-		if len(split) != 2 {
-			return nil, fmt.Errorf("Tag input not formatted correctly: %s", pair)
+	for _, kv := range keyValPairs {
+		pair := strings.Split(kv, "=")
+		if len(pair) != 2 {
+			return nil, fmt.Errorf("Tag input not formatted correctly: %s", kv)
 		}
 		tags = append(tags, &ecs.Tag{
-			Key:   aws.String(split[0]),
-			Value: aws.String(split[1]),
+			Key:   aws.String(pair[0]),
+			Value: aws.String(pair[1]),
 		})
 	}
 	return tags, nil


### PR DESCRIPTION
*Issue #, if available:*
#670

*Description of changes:*
Support tagging for resources created by `ecs-cli up`, with the exception of:

- Container Instances (more complicated, will be in a separate PR - EC2 Instances are supported in this PR tho)
- Instance IAM Role (CloudFormation doesn't support tags)
- Instance Profile (Doesn't support tagging)
- Autoscaling Launch Config (Doesn't support tagging)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
