### PR TITLE
Resource tagging in the registry-creds up command

### DIFF
--- a/ecs-cli/modules/cli/regcreds/create_task_execution_role_test.go
+++ b/ecs-cli/modules/cli/regcreds/create_task_execution_role_test.go
@@ -41,7 +41,7 @@ func TestCreateTaskExecutionRole(t *testing.T) {
 
 	mocks := setupTestController(t)
 	gomock.InOrder(
-		mocks.MockIAM.EXPECT().CreateOrFindRole(testRoleName, roleDescriptionString, assumeRolePolicyDocString).Return(*testRoleArn, nil),
+		mocks.MockIAM.EXPECT().CreateOrFindRole(testRoleName, roleDescriptionString, assumeRolePolicyDocString, nil).Return(*testRoleArn, nil),
 		mocks.MockIAM.EXPECT().CreateRole(gomock.Any()).Return(&iam.CreateRoleOutput{Role: &iam.Role{Arn: testRoleArn}}, nil),
 	)
 	gomock.InOrder(
@@ -76,7 +76,7 @@ func TestCreateTaskExecutionRole_NoKMSKey(t *testing.T) {
 
 	mocks := setupTestController(t)
 	gomock.InOrder(
-		mocks.MockIAM.EXPECT().CreateOrFindRole(testRoleName, roleDescriptionString, assumeRolePolicyDocString).Return(*testRoleArn, nil),
+		mocks.MockIAM.EXPECT().CreateOrFindRole(testRoleName, roleDescriptionString, assumeRolePolicyDocString, nil).Return(*testRoleArn, nil),
 		mocks.MockIAM.EXPECT().CreateRole(gomock.Any()).Return(&iam.CreateRoleOutput{Role: &iam.Role{Arn: testRoleArn}}, nil),
 	)
 	gomock.InOrder(
@@ -110,7 +110,7 @@ func TestCreateTaskExecutionRole_RoleExists(t *testing.T) {
 	mocks := setupTestController(t)
 	gomock.InOrder(
 		// CreateOrFindRole should return nil if given role already exists
-		mocks.MockIAM.EXPECT().CreateOrFindRole(testRoleName, roleDescriptionString, assumeRolePolicyDocString).Return("", nil),
+		mocks.MockIAM.EXPECT().CreateOrFindRole(testRoleName, roleDescriptionString, assumeRolePolicyDocString, nil).Return("", nil),
 		mocks.MockIAM.EXPECT().CreateRole(gomock.Any()).Return(nil, roleExistsError),
 	)
 	gomock.InOrder(
@@ -140,7 +140,7 @@ func TestCreateTaskExecutionRole_ErrorOnCreateRoleFails(t *testing.T) {
 
 	mocks := setupTestController(t)
 	gomock.InOrder(
-		mocks.MockIAM.EXPECT().CreateOrFindRole(testRoleName, roleDescriptionString, assumeRolePolicyDocString).Return("", errors.New("something went wrong")),
+		mocks.MockIAM.EXPECT().CreateOrFindRole(testRoleName, roleDescriptionString, assumeRolePolicyDocString, nil).Return("", errors.New("something went wrong")),
 		mocks.MockIAM.EXPECT().CreateRole(gomock.Any()).Return(nil, errors.New("something went wrong")),
 	)
 
@@ -166,7 +166,7 @@ func TestCreateTaskExecutionRole_ErrorOnCreatePolicyFails(t *testing.T) {
 
 	mocks := setupTestController(t)
 	gomock.InOrder(
-		mocks.MockIAM.EXPECT().CreateOrFindRole(testRoleName, roleDescriptionString, assumeRolePolicyDocString).Return(*testRoleArn, nil),
+		mocks.MockIAM.EXPECT().CreateOrFindRole(testRoleName, roleDescriptionString, assumeRolePolicyDocString, nil).Return(*testRoleArn, nil),
 		mocks.MockIAM.EXPECT().CreateRole(gomock.Any()).Return(&iam.CreateRoleOutput{Role: &iam.Role{Arn: testRoleArn}}, nil),
 	)
 	gomock.InOrder(
@@ -181,4 +181,70 @@ func TestCreateTaskExecutionRole_ErrorOnCreatePolicyFails(t *testing.T) {
 
 	_, err := createTaskExecutionRole(testParams, mocks.MockIAM, mocks.MockKMS)
 	assert.Error(t, err, "Expected error when CreatePolicy fails")
+}
+
+func TestCreateTaskExecutionRoleWithTags(t *testing.T) {
+	testRegistry := "myreg.test.io"
+	testRegCredARN := "arn:aws:secret/some-test-arn"
+	testRegKMSKey := "arn:aws:kms:key/67yt-756yth"
+
+	testCreds := map[string]regcredio.CredsOutputEntry{
+		testRegistry: regcredio.BuildOutputEntry(testRegCredARN, testRegKMSKey, []string{"test"}),
+	}
+
+	testRoleName := "myNginxProjectRole"
+
+	testPolicyArn := aws.String("arn:aws:iam::policy/" + testRoleName + "-policy")
+	testRoleArn := aws.String("arn:aws:iam::role/" + testRoleName)
+
+	testParams := executionRoleParams{
+		CredEntries: testCreds,
+		RoleName:    testRoleName,
+		Region:      "us-west-2",
+		Tags: map[string]*string{
+			"Hey":   aws.String("Jude"),
+			"Come":  aws.String("Together"),
+			"Hello": aws.String("Goodbye"),
+			"Abbey": aws.String("Road"),
+		},
+	}
+
+	expectedTags := []*iam.Tag{
+		&iam.Tag{
+			Key:   aws.String("Hey"),
+			Value: aws.String("Jude"),
+		},
+		&iam.Tag{
+			Key:   aws.String("Come"),
+			Value: aws.String("Together"),
+		},
+		&iam.Tag{
+			Key:   aws.String("Hello"),
+			Value: aws.String("Goodbye"),
+		},
+		&iam.Tag{
+			Key:   aws.String("Abbey"),
+			Value: aws.String("Road"),
+		},
+	}
+
+	mocks := setupTestController(t)
+	gomock.InOrder(
+		mocks.MockIAM.EXPECT().CreateOrFindRole(testRoleName, roleDescriptionString, assumeRolePolicyDocString, gomock.Any()).Do(func(w, x, y, z interface{}) {
+			tags := z.([]*iam.Tag)
+			assert.ElementsMatch(t, tags, expectedTags, "Expected Tags to match")
+		}).Return(*testRoleArn, nil),
+		mocks.MockIAM.EXPECT().CreateRole(gomock.Any()).Return(&iam.CreateRoleOutput{Role: &iam.Role{Arn: testRoleArn}}, nil),
+	)
+	gomock.InOrder(
+		// If KMSKeyID present, first thing to happen should be verifying its ARN
+		mocks.MockKMS.EXPECT().GetValidKeyARN(testRegKMSKey).Return(testRegKMSKey, nil),
+		mocks.MockIAM.EXPECT().CreatePolicy(gomock.Any()).Return(&iam.CreatePolicyOutput{Policy: &iam.Policy{Arn: testPolicyArn}}, nil),
+		mocks.MockIAM.EXPECT().AttachRolePolicy(getExecutionRolePolicyARN("us-west-2"), testRoleName).Return(nil, nil),
+		mocks.MockIAM.EXPECT().AttachRolePolicy(*testPolicyArn, testRoleName).Return(nil, nil),
+	)
+
+	policyCreateTime, err := createTaskExecutionRole(testParams, mocks.MockIAM, mocks.MockKMS)
+	assert.NoError(t, err, "Unexpected error when creating task execution role")
+	assert.NotNil(t, policyCreateTime, "Expected policy create time to be non-nil")
 }

--- a/ecs-cli/modules/clients/aws/iam/client.go
+++ b/ecs-cli/modules/clients/aws/iam/client.go
@@ -27,7 +27,7 @@ type Client interface {
 	AttachRolePolicy(policyArn, roleName string) (*iam.AttachRolePolicyOutput, error)
 	CreateRole(iam.CreateRoleInput) (*iam.CreateRoleOutput, error)
 	CreatePolicy(iam.CreatePolicyInput) (*iam.CreatePolicyOutput, error)
-	CreateOrFindRole(string, string, string) (string, error)
+	CreateOrFindRole(string, string, string, []*iam.Tag) (string, error)
 }
 
 type iamClient struct {
@@ -81,11 +81,14 @@ func (c *iamClient) CreatePolicy(input iam.CreatePolicyInput) (*iam.CreatePolicy
 }
 
 // CreateOrFindRole returns a new role ARN or an empty string if role already exists
-func (c *iamClient) CreateOrFindRole(roleName, roleDescription, assumeRolePolicyDoc string) (string, error) {
+func (c *iamClient) CreateOrFindRole(roleName, roleDescription, assumeRolePolicyDoc string, tags []*iam.Tag) (string, error) {
 	createRoleRequest := iam.CreateRoleInput{
 		AssumeRolePolicyDocument: aws.String(assumeRolePolicyDoc),
 		Description:              aws.String(roleDescription),
 		RoleName:                 aws.String(roleName),
+	}
+	if len(tags) > 0 {
+		createRoleRequest.Tags = tags
 	}
 	roleResult, err := c.CreateRole(createRoleRequest)
 	// if err is b/c role already exists, OK to continue

--- a/ecs-cli/modules/clients/aws/iam/mock/client.go
+++ b/ecs-cli/modules/clients/aws/iam/mock/client.go
@@ -61,16 +61,16 @@ func (mr *MockClientMockRecorder) AttachRolePolicy(arg0, arg1 interface{}) *gomo
 }
 
 // CreateOrFindRole mocks base method
-func (m *MockClient) CreateOrFindRole(arg0, arg1, arg2 string) (string, error) {
-	ret := m.ctrl.Call(m, "CreateOrFindRole", arg0, arg1, arg2)
+func (m *MockClient) CreateOrFindRole(arg0, arg1, arg2 string, arg3 []*iam.Tag) (string, error) {
+	ret := m.ctrl.Call(m, "CreateOrFindRole", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CreateOrFindRole indicates an expected call of CreateOrFindRole
-func (mr *MockClientMockRecorder) CreateOrFindRole(arg0, arg1, arg2 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateOrFindRole", reflect.TypeOf((*MockClient)(nil).CreateOrFindRole), arg0, arg1, arg2)
+func (mr *MockClientMockRecorder) CreateOrFindRole(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateOrFindRole", reflect.TypeOf((*MockClient)(nil).CreateOrFindRole), arg0, arg1, arg2, arg3)
 }
 
 // CreatePolicy mocks base method

--- a/ecs-cli/modules/commands/regcreds/regcreds_command.go
+++ b/ecs-cli/modules/commands/regcreds/regcreds_command.go
@@ -65,5 +65,9 @@ func regcredsUpFlags() []cli.Flag {
 			Name:  flags.OutputDirFlag,
 			Usage: "[Optional] The directory where the output file should be created. If none specified, file will be created in the current working directory.",
 		},
+		cli.StringFlag{
+			Name:  flags.ResourceTagsFlag,
+			Usage: "[Optional] The AWS Resource tags to add to the Secrets Manager secrets and new IAM Role. Existing IAM Roles cannot be tagged.",
+		},
 	}
 }


### PR DESCRIPTION
*Description of changes:*
Tag SM secrets and new IAM roles. (IAM is not supported by the standalone resource tagging API, so tagging can only be supported during role creation).


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
