### PR TITLE
Fix getExecutionRolePolicyARN() in regcreds

### DIFF
--- a/ecs-cli/modules/cli/regcreds/regcreds_app_helpers.go
+++ b/ecs-cli/modules/cli/regcreds/regcreds_app_helpers.go
@@ -48,12 +48,13 @@ func getExecutionRolePolicyARN(region string) string {
 		AccountID: "aws",
 	}
 
+	// TODO: use utils.GetPartition func once merged
 	if regionToPartition[region] != "" {
 		expectedARN.Partition = regionToPartition[region]
+		return expectedARN.String()
 	}
 
 	expectedARN.Partition = "aws"
-
 	return expectedARN.String()
 }
 


### PR DESCRIPTION
Previously, ARN partition was always being set as "aws". Fixed this and added unit tests for role creation in diff partitions.

--
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
