### PR TITLE
Resource Tagging and ECS Managed Tags in Compose Commands

### DIFF
--- a/ecs-cli/modules/cli/cluster/cluster_app.go
+++ b/ecs-cli/modules/cli/cluster/cluster_app.go
@@ -289,7 +289,7 @@ func createCluster(context *cli.Context, awsClients *AWSClients, commandConfig *
 
 	tags := make([]*ecs.Tag, 0)
 	if tagVal := context.String(flags.ResourceTagsFlag); tagVal != "" {
-		tags, err = utils.GetTags(tagVal, tags)
+		tags, err = utils.ParseTags(tagVal, tags)
 		if err != nil {
 			return err
 		}
@@ -409,7 +409,7 @@ func createEmptyCluster(context *cli.Context, ecsClient ecsclient.ECSClient, cfn
 	tags := make([]*ecs.Tag, 0)
 	var err error
 	if tagVal := context.String(flags.ResourceTagsFlag); tagVal != "" {
-		tags, err = utils.GetTags(tagVal, tags)
+		tags, err = utils.ParseTags(tagVal, tags)
 		if err != nil {
 			return err
 		}

--- a/ecs-cli/modules/cli/compose/entity/entity.go
+++ b/ecs-cli/modules/cli/compose/entity/entity.go
@@ -41,4 +41,5 @@ type ProjectEntity interface {
 	TaskDefinitionCache() cache.Cache
 	SetTaskDefinition(taskDefinition *ecs.TaskDefinition)
 	EntityType() types.Type
+	GetTags() ([]*ecs.Tag, error)
 }

--- a/ecs-cli/modules/cli/compose/entity/mock/entity.go
+++ b/ecs-cli/modules/cli/compose/entity/mock/entity.go
@@ -100,6 +100,19 @@ func (mr *MockProjectEntityMockRecorder) EntityType() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EntityType", reflect.TypeOf((*MockProjectEntity)(nil).EntityType))
 }
 
+// GetTags mocks base method
+func (m *MockProjectEntity) GetTags() ([]*ecs.Tag, error) {
+	ret := m.ctrl.Call(m, "GetTags")
+	ret0, _ := ret[0].([]*ecs.Tag)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetTags indicates an expected call of GetTags
+func (mr *MockProjectEntityMockRecorder) GetTags() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTags", reflect.TypeOf((*MockProjectEntity)(nil).GetTags))
+}
+
 // Info mocks base method
 func (m *MockProjectEntity) Info(arg0 bool, arg1 string) (project.InfoSet, error) {
 	ret := m.ctrl.Call(m, "Info", arg0, arg1)

--- a/ecs-cli/modules/clients/aws/ecs/client.go
+++ b/ecs-cli/modules/clients/aws/ecs/client.go
@@ -48,7 +48,6 @@ type ECSClient interface {
 	DeleteService(serviceName string) error
 
 	// Task Definition related
-	RegisterTaskDefinition(request *ecs.RegisterTaskDefinitionInput) (*ecs.TaskDefinition, error)
 	RegisterTaskDefinitionIfNeeded(request *ecs.RegisterTaskDefinitionInput, tdCache cache.Cache) (*ecs.TaskDefinition, error)
 	DescribeTaskDefinition(taskDefinitionName string) (*ecs.TaskDefinition, error)
 
@@ -177,7 +176,7 @@ func (c *ecsClient) DescribeService(serviceName string) (*ecs.DescribeServicesOu
 	return output, err
 }
 
-func (c *ecsClient) RegisterTaskDefinition(request *ecs.RegisterTaskDefinitionInput) (*ecs.TaskDefinition, error) {
+func (c *ecsClient) registerTaskDefinition(request *ecs.RegisterTaskDefinitionInput) (*ecs.TaskDefinition, error) {
 	resp, err := c.client.RegisterTaskDefinition(request)
 	if err != nil {
 		log.WithFields(log.Fields{
@@ -260,7 +259,7 @@ func (c *ecsClient) constructTaskDefinitionCacheHash(taskDefinition *ecs.TaskDef
 
 // persistTaskDefinition registers the task definition with ECS and creates a new local cache entry
 func persistTaskDefinition(request *ecs.RegisterTaskDefinitionInput, client *ecsClient, taskDefinitionCache cache.Cache) (*ecs.TaskDefinition, error) {
-	resp, err := client.RegisterTaskDefinition(request)
+	resp, err := client.registerTaskDefinition(request)
 	if err != nil {
 		return nil, err
 	}

--- a/ecs-cli/modules/clients/aws/ecs/mock/client.go
+++ b/ecs-cli/modules/clients/aws/ecs/mock/client.go
@@ -176,19 +176,6 @@ func (mr *MockECSClientMockRecorder) IsActiveCluster(arg0 interface{}) *gomock.C
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsActiveCluster", reflect.TypeOf((*MockECSClient)(nil).IsActiveCluster), arg0)
 }
 
-// RegisterTaskDefinition mocks base method
-func (m *MockECSClient) RegisterTaskDefinition(arg0 *ecs0.RegisterTaskDefinitionInput) (*ecs0.TaskDefinition, error) {
-	ret := m.ctrl.Call(m, "RegisterTaskDefinition", arg0)
-	ret0, _ := ret[0].(*ecs0.TaskDefinition)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// RegisterTaskDefinition indicates an expected call of RegisterTaskDefinition
-func (mr *MockECSClientMockRecorder) RegisterTaskDefinition(arg0 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterTaskDefinition", reflect.TypeOf((*MockECSClient)(nil).RegisterTaskDefinition), arg0)
-}
-
 // RegisterTaskDefinitionIfNeeded mocks base method
 func (m *MockECSClient) RegisterTaskDefinitionIfNeeded(arg0 *ecs0.RegisterTaskDefinitionInput, arg1 cache.Cache) (*ecs0.TaskDefinition, error) {
 	ret := m.ctrl.Call(m, "RegisterTaskDefinitionIfNeeded", arg0, arg1)

--- a/ecs-cli/modules/commands/compose/compose_command.go
+++ b/ecs-cli/modules/commands/compose/compose_command.go
@@ -111,7 +111,7 @@ func createCommand(factory composeFactory.ProjectFactory) cli.Command {
 		Name:         "create",
 		Usage:        "Creates an ECS task definition from your compose file. Note that we do not recommend using plain text environment variables for sensitive information, such as credential data.",
 		Action:       compose.WithProject(factory, compose.ProjectCreate, false),
-		Flags:        flags.AppendFlags(flags.OptionalConfigFlags(), flags.OptionalLaunchTypeFlag(), flags.OptionalCreateLogsFlag()),
+		Flags:        flags.AppendFlags(flags.OptionalConfigFlags(), flags.OptionalLaunchTypeFlag(), flags.OptionalCreateLogsFlag(), resourceTagsFlag(false)),
 		OnUsageError: flags.UsageErrorFactory("create"),
 	}
 }
@@ -132,7 +132,7 @@ func upCommand(factory composeFactory.ProjectFactory) cli.Command {
 		Name:         "up",
 		Usage:        "Creates an ECS task definition from your compose file (if it does not already exist) and runs one instance of that task on your cluster (a combination of create and start).",
 		Action:       compose.WithProject(factory, compose.ProjectUp, false),
-		Flags:        flags.AppendFlags(flags.OptionalConfigFlags(), flags.OptionalLaunchTypeFlag(), flags.OptionalCreateLogsFlag(), flags.OptionalForceUpdateFlag()),
+		Flags:        flags.AppendFlags(flags.OptionalConfigFlags(), flags.OptionalLaunchTypeFlag(), flags.OptionalCreateLogsFlag(), flags.OptionalForceUpdateFlag(), resourceTagsFlag(true), disableECSManagedTagsFlag()),
 		OnUsageError: flags.UsageErrorFactory("up"),
 	}
 }
@@ -142,7 +142,7 @@ func startCommand(factory composeFactory.ProjectFactory) cli.Command {
 		Name:         "start",
 		Usage:        "Starts a single task from the task definition created from your compose file.",
 		Action:       compose.WithProject(factory, compose.ProjectStart, false),
-		Flags:        flags.AppendFlags(flags.OptionalConfigFlags(), flags.OptionalLaunchTypeFlag(), flags.OptionalCreateLogsFlag()),
+		Flags:        flags.AppendFlags(flags.OptionalConfigFlags(), flags.OptionalLaunchTypeFlag(), flags.OptionalCreateLogsFlag(), resourceTagsFlag(true), disableECSManagedTagsFlag()),
 		OnUsageError: flags.UsageErrorFactory("start"),
 	}
 }
@@ -153,7 +153,7 @@ func runCommand(factory composeFactory.ProjectFactory) cli.Command {
 		Usage:        "Starts all containers overriding commands with the supplied one-off commands for the containers.",
 		ArgsUsage:    "[CONTAINER_NAME] [\"COMMAND ...\"] [CONTAINER_NAME] [\"COMMAND ...\"] ...",
 		Action:       compose.WithProject(factory, compose.ProjectRun, false),
-		Flags:        flags.OptionalConfigFlags(),
+		Flags:        flags.AppendFlags(flags.OptionalConfigFlags(), resourceTagsFlag(true), disableECSManagedTagsFlag()),
 		OnUsageError: flags.UsageErrorFactory("run"),
 	}
 }
@@ -174,7 +174,29 @@ func scaleCommand(factory composeFactory.ProjectFactory) cli.Command {
 		Name:         "scale",
 		Usage:        "ecs-cli compose scale [count] - scales the number of running tasks to the specified count.",
 		Action:       compose.WithProject(factory, compose.ProjectScale, false),
-		Flags:        flags.AppendFlags(flags.OptionalConfigFlags(), flags.OptionalLaunchTypeFlag()),
+		Flags:        flags.AppendFlags(flags.OptionalConfigFlags(), flags.OptionalLaunchTypeFlag(), resourceTagsFlag(true), disableECSManagedTagsFlag()),
 		OnUsageError: flags.UsageErrorFactory("scale"),
+	}
+}
+
+func resourceTagsFlag(runTasks bool) []cli.Flag {
+	usage := "[Optional] Specify resource tags for your Task Definition. Specify tags in the format 'key1=value1,key2=value2,key3=value3'."
+	if runTasks {
+		usage = "[Optional] Specify resource tags for your ECS Tasks and Task Definition. Specify tags in the format 'key1=value1,key2=value2,key3=value3'."
+	}
+	return []cli.Flag{
+		cli.StringFlag{
+			Name:  flags.ResourceTagsFlag,
+			Usage: usage,
+		},
+	}
+}
+
+func disableECSManagedTagsFlag() []cli.Flag {
+	return []cli.Flag{
+		cli.BoolFlag{
+			Name:  flags.DisableECSManagedTagsFlag,
+			Usage: "[Optional] Disable ECS Managed Tags (A Cluster name tag will not be automatically added to tasks).",
+		},
 	}
 }

--- a/ecs-cli/modules/commands/compose/service/compose_service_command.go
+++ b/ecs-cli/modules/commands/compose/service/compose_service_command.go
@@ -66,7 +66,7 @@ func createServiceCommand(factory composeFactory.ProjectFactory) cli.Command {
 		Name:         "create",
 		Usage:        "Creates an ECS service from your compose file. The service is created with a desired count of 0, so no containers are started by this command. Note that we do not recommend using plain text environment variables for sensitive information, such as credential data.",
 		Action:       compose.WithProject(factory, compose.ProjectCreate, true),
-		Flags:        flags.AppendFlags(deploymentConfigFlags(true), loadBalancerFlags(), flags.OptionalConfigFlags(), flags.OptionalLaunchTypeFlag(), flags.OptionalCreateLogsFlag(), serviceDiscoveryFlags(), flags.OptionalSchedulingStrategyFlag()),
+		Flags:        flags.AppendFlags(deploymentConfigFlags(true), loadBalancerFlags(), flags.OptionalConfigFlags(), flags.OptionalLaunchTypeFlag(), flags.OptionalCreateLogsFlag(), serviceDiscoveryFlags(), flags.OptionalSchedulingStrategyFlag(), taggingFlags()),
 		OnUsageError: flags.UsageErrorFactory("create"),
 	}
 }
@@ -86,7 +86,7 @@ func upServiceCommand(factory composeFactory.ProjectFactory) cli.Command {
 		Name:         "up",
 		Usage:        "Creates a new ECS service or updates an existing one according to your compose file. For new services or existing services with a current desired count of 0, the desired count for the service is set to 1. For existing services with non-zero desired counts, a new task definition is created to reflect any changes to the compose file and the service is updated to use that task definition. In this case, the desired count does not change.",
 		Action:       compose.WithProject(factory, compose.ProjectUp, true),
-		Flags:        flags.AppendFlags(deploymentConfigFlags(true), loadBalancerFlags(), flags.OptionalConfigFlags(), ComposeServiceTimeoutFlag(), flags.OptionalLaunchTypeFlag(), flags.OptionalCreateLogsFlag(), ForceNewDeploymentFlag(), serviceDiscoveryFlags(), updateServiceDiscoveryFlags(), flags.OptionalSchedulingStrategyFlag()),
+		Flags:        flags.AppendFlags(deploymentConfigFlags(true), loadBalancerFlags(), flags.OptionalConfigFlags(), ComposeServiceTimeoutFlag(), flags.OptionalLaunchTypeFlag(), flags.OptionalCreateLogsFlag(), ForceNewDeploymentFlag(), serviceDiscoveryFlags(), updateServiceDiscoveryFlags(), flags.OptionalSchedulingStrategyFlag(), taggingFlags()),
 		OnUsageError: flags.UsageErrorFactory("up"),
 	}
 }
@@ -273,6 +273,19 @@ func ForceNewDeploymentFlag() []cli.Flag {
 		cli.BoolFlag{
 			Name:  flags.ForceDeploymentFlag,
 			Usage: "[Optional] Whether or not to force a new deployment of the service.",
+		},
+	}
+}
+
+func taggingFlags() []cli.Flag {
+	return []cli.Flag{
+		cli.BoolFlag{
+			Name:  flags.DisableECSManagedTagsFlag,
+			Usage: "[Optional] Disable ECS Managed Tags (Cluster name and Service name tags will not be automatically added to tasks). Only affects new Services.",
+		},
+		cli.StringFlag{
+			Name:  flags.ResourceTagsFlag,
+			Usage: "[Optional] Specify resource tags for your ECS Service and Task Definition; tags are only added when resources are created. Tags will be propogated from your task definition to tasks created by the service. Specify tags in the format 'key1=value1,key2=value2,key3=value3'",
 		},
 	}
 }

--- a/ecs-cli/modules/commands/flags/flags.go
+++ b/ecs-cli/modules/commands/flags/flags.go
@@ -141,7 +141,8 @@ const (
 
 	DesiredTaskStatus = "desired-status"
 
-	ResourceTagsFlag = "tags"
+	ResourceTagsFlag          = "tags"
+	DisableECSManagedTagsFlag = "disable-ecs-managed-tags"
 )
 
 // OptionalRegionAndProfileFlags provides these flags:

--- a/ecs-cli/modules/utils/utils.go
+++ b/ecs-cli/modules/utils/utils.go
@@ -62,9 +62,9 @@ func EntityAlreadyExists(err error) bool {
 	return false
 }
 
-// GetTags parses AWS Resource tags from the flag value
+// ParseTags parses AWS Resource tags from the flag value
 // users specify tags in this format: key1=value1,key2=value2,key3=value3
-func GetTags(flagValue string, tags []*ecs.Tag) ([]*ecs.Tag, error) {
+func ParseTags(flagValue string, tags []*ecs.Tag) ([]*ecs.Tag, error) {
 	keyValPairs := strings.Split(flagValue, ",")
 	for _, kv := range keyValPairs {
 		pair := strings.Split(kv, "=")

--- a/ecs-cli/modules/utils/utils_test.go
+++ b/ecs-cli/modules/utils/utils_test.go
@@ -18,6 +18,8 @@ import (
 	"os"
 	"testing"
 
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ecs"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -49,6 +51,54 @@ func TestGetHomeDirInWindows(t *testing.T) {
 
 	_, err := GetHomeDir()
 	assert.NoError(t, err, "Unexpected error getting home dir")
+}
+
+func TestParseTags(t *testing.T) {
+	actualTags := make([]*ecs.Tag, 0)
+	expectedTags := []*ecs.Tag{
+		&ecs.Tag{
+			Key:   aws.String("Pink"),
+			Value: aws.String("Floyd"),
+		},
+		&ecs.Tag{
+			Key:   aws.String("Tame"),
+			Value: aws.String("Impala"),
+		},
+	}
+
+	var err error
+	actualTags, err = ParseTags("Pink=Floyd,Tame=Impala", actualTags)
+	assert.NoError(t, err, "Unexpected error calling ParseTags")
+	assert.ElementsMatch(t, actualTags, expectedTags, "Expected tags to match")
+
+}
+
+func TestParseTagsEmptyValue(t *testing.T) {
+	actualTags := make([]*ecs.Tag, 0)
+	expectedTags := []*ecs.Tag{
+		&ecs.Tag{
+			Key:   aws.String("thecheese"),
+			Value: aws.String(""),
+		},
+		&ecs.Tag{
+			Key:   aws.String("standsalone"),
+			Value: aws.String(""),
+		},
+	}
+
+	var err error
+	actualTags, err = ParseTags("thecheese=,standsalone=", actualTags)
+	assert.NoError(t, err, "Unexpected error calling ParseTags")
+	assert.ElementsMatch(t, actualTags, expectedTags, "Expected tags to match")
+
+}
+
+func TestParseTagInvalidFormat(t *testing.T) {
+	actualTags := make([]*ecs.Tag, 0)
+
+	var err error
+	_, err = ParseTags("incorrectly=formatted,tags", actualTags)
+	assert.Error(t, err, "Expected error calling ParseTags")
 }
 
 func tempDir(t *testing.T) string {


### PR DESCRIPTION
*Description of changes:*
Added `--tags` to compose commands. Also:

- Tags propagate from a Service's Task Definition to its Tasks
- ECS Managed Tags (Cluster name and Service name tags) are enabled by default. This can be turned off with `--disable-ecs-managed-tags`. Rationale: tags are free and useful, might as well make using them the default, rather than an annoyingly long flag that must always be added to each command.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
