### PR TITLE
Add Integ test resources, "ps" test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,14 @@ $(LOCAL_BINARY): $(SOURCES)
 test:
 	env -i PATH=$$PATH GOPATH=$$GOPATH GOROOT=$$GOROOT go test -timeout=120s -v -cover ./ecs-cli/modules/...
 
+
+.PHONY: integ-test
+integ-test:
+	@echo "Building ecs-cli..."
+	./scripts/build_binary.sh ./bin/local
+	@echo "Running integration tests..."
+	go test -tags integ -v ./ecs-cli/integ/...
+
 .PHONY: generate
 generate: $(SOURCES)
 	PATH=$(LOCAL_PATH) go generate ./ecs-cli/modules/...

--- a/ecs-cli/integ/README.md
+++ b/ecs-cli/integ/README.md
@@ -1,0 +1,17 @@
+# Amazon ECS CLI - Integration Tests
+
+This directory contains tests intended to run against public Amazon Elastic Container Service endpoints and other AWS Services. They are meant to test end-to-end functionality by executing commands as an ecs-cli user would.
+
+You may be charged for the AWS resources utilized while running these tests. It's not recommended to run these on an AWS account handling production work-loads.
+
+## Test setup
+
+Some tests assume the existance of an "ecs-cli-integ" cluster in the currently configured region. Prior to running these tests, create this cluster using the template in `/resources/ecs_cli_integ_template.json`
+
+## Running the tests
+
+The best way to run them on Linux is via the `make integ-test` target.
+
+The best way to run them on Windows is by building and running the tests with `go` from the project root:
+ * `go build -installsuffix cgo -a -ldflags '-s' -o ./bin/local/ecs-cli.exe ./ecs-cli/`
+ * `go test -tags integ -v ./ecs-cli/integ/...`

--- a/ecs-cli/integ/cmd_ps.go/ps_test.go
+++ b/ecs-cli/integ/cmd_ps.go/ps_test.go
@@ -1,0 +1,65 @@
+// +build integ
+
+// Copyright 2015-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package integ
+
+import (
+	"bytes"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/aws/amazon-ecs-cli/ecs-cli/integ"
+	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/cli/compose/container"
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	integClusterName = "ecs-cli-integ"
+)
+
+// Test assumes binary has been built, named cluster contains 3 containers
+func TestCmd_PS(t *testing.T) {
+	// set up command
+	ps_args := []string{"ps", "--cluster", integClusterName}
+	cmd := integ.GetCommand(ps_args)
+
+	var stdoutWriter bytes.Buffer
+	writer := io.MultiWriter(&stdoutWriter)
+
+	cmd.Stdout = writer
+
+	// execute command
+	err := cmd.Run()
+	assert.NoError(t, err, "Unexpected error starting 'ps'")
+
+	// assert on result
+	actualStdout := stdoutWriter.String()
+	assert.NotEmpty(t, actualStdout)
+
+	stdoutLines := strings.Split(actualStdout, "\n")
+	length := len(stdoutLines)
+
+	// trim off empty last row is needed
+	if stdoutLines[length-1] == "" {
+		stdoutLines = stdoutLines[:length-1]
+	}
+
+	headers := integ.GetRowValues(stdoutLines[0])
+	assert.Equal(t, container.ContainerInfoColumns, headers)
+
+	runningContainers := stdoutLines[1:]
+	assert.Equal(t, 3, len(runningContainers))
+}

--- a/ecs-cli/integ/resources/ecs_cli_integ_template.json
+++ b/ecs-cli/integ/resources/ecs_cli_integ_template.json
@@ -1,0 +1,271 @@
+{
+    "AWSTemplateFormatVersion": "2010-09-09",
+    "Description": "AWS CloudFormation template for ecs-cli integ resources.",
+    "Conditions": {
+        "IsCNRegion": {
+            "Fn::Or" : [
+                {"Fn::Equals": [ { "Ref": "AWS::Region" }, "cn-north-1" ]},
+                {"Fn::Equals": [ { "Ref": "AWS::Region" }, "cn-northwest-1" ]}
+            ]
+        }
+    },
+    "Parameters": {
+        "EcsAmiId": {
+            "Type": "AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>",
+            "Description": "ECS EC2 AMI id",
+            "Default": "/aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id"
+        },
+        "EcsPort": {
+            "Type" : "String",
+            "Description" : "Security Group port to open on ECS instances",
+            "Default" : "80"
+        },
+        "EcsServiceCount": {
+            "Type" : "Number",
+            "Description" : "Desired task count for the ECS Service",
+            "Default" : "3"
+        },
+        "AsgMinSize": {
+            "Type": "Number",
+            "Description": "Minimum size of ECS Auto Scaling Group",
+            "Default": "0"
+        },
+        "AsgMaxSize": {
+            "Type": "Number",
+            "Description": "Maximum size of ECS Auto Scaling Group",
+            "Default": "10"
+        },
+        "AsgDesiredCapacity": {
+            "Type": "Number",
+            "Description": "The initial desired capacity of ECS Auto Scaling Group",
+            "Default": "3"
+        }
+    },
+    "Resources": {
+        "Vpc": {
+            "Type": "AWS::EC2::VPC",
+            "Properties" : {
+                "CidrBlock" : "10.0.0.0/16",
+                "EnableDnsSupport" : true,
+                "EnableDnsHostnames" : true,
+                "Tags" : [ {"Key" : "Name", "Value" : "ECS CLI Integ cluster"} ]
+            }
+        },
+        "PubSubnetAz1": {
+            "Type": "AWS::EC2::Subnet",
+            "Properties" : {
+                "CidrBlock" : "10.0.0.0/24",
+                "Tags" : [ {"Key" : "Name", "Value" : "ECS CLI Integ cluster"} ],
+                "VpcId" : {
+                    "Ref": "Vpc"
+                }
+            }
+        },
+        "PubSubnetAz2": {
+            "Type": "AWS::EC2::Subnet",
+            "Properties" : {
+                "CidrBlock" : "10.0.1.0/24",
+                "Tags" : [ {"Key" : "Name", "Value" : "ECS CLI Integ cluster"} ],
+                "VpcId" : {
+                    "Ref": "Vpc"
+                }
+            }
+        },
+        "InternetGateway": {
+            "Type": "AWS::EC2::InternetGateway",
+            "Properties": {
+                "Tags": [ {"Key" : "Name", "Value" : "ECS CLI Integ cluster"} ]
+            }
+        },
+        "AttachGateway": {
+            "Type": "AWS::EC2::VPCGatewayAttachment",
+            "Properties": {
+                "VpcId": {
+                    "Ref": "Vpc"
+                },
+                "InternetGatewayId": {
+                    "Ref": "InternetGateway"
+                }
+            }
+        },
+        "RouteViaIgw": {
+            "Type": "AWS::EC2::RouteTable",
+            "Properties": {
+                "VpcId": {
+                    "Ref": "Vpc"
+                }
+            }
+        },
+        "PublicRouteViaIgw": {
+            "Type": "AWS::EC2::Route",
+            "Properties": {
+                "RouteTableId": {
+                    "Ref": "RouteViaIgw"
+                },
+                "DestinationCidrBlock": "0.0.0.0/0",
+                "GatewayId": {
+                    "Ref": "InternetGateway"
+                }
+            }
+        },
+        "PubSubnet1RouteTableAssociation": {
+            "Type": "AWS::EC2::SubnetRouteTableAssociation",
+            "Properties": {
+                "SubnetId": {
+                    "Ref": "PubSubnetAz1"
+                },
+                "RouteTableId": {
+                    "Ref": "RouteViaIgw"
+                }
+            }
+        },
+        "PubSubnet2RouteTableAssociation": {
+            "Type": "AWS::EC2::SubnetRouteTableAssociation",
+            "Properties": {
+                "SubnetId": {
+                    "Ref": "PubSubnetAz2"
+                },
+                "RouteTableId": {
+                    "Ref": "RouteViaIgw"
+                }
+            }
+        },
+        "EcsSecurityGroup": {
+            "Type": "AWS::EC2::SecurityGroup",
+            "Properties": {
+                "GroupDescription": "ECS Allowed Ports",
+                "VpcId": {
+                    "Ref": "Vpc"
+                },
+                "SecurityGroupIngress": [{
+                    "IpProtocol": "tcp",
+                    "FromPort": "80",
+                    "ToPort": "80",
+                    "CidrIp": "0.0.0.0/0"
+                }]
+            }
+        },
+        "EcsInstanceRole": {
+            "Type": "AWS::IAM::Role",
+            "Properties": {
+                "AssumeRolePolicyDocument": {
+                    "Version": "2012-10-17",
+                    "Statement": [
+                        {
+                            "Effect": "Allow",
+                            "Principal": {
+                                "Service": [
+                                    "Fn::If": [
+                                        "IsCNRegion",
+                                        "ec2.amazonaws.com.cn",
+                                        "ec2.amazonaws.com"
+                                    ]
+                                ]
+                            },
+                            "Action": [
+                                "sts:AssumeRole"
+                            ]
+                        }
+                    ] 
+                },
+                "ManagedPolicyArns": [ 
+                    "arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceforEC2Role" 
+                ]
+            }
+        },
+        "EcsInstanceProfile": {
+            "Type": "AWS::IAM::InstanceProfile",
+            "Properties": {
+                "Roles": [{ "Ref": "EcsInstanceRole" }]
+            }
+        },
+        "EcsInstanceLc": {
+            "Type": "AWS::AutoScaling::LaunchConfiguration",
+            "Properties": {
+                "AssociatePublicIpAddress": true,
+                "ImageId": {
+                    "Ref": "EcsAmiId"
+                },
+                "InstanceType": "m5.large",
+                "IamInstanceProfile": {
+                    "Ref": "EcsInstanceProfile"
+                },
+                "SecurityGroups": [{
+                    "Ref": "EcsSecurityGroup"
+                }],
+                "UserData": {
+                    "Fn::Base64": {
+                        "Fn::Join": ["", [
+                            "#!/bin/bash\n",
+                            "echo ECS_CLUSTER=ecs-cli-integ >> /etc/ecs/ecs.config"
+                        ]]
+                    }
+                }
+            }
+        },
+        "EcsInstanceAsg": {
+            "Type": "AWS::AutoScaling::AutoScalingGroup",
+            "Properties": {
+                "VPCZoneIdentifier": [{ "Ref": "PubSubnetAz1"}, {"Ref": "PubSubnetAz2"}],
+                "LaunchConfigurationName": {
+                    "Ref": "EcsInstanceLc"
+                },
+                "MinSize": {
+                    "Ref": "AsgMinSize"
+                },
+                "MaxSize": {
+                    "Ref": "AsgMaxSize"
+                },
+                "DesiredCapacity": {
+                    "Ref": "AsgDesiredCapacity"
+                }, 
+                "Tags": [
+                    {
+                      "Key": "Name",
+                      "Value": "ECS CLI Integ cluster",
+                      "PropagateAtLaunch": true
+                    }
+                ]
+            }
+        },
+        "EcsCluster": {
+            "Type" : "AWS::ECS::Cluster",
+            "Properties": {
+                "ClusterName": "ecs-cli-integ"
+            }
+        },
+        "EcsTaskDefinition": {
+            "Type" : "AWS::ECS::TaskDefinition",
+            "Properties": {
+                "Family": "ecs-cli-integ",
+                "Memory": "1GB",
+                "NetworkMode": "awsvpc",
+                "Cpu": "512",
+                "RequiresCompatibilities": ["EC2", "FARGATE"],
+                "ContainerDefinitions": [{
+                    "Name": "httpd",
+                    "Image": "httpd",
+                    "PortMappings": [{
+                        "ContainerPort": "80"
+                    }]
+                }]
+            }
+        },
+        "EcsService": {
+            "Type": "AWS::ECS::Service",
+            "Properties": {
+                "Cluster": { "Ref": "EcsCluster" },
+                "DesiredCount": { "Ref": "EcsServiceCount" },
+                "ServiceName": "ecs-cli-integ-service",
+                "TaskDefinition": { "Ref": "EcsTaskDefinition" },
+                "NetworkConfiguration": {
+                    "AwsvpcConfiguration": {
+                        "AssignPublicIp": "DISABLED",
+                        "SecurityGroups": [{ "Ref": "EcsSecurityGroup" }],
+                        "Subnets": [{ "Ref": "PubSubnetAz1" }, { "Ref": "PubSubnetAz2" }]
+                    }
+                }
+            }
+        }
+    }
+}

--- a/ecs-cli/integ/runner.go
+++ b/ecs-cli/integ/runner.go
@@ -1,0 +1,43 @@
+// Copyright 2015-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package integ
+
+import (
+	"os/exec"
+	"regexp"
+	"runtime"
+	"strings"
+)
+
+const (
+	binPath = "../../../bin/local/ecs-cli" // TODO: use abs path or env var
+)
+
+// GetCommand returns a Cmd struct with the right binary path & arguments
+func GetCommand(args []string) *exec.Cmd {
+	cmdPath := binPath
+
+	if runtime.GOOS == "windows" {
+		cmdPath = cmdPath + ".exe"
+	}
+
+	cmd := exec.Command(cmdPath, args...)
+	return cmd
+}
+
+// GetRowValues takes a row of stdout and returns a slice of strings split by arbirary whitespace
+func GetRowValues(row string) []string {
+	spaces := regexp.MustCompile(`\s+`)
+	return strings.Split(spaces.ReplaceAllString(row, " "), " ")
+}


### PR DESCRIPTION
Adding integration test wiring, README, and test for `ps` command.

### Test output (linux):
```
$>  /usr/bin/make integ-test
Building ecs-cli...
./scripts/build_binary.sh ./bin/local
Running integration tests...
go test -tags integ -v ./ecs-cli/integ/...
?   	github.com/aws/amazon-ecs-cli/ecs-cli/integ	[no test files]
=== RUN   TestCmd_PS
--- PASS: TestCmd_PS (0.74s)
PASS
ok  	github.com/aws/amazon-ecs-cli/ecs-cli/integ/cmd_ps.go	0.748s

$>
```

### Test output (Windows):
```
PS C:\...\GO\src\github.com\aws\amazon-ecs-cli> go build -installsuffix cgo -a -ldflags '-s' -o ./bin/local/ecs-cli.exe ./ecs-cli/
PS C:\...\GO\src\github.com\aws\amazon-ecs-cli>
PS C:\...\GO\src\github.com\aws\amazon-ecs-cli> go test -tags integ -v ./ecs-cli/integ/...
?       github.com/aws/amazon-ecs-cli/ecs-cli/integ     [no test files]
=== RUN   TestCmd_PS
--- PASS: TestCmd_PS (6.26s)
PASS
ok      github.com/aws/amazon-ecs-cli/ecs-cli/integ/cmd_ps.go   6.682s
PS C:\...\GO\src\github.com\aws\amazon-ecs-cli>
```

--
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
