### PR TITLE
support build 1.12.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ go:
     - 1.9.x
     - 1.10.x
     - 1.11.x
+    - 1.12.x
 script:
     - make test
     - make

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ sudo: false
 os:
     - linux
     - osx
+env:
+  - GOCACHE=$HOME/.cache/go-build
 go_import_path: github.com/aws/amazon-ecs-cli
 go:
     - 1.8.x

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ $(LOCAL_BINARY): $(SOURCES)
 
 .PHONY: test
 test:
-	env -i PATH=$$PATH GOPATH=$$GOPATH GOROOT=$$GOROOT GOCACHE=$$HOME/.gocache go test -timeout=120s -v -cover ./ecs-cli/modules/...
+	env -i PATH=$$PATH GOPATH=$$GOPATH GOROOT=$$GOROOT GOCACHE=$$GOCACHE go test -timeout=120s -v -cover ./ecs-cli/modules/...
 
 .PHONY: generate
 generate: $(SOURCES)

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ $(LOCAL_BINARY): $(SOURCES)
 
 .PHONY: test
 test:
-	env -i PATH=$$PATH GOPATH=$$GOPATH GOROOT=$$GOROOT go test -timeout=120s -v -cover ./ecs-cli/modules/...
+	env -i PATH=$$PATH GOPATH=$$GOPATH GOROOT=$$GOROOT GOCACHE=$$HOME/.gocache go test -timeout=120s -v -cover ./ecs-cli/modules/...
 
 .PHONY: generate
 generate: $(SOURCES)


### PR DESCRIPTION
Support build 1.12.x
Golang 1.12 requires GOCACHE, therefore add environment variable.