### PR TITLE
Back to the future: fix license year

### DIFF
--- a/ecs-cli/modules/cli/compose/entity/mock/entity.go
+++ b/ecs-cli/modules/cli/compose/entity/mock/entity.go
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2015-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the
@@ -54,7 +54,6 @@ func (m *MockProjectEntity) EXPECT() *MockProjectEntityMockRecorder {
 
 // Context mocks base method
 func (m *MockProjectEntity) Context() *context.ECSContext {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Context")
 	ret0, _ := ret[0].(*context.ECSContext)
 	return ret0
@@ -62,13 +61,11 @@ func (m *MockProjectEntity) Context() *context.ECSContext {
 
 // Context indicates an expected call of Context
 func (mr *MockProjectEntityMockRecorder) Context() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Context", reflect.TypeOf((*MockProjectEntity)(nil).Context))
 }
 
 // Create mocks base method
 func (m *MockProjectEntity) Create() error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Create")
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -76,13 +73,11 @@ func (m *MockProjectEntity) Create() error {
 
 // Create indicates an expected call of Create
 func (mr *MockProjectEntityMockRecorder) Create() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockProjectEntity)(nil).Create))
 }
 
 // Down mocks base method
 func (m *MockProjectEntity) Down() error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Down")
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -90,13 +85,11 @@ func (m *MockProjectEntity) Down() error {
 
 // Down indicates an expected call of Down
 func (mr *MockProjectEntityMockRecorder) Down() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Down", reflect.TypeOf((*MockProjectEntity)(nil).Down))
 }
 
 // EntityType mocks base method
 func (m *MockProjectEntity) EntityType() types.Type {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "EntityType")
 	ret0, _ := ret[0].(types.Type)
 	return ret0
@@ -104,13 +97,11 @@ func (m *MockProjectEntity) EntityType() types.Type {
 
 // EntityType indicates an expected call of EntityType
 func (mr *MockProjectEntityMockRecorder) EntityType() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EntityType", reflect.TypeOf((*MockProjectEntity)(nil).EntityType))
 }
 
 // GetTags mocks base method
 func (m *MockProjectEntity) GetTags() ([]*ecs.Tag, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetTags")
 	ret0, _ := ret[0].([]*ecs.Tag)
 	ret1, _ := ret[1].(error)
@@ -119,13 +110,11 @@ func (m *MockProjectEntity) GetTags() ([]*ecs.Tag, error) {
 
 // GetTags indicates an expected call of GetTags
 func (mr *MockProjectEntityMockRecorder) GetTags() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTags", reflect.TypeOf((*MockProjectEntity)(nil).GetTags))
 }
 
 // Info mocks base method
 func (m *MockProjectEntity) Info(arg0 bool, arg1 string) (project.InfoSet, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Info", arg0, arg1)
 	ret0, _ := ret[0].(project.InfoSet)
 	ret1, _ := ret[1].(error)
@@ -134,13 +123,11 @@ func (m *MockProjectEntity) Info(arg0 bool, arg1 string) (project.InfoSet, error
 
 // Info indicates an expected call of Info
 func (mr *MockProjectEntityMockRecorder) Info(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Info", reflect.TypeOf((*MockProjectEntity)(nil).Info), arg0, arg1)
 }
 
 // LoadContext mocks base method
 func (m *MockProjectEntity) LoadContext() error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "LoadContext")
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -148,13 +135,11 @@ func (m *MockProjectEntity) LoadContext() error {
 
 // LoadContext indicates an expected call of LoadContext
 func (mr *MockProjectEntityMockRecorder) LoadContext() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadContext", reflect.TypeOf((*MockProjectEntity)(nil).LoadContext))
 }
 
 // Run mocks base method
 func (m *MockProjectEntity) Run(arg0 map[string][]string) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Run", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -162,13 +147,11 @@ func (m *MockProjectEntity) Run(arg0 map[string][]string) error {
 
 // Run indicates an expected call of Run
 func (mr *MockProjectEntityMockRecorder) Run(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Run", reflect.TypeOf((*MockProjectEntity)(nil).Run), arg0)
 }
 
 // Scale mocks base method
 func (m *MockProjectEntity) Scale(arg0 int) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Scale", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -176,25 +159,21 @@ func (m *MockProjectEntity) Scale(arg0 int) error {
 
 // Scale indicates an expected call of Scale
 func (mr *MockProjectEntityMockRecorder) Scale(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Scale", reflect.TypeOf((*MockProjectEntity)(nil).Scale), arg0)
 }
 
 // SetTaskDefinition mocks base method
 func (m *MockProjectEntity) SetTaskDefinition(arg0 *ecs.TaskDefinition) {
-	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "SetTaskDefinition", arg0)
 }
 
 // SetTaskDefinition indicates an expected call of SetTaskDefinition
 func (mr *MockProjectEntityMockRecorder) SetTaskDefinition(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetTaskDefinition", reflect.TypeOf((*MockProjectEntity)(nil).SetTaskDefinition), arg0)
 }
 
 // Sleeper mocks base method
 func (m *MockProjectEntity) Sleeper() *utils.TimeSleeper {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Sleeper")
 	ret0, _ := ret[0].(*utils.TimeSleeper)
 	return ret0
@@ -202,13 +181,11 @@ func (m *MockProjectEntity) Sleeper() *utils.TimeSleeper {
 
 // Sleeper indicates an expected call of Sleeper
 func (mr *MockProjectEntityMockRecorder) Sleeper() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Sleeper", reflect.TypeOf((*MockProjectEntity)(nil).Sleeper))
 }
 
 // Start mocks base method
 func (m *MockProjectEntity) Start() error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Start")
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -216,13 +193,11 @@ func (m *MockProjectEntity) Start() error {
 
 // Start indicates an expected call of Start
 func (mr *MockProjectEntityMockRecorder) Start() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Start", reflect.TypeOf((*MockProjectEntity)(nil).Start))
 }
 
 // Stop mocks base method
 func (m *MockProjectEntity) Stop() error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Stop")
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -230,13 +205,11 @@ func (m *MockProjectEntity) Stop() error {
 
 // Stop indicates an expected call of Stop
 func (mr *MockProjectEntityMockRecorder) Stop() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Stop", reflect.TypeOf((*MockProjectEntity)(nil).Stop))
 }
 
 // TaskDefinition mocks base method
 func (m *MockProjectEntity) TaskDefinition() *ecs.TaskDefinition {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "TaskDefinition")
 	ret0, _ := ret[0].(*ecs.TaskDefinition)
 	return ret0
@@ -244,13 +217,11 @@ func (m *MockProjectEntity) TaskDefinition() *ecs.TaskDefinition {
 
 // TaskDefinition indicates an expected call of TaskDefinition
 func (mr *MockProjectEntityMockRecorder) TaskDefinition() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TaskDefinition", reflect.TypeOf((*MockProjectEntity)(nil).TaskDefinition))
 }
 
 // TaskDefinitionCache mocks base method
 func (m *MockProjectEntity) TaskDefinitionCache() cache.Cache {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "TaskDefinitionCache")
 	ret0, _ := ret[0].(cache.Cache)
 	return ret0
@@ -258,13 +229,11 @@ func (m *MockProjectEntity) TaskDefinitionCache() cache.Cache {
 
 // TaskDefinitionCache indicates an expected call of TaskDefinitionCache
 func (mr *MockProjectEntityMockRecorder) TaskDefinitionCache() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TaskDefinitionCache", reflect.TypeOf((*MockProjectEntity)(nil).TaskDefinitionCache))
 }
 
 // Up mocks base method
 func (m *MockProjectEntity) Up() error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Up")
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -272,6 +241,5 @@ func (m *MockProjectEntity) Up() error {
 
 // Up indicates an expected call of Up
 func (mr *MockProjectEntityMockRecorder) Up() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Up", reflect.TypeOf((*MockProjectEntity)(nil).Up))
 }

--- a/ecs-cli/modules/cli/compose/factory/mock/factory.go
+++ b/ecs-cli/modules/cli/compose/factory/mock/factory.go
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2015-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the
@@ -50,7 +50,6 @@ func (m *MockProjectFactory) EXPECT() *MockProjectFactoryMockRecorder {
 
 // Create mocks base method
 func (m *MockProjectFactory) Create(arg0 *cli.Context, arg1 bool) (project.Project, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Create", arg0, arg1)
 	ret0, _ := ret[0].(project.Project)
 	ret1, _ := ret[1].(error)
@@ -59,6 +58,5 @@ func (m *MockProjectFactory) Create(arg0 *cli.Context, arg1 bool) (project.Proje
 
 // Create indicates an expected call of Create
 func (mr *MockProjectFactoryMockRecorder) Create(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockProjectFactory)(nil).Create), arg0, arg1)
 }

--- a/ecs-cli/modules/cli/compose/project/mock/project.go
+++ b/ecs-cli/modules/cli/compose/project/mock/project.go
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2015-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the
@@ -52,7 +52,6 @@ func (m *MockProject) EXPECT() *MockProjectMockRecorder {
 
 // ContainerConfigs mocks base method
 func (m *MockProject) ContainerConfigs() []adapter.ContainerConfig {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ContainerConfigs")
 	ret0, _ := ret[0].([]adapter.ContainerConfig)
 	return ret0
@@ -60,13 +59,11 @@ func (m *MockProject) ContainerConfigs() []adapter.ContainerConfig {
 
 // ContainerConfigs indicates an expected call of ContainerConfigs
 func (mr *MockProjectMockRecorder) ContainerConfigs() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContainerConfigs", reflect.TypeOf((*MockProject)(nil).ContainerConfigs))
 }
 
 // Context mocks base method
 func (m *MockProject) Context() *context.ECSContext {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Context")
 	ret0, _ := ret[0].(*context.ECSContext)
 	return ret0
@@ -74,13 +71,11 @@ func (m *MockProject) Context() *context.ECSContext {
 
 // Context indicates an expected call of Context
 func (mr *MockProjectMockRecorder) Context() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Context", reflect.TypeOf((*MockProject)(nil).Context))
 }
 
 // Create mocks base method
 func (m *MockProject) Create() error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Create")
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -88,13 +83,11 @@ func (m *MockProject) Create() error {
 
 // Create indicates an expected call of Create
 func (mr *MockProjectMockRecorder) Create() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockProject)(nil).Create))
 }
 
 // Down mocks base method
 func (m *MockProject) Down() error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Down")
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -102,13 +95,11 @@ func (m *MockProject) Down() error {
 
 // Down indicates an expected call of Down
 func (mr *MockProjectMockRecorder) Down() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Down", reflect.TypeOf((*MockProject)(nil).Down))
 }
 
 // Entity mocks base method
 func (m *MockProject) Entity() entity.ProjectEntity {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Entity")
 	ret0, _ := ret[0].(entity.ProjectEntity)
 	return ret0
@@ -116,13 +107,11 @@ func (m *MockProject) Entity() entity.ProjectEntity {
 
 // Entity indicates an expected call of Entity
 func (mr *MockProjectMockRecorder) Entity() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Entity", reflect.TypeOf((*MockProject)(nil).Entity))
 }
 
 // Info mocks base method
 func (m *MockProject) Info(arg0 string) (project.InfoSet, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Info", arg0)
 	ret0, _ := ret[0].(project.InfoSet)
 	ret1, _ := ret[1].(error)
@@ -131,13 +120,11 @@ func (m *MockProject) Info(arg0 string) (project.InfoSet, error) {
 
 // Info indicates an expected call of Info
 func (mr *MockProjectMockRecorder) Info(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Info", reflect.TypeOf((*MockProject)(nil).Info), arg0)
 }
 
 // Name mocks base method
 func (m *MockProject) Name() string {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Name")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -145,13 +132,11 @@ func (m *MockProject) Name() string {
 
 // Name indicates an expected call of Name
 func (mr *MockProjectMockRecorder) Name() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Name", reflect.TypeOf((*MockProject)(nil).Name))
 }
 
 // Parse mocks base method
 func (m *MockProject) Parse() error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Parse")
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -159,13 +144,11 @@ func (m *MockProject) Parse() error {
 
 // Parse indicates an expected call of Parse
 func (mr *MockProjectMockRecorder) Parse() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Parse", reflect.TypeOf((*MockProject)(nil).Parse))
 }
 
 // Run mocks base method
 func (m *MockProject) Run(arg0 map[string][]string) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Run", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -173,13 +156,11 @@ func (m *MockProject) Run(arg0 map[string][]string) error {
 
 // Run indicates an expected call of Run
 func (mr *MockProjectMockRecorder) Run(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Run", reflect.TypeOf((*MockProject)(nil).Run), arg0)
 }
 
 // Scale mocks base method
 func (m *MockProject) Scale(arg0 int) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Scale", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -187,13 +168,11 @@ func (m *MockProject) Scale(arg0 int) error {
 
 // Scale indicates an expected call of Scale
 func (mr *MockProjectMockRecorder) Scale(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Scale", reflect.TypeOf((*MockProject)(nil).Scale), arg0)
 }
 
 // Start mocks base method
 func (m *MockProject) Start() error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Start")
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -201,13 +180,11 @@ func (m *MockProject) Start() error {
 
 // Start indicates an expected call of Start
 func (mr *MockProjectMockRecorder) Start() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Start", reflect.TypeOf((*MockProject)(nil).Start))
 }
 
 // Stop mocks base method
 func (m *MockProject) Stop() error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Stop")
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -215,13 +192,11 @@ func (m *MockProject) Stop() error {
 
 // Stop indicates an expected call of Stop
 func (mr *MockProjectMockRecorder) Stop() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Stop", reflect.TypeOf((*MockProject)(nil).Stop))
 }
 
 // Up mocks base method
 func (m *MockProject) Up() error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Up")
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -229,13 +204,11 @@ func (m *MockProject) Up() error {
 
 // Up indicates an expected call of Up
 func (mr *MockProjectMockRecorder) Up() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Up", reflect.TypeOf((*MockProject)(nil).Up))
 }
 
 // VolumeConfigs mocks base method
 func (m *MockProject) VolumeConfigs() *adapter.Volumes {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "VolumeConfigs")
 	ret0, _ := ret[0].(*adapter.Volumes)
 	return ret0
@@ -243,6 +216,5 @@ func (m *MockProject) VolumeConfigs() *adapter.Volumes {
 
 // VolumeConfigs indicates an expected call of VolumeConfigs
 func (mr *MockProjectMockRecorder) VolumeConfigs() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VolumeConfigs", reflect.TypeOf((*MockProject)(nil).VolumeConfigs))
 }

--- a/ecs-cli/modules/clients/aws/amimetadata/mock/client.go
+++ b/ecs-cli/modules/clients/aws/amimetadata/mock/client.go
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2015-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the
@@ -49,7 +49,6 @@ func (m *MockClient) EXPECT() *MockClientMockRecorder {
 
 // GetRecommendedECSLinuxAMI mocks base method
 func (m *MockClient) GetRecommendedECSLinuxAMI(arg0 string) (*amimetadata.AMIMetadata, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetRecommendedECSLinuxAMI", arg0)
 	ret0, _ := ret[0].(*amimetadata.AMIMetadata)
 	ret1, _ := ret[1].(error)
@@ -58,6 +57,5 @@ func (m *MockClient) GetRecommendedECSLinuxAMI(arg0 string) (*amimetadata.AMIMet
 
 // GetRecommendedECSLinuxAMI indicates an expected call of GetRecommendedECSLinuxAMI
 func (mr *MockClientMockRecorder) GetRecommendedECSLinuxAMI(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRecommendedECSLinuxAMI", reflect.TypeOf((*MockClient)(nil).GetRecommendedECSLinuxAMI), arg0)
 }

--- a/ecs-cli/modules/clients/aws/amimetadata/mock/sdk/ssmiface.go
+++ b/ecs-cli/modules/clients/aws/amimetadata/mock/sdk/ssmiface.go
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2015-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the
@@ -51,7 +51,6 @@ func (m *MockSSMAPI) EXPECT() *MockSSMAPIMockRecorder {
 
 // AddTagsToResource mocks base method
 func (m *MockSSMAPI) AddTagsToResource(arg0 *ssm.AddTagsToResourceInput) (*ssm.AddTagsToResourceOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AddTagsToResource", arg0)
 	ret0, _ := ret[0].(*ssm.AddTagsToResourceOutput)
 	ret1, _ := ret[1].(error)
@@ -60,13 +59,11 @@ func (m *MockSSMAPI) AddTagsToResource(arg0 *ssm.AddTagsToResourceInput) (*ssm.A
 
 // AddTagsToResource indicates an expected call of AddTagsToResource
 func (mr *MockSSMAPIMockRecorder) AddTagsToResource(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddTagsToResource", reflect.TypeOf((*MockSSMAPI)(nil).AddTagsToResource), arg0)
 }
 
 // AddTagsToResourceRequest mocks base method
 func (m *MockSSMAPI) AddTagsToResourceRequest(arg0 *ssm.AddTagsToResourceInput) (*request.Request, *ssm.AddTagsToResourceOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AddTagsToResourceRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ssm.AddTagsToResourceOutput)
@@ -75,13 +72,11 @@ func (m *MockSSMAPI) AddTagsToResourceRequest(arg0 *ssm.AddTagsToResourceInput) 
 
 // AddTagsToResourceRequest indicates an expected call of AddTagsToResourceRequest
 func (mr *MockSSMAPIMockRecorder) AddTagsToResourceRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddTagsToResourceRequest", reflect.TypeOf((*MockSSMAPI)(nil).AddTagsToResourceRequest), arg0)
 }
 
 // AddTagsToResourceWithContext mocks base method
 func (m *MockSSMAPI) AddTagsToResourceWithContext(arg0 context.Context, arg1 *ssm.AddTagsToResourceInput, arg2 ...request.Option) (*ssm.AddTagsToResourceOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -94,14 +89,12 @@ func (m *MockSSMAPI) AddTagsToResourceWithContext(arg0 context.Context, arg1 *ss
 
 // AddTagsToResourceWithContext indicates an expected call of AddTagsToResourceWithContext
 func (mr *MockSSMAPIMockRecorder) AddTagsToResourceWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddTagsToResourceWithContext", reflect.TypeOf((*MockSSMAPI)(nil).AddTagsToResourceWithContext), varargs...)
 }
 
 // CancelCommand mocks base method
 func (m *MockSSMAPI) CancelCommand(arg0 *ssm.CancelCommandInput) (*ssm.CancelCommandOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CancelCommand", arg0)
 	ret0, _ := ret[0].(*ssm.CancelCommandOutput)
 	ret1, _ := ret[1].(error)
@@ -110,13 +103,11 @@ func (m *MockSSMAPI) CancelCommand(arg0 *ssm.CancelCommandInput) (*ssm.CancelCom
 
 // CancelCommand indicates an expected call of CancelCommand
 func (mr *MockSSMAPIMockRecorder) CancelCommand(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CancelCommand", reflect.TypeOf((*MockSSMAPI)(nil).CancelCommand), arg0)
 }
 
 // CancelCommandRequest mocks base method
 func (m *MockSSMAPI) CancelCommandRequest(arg0 *ssm.CancelCommandInput) (*request.Request, *ssm.CancelCommandOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CancelCommandRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ssm.CancelCommandOutput)
@@ -125,13 +116,11 @@ func (m *MockSSMAPI) CancelCommandRequest(arg0 *ssm.CancelCommandInput) (*reques
 
 // CancelCommandRequest indicates an expected call of CancelCommandRequest
 func (mr *MockSSMAPIMockRecorder) CancelCommandRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CancelCommandRequest", reflect.TypeOf((*MockSSMAPI)(nil).CancelCommandRequest), arg0)
 }
 
 // CancelCommandWithContext mocks base method
 func (m *MockSSMAPI) CancelCommandWithContext(arg0 context.Context, arg1 *ssm.CancelCommandInput, arg2 ...request.Option) (*ssm.CancelCommandOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -144,14 +133,12 @@ func (m *MockSSMAPI) CancelCommandWithContext(arg0 context.Context, arg1 *ssm.Ca
 
 // CancelCommandWithContext indicates an expected call of CancelCommandWithContext
 func (mr *MockSSMAPIMockRecorder) CancelCommandWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CancelCommandWithContext", reflect.TypeOf((*MockSSMAPI)(nil).CancelCommandWithContext), varargs...)
 }
 
 // CancelMaintenanceWindowExecution mocks base method
 func (m *MockSSMAPI) CancelMaintenanceWindowExecution(arg0 *ssm.CancelMaintenanceWindowExecutionInput) (*ssm.CancelMaintenanceWindowExecutionOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CancelMaintenanceWindowExecution", arg0)
 	ret0, _ := ret[0].(*ssm.CancelMaintenanceWindowExecutionOutput)
 	ret1, _ := ret[1].(error)
@@ -160,13 +147,11 @@ func (m *MockSSMAPI) CancelMaintenanceWindowExecution(arg0 *ssm.CancelMaintenanc
 
 // CancelMaintenanceWindowExecution indicates an expected call of CancelMaintenanceWindowExecution
 func (mr *MockSSMAPIMockRecorder) CancelMaintenanceWindowExecution(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CancelMaintenanceWindowExecution", reflect.TypeOf((*MockSSMAPI)(nil).CancelMaintenanceWindowExecution), arg0)
 }
 
 // CancelMaintenanceWindowExecutionRequest mocks base method
 func (m *MockSSMAPI) CancelMaintenanceWindowExecutionRequest(arg0 *ssm.CancelMaintenanceWindowExecutionInput) (*request.Request, *ssm.CancelMaintenanceWindowExecutionOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CancelMaintenanceWindowExecutionRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ssm.CancelMaintenanceWindowExecutionOutput)
@@ -175,13 +160,11 @@ func (m *MockSSMAPI) CancelMaintenanceWindowExecutionRequest(arg0 *ssm.CancelMai
 
 // CancelMaintenanceWindowExecutionRequest indicates an expected call of CancelMaintenanceWindowExecutionRequest
 func (mr *MockSSMAPIMockRecorder) CancelMaintenanceWindowExecutionRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CancelMaintenanceWindowExecutionRequest", reflect.TypeOf((*MockSSMAPI)(nil).CancelMaintenanceWindowExecutionRequest), arg0)
 }
 
 // CancelMaintenanceWindowExecutionWithContext mocks base method
 func (m *MockSSMAPI) CancelMaintenanceWindowExecutionWithContext(arg0 context.Context, arg1 *ssm.CancelMaintenanceWindowExecutionInput, arg2 ...request.Option) (*ssm.CancelMaintenanceWindowExecutionOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -194,14 +177,12 @@ func (m *MockSSMAPI) CancelMaintenanceWindowExecutionWithContext(arg0 context.Co
 
 // CancelMaintenanceWindowExecutionWithContext indicates an expected call of CancelMaintenanceWindowExecutionWithContext
 func (mr *MockSSMAPIMockRecorder) CancelMaintenanceWindowExecutionWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CancelMaintenanceWindowExecutionWithContext", reflect.TypeOf((*MockSSMAPI)(nil).CancelMaintenanceWindowExecutionWithContext), varargs...)
 }
 
 // CreateActivation mocks base method
 func (m *MockSSMAPI) CreateActivation(arg0 *ssm.CreateActivationInput) (*ssm.CreateActivationOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateActivation", arg0)
 	ret0, _ := ret[0].(*ssm.CreateActivationOutput)
 	ret1, _ := ret[1].(error)
@@ -210,13 +191,11 @@ func (m *MockSSMAPI) CreateActivation(arg0 *ssm.CreateActivationInput) (*ssm.Cre
 
 // CreateActivation indicates an expected call of CreateActivation
 func (mr *MockSSMAPIMockRecorder) CreateActivation(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateActivation", reflect.TypeOf((*MockSSMAPI)(nil).CreateActivation), arg0)
 }
 
 // CreateActivationRequest mocks base method
 func (m *MockSSMAPI) CreateActivationRequest(arg0 *ssm.CreateActivationInput) (*request.Request, *ssm.CreateActivationOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateActivationRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ssm.CreateActivationOutput)
@@ -225,13 +204,11 @@ func (m *MockSSMAPI) CreateActivationRequest(arg0 *ssm.CreateActivationInput) (*
 
 // CreateActivationRequest indicates an expected call of CreateActivationRequest
 func (mr *MockSSMAPIMockRecorder) CreateActivationRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateActivationRequest", reflect.TypeOf((*MockSSMAPI)(nil).CreateActivationRequest), arg0)
 }
 
 // CreateActivationWithContext mocks base method
 func (m *MockSSMAPI) CreateActivationWithContext(arg0 context.Context, arg1 *ssm.CreateActivationInput, arg2 ...request.Option) (*ssm.CreateActivationOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -244,14 +221,12 @@ func (m *MockSSMAPI) CreateActivationWithContext(arg0 context.Context, arg1 *ssm
 
 // CreateActivationWithContext indicates an expected call of CreateActivationWithContext
 func (mr *MockSSMAPIMockRecorder) CreateActivationWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateActivationWithContext", reflect.TypeOf((*MockSSMAPI)(nil).CreateActivationWithContext), varargs...)
 }
 
 // CreateAssociation mocks base method
 func (m *MockSSMAPI) CreateAssociation(arg0 *ssm.CreateAssociationInput) (*ssm.CreateAssociationOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateAssociation", arg0)
 	ret0, _ := ret[0].(*ssm.CreateAssociationOutput)
 	ret1, _ := ret[1].(error)
@@ -260,13 +235,11 @@ func (m *MockSSMAPI) CreateAssociation(arg0 *ssm.CreateAssociationInput) (*ssm.C
 
 // CreateAssociation indicates an expected call of CreateAssociation
 func (mr *MockSSMAPIMockRecorder) CreateAssociation(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateAssociation", reflect.TypeOf((*MockSSMAPI)(nil).CreateAssociation), arg0)
 }
 
 // CreateAssociationBatch mocks base method
 func (m *MockSSMAPI) CreateAssociationBatch(arg0 *ssm.CreateAssociationBatchInput) (*ssm.CreateAssociationBatchOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateAssociationBatch", arg0)
 	ret0, _ := ret[0].(*ssm.CreateAssociationBatchOutput)
 	ret1, _ := ret[1].(error)
@@ -275,13 +248,11 @@ func (m *MockSSMAPI) CreateAssociationBatch(arg0 *ssm.CreateAssociationBatchInpu
 
 // CreateAssociationBatch indicates an expected call of CreateAssociationBatch
 func (mr *MockSSMAPIMockRecorder) CreateAssociationBatch(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateAssociationBatch", reflect.TypeOf((*MockSSMAPI)(nil).CreateAssociationBatch), arg0)
 }
 
 // CreateAssociationBatchRequest mocks base method
 func (m *MockSSMAPI) CreateAssociationBatchRequest(arg0 *ssm.CreateAssociationBatchInput) (*request.Request, *ssm.CreateAssociationBatchOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateAssociationBatchRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ssm.CreateAssociationBatchOutput)
@@ -290,13 +261,11 @@ func (m *MockSSMAPI) CreateAssociationBatchRequest(arg0 *ssm.CreateAssociationBa
 
 // CreateAssociationBatchRequest indicates an expected call of CreateAssociationBatchRequest
 func (mr *MockSSMAPIMockRecorder) CreateAssociationBatchRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateAssociationBatchRequest", reflect.TypeOf((*MockSSMAPI)(nil).CreateAssociationBatchRequest), arg0)
 }
 
 // CreateAssociationBatchWithContext mocks base method
 func (m *MockSSMAPI) CreateAssociationBatchWithContext(arg0 context.Context, arg1 *ssm.CreateAssociationBatchInput, arg2 ...request.Option) (*ssm.CreateAssociationBatchOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -309,14 +278,12 @@ func (m *MockSSMAPI) CreateAssociationBatchWithContext(arg0 context.Context, arg
 
 // CreateAssociationBatchWithContext indicates an expected call of CreateAssociationBatchWithContext
 func (mr *MockSSMAPIMockRecorder) CreateAssociationBatchWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateAssociationBatchWithContext", reflect.TypeOf((*MockSSMAPI)(nil).CreateAssociationBatchWithContext), varargs...)
 }
 
 // CreateAssociationRequest mocks base method
 func (m *MockSSMAPI) CreateAssociationRequest(arg0 *ssm.CreateAssociationInput) (*request.Request, *ssm.CreateAssociationOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateAssociationRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ssm.CreateAssociationOutput)
@@ -325,13 +292,11 @@ func (m *MockSSMAPI) CreateAssociationRequest(arg0 *ssm.CreateAssociationInput) 
 
 // CreateAssociationRequest indicates an expected call of CreateAssociationRequest
 func (mr *MockSSMAPIMockRecorder) CreateAssociationRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateAssociationRequest", reflect.TypeOf((*MockSSMAPI)(nil).CreateAssociationRequest), arg0)
 }
 
 // CreateAssociationWithContext mocks base method
 func (m *MockSSMAPI) CreateAssociationWithContext(arg0 context.Context, arg1 *ssm.CreateAssociationInput, arg2 ...request.Option) (*ssm.CreateAssociationOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -344,14 +309,12 @@ func (m *MockSSMAPI) CreateAssociationWithContext(arg0 context.Context, arg1 *ss
 
 // CreateAssociationWithContext indicates an expected call of CreateAssociationWithContext
 func (mr *MockSSMAPIMockRecorder) CreateAssociationWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateAssociationWithContext", reflect.TypeOf((*MockSSMAPI)(nil).CreateAssociationWithContext), varargs...)
 }
 
 // CreateDocument mocks base method
 func (m *MockSSMAPI) CreateDocument(arg0 *ssm.CreateDocumentInput) (*ssm.CreateDocumentOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateDocument", arg0)
 	ret0, _ := ret[0].(*ssm.CreateDocumentOutput)
 	ret1, _ := ret[1].(error)
@@ -360,13 +323,11 @@ func (m *MockSSMAPI) CreateDocument(arg0 *ssm.CreateDocumentInput) (*ssm.CreateD
 
 // CreateDocument indicates an expected call of CreateDocument
 func (mr *MockSSMAPIMockRecorder) CreateDocument(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateDocument", reflect.TypeOf((*MockSSMAPI)(nil).CreateDocument), arg0)
 }
 
 // CreateDocumentRequest mocks base method
 func (m *MockSSMAPI) CreateDocumentRequest(arg0 *ssm.CreateDocumentInput) (*request.Request, *ssm.CreateDocumentOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateDocumentRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ssm.CreateDocumentOutput)
@@ -375,13 +336,11 @@ func (m *MockSSMAPI) CreateDocumentRequest(arg0 *ssm.CreateDocumentInput) (*requ
 
 // CreateDocumentRequest indicates an expected call of CreateDocumentRequest
 func (mr *MockSSMAPIMockRecorder) CreateDocumentRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateDocumentRequest", reflect.TypeOf((*MockSSMAPI)(nil).CreateDocumentRequest), arg0)
 }
 
 // CreateDocumentWithContext mocks base method
 func (m *MockSSMAPI) CreateDocumentWithContext(arg0 context.Context, arg1 *ssm.CreateDocumentInput, arg2 ...request.Option) (*ssm.CreateDocumentOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -394,14 +353,12 @@ func (m *MockSSMAPI) CreateDocumentWithContext(arg0 context.Context, arg1 *ssm.C
 
 // CreateDocumentWithContext indicates an expected call of CreateDocumentWithContext
 func (mr *MockSSMAPIMockRecorder) CreateDocumentWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateDocumentWithContext", reflect.TypeOf((*MockSSMAPI)(nil).CreateDocumentWithContext), varargs...)
 }
 
 // CreateMaintenanceWindow mocks base method
 func (m *MockSSMAPI) CreateMaintenanceWindow(arg0 *ssm.CreateMaintenanceWindowInput) (*ssm.CreateMaintenanceWindowOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateMaintenanceWindow", arg0)
 	ret0, _ := ret[0].(*ssm.CreateMaintenanceWindowOutput)
 	ret1, _ := ret[1].(error)
@@ -410,13 +367,11 @@ func (m *MockSSMAPI) CreateMaintenanceWindow(arg0 *ssm.CreateMaintenanceWindowIn
 
 // CreateMaintenanceWindow indicates an expected call of CreateMaintenanceWindow
 func (mr *MockSSMAPIMockRecorder) CreateMaintenanceWindow(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateMaintenanceWindow", reflect.TypeOf((*MockSSMAPI)(nil).CreateMaintenanceWindow), arg0)
 }
 
 // CreateMaintenanceWindowRequest mocks base method
 func (m *MockSSMAPI) CreateMaintenanceWindowRequest(arg0 *ssm.CreateMaintenanceWindowInput) (*request.Request, *ssm.CreateMaintenanceWindowOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateMaintenanceWindowRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ssm.CreateMaintenanceWindowOutput)
@@ -425,13 +380,11 @@ func (m *MockSSMAPI) CreateMaintenanceWindowRequest(arg0 *ssm.CreateMaintenanceW
 
 // CreateMaintenanceWindowRequest indicates an expected call of CreateMaintenanceWindowRequest
 func (mr *MockSSMAPIMockRecorder) CreateMaintenanceWindowRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateMaintenanceWindowRequest", reflect.TypeOf((*MockSSMAPI)(nil).CreateMaintenanceWindowRequest), arg0)
 }
 
 // CreateMaintenanceWindowWithContext mocks base method
 func (m *MockSSMAPI) CreateMaintenanceWindowWithContext(arg0 context.Context, arg1 *ssm.CreateMaintenanceWindowInput, arg2 ...request.Option) (*ssm.CreateMaintenanceWindowOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -444,14 +397,12 @@ func (m *MockSSMAPI) CreateMaintenanceWindowWithContext(arg0 context.Context, ar
 
 // CreateMaintenanceWindowWithContext indicates an expected call of CreateMaintenanceWindowWithContext
 func (mr *MockSSMAPIMockRecorder) CreateMaintenanceWindowWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateMaintenanceWindowWithContext", reflect.TypeOf((*MockSSMAPI)(nil).CreateMaintenanceWindowWithContext), varargs...)
 }
 
 // CreatePatchBaseline mocks base method
 func (m *MockSSMAPI) CreatePatchBaseline(arg0 *ssm.CreatePatchBaselineInput) (*ssm.CreatePatchBaselineOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreatePatchBaseline", arg0)
 	ret0, _ := ret[0].(*ssm.CreatePatchBaselineOutput)
 	ret1, _ := ret[1].(error)
@@ -460,13 +411,11 @@ func (m *MockSSMAPI) CreatePatchBaseline(arg0 *ssm.CreatePatchBaselineInput) (*s
 
 // CreatePatchBaseline indicates an expected call of CreatePatchBaseline
 func (mr *MockSSMAPIMockRecorder) CreatePatchBaseline(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreatePatchBaseline", reflect.TypeOf((*MockSSMAPI)(nil).CreatePatchBaseline), arg0)
 }
 
 // CreatePatchBaselineRequest mocks base method
 func (m *MockSSMAPI) CreatePatchBaselineRequest(arg0 *ssm.CreatePatchBaselineInput) (*request.Request, *ssm.CreatePatchBaselineOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreatePatchBaselineRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ssm.CreatePatchBaselineOutput)
@@ -475,13 +424,11 @@ func (m *MockSSMAPI) CreatePatchBaselineRequest(arg0 *ssm.CreatePatchBaselineInp
 
 // CreatePatchBaselineRequest indicates an expected call of CreatePatchBaselineRequest
 func (mr *MockSSMAPIMockRecorder) CreatePatchBaselineRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreatePatchBaselineRequest", reflect.TypeOf((*MockSSMAPI)(nil).CreatePatchBaselineRequest), arg0)
 }
 
 // CreatePatchBaselineWithContext mocks base method
 func (m *MockSSMAPI) CreatePatchBaselineWithContext(arg0 context.Context, arg1 *ssm.CreatePatchBaselineInput, arg2 ...request.Option) (*ssm.CreatePatchBaselineOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -494,14 +441,12 @@ func (m *MockSSMAPI) CreatePatchBaselineWithContext(arg0 context.Context, arg1 *
 
 // CreatePatchBaselineWithContext indicates an expected call of CreatePatchBaselineWithContext
 func (mr *MockSSMAPIMockRecorder) CreatePatchBaselineWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreatePatchBaselineWithContext", reflect.TypeOf((*MockSSMAPI)(nil).CreatePatchBaselineWithContext), varargs...)
 }
 
 // CreateResourceDataSync mocks base method
 func (m *MockSSMAPI) CreateResourceDataSync(arg0 *ssm.CreateResourceDataSyncInput) (*ssm.CreateResourceDataSyncOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateResourceDataSync", arg0)
 	ret0, _ := ret[0].(*ssm.CreateResourceDataSyncOutput)
 	ret1, _ := ret[1].(error)
@@ -510,13 +455,11 @@ func (m *MockSSMAPI) CreateResourceDataSync(arg0 *ssm.CreateResourceDataSyncInpu
 
 // CreateResourceDataSync indicates an expected call of CreateResourceDataSync
 func (mr *MockSSMAPIMockRecorder) CreateResourceDataSync(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateResourceDataSync", reflect.TypeOf((*MockSSMAPI)(nil).CreateResourceDataSync), arg0)
 }
 
 // CreateResourceDataSyncRequest mocks base method
 func (m *MockSSMAPI) CreateResourceDataSyncRequest(arg0 *ssm.CreateResourceDataSyncInput) (*request.Request, *ssm.CreateResourceDataSyncOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateResourceDataSyncRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ssm.CreateResourceDataSyncOutput)
@@ -525,13 +468,11 @@ func (m *MockSSMAPI) CreateResourceDataSyncRequest(arg0 *ssm.CreateResourceDataS
 
 // CreateResourceDataSyncRequest indicates an expected call of CreateResourceDataSyncRequest
 func (mr *MockSSMAPIMockRecorder) CreateResourceDataSyncRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateResourceDataSyncRequest", reflect.TypeOf((*MockSSMAPI)(nil).CreateResourceDataSyncRequest), arg0)
 }
 
 // CreateResourceDataSyncWithContext mocks base method
 func (m *MockSSMAPI) CreateResourceDataSyncWithContext(arg0 context.Context, arg1 *ssm.CreateResourceDataSyncInput, arg2 ...request.Option) (*ssm.CreateResourceDataSyncOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -544,14 +485,12 @@ func (m *MockSSMAPI) CreateResourceDataSyncWithContext(arg0 context.Context, arg
 
 // CreateResourceDataSyncWithContext indicates an expected call of CreateResourceDataSyncWithContext
 func (mr *MockSSMAPIMockRecorder) CreateResourceDataSyncWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateResourceDataSyncWithContext", reflect.TypeOf((*MockSSMAPI)(nil).CreateResourceDataSyncWithContext), varargs...)
 }
 
 // DeleteActivation mocks base method
 func (m *MockSSMAPI) DeleteActivation(arg0 *ssm.DeleteActivationInput) (*ssm.DeleteActivationOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteActivation", arg0)
 	ret0, _ := ret[0].(*ssm.DeleteActivationOutput)
 	ret1, _ := ret[1].(error)
@@ -560,13 +499,11 @@ func (m *MockSSMAPI) DeleteActivation(arg0 *ssm.DeleteActivationInput) (*ssm.Del
 
 // DeleteActivation indicates an expected call of DeleteActivation
 func (mr *MockSSMAPIMockRecorder) DeleteActivation(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteActivation", reflect.TypeOf((*MockSSMAPI)(nil).DeleteActivation), arg0)
 }
 
 // DeleteActivationRequest mocks base method
 func (m *MockSSMAPI) DeleteActivationRequest(arg0 *ssm.DeleteActivationInput) (*request.Request, *ssm.DeleteActivationOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteActivationRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ssm.DeleteActivationOutput)
@@ -575,13 +512,11 @@ func (m *MockSSMAPI) DeleteActivationRequest(arg0 *ssm.DeleteActivationInput) (*
 
 // DeleteActivationRequest indicates an expected call of DeleteActivationRequest
 func (mr *MockSSMAPIMockRecorder) DeleteActivationRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteActivationRequest", reflect.TypeOf((*MockSSMAPI)(nil).DeleteActivationRequest), arg0)
 }
 
 // DeleteActivationWithContext mocks base method
 func (m *MockSSMAPI) DeleteActivationWithContext(arg0 context.Context, arg1 *ssm.DeleteActivationInput, arg2 ...request.Option) (*ssm.DeleteActivationOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -594,14 +529,12 @@ func (m *MockSSMAPI) DeleteActivationWithContext(arg0 context.Context, arg1 *ssm
 
 // DeleteActivationWithContext indicates an expected call of DeleteActivationWithContext
 func (mr *MockSSMAPIMockRecorder) DeleteActivationWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteActivationWithContext", reflect.TypeOf((*MockSSMAPI)(nil).DeleteActivationWithContext), varargs...)
 }
 
 // DeleteAssociation mocks base method
 func (m *MockSSMAPI) DeleteAssociation(arg0 *ssm.DeleteAssociationInput) (*ssm.DeleteAssociationOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteAssociation", arg0)
 	ret0, _ := ret[0].(*ssm.DeleteAssociationOutput)
 	ret1, _ := ret[1].(error)
@@ -610,13 +543,11 @@ func (m *MockSSMAPI) DeleteAssociation(arg0 *ssm.DeleteAssociationInput) (*ssm.D
 
 // DeleteAssociation indicates an expected call of DeleteAssociation
 func (mr *MockSSMAPIMockRecorder) DeleteAssociation(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteAssociation", reflect.TypeOf((*MockSSMAPI)(nil).DeleteAssociation), arg0)
 }
 
 // DeleteAssociationRequest mocks base method
 func (m *MockSSMAPI) DeleteAssociationRequest(arg0 *ssm.DeleteAssociationInput) (*request.Request, *ssm.DeleteAssociationOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteAssociationRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ssm.DeleteAssociationOutput)
@@ -625,13 +556,11 @@ func (m *MockSSMAPI) DeleteAssociationRequest(arg0 *ssm.DeleteAssociationInput) 
 
 // DeleteAssociationRequest indicates an expected call of DeleteAssociationRequest
 func (mr *MockSSMAPIMockRecorder) DeleteAssociationRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteAssociationRequest", reflect.TypeOf((*MockSSMAPI)(nil).DeleteAssociationRequest), arg0)
 }
 
 // DeleteAssociationWithContext mocks base method
 func (m *MockSSMAPI) DeleteAssociationWithContext(arg0 context.Context, arg1 *ssm.DeleteAssociationInput, arg2 ...request.Option) (*ssm.DeleteAssociationOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -644,14 +573,12 @@ func (m *MockSSMAPI) DeleteAssociationWithContext(arg0 context.Context, arg1 *ss
 
 // DeleteAssociationWithContext indicates an expected call of DeleteAssociationWithContext
 func (mr *MockSSMAPIMockRecorder) DeleteAssociationWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteAssociationWithContext", reflect.TypeOf((*MockSSMAPI)(nil).DeleteAssociationWithContext), varargs...)
 }
 
 // DeleteDocument mocks base method
 func (m *MockSSMAPI) DeleteDocument(arg0 *ssm.DeleteDocumentInput) (*ssm.DeleteDocumentOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteDocument", arg0)
 	ret0, _ := ret[0].(*ssm.DeleteDocumentOutput)
 	ret1, _ := ret[1].(error)
@@ -660,13 +587,11 @@ func (m *MockSSMAPI) DeleteDocument(arg0 *ssm.DeleteDocumentInput) (*ssm.DeleteD
 
 // DeleteDocument indicates an expected call of DeleteDocument
 func (mr *MockSSMAPIMockRecorder) DeleteDocument(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteDocument", reflect.TypeOf((*MockSSMAPI)(nil).DeleteDocument), arg0)
 }
 
 // DeleteDocumentRequest mocks base method
 func (m *MockSSMAPI) DeleteDocumentRequest(arg0 *ssm.DeleteDocumentInput) (*request.Request, *ssm.DeleteDocumentOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteDocumentRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ssm.DeleteDocumentOutput)
@@ -675,13 +600,11 @@ func (m *MockSSMAPI) DeleteDocumentRequest(arg0 *ssm.DeleteDocumentInput) (*requ
 
 // DeleteDocumentRequest indicates an expected call of DeleteDocumentRequest
 func (mr *MockSSMAPIMockRecorder) DeleteDocumentRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteDocumentRequest", reflect.TypeOf((*MockSSMAPI)(nil).DeleteDocumentRequest), arg0)
 }
 
 // DeleteDocumentWithContext mocks base method
 func (m *MockSSMAPI) DeleteDocumentWithContext(arg0 context.Context, arg1 *ssm.DeleteDocumentInput, arg2 ...request.Option) (*ssm.DeleteDocumentOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -694,14 +617,12 @@ func (m *MockSSMAPI) DeleteDocumentWithContext(arg0 context.Context, arg1 *ssm.D
 
 // DeleteDocumentWithContext indicates an expected call of DeleteDocumentWithContext
 func (mr *MockSSMAPIMockRecorder) DeleteDocumentWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteDocumentWithContext", reflect.TypeOf((*MockSSMAPI)(nil).DeleteDocumentWithContext), varargs...)
 }
 
 // DeleteInventory mocks base method
 func (m *MockSSMAPI) DeleteInventory(arg0 *ssm.DeleteInventoryInput) (*ssm.DeleteInventoryOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteInventory", arg0)
 	ret0, _ := ret[0].(*ssm.DeleteInventoryOutput)
 	ret1, _ := ret[1].(error)
@@ -710,13 +631,11 @@ func (m *MockSSMAPI) DeleteInventory(arg0 *ssm.DeleteInventoryInput) (*ssm.Delet
 
 // DeleteInventory indicates an expected call of DeleteInventory
 func (mr *MockSSMAPIMockRecorder) DeleteInventory(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteInventory", reflect.TypeOf((*MockSSMAPI)(nil).DeleteInventory), arg0)
 }
 
 // DeleteInventoryRequest mocks base method
 func (m *MockSSMAPI) DeleteInventoryRequest(arg0 *ssm.DeleteInventoryInput) (*request.Request, *ssm.DeleteInventoryOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteInventoryRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ssm.DeleteInventoryOutput)
@@ -725,13 +644,11 @@ func (m *MockSSMAPI) DeleteInventoryRequest(arg0 *ssm.DeleteInventoryInput) (*re
 
 // DeleteInventoryRequest indicates an expected call of DeleteInventoryRequest
 func (mr *MockSSMAPIMockRecorder) DeleteInventoryRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteInventoryRequest", reflect.TypeOf((*MockSSMAPI)(nil).DeleteInventoryRequest), arg0)
 }
 
 // DeleteInventoryWithContext mocks base method
 func (m *MockSSMAPI) DeleteInventoryWithContext(arg0 context.Context, arg1 *ssm.DeleteInventoryInput, arg2 ...request.Option) (*ssm.DeleteInventoryOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -744,14 +661,12 @@ func (m *MockSSMAPI) DeleteInventoryWithContext(arg0 context.Context, arg1 *ssm.
 
 // DeleteInventoryWithContext indicates an expected call of DeleteInventoryWithContext
 func (mr *MockSSMAPIMockRecorder) DeleteInventoryWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteInventoryWithContext", reflect.TypeOf((*MockSSMAPI)(nil).DeleteInventoryWithContext), varargs...)
 }
 
 // DeleteMaintenanceWindow mocks base method
 func (m *MockSSMAPI) DeleteMaintenanceWindow(arg0 *ssm.DeleteMaintenanceWindowInput) (*ssm.DeleteMaintenanceWindowOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteMaintenanceWindow", arg0)
 	ret0, _ := ret[0].(*ssm.DeleteMaintenanceWindowOutput)
 	ret1, _ := ret[1].(error)
@@ -760,13 +675,11 @@ func (m *MockSSMAPI) DeleteMaintenanceWindow(arg0 *ssm.DeleteMaintenanceWindowIn
 
 // DeleteMaintenanceWindow indicates an expected call of DeleteMaintenanceWindow
 func (mr *MockSSMAPIMockRecorder) DeleteMaintenanceWindow(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteMaintenanceWindow", reflect.TypeOf((*MockSSMAPI)(nil).DeleteMaintenanceWindow), arg0)
 }
 
 // DeleteMaintenanceWindowRequest mocks base method
 func (m *MockSSMAPI) DeleteMaintenanceWindowRequest(arg0 *ssm.DeleteMaintenanceWindowInput) (*request.Request, *ssm.DeleteMaintenanceWindowOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteMaintenanceWindowRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ssm.DeleteMaintenanceWindowOutput)
@@ -775,13 +688,11 @@ func (m *MockSSMAPI) DeleteMaintenanceWindowRequest(arg0 *ssm.DeleteMaintenanceW
 
 // DeleteMaintenanceWindowRequest indicates an expected call of DeleteMaintenanceWindowRequest
 func (mr *MockSSMAPIMockRecorder) DeleteMaintenanceWindowRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteMaintenanceWindowRequest", reflect.TypeOf((*MockSSMAPI)(nil).DeleteMaintenanceWindowRequest), arg0)
 }
 
 // DeleteMaintenanceWindowWithContext mocks base method
 func (m *MockSSMAPI) DeleteMaintenanceWindowWithContext(arg0 context.Context, arg1 *ssm.DeleteMaintenanceWindowInput, arg2 ...request.Option) (*ssm.DeleteMaintenanceWindowOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -794,14 +705,12 @@ func (m *MockSSMAPI) DeleteMaintenanceWindowWithContext(arg0 context.Context, ar
 
 // DeleteMaintenanceWindowWithContext indicates an expected call of DeleteMaintenanceWindowWithContext
 func (mr *MockSSMAPIMockRecorder) DeleteMaintenanceWindowWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteMaintenanceWindowWithContext", reflect.TypeOf((*MockSSMAPI)(nil).DeleteMaintenanceWindowWithContext), varargs...)
 }
 
 // DeleteParameter mocks base method
 func (m *MockSSMAPI) DeleteParameter(arg0 *ssm.DeleteParameterInput) (*ssm.DeleteParameterOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteParameter", arg0)
 	ret0, _ := ret[0].(*ssm.DeleteParameterOutput)
 	ret1, _ := ret[1].(error)
@@ -810,13 +719,11 @@ func (m *MockSSMAPI) DeleteParameter(arg0 *ssm.DeleteParameterInput) (*ssm.Delet
 
 // DeleteParameter indicates an expected call of DeleteParameter
 func (mr *MockSSMAPIMockRecorder) DeleteParameter(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteParameter", reflect.TypeOf((*MockSSMAPI)(nil).DeleteParameter), arg0)
 }
 
 // DeleteParameterRequest mocks base method
 func (m *MockSSMAPI) DeleteParameterRequest(arg0 *ssm.DeleteParameterInput) (*request.Request, *ssm.DeleteParameterOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteParameterRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ssm.DeleteParameterOutput)
@@ -825,13 +732,11 @@ func (m *MockSSMAPI) DeleteParameterRequest(arg0 *ssm.DeleteParameterInput) (*re
 
 // DeleteParameterRequest indicates an expected call of DeleteParameterRequest
 func (mr *MockSSMAPIMockRecorder) DeleteParameterRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteParameterRequest", reflect.TypeOf((*MockSSMAPI)(nil).DeleteParameterRequest), arg0)
 }
 
 // DeleteParameterWithContext mocks base method
 func (m *MockSSMAPI) DeleteParameterWithContext(arg0 context.Context, arg1 *ssm.DeleteParameterInput, arg2 ...request.Option) (*ssm.DeleteParameterOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -844,14 +749,12 @@ func (m *MockSSMAPI) DeleteParameterWithContext(arg0 context.Context, arg1 *ssm.
 
 // DeleteParameterWithContext indicates an expected call of DeleteParameterWithContext
 func (mr *MockSSMAPIMockRecorder) DeleteParameterWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteParameterWithContext", reflect.TypeOf((*MockSSMAPI)(nil).DeleteParameterWithContext), varargs...)
 }
 
 // DeleteParameters mocks base method
 func (m *MockSSMAPI) DeleteParameters(arg0 *ssm.DeleteParametersInput) (*ssm.DeleteParametersOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteParameters", arg0)
 	ret0, _ := ret[0].(*ssm.DeleteParametersOutput)
 	ret1, _ := ret[1].(error)
@@ -860,13 +763,11 @@ func (m *MockSSMAPI) DeleteParameters(arg0 *ssm.DeleteParametersInput) (*ssm.Del
 
 // DeleteParameters indicates an expected call of DeleteParameters
 func (mr *MockSSMAPIMockRecorder) DeleteParameters(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteParameters", reflect.TypeOf((*MockSSMAPI)(nil).DeleteParameters), arg0)
 }
 
 // DeleteParametersRequest mocks base method
 func (m *MockSSMAPI) DeleteParametersRequest(arg0 *ssm.DeleteParametersInput) (*request.Request, *ssm.DeleteParametersOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteParametersRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ssm.DeleteParametersOutput)
@@ -875,13 +776,11 @@ func (m *MockSSMAPI) DeleteParametersRequest(arg0 *ssm.DeleteParametersInput) (*
 
 // DeleteParametersRequest indicates an expected call of DeleteParametersRequest
 func (mr *MockSSMAPIMockRecorder) DeleteParametersRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteParametersRequest", reflect.TypeOf((*MockSSMAPI)(nil).DeleteParametersRequest), arg0)
 }
 
 // DeleteParametersWithContext mocks base method
 func (m *MockSSMAPI) DeleteParametersWithContext(arg0 context.Context, arg1 *ssm.DeleteParametersInput, arg2 ...request.Option) (*ssm.DeleteParametersOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -894,14 +793,12 @@ func (m *MockSSMAPI) DeleteParametersWithContext(arg0 context.Context, arg1 *ssm
 
 // DeleteParametersWithContext indicates an expected call of DeleteParametersWithContext
 func (mr *MockSSMAPIMockRecorder) DeleteParametersWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteParametersWithContext", reflect.TypeOf((*MockSSMAPI)(nil).DeleteParametersWithContext), varargs...)
 }
 
 // DeletePatchBaseline mocks base method
 func (m *MockSSMAPI) DeletePatchBaseline(arg0 *ssm.DeletePatchBaselineInput) (*ssm.DeletePatchBaselineOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeletePatchBaseline", arg0)
 	ret0, _ := ret[0].(*ssm.DeletePatchBaselineOutput)
 	ret1, _ := ret[1].(error)
@@ -910,13 +807,11 @@ func (m *MockSSMAPI) DeletePatchBaseline(arg0 *ssm.DeletePatchBaselineInput) (*s
 
 // DeletePatchBaseline indicates an expected call of DeletePatchBaseline
 func (mr *MockSSMAPIMockRecorder) DeletePatchBaseline(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeletePatchBaseline", reflect.TypeOf((*MockSSMAPI)(nil).DeletePatchBaseline), arg0)
 }
 
 // DeletePatchBaselineRequest mocks base method
 func (m *MockSSMAPI) DeletePatchBaselineRequest(arg0 *ssm.DeletePatchBaselineInput) (*request.Request, *ssm.DeletePatchBaselineOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeletePatchBaselineRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ssm.DeletePatchBaselineOutput)
@@ -925,13 +820,11 @@ func (m *MockSSMAPI) DeletePatchBaselineRequest(arg0 *ssm.DeletePatchBaselineInp
 
 // DeletePatchBaselineRequest indicates an expected call of DeletePatchBaselineRequest
 func (mr *MockSSMAPIMockRecorder) DeletePatchBaselineRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeletePatchBaselineRequest", reflect.TypeOf((*MockSSMAPI)(nil).DeletePatchBaselineRequest), arg0)
 }
 
 // DeletePatchBaselineWithContext mocks base method
 func (m *MockSSMAPI) DeletePatchBaselineWithContext(arg0 context.Context, arg1 *ssm.DeletePatchBaselineInput, arg2 ...request.Option) (*ssm.DeletePatchBaselineOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -944,14 +837,12 @@ func (m *MockSSMAPI) DeletePatchBaselineWithContext(arg0 context.Context, arg1 *
 
 // DeletePatchBaselineWithContext indicates an expected call of DeletePatchBaselineWithContext
 func (mr *MockSSMAPIMockRecorder) DeletePatchBaselineWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeletePatchBaselineWithContext", reflect.TypeOf((*MockSSMAPI)(nil).DeletePatchBaselineWithContext), varargs...)
 }
 
 // DeleteResourceDataSync mocks base method
 func (m *MockSSMAPI) DeleteResourceDataSync(arg0 *ssm.DeleteResourceDataSyncInput) (*ssm.DeleteResourceDataSyncOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteResourceDataSync", arg0)
 	ret0, _ := ret[0].(*ssm.DeleteResourceDataSyncOutput)
 	ret1, _ := ret[1].(error)
@@ -960,13 +851,11 @@ func (m *MockSSMAPI) DeleteResourceDataSync(arg0 *ssm.DeleteResourceDataSyncInpu
 
 // DeleteResourceDataSync indicates an expected call of DeleteResourceDataSync
 func (mr *MockSSMAPIMockRecorder) DeleteResourceDataSync(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteResourceDataSync", reflect.TypeOf((*MockSSMAPI)(nil).DeleteResourceDataSync), arg0)
 }
 
 // DeleteResourceDataSyncRequest mocks base method
 func (m *MockSSMAPI) DeleteResourceDataSyncRequest(arg0 *ssm.DeleteResourceDataSyncInput) (*request.Request, *ssm.DeleteResourceDataSyncOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteResourceDataSyncRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ssm.DeleteResourceDataSyncOutput)
@@ -975,13 +864,11 @@ func (m *MockSSMAPI) DeleteResourceDataSyncRequest(arg0 *ssm.DeleteResourceDataS
 
 // DeleteResourceDataSyncRequest indicates an expected call of DeleteResourceDataSyncRequest
 func (mr *MockSSMAPIMockRecorder) DeleteResourceDataSyncRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteResourceDataSyncRequest", reflect.TypeOf((*MockSSMAPI)(nil).DeleteResourceDataSyncRequest), arg0)
 }
 
 // DeleteResourceDataSyncWithContext mocks base method
 func (m *MockSSMAPI) DeleteResourceDataSyncWithContext(arg0 context.Context, arg1 *ssm.DeleteResourceDataSyncInput, arg2 ...request.Option) (*ssm.DeleteResourceDataSyncOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -994,14 +881,12 @@ func (m *MockSSMAPI) DeleteResourceDataSyncWithContext(arg0 context.Context, arg
 
 // DeleteResourceDataSyncWithContext indicates an expected call of DeleteResourceDataSyncWithContext
 func (mr *MockSSMAPIMockRecorder) DeleteResourceDataSyncWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteResourceDataSyncWithContext", reflect.TypeOf((*MockSSMAPI)(nil).DeleteResourceDataSyncWithContext), varargs...)
 }
 
 // DeregisterManagedInstance mocks base method
 func (m *MockSSMAPI) DeregisterManagedInstance(arg0 *ssm.DeregisterManagedInstanceInput) (*ssm.DeregisterManagedInstanceOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeregisterManagedInstance", arg0)
 	ret0, _ := ret[0].(*ssm.DeregisterManagedInstanceOutput)
 	ret1, _ := ret[1].(error)
@@ -1010,13 +895,11 @@ func (m *MockSSMAPI) DeregisterManagedInstance(arg0 *ssm.DeregisterManagedInstan
 
 // DeregisterManagedInstance indicates an expected call of DeregisterManagedInstance
 func (mr *MockSSMAPIMockRecorder) DeregisterManagedInstance(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeregisterManagedInstance", reflect.TypeOf((*MockSSMAPI)(nil).DeregisterManagedInstance), arg0)
 }
 
 // DeregisterManagedInstanceRequest mocks base method
 func (m *MockSSMAPI) DeregisterManagedInstanceRequest(arg0 *ssm.DeregisterManagedInstanceInput) (*request.Request, *ssm.DeregisterManagedInstanceOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeregisterManagedInstanceRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ssm.DeregisterManagedInstanceOutput)
@@ -1025,13 +908,11 @@ func (m *MockSSMAPI) DeregisterManagedInstanceRequest(arg0 *ssm.DeregisterManage
 
 // DeregisterManagedInstanceRequest indicates an expected call of DeregisterManagedInstanceRequest
 func (mr *MockSSMAPIMockRecorder) DeregisterManagedInstanceRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeregisterManagedInstanceRequest", reflect.TypeOf((*MockSSMAPI)(nil).DeregisterManagedInstanceRequest), arg0)
 }
 
 // DeregisterManagedInstanceWithContext mocks base method
 func (m *MockSSMAPI) DeregisterManagedInstanceWithContext(arg0 context.Context, arg1 *ssm.DeregisterManagedInstanceInput, arg2 ...request.Option) (*ssm.DeregisterManagedInstanceOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -1044,14 +925,12 @@ func (m *MockSSMAPI) DeregisterManagedInstanceWithContext(arg0 context.Context, 
 
 // DeregisterManagedInstanceWithContext indicates an expected call of DeregisterManagedInstanceWithContext
 func (mr *MockSSMAPIMockRecorder) DeregisterManagedInstanceWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeregisterManagedInstanceWithContext", reflect.TypeOf((*MockSSMAPI)(nil).DeregisterManagedInstanceWithContext), varargs...)
 }
 
 // DeregisterPatchBaselineForPatchGroup mocks base method
 func (m *MockSSMAPI) DeregisterPatchBaselineForPatchGroup(arg0 *ssm.DeregisterPatchBaselineForPatchGroupInput) (*ssm.DeregisterPatchBaselineForPatchGroupOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeregisterPatchBaselineForPatchGroup", arg0)
 	ret0, _ := ret[0].(*ssm.DeregisterPatchBaselineForPatchGroupOutput)
 	ret1, _ := ret[1].(error)
@@ -1060,13 +939,11 @@ func (m *MockSSMAPI) DeregisterPatchBaselineForPatchGroup(arg0 *ssm.DeregisterPa
 
 // DeregisterPatchBaselineForPatchGroup indicates an expected call of DeregisterPatchBaselineForPatchGroup
 func (mr *MockSSMAPIMockRecorder) DeregisterPatchBaselineForPatchGroup(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeregisterPatchBaselineForPatchGroup", reflect.TypeOf((*MockSSMAPI)(nil).DeregisterPatchBaselineForPatchGroup), arg0)
 }
 
 // DeregisterPatchBaselineForPatchGroupRequest mocks base method
 func (m *MockSSMAPI) DeregisterPatchBaselineForPatchGroupRequest(arg0 *ssm.DeregisterPatchBaselineForPatchGroupInput) (*request.Request, *ssm.DeregisterPatchBaselineForPatchGroupOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeregisterPatchBaselineForPatchGroupRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ssm.DeregisterPatchBaselineForPatchGroupOutput)
@@ -1075,13 +952,11 @@ func (m *MockSSMAPI) DeregisterPatchBaselineForPatchGroupRequest(arg0 *ssm.Dereg
 
 // DeregisterPatchBaselineForPatchGroupRequest indicates an expected call of DeregisterPatchBaselineForPatchGroupRequest
 func (mr *MockSSMAPIMockRecorder) DeregisterPatchBaselineForPatchGroupRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeregisterPatchBaselineForPatchGroupRequest", reflect.TypeOf((*MockSSMAPI)(nil).DeregisterPatchBaselineForPatchGroupRequest), arg0)
 }
 
 // DeregisterPatchBaselineForPatchGroupWithContext mocks base method
 func (m *MockSSMAPI) DeregisterPatchBaselineForPatchGroupWithContext(arg0 context.Context, arg1 *ssm.DeregisterPatchBaselineForPatchGroupInput, arg2 ...request.Option) (*ssm.DeregisterPatchBaselineForPatchGroupOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -1094,14 +969,12 @@ func (m *MockSSMAPI) DeregisterPatchBaselineForPatchGroupWithContext(arg0 contex
 
 // DeregisterPatchBaselineForPatchGroupWithContext indicates an expected call of DeregisterPatchBaselineForPatchGroupWithContext
 func (mr *MockSSMAPIMockRecorder) DeregisterPatchBaselineForPatchGroupWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeregisterPatchBaselineForPatchGroupWithContext", reflect.TypeOf((*MockSSMAPI)(nil).DeregisterPatchBaselineForPatchGroupWithContext), varargs...)
 }
 
 // DeregisterTargetFromMaintenanceWindow mocks base method
 func (m *MockSSMAPI) DeregisterTargetFromMaintenanceWindow(arg0 *ssm.DeregisterTargetFromMaintenanceWindowInput) (*ssm.DeregisterTargetFromMaintenanceWindowOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeregisterTargetFromMaintenanceWindow", arg0)
 	ret0, _ := ret[0].(*ssm.DeregisterTargetFromMaintenanceWindowOutput)
 	ret1, _ := ret[1].(error)
@@ -1110,13 +983,11 @@ func (m *MockSSMAPI) DeregisterTargetFromMaintenanceWindow(arg0 *ssm.DeregisterT
 
 // DeregisterTargetFromMaintenanceWindow indicates an expected call of DeregisterTargetFromMaintenanceWindow
 func (mr *MockSSMAPIMockRecorder) DeregisterTargetFromMaintenanceWindow(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeregisterTargetFromMaintenanceWindow", reflect.TypeOf((*MockSSMAPI)(nil).DeregisterTargetFromMaintenanceWindow), arg0)
 }
 
 // DeregisterTargetFromMaintenanceWindowRequest mocks base method
 func (m *MockSSMAPI) DeregisterTargetFromMaintenanceWindowRequest(arg0 *ssm.DeregisterTargetFromMaintenanceWindowInput) (*request.Request, *ssm.DeregisterTargetFromMaintenanceWindowOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeregisterTargetFromMaintenanceWindowRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ssm.DeregisterTargetFromMaintenanceWindowOutput)
@@ -1125,13 +996,11 @@ func (m *MockSSMAPI) DeregisterTargetFromMaintenanceWindowRequest(arg0 *ssm.Dere
 
 // DeregisterTargetFromMaintenanceWindowRequest indicates an expected call of DeregisterTargetFromMaintenanceWindowRequest
 func (mr *MockSSMAPIMockRecorder) DeregisterTargetFromMaintenanceWindowRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeregisterTargetFromMaintenanceWindowRequest", reflect.TypeOf((*MockSSMAPI)(nil).DeregisterTargetFromMaintenanceWindowRequest), arg0)
 }
 
 // DeregisterTargetFromMaintenanceWindowWithContext mocks base method
 func (m *MockSSMAPI) DeregisterTargetFromMaintenanceWindowWithContext(arg0 context.Context, arg1 *ssm.DeregisterTargetFromMaintenanceWindowInput, arg2 ...request.Option) (*ssm.DeregisterTargetFromMaintenanceWindowOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -1144,14 +1013,12 @@ func (m *MockSSMAPI) DeregisterTargetFromMaintenanceWindowWithContext(arg0 conte
 
 // DeregisterTargetFromMaintenanceWindowWithContext indicates an expected call of DeregisterTargetFromMaintenanceWindowWithContext
 func (mr *MockSSMAPIMockRecorder) DeregisterTargetFromMaintenanceWindowWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeregisterTargetFromMaintenanceWindowWithContext", reflect.TypeOf((*MockSSMAPI)(nil).DeregisterTargetFromMaintenanceWindowWithContext), varargs...)
 }
 
 // DeregisterTaskFromMaintenanceWindow mocks base method
 func (m *MockSSMAPI) DeregisterTaskFromMaintenanceWindow(arg0 *ssm.DeregisterTaskFromMaintenanceWindowInput) (*ssm.DeregisterTaskFromMaintenanceWindowOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeregisterTaskFromMaintenanceWindow", arg0)
 	ret0, _ := ret[0].(*ssm.DeregisterTaskFromMaintenanceWindowOutput)
 	ret1, _ := ret[1].(error)
@@ -1160,13 +1027,11 @@ func (m *MockSSMAPI) DeregisterTaskFromMaintenanceWindow(arg0 *ssm.DeregisterTas
 
 // DeregisterTaskFromMaintenanceWindow indicates an expected call of DeregisterTaskFromMaintenanceWindow
 func (mr *MockSSMAPIMockRecorder) DeregisterTaskFromMaintenanceWindow(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeregisterTaskFromMaintenanceWindow", reflect.TypeOf((*MockSSMAPI)(nil).DeregisterTaskFromMaintenanceWindow), arg0)
 }
 
 // DeregisterTaskFromMaintenanceWindowRequest mocks base method
 func (m *MockSSMAPI) DeregisterTaskFromMaintenanceWindowRequest(arg0 *ssm.DeregisterTaskFromMaintenanceWindowInput) (*request.Request, *ssm.DeregisterTaskFromMaintenanceWindowOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeregisterTaskFromMaintenanceWindowRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ssm.DeregisterTaskFromMaintenanceWindowOutput)
@@ -1175,13 +1040,11 @@ func (m *MockSSMAPI) DeregisterTaskFromMaintenanceWindowRequest(arg0 *ssm.Deregi
 
 // DeregisterTaskFromMaintenanceWindowRequest indicates an expected call of DeregisterTaskFromMaintenanceWindowRequest
 func (mr *MockSSMAPIMockRecorder) DeregisterTaskFromMaintenanceWindowRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeregisterTaskFromMaintenanceWindowRequest", reflect.TypeOf((*MockSSMAPI)(nil).DeregisterTaskFromMaintenanceWindowRequest), arg0)
 }
 
 // DeregisterTaskFromMaintenanceWindowWithContext mocks base method
 func (m *MockSSMAPI) DeregisterTaskFromMaintenanceWindowWithContext(arg0 context.Context, arg1 *ssm.DeregisterTaskFromMaintenanceWindowInput, arg2 ...request.Option) (*ssm.DeregisterTaskFromMaintenanceWindowOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -1194,14 +1057,12 @@ func (m *MockSSMAPI) DeregisterTaskFromMaintenanceWindowWithContext(arg0 context
 
 // DeregisterTaskFromMaintenanceWindowWithContext indicates an expected call of DeregisterTaskFromMaintenanceWindowWithContext
 func (mr *MockSSMAPIMockRecorder) DeregisterTaskFromMaintenanceWindowWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeregisterTaskFromMaintenanceWindowWithContext", reflect.TypeOf((*MockSSMAPI)(nil).DeregisterTaskFromMaintenanceWindowWithContext), varargs...)
 }
 
 // DescribeActivations mocks base method
 func (m *MockSSMAPI) DescribeActivations(arg0 *ssm.DescribeActivationsInput) (*ssm.DescribeActivationsOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeActivations", arg0)
 	ret0, _ := ret[0].(*ssm.DescribeActivationsOutput)
 	ret1, _ := ret[1].(error)
@@ -1210,13 +1071,11 @@ func (m *MockSSMAPI) DescribeActivations(arg0 *ssm.DescribeActivationsInput) (*s
 
 // DescribeActivations indicates an expected call of DescribeActivations
 func (mr *MockSSMAPIMockRecorder) DescribeActivations(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeActivations", reflect.TypeOf((*MockSSMAPI)(nil).DescribeActivations), arg0)
 }
 
 // DescribeActivationsPages mocks base method
 func (m *MockSSMAPI) DescribeActivationsPages(arg0 *ssm.DescribeActivationsInput, arg1 func(*ssm.DescribeActivationsOutput, bool) bool) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeActivationsPages", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -1224,13 +1083,11 @@ func (m *MockSSMAPI) DescribeActivationsPages(arg0 *ssm.DescribeActivationsInput
 
 // DescribeActivationsPages indicates an expected call of DescribeActivationsPages
 func (mr *MockSSMAPIMockRecorder) DescribeActivationsPages(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeActivationsPages", reflect.TypeOf((*MockSSMAPI)(nil).DescribeActivationsPages), arg0, arg1)
 }
 
 // DescribeActivationsPagesWithContext mocks base method
 func (m *MockSSMAPI) DescribeActivationsPagesWithContext(arg0 context.Context, arg1 *ssm.DescribeActivationsInput, arg2 func(*ssm.DescribeActivationsOutput, bool) bool, arg3 ...request.Option) error {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1, arg2}
 	for _, a := range arg3 {
 		varargs = append(varargs, a)
@@ -1242,14 +1099,12 @@ func (m *MockSSMAPI) DescribeActivationsPagesWithContext(arg0 context.Context, a
 
 // DescribeActivationsPagesWithContext indicates an expected call of DescribeActivationsPagesWithContext
 func (mr *MockSSMAPIMockRecorder) DescribeActivationsPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeActivationsPagesWithContext", reflect.TypeOf((*MockSSMAPI)(nil).DescribeActivationsPagesWithContext), varargs...)
 }
 
 // DescribeActivationsRequest mocks base method
 func (m *MockSSMAPI) DescribeActivationsRequest(arg0 *ssm.DescribeActivationsInput) (*request.Request, *ssm.DescribeActivationsOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeActivationsRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ssm.DescribeActivationsOutput)
@@ -1258,13 +1113,11 @@ func (m *MockSSMAPI) DescribeActivationsRequest(arg0 *ssm.DescribeActivationsInp
 
 // DescribeActivationsRequest indicates an expected call of DescribeActivationsRequest
 func (mr *MockSSMAPIMockRecorder) DescribeActivationsRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeActivationsRequest", reflect.TypeOf((*MockSSMAPI)(nil).DescribeActivationsRequest), arg0)
 }
 
 // DescribeActivationsWithContext mocks base method
 func (m *MockSSMAPI) DescribeActivationsWithContext(arg0 context.Context, arg1 *ssm.DescribeActivationsInput, arg2 ...request.Option) (*ssm.DescribeActivationsOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -1277,14 +1130,12 @@ func (m *MockSSMAPI) DescribeActivationsWithContext(arg0 context.Context, arg1 *
 
 // DescribeActivationsWithContext indicates an expected call of DescribeActivationsWithContext
 func (mr *MockSSMAPIMockRecorder) DescribeActivationsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeActivationsWithContext", reflect.TypeOf((*MockSSMAPI)(nil).DescribeActivationsWithContext), varargs...)
 }
 
 // DescribeAssociation mocks base method
 func (m *MockSSMAPI) DescribeAssociation(arg0 *ssm.DescribeAssociationInput) (*ssm.DescribeAssociationOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeAssociation", arg0)
 	ret0, _ := ret[0].(*ssm.DescribeAssociationOutput)
 	ret1, _ := ret[1].(error)
@@ -1293,13 +1144,11 @@ func (m *MockSSMAPI) DescribeAssociation(arg0 *ssm.DescribeAssociationInput) (*s
 
 // DescribeAssociation indicates an expected call of DescribeAssociation
 func (mr *MockSSMAPIMockRecorder) DescribeAssociation(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeAssociation", reflect.TypeOf((*MockSSMAPI)(nil).DescribeAssociation), arg0)
 }
 
 // DescribeAssociationExecutionTargets mocks base method
 func (m *MockSSMAPI) DescribeAssociationExecutionTargets(arg0 *ssm.DescribeAssociationExecutionTargetsInput) (*ssm.DescribeAssociationExecutionTargetsOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeAssociationExecutionTargets", arg0)
 	ret0, _ := ret[0].(*ssm.DescribeAssociationExecutionTargetsOutput)
 	ret1, _ := ret[1].(error)
@@ -1308,13 +1157,11 @@ func (m *MockSSMAPI) DescribeAssociationExecutionTargets(arg0 *ssm.DescribeAssoc
 
 // DescribeAssociationExecutionTargets indicates an expected call of DescribeAssociationExecutionTargets
 func (mr *MockSSMAPIMockRecorder) DescribeAssociationExecutionTargets(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeAssociationExecutionTargets", reflect.TypeOf((*MockSSMAPI)(nil).DescribeAssociationExecutionTargets), arg0)
 }
 
 // DescribeAssociationExecutionTargetsRequest mocks base method
 func (m *MockSSMAPI) DescribeAssociationExecutionTargetsRequest(arg0 *ssm.DescribeAssociationExecutionTargetsInput) (*request.Request, *ssm.DescribeAssociationExecutionTargetsOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeAssociationExecutionTargetsRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ssm.DescribeAssociationExecutionTargetsOutput)
@@ -1323,13 +1170,11 @@ func (m *MockSSMAPI) DescribeAssociationExecutionTargetsRequest(arg0 *ssm.Descri
 
 // DescribeAssociationExecutionTargetsRequest indicates an expected call of DescribeAssociationExecutionTargetsRequest
 func (mr *MockSSMAPIMockRecorder) DescribeAssociationExecutionTargetsRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeAssociationExecutionTargetsRequest", reflect.TypeOf((*MockSSMAPI)(nil).DescribeAssociationExecutionTargetsRequest), arg0)
 }
 
 // DescribeAssociationExecutionTargetsWithContext mocks base method
 func (m *MockSSMAPI) DescribeAssociationExecutionTargetsWithContext(arg0 context.Context, arg1 *ssm.DescribeAssociationExecutionTargetsInput, arg2 ...request.Option) (*ssm.DescribeAssociationExecutionTargetsOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -1342,14 +1187,12 @@ func (m *MockSSMAPI) DescribeAssociationExecutionTargetsWithContext(arg0 context
 
 // DescribeAssociationExecutionTargetsWithContext indicates an expected call of DescribeAssociationExecutionTargetsWithContext
 func (mr *MockSSMAPIMockRecorder) DescribeAssociationExecutionTargetsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeAssociationExecutionTargetsWithContext", reflect.TypeOf((*MockSSMAPI)(nil).DescribeAssociationExecutionTargetsWithContext), varargs...)
 }
 
 // DescribeAssociationExecutions mocks base method
 func (m *MockSSMAPI) DescribeAssociationExecutions(arg0 *ssm.DescribeAssociationExecutionsInput) (*ssm.DescribeAssociationExecutionsOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeAssociationExecutions", arg0)
 	ret0, _ := ret[0].(*ssm.DescribeAssociationExecutionsOutput)
 	ret1, _ := ret[1].(error)
@@ -1358,13 +1201,11 @@ func (m *MockSSMAPI) DescribeAssociationExecutions(arg0 *ssm.DescribeAssociation
 
 // DescribeAssociationExecutions indicates an expected call of DescribeAssociationExecutions
 func (mr *MockSSMAPIMockRecorder) DescribeAssociationExecutions(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeAssociationExecutions", reflect.TypeOf((*MockSSMAPI)(nil).DescribeAssociationExecutions), arg0)
 }
 
 // DescribeAssociationExecutionsRequest mocks base method
 func (m *MockSSMAPI) DescribeAssociationExecutionsRequest(arg0 *ssm.DescribeAssociationExecutionsInput) (*request.Request, *ssm.DescribeAssociationExecutionsOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeAssociationExecutionsRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ssm.DescribeAssociationExecutionsOutput)
@@ -1373,13 +1214,11 @@ func (m *MockSSMAPI) DescribeAssociationExecutionsRequest(arg0 *ssm.DescribeAsso
 
 // DescribeAssociationExecutionsRequest indicates an expected call of DescribeAssociationExecutionsRequest
 func (mr *MockSSMAPIMockRecorder) DescribeAssociationExecutionsRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeAssociationExecutionsRequest", reflect.TypeOf((*MockSSMAPI)(nil).DescribeAssociationExecutionsRequest), arg0)
 }
 
 // DescribeAssociationExecutionsWithContext mocks base method
 func (m *MockSSMAPI) DescribeAssociationExecutionsWithContext(arg0 context.Context, arg1 *ssm.DescribeAssociationExecutionsInput, arg2 ...request.Option) (*ssm.DescribeAssociationExecutionsOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -1392,14 +1231,12 @@ func (m *MockSSMAPI) DescribeAssociationExecutionsWithContext(arg0 context.Conte
 
 // DescribeAssociationExecutionsWithContext indicates an expected call of DescribeAssociationExecutionsWithContext
 func (mr *MockSSMAPIMockRecorder) DescribeAssociationExecutionsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeAssociationExecutionsWithContext", reflect.TypeOf((*MockSSMAPI)(nil).DescribeAssociationExecutionsWithContext), varargs...)
 }
 
 // DescribeAssociationRequest mocks base method
 func (m *MockSSMAPI) DescribeAssociationRequest(arg0 *ssm.DescribeAssociationInput) (*request.Request, *ssm.DescribeAssociationOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeAssociationRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ssm.DescribeAssociationOutput)
@@ -1408,13 +1245,11 @@ func (m *MockSSMAPI) DescribeAssociationRequest(arg0 *ssm.DescribeAssociationInp
 
 // DescribeAssociationRequest indicates an expected call of DescribeAssociationRequest
 func (mr *MockSSMAPIMockRecorder) DescribeAssociationRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeAssociationRequest", reflect.TypeOf((*MockSSMAPI)(nil).DescribeAssociationRequest), arg0)
 }
 
 // DescribeAssociationWithContext mocks base method
 func (m *MockSSMAPI) DescribeAssociationWithContext(arg0 context.Context, arg1 *ssm.DescribeAssociationInput, arg2 ...request.Option) (*ssm.DescribeAssociationOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -1427,14 +1262,12 @@ func (m *MockSSMAPI) DescribeAssociationWithContext(arg0 context.Context, arg1 *
 
 // DescribeAssociationWithContext indicates an expected call of DescribeAssociationWithContext
 func (mr *MockSSMAPIMockRecorder) DescribeAssociationWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeAssociationWithContext", reflect.TypeOf((*MockSSMAPI)(nil).DescribeAssociationWithContext), varargs...)
 }
 
 // DescribeAutomationExecutions mocks base method
 func (m *MockSSMAPI) DescribeAutomationExecutions(arg0 *ssm.DescribeAutomationExecutionsInput) (*ssm.DescribeAutomationExecutionsOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeAutomationExecutions", arg0)
 	ret0, _ := ret[0].(*ssm.DescribeAutomationExecutionsOutput)
 	ret1, _ := ret[1].(error)
@@ -1443,13 +1276,11 @@ func (m *MockSSMAPI) DescribeAutomationExecutions(arg0 *ssm.DescribeAutomationEx
 
 // DescribeAutomationExecutions indicates an expected call of DescribeAutomationExecutions
 func (mr *MockSSMAPIMockRecorder) DescribeAutomationExecutions(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeAutomationExecutions", reflect.TypeOf((*MockSSMAPI)(nil).DescribeAutomationExecutions), arg0)
 }
 
 // DescribeAutomationExecutionsRequest mocks base method
 func (m *MockSSMAPI) DescribeAutomationExecutionsRequest(arg0 *ssm.DescribeAutomationExecutionsInput) (*request.Request, *ssm.DescribeAutomationExecutionsOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeAutomationExecutionsRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ssm.DescribeAutomationExecutionsOutput)
@@ -1458,13 +1289,11 @@ func (m *MockSSMAPI) DescribeAutomationExecutionsRequest(arg0 *ssm.DescribeAutom
 
 // DescribeAutomationExecutionsRequest indicates an expected call of DescribeAutomationExecutionsRequest
 func (mr *MockSSMAPIMockRecorder) DescribeAutomationExecutionsRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeAutomationExecutionsRequest", reflect.TypeOf((*MockSSMAPI)(nil).DescribeAutomationExecutionsRequest), arg0)
 }
 
 // DescribeAutomationExecutionsWithContext mocks base method
 func (m *MockSSMAPI) DescribeAutomationExecutionsWithContext(arg0 context.Context, arg1 *ssm.DescribeAutomationExecutionsInput, arg2 ...request.Option) (*ssm.DescribeAutomationExecutionsOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -1477,14 +1306,12 @@ func (m *MockSSMAPI) DescribeAutomationExecutionsWithContext(arg0 context.Contex
 
 // DescribeAutomationExecutionsWithContext indicates an expected call of DescribeAutomationExecutionsWithContext
 func (mr *MockSSMAPIMockRecorder) DescribeAutomationExecutionsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeAutomationExecutionsWithContext", reflect.TypeOf((*MockSSMAPI)(nil).DescribeAutomationExecutionsWithContext), varargs...)
 }
 
 // DescribeAutomationStepExecutions mocks base method
 func (m *MockSSMAPI) DescribeAutomationStepExecutions(arg0 *ssm.DescribeAutomationStepExecutionsInput) (*ssm.DescribeAutomationStepExecutionsOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeAutomationStepExecutions", arg0)
 	ret0, _ := ret[0].(*ssm.DescribeAutomationStepExecutionsOutput)
 	ret1, _ := ret[1].(error)
@@ -1493,13 +1320,11 @@ func (m *MockSSMAPI) DescribeAutomationStepExecutions(arg0 *ssm.DescribeAutomati
 
 // DescribeAutomationStepExecutions indicates an expected call of DescribeAutomationStepExecutions
 func (mr *MockSSMAPIMockRecorder) DescribeAutomationStepExecutions(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeAutomationStepExecutions", reflect.TypeOf((*MockSSMAPI)(nil).DescribeAutomationStepExecutions), arg0)
 }
 
 // DescribeAutomationStepExecutionsRequest mocks base method
 func (m *MockSSMAPI) DescribeAutomationStepExecutionsRequest(arg0 *ssm.DescribeAutomationStepExecutionsInput) (*request.Request, *ssm.DescribeAutomationStepExecutionsOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeAutomationStepExecutionsRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ssm.DescribeAutomationStepExecutionsOutput)
@@ -1508,13 +1333,11 @@ func (m *MockSSMAPI) DescribeAutomationStepExecutionsRequest(arg0 *ssm.DescribeA
 
 // DescribeAutomationStepExecutionsRequest indicates an expected call of DescribeAutomationStepExecutionsRequest
 func (mr *MockSSMAPIMockRecorder) DescribeAutomationStepExecutionsRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeAutomationStepExecutionsRequest", reflect.TypeOf((*MockSSMAPI)(nil).DescribeAutomationStepExecutionsRequest), arg0)
 }
 
 // DescribeAutomationStepExecutionsWithContext mocks base method
 func (m *MockSSMAPI) DescribeAutomationStepExecutionsWithContext(arg0 context.Context, arg1 *ssm.DescribeAutomationStepExecutionsInput, arg2 ...request.Option) (*ssm.DescribeAutomationStepExecutionsOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -1527,14 +1350,12 @@ func (m *MockSSMAPI) DescribeAutomationStepExecutionsWithContext(arg0 context.Co
 
 // DescribeAutomationStepExecutionsWithContext indicates an expected call of DescribeAutomationStepExecutionsWithContext
 func (mr *MockSSMAPIMockRecorder) DescribeAutomationStepExecutionsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeAutomationStepExecutionsWithContext", reflect.TypeOf((*MockSSMAPI)(nil).DescribeAutomationStepExecutionsWithContext), varargs...)
 }
 
 // DescribeAvailablePatches mocks base method
 func (m *MockSSMAPI) DescribeAvailablePatches(arg0 *ssm.DescribeAvailablePatchesInput) (*ssm.DescribeAvailablePatchesOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeAvailablePatches", arg0)
 	ret0, _ := ret[0].(*ssm.DescribeAvailablePatchesOutput)
 	ret1, _ := ret[1].(error)
@@ -1543,13 +1364,11 @@ func (m *MockSSMAPI) DescribeAvailablePatches(arg0 *ssm.DescribeAvailablePatches
 
 // DescribeAvailablePatches indicates an expected call of DescribeAvailablePatches
 func (mr *MockSSMAPIMockRecorder) DescribeAvailablePatches(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeAvailablePatches", reflect.TypeOf((*MockSSMAPI)(nil).DescribeAvailablePatches), arg0)
 }
 
 // DescribeAvailablePatchesRequest mocks base method
 func (m *MockSSMAPI) DescribeAvailablePatchesRequest(arg0 *ssm.DescribeAvailablePatchesInput) (*request.Request, *ssm.DescribeAvailablePatchesOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeAvailablePatchesRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ssm.DescribeAvailablePatchesOutput)
@@ -1558,13 +1377,11 @@ func (m *MockSSMAPI) DescribeAvailablePatchesRequest(arg0 *ssm.DescribeAvailable
 
 // DescribeAvailablePatchesRequest indicates an expected call of DescribeAvailablePatchesRequest
 func (mr *MockSSMAPIMockRecorder) DescribeAvailablePatchesRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeAvailablePatchesRequest", reflect.TypeOf((*MockSSMAPI)(nil).DescribeAvailablePatchesRequest), arg0)
 }
 
 // DescribeAvailablePatchesWithContext mocks base method
 func (m *MockSSMAPI) DescribeAvailablePatchesWithContext(arg0 context.Context, arg1 *ssm.DescribeAvailablePatchesInput, arg2 ...request.Option) (*ssm.DescribeAvailablePatchesOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -1577,14 +1394,12 @@ func (m *MockSSMAPI) DescribeAvailablePatchesWithContext(arg0 context.Context, a
 
 // DescribeAvailablePatchesWithContext indicates an expected call of DescribeAvailablePatchesWithContext
 func (mr *MockSSMAPIMockRecorder) DescribeAvailablePatchesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeAvailablePatchesWithContext", reflect.TypeOf((*MockSSMAPI)(nil).DescribeAvailablePatchesWithContext), varargs...)
 }
 
 // DescribeDocument mocks base method
 func (m *MockSSMAPI) DescribeDocument(arg0 *ssm.DescribeDocumentInput) (*ssm.DescribeDocumentOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeDocument", arg0)
 	ret0, _ := ret[0].(*ssm.DescribeDocumentOutput)
 	ret1, _ := ret[1].(error)
@@ -1593,13 +1408,11 @@ func (m *MockSSMAPI) DescribeDocument(arg0 *ssm.DescribeDocumentInput) (*ssm.Des
 
 // DescribeDocument indicates an expected call of DescribeDocument
 func (mr *MockSSMAPIMockRecorder) DescribeDocument(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeDocument", reflect.TypeOf((*MockSSMAPI)(nil).DescribeDocument), arg0)
 }
 
 // DescribeDocumentPermission mocks base method
 func (m *MockSSMAPI) DescribeDocumentPermission(arg0 *ssm.DescribeDocumentPermissionInput) (*ssm.DescribeDocumentPermissionOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeDocumentPermission", arg0)
 	ret0, _ := ret[0].(*ssm.DescribeDocumentPermissionOutput)
 	ret1, _ := ret[1].(error)
@@ -1608,13 +1421,11 @@ func (m *MockSSMAPI) DescribeDocumentPermission(arg0 *ssm.DescribeDocumentPermis
 
 // DescribeDocumentPermission indicates an expected call of DescribeDocumentPermission
 func (mr *MockSSMAPIMockRecorder) DescribeDocumentPermission(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeDocumentPermission", reflect.TypeOf((*MockSSMAPI)(nil).DescribeDocumentPermission), arg0)
 }
 
 // DescribeDocumentPermissionRequest mocks base method
 func (m *MockSSMAPI) DescribeDocumentPermissionRequest(arg0 *ssm.DescribeDocumentPermissionInput) (*request.Request, *ssm.DescribeDocumentPermissionOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeDocumentPermissionRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ssm.DescribeDocumentPermissionOutput)
@@ -1623,13 +1434,11 @@ func (m *MockSSMAPI) DescribeDocumentPermissionRequest(arg0 *ssm.DescribeDocumen
 
 // DescribeDocumentPermissionRequest indicates an expected call of DescribeDocumentPermissionRequest
 func (mr *MockSSMAPIMockRecorder) DescribeDocumentPermissionRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeDocumentPermissionRequest", reflect.TypeOf((*MockSSMAPI)(nil).DescribeDocumentPermissionRequest), arg0)
 }
 
 // DescribeDocumentPermissionWithContext mocks base method
 func (m *MockSSMAPI) DescribeDocumentPermissionWithContext(arg0 context.Context, arg1 *ssm.DescribeDocumentPermissionInput, arg2 ...request.Option) (*ssm.DescribeDocumentPermissionOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -1642,14 +1451,12 @@ func (m *MockSSMAPI) DescribeDocumentPermissionWithContext(arg0 context.Context,
 
 // DescribeDocumentPermissionWithContext indicates an expected call of DescribeDocumentPermissionWithContext
 func (mr *MockSSMAPIMockRecorder) DescribeDocumentPermissionWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeDocumentPermissionWithContext", reflect.TypeOf((*MockSSMAPI)(nil).DescribeDocumentPermissionWithContext), varargs...)
 }
 
 // DescribeDocumentRequest mocks base method
 func (m *MockSSMAPI) DescribeDocumentRequest(arg0 *ssm.DescribeDocumentInput) (*request.Request, *ssm.DescribeDocumentOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeDocumentRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ssm.DescribeDocumentOutput)
@@ -1658,13 +1465,11 @@ func (m *MockSSMAPI) DescribeDocumentRequest(arg0 *ssm.DescribeDocumentInput) (*
 
 // DescribeDocumentRequest indicates an expected call of DescribeDocumentRequest
 func (mr *MockSSMAPIMockRecorder) DescribeDocumentRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeDocumentRequest", reflect.TypeOf((*MockSSMAPI)(nil).DescribeDocumentRequest), arg0)
 }
 
 // DescribeDocumentWithContext mocks base method
 func (m *MockSSMAPI) DescribeDocumentWithContext(arg0 context.Context, arg1 *ssm.DescribeDocumentInput, arg2 ...request.Option) (*ssm.DescribeDocumentOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -1677,14 +1482,12 @@ func (m *MockSSMAPI) DescribeDocumentWithContext(arg0 context.Context, arg1 *ssm
 
 // DescribeDocumentWithContext indicates an expected call of DescribeDocumentWithContext
 func (mr *MockSSMAPIMockRecorder) DescribeDocumentWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeDocumentWithContext", reflect.TypeOf((*MockSSMAPI)(nil).DescribeDocumentWithContext), varargs...)
 }
 
 // DescribeEffectiveInstanceAssociations mocks base method
 func (m *MockSSMAPI) DescribeEffectiveInstanceAssociations(arg0 *ssm.DescribeEffectiveInstanceAssociationsInput) (*ssm.DescribeEffectiveInstanceAssociationsOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeEffectiveInstanceAssociations", arg0)
 	ret0, _ := ret[0].(*ssm.DescribeEffectiveInstanceAssociationsOutput)
 	ret1, _ := ret[1].(error)
@@ -1693,13 +1496,11 @@ func (m *MockSSMAPI) DescribeEffectiveInstanceAssociations(arg0 *ssm.DescribeEff
 
 // DescribeEffectiveInstanceAssociations indicates an expected call of DescribeEffectiveInstanceAssociations
 func (mr *MockSSMAPIMockRecorder) DescribeEffectiveInstanceAssociations(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeEffectiveInstanceAssociations", reflect.TypeOf((*MockSSMAPI)(nil).DescribeEffectiveInstanceAssociations), arg0)
 }
 
 // DescribeEffectiveInstanceAssociationsRequest mocks base method
 func (m *MockSSMAPI) DescribeEffectiveInstanceAssociationsRequest(arg0 *ssm.DescribeEffectiveInstanceAssociationsInput) (*request.Request, *ssm.DescribeEffectiveInstanceAssociationsOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeEffectiveInstanceAssociationsRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ssm.DescribeEffectiveInstanceAssociationsOutput)
@@ -1708,13 +1509,11 @@ func (m *MockSSMAPI) DescribeEffectiveInstanceAssociationsRequest(arg0 *ssm.Desc
 
 // DescribeEffectiveInstanceAssociationsRequest indicates an expected call of DescribeEffectiveInstanceAssociationsRequest
 func (mr *MockSSMAPIMockRecorder) DescribeEffectiveInstanceAssociationsRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeEffectiveInstanceAssociationsRequest", reflect.TypeOf((*MockSSMAPI)(nil).DescribeEffectiveInstanceAssociationsRequest), arg0)
 }
 
 // DescribeEffectiveInstanceAssociationsWithContext mocks base method
 func (m *MockSSMAPI) DescribeEffectiveInstanceAssociationsWithContext(arg0 context.Context, arg1 *ssm.DescribeEffectiveInstanceAssociationsInput, arg2 ...request.Option) (*ssm.DescribeEffectiveInstanceAssociationsOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -1727,14 +1526,12 @@ func (m *MockSSMAPI) DescribeEffectiveInstanceAssociationsWithContext(arg0 conte
 
 // DescribeEffectiveInstanceAssociationsWithContext indicates an expected call of DescribeEffectiveInstanceAssociationsWithContext
 func (mr *MockSSMAPIMockRecorder) DescribeEffectiveInstanceAssociationsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeEffectiveInstanceAssociationsWithContext", reflect.TypeOf((*MockSSMAPI)(nil).DescribeEffectiveInstanceAssociationsWithContext), varargs...)
 }
 
 // DescribeEffectivePatchesForPatchBaseline mocks base method
 func (m *MockSSMAPI) DescribeEffectivePatchesForPatchBaseline(arg0 *ssm.DescribeEffectivePatchesForPatchBaselineInput) (*ssm.DescribeEffectivePatchesForPatchBaselineOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeEffectivePatchesForPatchBaseline", arg0)
 	ret0, _ := ret[0].(*ssm.DescribeEffectivePatchesForPatchBaselineOutput)
 	ret1, _ := ret[1].(error)
@@ -1743,13 +1540,11 @@ func (m *MockSSMAPI) DescribeEffectivePatchesForPatchBaseline(arg0 *ssm.Describe
 
 // DescribeEffectivePatchesForPatchBaseline indicates an expected call of DescribeEffectivePatchesForPatchBaseline
 func (mr *MockSSMAPIMockRecorder) DescribeEffectivePatchesForPatchBaseline(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeEffectivePatchesForPatchBaseline", reflect.TypeOf((*MockSSMAPI)(nil).DescribeEffectivePatchesForPatchBaseline), arg0)
 }
 
 // DescribeEffectivePatchesForPatchBaselineRequest mocks base method
 func (m *MockSSMAPI) DescribeEffectivePatchesForPatchBaselineRequest(arg0 *ssm.DescribeEffectivePatchesForPatchBaselineInput) (*request.Request, *ssm.DescribeEffectivePatchesForPatchBaselineOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeEffectivePatchesForPatchBaselineRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ssm.DescribeEffectivePatchesForPatchBaselineOutput)
@@ -1758,13 +1553,11 @@ func (m *MockSSMAPI) DescribeEffectivePatchesForPatchBaselineRequest(arg0 *ssm.D
 
 // DescribeEffectivePatchesForPatchBaselineRequest indicates an expected call of DescribeEffectivePatchesForPatchBaselineRequest
 func (mr *MockSSMAPIMockRecorder) DescribeEffectivePatchesForPatchBaselineRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeEffectivePatchesForPatchBaselineRequest", reflect.TypeOf((*MockSSMAPI)(nil).DescribeEffectivePatchesForPatchBaselineRequest), arg0)
 }
 
 // DescribeEffectivePatchesForPatchBaselineWithContext mocks base method
 func (m *MockSSMAPI) DescribeEffectivePatchesForPatchBaselineWithContext(arg0 context.Context, arg1 *ssm.DescribeEffectivePatchesForPatchBaselineInput, arg2 ...request.Option) (*ssm.DescribeEffectivePatchesForPatchBaselineOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -1777,14 +1570,12 @@ func (m *MockSSMAPI) DescribeEffectivePatchesForPatchBaselineWithContext(arg0 co
 
 // DescribeEffectivePatchesForPatchBaselineWithContext indicates an expected call of DescribeEffectivePatchesForPatchBaselineWithContext
 func (mr *MockSSMAPIMockRecorder) DescribeEffectivePatchesForPatchBaselineWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeEffectivePatchesForPatchBaselineWithContext", reflect.TypeOf((*MockSSMAPI)(nil).DescribeEffectivePatchesForPatchBaselineWithContext), varargs...)
 }
 
 // DescribeInstanceAssociationsStatus mocks base method
 func (m *MockSSMAPI) DescribeInstanceAssociationsStatus(arg0 *ssm.DescribeInstanceAssociationsStatusInput) (*ssm.DescribeInstanceAssociationsStatusOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeInstanceAssociationsStatus", arg0)
 	ret0, _ := ret[0].(*ssm.DescribeInstanceAssociationsStatusOutput)
 	ret1, _ := ret[1].(error)
@@ -1793,13 +1584,11 @@ func (m *MockSSMAPI) DescribeInstanceAssociationsStatus(arg0 *ssm.DescribeInstan
 
 // DescribeInstanceAssociationsStatus indicates an expected call of DescribeInstanceAssociationsStatus
 func (mr *MockSSMAPIMockRecorder) DescribeInstanceAssociationsStatus(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeInstanceAssociationsStatus", reflect.TypeOf((*MockSSMAPI)(nil).DescribeInstanceAssociationsStatus), arg0)
 }
 
 // DescribeInstanceAssociationsStatusRequest mocks base method
 func (m *MockSSMAPI) DescribeInstanceAssociationsStatusRequest(arg0 *ssm.DescribeInstanceAssociationsStatusInput) (*request.Request, *ssm.DescribeInstanceAssociationsStatusOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeInstanceAssociationsStatusRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ssm.DescribeInstanceAssociationsStatusOutput)
@@ -1808,13 +1597,11 @@ func (m *MockSSMAPI) DescribeInstanceAssociationsStatusRequest(arg0 *ssm.Describ
 
 // DescribeInstanceAssociationsStatusRequest indicates an expected call of DescribeInstanceAssociationsStatusRequest
 func (mr *MockSSMAPIMockRecorder) DescribeInstanceAssociationsStatusRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeInstanceAssociationsStatusRequest", reflect.TypeOf((*MockSSMAPI)(nil).DescribeInstanceAssociationsStatusRequest), arg0)
 }
 
 // DescribeInstanceAssociationsStatusWithContext mocks base method
 func (m *MockSSMAPI) DescribeInstanceAssociationsStatusWithContext(arg0 context.Context, arg1 *ssm.DescribeInstanceAssociationsStatusInput, arg2 ...request.Option) (*ssm.DescribeInstanceAssociationsStatusOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -1827,14 +1614,12 @@ func (m *MockSSMAPI) DescribeInstanceAssociationsStatusWithContext(arg0 context.
 
 // DescribeInstanceAssociationsStatusWithContext indicates an expected call of DescribeInstanceAssociationsStatusWithContext
 func (mr *MockSSMAPIMockRecorder) DescribeInstanceAssociationsStatusWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeInstanceAssociationsStatusWithContext", reflect.TypeOf((*MockSSMAPI)(nil).DescribeInstanceAssociationsStatusWithContext), varargs...)
 }
 
 // DescribeInstanceInformation mocks base method
 func (m *MockSSMAPI) DescribeInstanceInformation(arg0 *ssm.DescribeInstanceInformationInput) (*ssm.DescribeInstanceInformationOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeInstanceInformation", arg0)
 	ret0, _ := ret[0].(*ssm.DescribeInstanceInformationOutput)
 	ret1, _ := ret[1].(error)
@@ -1843,13 +1628,11 @@ func (m *MockSSMAPI) DescribeInstanceInformation(arg0 *ssm.DescribeInstanceInfor
 
 // DescribeInstanceInformation indicates an expected call of DescribeInstanceInformation
 func (mr *MockSSMAPIMockRecorder) DescribeInstanceInformation(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeInstanceInformation", reflect.TypeOf((*MockSSMAPI)(nil).DescribeInstanceInformation), arg0)
 }
 
 // DescribeInstanceInformationPages mocks base method
 func (m *MockSSMAPI) DescribeInstanceInformationPages(arg0 *ssm.DescribeInstanceInformationInput, arg1 func(*ssm.DescribeInstanceInformationOutput, bool) bool) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeInstanceInformationPages", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -1857,13 +1640,11 @@ func (m *MockSSMAPI) DescribeInstanceInformationPages(arg0 *ssm.DescribeInstance
 
 // DescribeInstanceInformationPages indicates an expected call of DescribeInstanceInformationPages
 func (mr *MockSSMAPIMockRecorder) DescribeInstanceInformationPages(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeInstanceInformationPages", reflect.TypeOf((*MockSSMAPI)(nil).DescribeInstanceInformationPages), arg0, arg1)
 }
 
 // DescribeInstanceInformationPagesWithContext mocks base method
 func (m *MockSSMAPI) DescribeInstanceInformationPagesWithContext(arg0 context.Context, arg1 *ssm.DescribeInstanceInformationInput, arg2 func(*ssm.DescribeInstanceInformationOutput, bool) bool, arg3 ...request.Option) error {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1, arg2}
 	for _, a := range arg3 {
 		varargs = append(varargs, a)
@@ -1875,14 +1656,12 @@ func (m *MockSSMAPI) DescribeInstanceInformationPagesWithContext(arg0 context.Co
 
 // DescribeInstanceInformationPagesWithContext indicates an expected call of DescribeInstanceInformationPagesWithContext
 func (mr *MockSSMAPIMockRecorder) DescribeInstanceInformationPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeInstanceInformationPagesWithContext", reflect.TypeOf((*MockSSMAPI)(nil).DescribeInstanceInformationPagesWithContext), varargs...)
 }
 
 // DescribeInstanceInformationRequest mocks base method
 func (m *MockSSMAPI) DescribeInstanceInformationRequest(arg0 *ssm.DescribeInstanceInformationInput) (*request.Request, *ssm.DescribeInstanceInformationOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeInstanceInformationRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ssm.DescribeInstanceInformationOutput)
@@ -1891,13 +1670,11 @@ func (m *MockSSMAPI) DescribeInstanceInformationRequest(arg0 *ssm.DescribeInstan
 
 // DescribeInstanceInformationRequest indicates an expected call of DescribeInstanceInformationRequest
 func (mr *MockSSMAPIMockRecorder) DescribeInstanceInformationRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeInstanceInformationRequest", reflect.TypeOf((*MockSSMAPI)(nil).DescribeInstanceInformationRequest), arg0)
 }
 
 // DescribeInstanceInformationWithContext mocks base method
 func (m *MockSSMAPI) DescribeInstanceInformationWithContext(arg0 context.Context, arg1 *ssm.DescribeInstanceInformationInput, arg2 ...request.Option) (*ssm.DescribeInstanceInformationOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -1910,14 +1687,12 @@ func (m *MockSSMAPI) DescribeInstanceInformationWithContext(arg0 context.Context
 
 // DescribeInstanceInformationWithContext indicates an expected call of DescribeInstanceInformationWithContext
 func (mr *MockSSMAPIMockRecorder) DescribeInstanceInformationWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeInstanceInformationWithContext", reflect.TypeOf((*MockSSMAPI)(nil).DescribeInstanceInformationWithContext), varargs...)
 }
 
 // DescribeInstancePatchStates mocks base method
 func (m *MockSSMAPI) DescribeInstancePatchStates(arg0 *ssm.DescribeInstancePatchStatesInput) (*ssm.DescribeInstancePatchStatesOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeInstancePatchStates", arg0)
 	ret0, _ := ret[0].(*ssm.DescribeInstancePatchStatesOutput)
 	ret1, _ := ret[1].(error)
@@ -1926,13 +1701,11 @@ func (m *MockSSMAPI) DescribeInstancePatchStates(arg0 *ssm.DescribeInstancePatch
 
 // DescribeInstancePatchStates indicates an expected call of DescribeInstancePatchStates
 func (mr *MockSSMAPIMockRecorder) DescribeInstancePatchStates(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeInstancePatchStates", reflect.TypeOf((*MockSSMAPI)(nil).DescribeInstancePatchStates), arg0)
 }
 
 // DescribeInstancePatchStatesForPatchGroup mocks base method
 func (m *MockSSMAPI) DescribeInstancePatchStatesForPatchGroup(arg0 *ssm.DescribeInstancePatchStatesForPatchGroupInput) (*ssm.DescribeInstancePatchStatesForPatchGroupOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeInstancePatchStatesForPatchGroup", arg0)
 	ret0, _ := ret[0].(*ssm.DescribeInstancePatchStatesForPatchGroupOutput)
 	ret1, _ := ret[1].(error)
@@ -1941,13 +1714,11 @@ func (m *MockSSMAPI) DescribeInstancePatchStatesForPatchGroup(arg0 *ssm.Describe
 
 // DescribeInstancePatchStatesForPatchGroup indicates an expected call of DescribeInstancePatchStatesForPatchGroup
 func (mr *MockSSMAPIMockRecorder) DescribeInstancePatchStatesForPatchGroup(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeInstancePatchStatesForPatchGroup", reflect.TypeOf((*MockSSMAPI)(nil).DescribeInstancePatchStatesForPatchGroup), arg0)
 }
 
 // DescribeInstancePatchStatesForPatchGroupRequest mocks base method
 func (m *MockSSMAPI) DescribeInstancePatchStatesForPatchGroupRequest(arg0 *ssm.DescribeInstancePatchStatesForPatchGroupInput) (*request.Request, *ssm.DescribeInstancePatchStatesForPatchGroupOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeInstancePatchStatesForPatchGroupRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ssm.DescribeInstancePatchStatesForPatchGroupOutput)
@@ -1956,13 +1727,11 @@ func (m *MockSSMAPI) DescribeInstancePatchStatesForPatchGroupRequest(arg0 *ssm.D
 
 // DescribeInstancePatchStatesForPatchGroupRequest indicates an expected call of DescribeInstancePatchStatesForPatchGroupRequest
 func (mr *MockSSMAPIMockRecorder) DescribeInstancePatchStatesForPatchGroupRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeInstancePatchStatesForPatchGroupRequest", reflect.TypeOf((*MockSSMAPI)(nil).DescribeInstancePatchStatesForPatchGroupRequest), arg0)
 }
 
 // DescribeInstancePatchStatesForPatchGroupWithContext mocks base method
 func (m *MockSSMAPI) DescribeInstancePatchStatesForPatchGroupWithContext(arg0 context.Context, arg1 *ssm.DescribeInstancePatchStatesForPatchGroupInput, arg2 ...request.Option) (*ssm.DescribeInstancePatchStatesForPatchGroupOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -1975,14 +1744,12 @@ func (m *MockSSMAPI) DescribeInstancePatchStatesForPatchGroupWithContext(arg0 co
 
 // DescribeInstancePatchStatesForPatchGroupWithContext indicates an expected call of DescribeInstancePatchStatesForPatchGroupWithContext
 func (mr *MockSSMAPIMockRecorder) DescribeInstancePatchStatesForPatchGroupWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeInstancePatchStatesForPatchGroupWithContext", reflect.TypeOf((*MockSSMAPI)(nil).DescribeInstancePatchStatesForPatchGroupWithContext), varargs...)
 }
 
 // DescribeInstancePatchStatesRequest mocks base method
 func (m *MockSSMAPI) DescribeInstancePatchStatesRequest(arg0 *ssm.DescribeInstancePatchStatesInput) (*request.Request, *ssm.DescribeInstancePatchStatesOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeInstancePatchStatesRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ssm.DescribeInstancePatchStatesOutput)
@@ -1991,13 +1758,11 @@ func (m *MockSSMAPI) DescribeInstancePatchStatesRequest(arg0 *ssm.DescribeInstan
 
 // DescribeInstancePatchStatesRequest indicates an expected call of DescribeInstancePatchStatesRequest
 func (mr *MockSSMAPIMockRecorder) DescribeInstancePatchStatesRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeInstancePatchStatesRequest", reflect.TypeOf((*MockSSMAPI)(nil).DescribeInstancePatchStatesRequest), arg0)
 }
 
 // DescribeInstancePatchStatesWithContext mocks base method
 func (m *MockSSMAPI) DescribeInstancePatchStatesWithContext(arg0 context.Context, arg1 *ssm.DescribeInstancePatchStatesInput, arg2 ...request.Option) (*ssm.DescribeInstancePatchStatesOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -2010,14 +1775,12 @@ func (m *MockSSMAPI) DescribeInstancePatchStatesWithContext(arg0 context.Context
 
 // DescribeInstancePatchStatesWithContext indicates an expected call of DescribeInstancePatchStatesWithContext
 func (mr *MockSSMAPIMockRecorder) DescribeInstancePatchStatesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeInstancePatchStatesWithContext", reflect.TypeOf((*MockSSMAPI)(nil).DescribeInstancePatchStatesWithContext), varargs...)
 }
 
 // DescribeInstancePatches mocks base method
 func (m *MockSSMAPI) DescribeInstancePatches(arg0 *ssm.DescribeInstancePatchesInput) (*ssm.DescribeInstancePatchesOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeInstancePatches", arg0)
 	ret0, _ := ret[0].(*ssm.DescribeInstancePatchesOutput)
 	ret1, _ := ret[1].(error)
@@ -2026,13 +1789,11 @@ func (m *MockSSMAPI) DescribeInstancePatches(arg0 *ssm.DescribeInstancePatchesIn
 
 // DescribeInstancePatches indicates an expected call of DescribeInstancePatches
 func (mr *MockSSMAPIMockRecorder) DescribeInstancePatches(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeInstancePatches", reflect.TypeOf((*MockSSMAPI)(nil).DescribeInstancePatches), arg0)
 }
 
 // DescribeInstancePatchesRequest mocks base method
 func (m *MockSSMAPI) DescribeInstancePatchesRequest(arg0 *ssm.DescribeInstancePatchesInput) (*request.Request, *ssm.DescribeInstancePatchesOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeInstancePatchesRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ssm.DescribeInstancePatchesOutput)
@@ -2041,13 +1802,11 @@ func (m *MockSSMAPI) DescribeInstancePatchesRequest(arg0 *ssm.DescribeInstancePa
 
 // DescribeInstancePatchesRequest indicates an expected call of DescribeInstancePatchesRequest
 func (mr *MockSSMAPIMockRecorder) DescribeInstancePatchesRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeInstancePatchesRequest", reflect.TypeOf((*MockSSMAPI)(nil).DescribeInstancePatchesRequest), arg0)
 }
 
 // DescribeInstancePatchesWithContext mocks base method
 func (m *MockSSMAPI) DescribeInstancePatchesWithContext(arg0 context.Context, arg1 *ssm.DescribeInstancePatchesInput, arg2 ...request.Option) (*ssm.DescribeInstancePatchesOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -2060,14 +1819,12 @@ func (m *MockSSMAPI) DescribeInstancePatchesWithContext(arg0 context.Context, ar
 
 // DescribeInstancePatchesWithContext indicates an expected call of DescribeInstancePatchesWithContext
 func (mr *MockSSMAPIMockRecorder) DescribeInstancePatchesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeInstancePatchesWithContext", reflect.TypeOf((*MockSSMAPI)(nil).DescribeInstancePatchesWithContext), varargs...)
 }
 
 // DescribeInventoryDeletions mocks base method
 func (m *MockSSMAPI) DescribeInventoryDeletions(arg0 *ssm.DescribeInventoryDeletionsInput) (*ssm.DescribeInventoryDeletionsOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeInventoryDeletions", arg0)
 	ret0, _ := ret[0].(*ssm.DescribeInventoryDeletionsOutput)
 	ret1, _ := ret[1].(error)
@@ -2076,13 +1833,11 @@ func (m *MockSSMAPI) DescribeInventoryDeletions(arg0 *ssm.DescribeInventoryDelet
 
 // DescribeInventoryDeletions indicates an expected call of DescribeInventoryDeletions
 func (mr *MockSSMAPIMockRecorder) DescribeInventoryDeletions(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeInventoryDeletions", reflect.TypeOf((*MockSSMAPI)(nil).DescribeInventoryDeletions), arg0)
 }
 
 // DescribeInventoryDeletionsRequest mocks base method
 func (m *MockSSMAPI) DescribeInventoryDeletionsRequest(arg0 *ssm.DescribeInventoryDeletionsInput) (*request.Request, *ssm.DescribeInventoryDeletionsOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeInventoryDeletionsRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ssm.DescribeInventoryDeletionsOutput)
@@ -2091,13 +1846,11 @@ func (m *MockSSMAPI) DescribeInventoryDeletionsRequest(arg0 *ssm.DescribeInvento
 
 // DescribeInventoryDeletionsRequest indicates an expected call of DescribeInventoryDeletionsRequest
 func (mr *MockSSMAPIMockRecorder) DescribeInventoryDeletionsRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeInventoryDeletionsRequest", reflect.TypeOf((*MockSSMAPI)(nil).DescribeInventoryDeletionsRequest), arg0)
 }
 
 // DescribeInventoryDeletionsWithContext mocks base method
 func (m *MockSSMAPI) DescribeInventoryDeletionsWithContext(arg0 context.Context, arg1 *ssm.DescribeInventoryDeletionsInput, arg2 ...request.Option) (*ssm.DescribeInventoryDeletionsOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -2110,14 +1863,12 @@ func (m *MockSSMAPI) DescribeInventoryDeletionsWithContext(arg0 context.Context,
 
 // DescribeInventoryDeletionsWithContext indicates an expected call of DescribeInventoryDeletionsWithContext
 func (mr *MockSSMAPIMockRecorder) DescribeInventoryDeletionsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeInventoryDeletionsWithContext", reflect.TypeOf((*MockSSMAPI)(nil).DescribeInventoryDeletionsWithContext), varargs...)
 }
 
 // DescribeMaintenanceWindowExecutionTaskInvocations mocks base method
 func (m *MockSSMAPI) DescribeMaintenanceWindowExecutionTaskInvocations(arg0 *ssm.DescribeMaintenanceWindowExecutionTaskInvocationsInput) (*ssm.DescribeMaintenanceWindowExecutionTaskInvocationsOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeMaintenanceWindowExecutionTaskInvocations", arg0)
 	ret0, _ := ret[0].(*ssm.DescribeMaintenanceWindowExecutionTaskInvocationsOutput)
 	ret1, _ := ret[1].(error)
@@ -2126,13 +1877,11 @@ func (m *MockSSMAPI) DescribeMaintenanceWindowExecutionTaskInvocations(arg0 *ssm
 
 // DescribeMaintenanceWindowExecutionTaskInvocations indicates an expected call of DescribeMaintenanceWindowExecutionTaskInvocations
 func (mr *MockSSMAPIMockRecorder) DescribeMaintenanceWindowExecutionTaskInvocations(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeMaintenanceWindowExecutionTaskInvocations", reflect.TypeOf((*MockSSMAPI)(nil).DescribeMaintenanceWindowExecutionTaskInvocations), arg0)
 }
 
 // DescribeMaintenanceWindowExecutionTaskInvocationsRequest mocks base method
 func (m *MockSSMAPI) DescribeMaintenanceWindowExecutionTaskInvocationsRequest(arg0 *ssm.DescribeMaintenanceWindowExecutionTaskInvocationsInput) (*request.Request, *ssm.DescribeMaintenanceWindowExecutionTaskInvocationsOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeMaintenanceWindowExecutionTaskInvocationsRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ssm.DescribeMaintenanceWindowExecutionTaskInvocationsOutput)
@@ -2141,13 +1890,11 @@ func (m *MockSSMAPI) DescribeMaintenanceWindowExecutionTaskInvocationsRequest(ar
 
 // DescribeMaintenanceWindowExecutionTaskInvocationsRequest indicates an expected call of DescribeMaintenanceWindowExecutionTaskInvocationsRequest
 func (mr *MockSSMAPIMockRecorder) DescribeMaintenanceWindowExecutionTaskInvocationsRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeMaintenanceWindowExecutionTaskInvocationsRequest", reflect.TypeOf((*MockSSMAPI)(nil).DescribeMaintenanceWindowExecutionTaskInvocationsRequest), arg0)
 }
 
 // DescribeMaintenanceWindowExecutionTaskInvocationsWithContext mocks base method
 func (m *MockSSMAPI) DescribeMaintenanceWindowExecutionTaskInvocationsWithContext(arg0 context.Context, arg1 *ssm.DescribeMaintenanceWindowExecutionTaskInvocationsInput, arg2 ...request.Option) (*ssm.DescribeMaintenanceWindowExecutionTaskInvocationsOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -2160,14 +1907,12 @@ func (m *MockSSMAPI) DescribeMaintenanceWindowExecutionTaskInvocationsWithContex
 
 // DescribeMaintenanceWindowExecutionTaskInvocationsWithContext indicates an expected call of DescribeMaintenanceWindowExecutionTaskInvocationsWithContext
 func (mr *MockSSMAPIMockRecorder) DescribeMaintenanceWindowExecutionTaskInvocationsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeMaintenanceWindowExecutionTaskInvocationsWithContext", reflect.TypeOf((*MockSSMAPI)(nil).DescribeMaintenanceWindowExecutionTaskInvocationsWithContext), varargs...)
 }
 
 // DescribeMaintenanceWindowExecutionTasks mocks base method
 func (m *MockSSMAPI) DescribeMaintenanceWindowExecutionTasks(arg0 *ssm.DescribeMaintenanceWindowExecutionTasksInput) (*ssm.DescribeMaintenanceWindowExecutionTasksOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeMaintenanceWindowExecutionTasks", arg0)
 	ret0, _ := ret[0].(*ssm.DescribeMaintenanceWindowExecutionTasksOutput)
 	ret1, _ := ret[1].(error)
@@ -2176,13 +1921,11 @@ func (m *MockSSMAPI) DescribeMaintenanceWindowExecutionTasks(arg0 *ssm.DescribeM
 
 // DescribeMaintenanceWindowExecutionTasks indicates an expected call of DescribeMaintenanceWindowExecutionTasks
 func (mr *MockSSMAPIMockRecorder) DescribeMaintenanceWindowExecutionTasks(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeMaintenanceWindowExecutionTasks", reflect.TypeOf((*MockSSMAPI)(nil).DescribeMaintenanceWindowExecutionTasks), arg0)
 }
 
 // DescribeMaintenanceWindowExecutionTasksRequest mocks base method
 func (m *MockSSMAPI) DescribeMaintenanceWindowExecutionTasksRequest(arg0 *ssm.DescribeMaintenanceWindowExecutionTasksInput) (*request.Request, *ssm.DescribeMaintenanceWindowExecutionTasksOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeMaintenanceWindowExecutionTasksRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ssm.DescribeMaintenanceWindowExecutionTasksOutput)
@@ -2191,13 +1934,11 @@ func (m *MockSSMAPI) DescribeMaintenanceWindowExecutionTasksRequest(arg0 *ssm.De
 
 // DescribeMaintenanceWindowExecutionTasksRequest indicates an expected call of DescribeMaintenanceWindowExecutionTasksRequest
 func (mr *MockSSMAPIMockRecorder) DescribeMaintenanceWindowExecutionTasksRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeMaintenanceWindowExecutionTasksRequest", reflect.TypeOf((*MockSSMAPI)(nil).DescribeMaintenanceWindowExecutionTasksRequest), arg0)
 }
 
 // DescribeMaintenanceWindowExecutionTasksWithContext mocks base method
 func (m *MockSSMAPI) DescribeMaintenanceWindowExecutionTasksWithContext(arg0 context.Context, arg1 *ssm.DescribeMaintenanceWindowExecutionTasksInput, arg2 ...request.Option) (*ssm.DescribeMaintenanceWindowExecutionTasksOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -2210,14 +1951,12 @@ func (m *MockSSMAPI) DescribeMaintenanceWindowExecutionTasksWithContext(arg0 con
 
 // DescribeMaintenanceWindowExecutionTasksWithContext indicates an expected call of DescribeMaintenanceWindowExecutionTasksWithContext
 func (mr *MockSSMAPIMockRecorder) DescribeMaintenanceWindowExecutionTasksWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeMaintenanceWindowExecutionTasksWithContext", reflect.TypeOf((*MockSSMAPI)(nil).DescribeMaintenanceWindowExecutionTasksWithContext), varargs...)
 }
 
 // DescribeMaintenanceWindowExecutions mocks base method
 func (m *MockSSMAPI) DescribeMaintenanceWindowExecutions(arg0 *ssm.DescribeMaintenanceWindowExecutionsInput) (*ssm.DescribeMaintenanceWindowExecutionsOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeMaintenanceWindowExecutions", arg0)
 	ret0, _ := ret[0].(*ssm.DescribeMaintenanceWindowExecutionsOutput)
 	ret1, _ := ret[1].(error)
@@ -2226,13 +1965,11 @@ func (m *MockSSMAPI) DescribeMaintenanceWindowExecutions(arg0 *ssm.DescribeMaint
 
 // DescribeMaintenanceWindowExecutions indicates an expected call of DescribeMaintenanceWindowExecutions
 func (mr *MockSSMAPIMockRecorder) DescribeMaintenanceWindowExecutions(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeMaintenanceWindowExecutions", reflect.TypeOf((*MockSSMAPI)(nil).DescribeMaintenanceWindowExecutions), arg0)
 }
 
 // DescribeMaintenanceWindowExecutionsRequest mocks base method
 func (m *MockSSMAPI) DescribeMaintenanceWindowExecutionsRequest(arg0 *ssm.DescribeMaintenanceWindowExecutionsInput) (*request.Request, *ssm.DescribeMaintenanceWindowExecutionsOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeMaintenanceWindowExecutionsRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ssm.DescribeMaintenanceWindowExecutionsOutput)
@@ -2241,13 +1978,11 @@ func (m *MockSSMAPI) DescribeMaintenanceWindowExecutionsRequest(arg0 *ssm.Descri
 
 // DescribeMaintenanceWindowExecutionsRequest indicates an expected call of DescribeMaintenanceWindowExecutionsRequest
 func (mr *MockSSMAPIMockRecorder) DescribeMaintenanceWindowExecutionsRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeMaintenanceWindowExecutionsRequest", reflect.TypeOf((*MockSSMAPI)(nil).DescribeMaintenanceWindowExecutionsRequest), arg0)
 }
 
 // DescribeMaintenanceWindowExecutionsWithContext mocks base method
 func (m *MockSSMAPI) DescribeMaintenanceWindowExecutionsWithContext(arg0 context.Context, arg1 *ssm.DescribeMaintenanceWindowExecutionsInput, arg2 ...request.Option) (*ssm.DescribeMaintenanceWindowExecutionsOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -2260,14 +1995,12 @@ func (m *MockSSMAPI) DescribeMaintenanceWindowExecutionsWithContext(arg0 context
 
 // DescribeMaintenanceWindowExecutionsWithContext indicates an expected call of DescribeMaintenanceWindowExecutionsWithContext
 func (mr *MockSSMAPIMockRecorder) DescribeMaintenanceWindowExecutionsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeMaintenanceWindowExecutionsWithContext", reflect.TypeOf((*MockSSMAPI)(nil).DescribeMaintenanceWindowExecutionsWithContext), varargs...)
 }
 
 // DescribeMaintenanceWindowSchedule mocks base method
 func (m *MockSSMAPI) DescribeMaintenanceWindowSchedule(arg0 *ssm.DescribeMaintenanceWindowScheduleInput) (*ssm.DescribeMaintenanceWindowScheduleOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeMaintenanceWindowSchedule", arg0)
 	ret0, _ := ret[0].(*ssm.DescribeMaintenanceWindowScheduleOutput)
 	ret1, _ := ret[1].(error)
@@ -2276,13 +2009,11 @@ func (m *MockSSMAPI) DescribeMaintenanceWindowSchedule(arg0 *ssm.DescribeMainten
 
 // DescribeMaintenanceWindowSchedule indicates an expected call of DescribeMaintenanceWindowSchedule
 func (mr *MockSSMAPIMockRecorder) DescribeMaintenanceWindowSchedule(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeMaintenanceWindowSchedule", reflect.TypeOf((*MockSSMAPI)(nil).DescribeMaintenanceWindowSchedule), arg0)
 }
 
 // DescribeMaintenanceWindowScheduleRequest mocks base method
 func (m *MockSSMAPI) DescribeMaintenanceWindowScheduleRequest(arg0 *ssm.DescribeMaintenanceWindowScheduleInput) (*request.Request, *ssm.DescribeMaintenanceWindowScheduleOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeMaintenanceWindowScheduleRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ssm.DescribeMaintenanceWindowScheduleOutput)
@@ -2291,13 +2022,11 @@ func (m *MockSSMAPI) DescribeMaintenanceWindowScheduleRequest(arg0 *ssm.Describe
 
 // DescribeMaintenanceWindowScheduleRequest indicates an expected call of DescribeMaintenanceWindowScheduleRequest
 func (mr *MockSSMAPIMockRecorder) DescribeMaintenanceWindowScheduleRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeMaintenanceWindowScheduleRequest", reflect.TypeOf((*MockSSMAPI)(nil).DescribeMaintenanceWindowScheduleRequest), arg0)
 }
 
 // DescribeMaintenanceWindowScheduleWithContext mocks base method
 func (m *MockSSMAPI) DescribeMaintenanceWindowScheduleWithContext(arg0 context.Context, arg1 *ssm.DescribeMaintenanceWindowScheduleInput, arg2 ...request.Option) (*ssm.DescribeMaintenanceWindowScheduleOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -2310,14 +2039,12 @@ func (m *MockSSMAPI) DescribeMaintenanceWindowScheduleWithContext(arg0 context.C
 
 // DescribeMaintenanceWindowScheduleWithContext indicates an expected call of DescribeMaintenanceWindowScheduleWithContext
 func (mr *MockSSMAPIMockRecorder) DescribeMaintenanceWindowScheduleWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeMaintenanceWindowScheduleWithContext", reflect.TypeOf((*MockSSMAPI)(nil).DescribeMaintenanceWindowScheduleWithContext), varargs...)
 }
 
 // DescribeMaintenanceWindowTargets mocks base method
 func (m *MockSSMAPI) DescribeMaintenanceWindowTargets(arg0 *ssm.DescribeMaintenanceWindowTargetsInput) (*ssm.DescribeMaintenanceWindowTargetsOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeMaintenanceWindowTargets", arg0)
 	ret0, _ := ret[0].(*ssm.DescribeMaintenanceWindowTargetsOutput)
 	ret1, _ := ret[1].(error)
@@ -2326,13 +2053,11 @@ func (m *MockSSMAPI) DescribeMaintenanceWindowTargets(arg0 *ssm.DescribeMaintena
 
 // DescribeMaintenanceWindowTargets indicates an expected call of DescribeMaintenanceWindowTargets
 func (mr *MockSSMAPIMockRecorder) DescribeMaintenanceWindowTargets(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeMaintenanceWindowTargets", reflect.TypeOf((*MockSSMAPI)(nil).DescribeMaintenanceWindowTargets), arg0)
 }
 
 // DescribeMaintenanceWindowTargetsRequest mocks base method
 func (m *MockSSMAPI) DescribeMaintenanceWindowTargetsRequest(arg0 *ssm.DescribeMaintenanceWindowTargetsInput) (*request.Request, *ssm.DescribeMaintenanceWindowTargetsOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeMaintenanceWindowTargetsRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ssm.DescribeMaintenanceWindowTargetsOutput)
@@ -2341,13 +2066,11 @@ func (m *MockSSMAPI) DescribeMaintenanceWindowTargetsRequest(arg0 *ssm.DescribeM
 
 // DescribeMaintenanceWindowTargetsRequest indicates an expected call of DescribeMaintenanceWindowTargetsRequest
 func (mr *MockSSMAPIMockRecorder) DescribeMaintenanceWindowTargetsRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeMaintenanceWindowTargetsRequest", reflect.TypeOf((*MockSSMAPI)(nil).DescribeMaintenanceWindowTargetsRequest), arg0)
 }
 
 // DescribeMaintenanceWindowTargetsWithContext mocks base method
 func (m *MockSSMAPI) DescribeMaintenanceWindowTargetsWithContext(arg0 context.Context, arg1 *ssm.DescribeMaintenanceWindowTargetsInput, arg2 ...request.Option) (*ssm.DescribeMaintenanceWindowTargetsOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -2360,14 +2083,12 @@ func (m *MockSSMAPI) DescribeMaintenanceWindowTargetsWithContext(arg0 context.Co
 
 // DescribeMaintenanceWindowTargetsWithContext indicates an expected call of DescribeMaintenanceWindowTargetsWithContext
 func (mr *MockSSMAPIMockRecorder) DescribeMaintenanceWindowTargetsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeMaintenanceWindowTargetsWithContext", reflect.TypeOf((*MockSSMAPI)(nil).DescribeMaintenanceWindowTargetsWithContext), varargs...)
 }
 
 // DescribeMaintenanceWindowTasks mocks base method
 func (m *MockSSMAPI) DescribeMaintenanceWindowTasks(arg0 *ssm.DescribeMaintenanceWindowTasksInput) (*ssm.DescribeMaintenanceWindowTasksOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeMaintenanceWindowTasks", arg0)
 	ret0, _ := ret[0].(*ssm.DescribeMaintenanceWindowTasksOutput)
 	ret1, _ := ret[1].(error)
@@ -2376,13 +2097,11 @@ func (m *MockSSMAPI) DescribeMaintenanceWindowTasks(arg0 *ssm.DescribeMaintenanc
 
 // DescribeMaintenanceWindowTasks indicates an expected call of DescribeMaintenanceWindowTasks
 func (mr *MockSSMAPIMockRecorder) DescribeMaintenanceWindowTasks(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeMaintenanceWindowTasks", reflect.TypeOf((*MockSSMAPI)(nil).DescribeMaintenanceWindowTasks), arg0)
 }
 
 // DescribeMaintenanceWindowTasksRequest mocks base method
 func (m *MockSSMAPI) DescribeMaintenanceWindowTasksRequest(arg0 *ssm.DescribeMaintenanceWindowTasksInput) (*request.Request, *ssm.DescribeMaintenanceWindowTasksOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeMaintenanceWindowTasksRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ssm.DescribeMaintenanceWindowTasksOutput)
@@ -2391,13 +2110,11 @@ func (m *MockSSMAPI) DescribeMaintenanceWindowTasksRequest(arg0 *ssm.DescribeMai
 
 // DescribeMaintenanceWindowTasksRequest indicates an expected call of DescribeMaintenanceWindowTasksRequest
 func (mr *MockSSMAPIMockRecorder) DescribeMaintenanceWindowTasksRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeMaintenanceWindowTasksRequest", reflect.TypeOf((*MockSSMAPI)(nil).DescribeMaintenanceWindowTasksRequest), arg0)
 }
 
 // DescribeMaintenanceWindowTasksWithContext mocks base method
 func (m *MockSSMAPI) DescribeMaintenanceWindowTasksWithContext(arg0 context.Context, arg1 *ssm.DescribeMaintenanceWindowTasksInput, arg2 ...request.Option) (*ssm.DescribeMaintenanceWindowTasksOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -2410,14 +2127,12 @@ func (m *MockSSMAPI) DescribeMaintenanceWindowTasksWithContext(arg0 context.Cont
 
 // DescribeMaintenanceWindowTasksWithContext indicates an expected call of DescribeMaintenanceWindowTasksWithContext
 func (mr *MockSSMAPIMockRecorder) DescribeMaintenanceWindowTasksWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeMaintenanceWindowTasksWithContext", reflect.TypeOf((*MockSSMAPI)(nil).DescribeMaintenanceWindowTasksWithContext), varargs...)
 }
 
 // DescribeMaintenanceWindows mocks base method
 func (m *MockSSMAPI) DescribeMaintenanceWindows(arg0 *ssm.DescribeMaintenanceWindowsInput) (*ssm.DescribeMaintenanceWindowsOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeMaintenanceWindows", arg0)
 	ret0, _ := ret[0].(*ssm.DescribeMaintenanceWindowsOutput)
 	ret1, _ := ret[1].(error)
@@ -2426,13 +2141,11 @@ func (m *MockSSMAPI) DescribeMaintenanceWindows(arg0 *ssm.DescribeMaintenanceWin
 
 // DescribeMaintenanceWindows indicates an expected call of DescribeMaintenanceWindows
 func (mr *MockSSMAPIMockRecorder) DescribeMaintenanceWindows(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeMaintenanceWindows", reflect.TypeOf((*MockSSMAPI)(nil).DescribeMaintenanceWindows), arg0)
 }
 
 // DescribeMaintenanceWindowsForTarget mocks base method
 func (m *MockSSMAPI) DescribeMaintenanceWindowsForTarget(arg0 *ssm.DescribeMaintenanceWindowsForTargetInput) (*ssm.DescribeMaintenanceWindowsForTargetOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeMaintenanceWindowsForTarget", arg0)
 	ret0, _ := ret[0].(*ssm.DescribeMaintenanceWindowsForTargetOutput)
 	ret1, _ := ret[1].(error)
@@ -2441,13 +2154,11 @@ func (m *MockSSMAPI) DescribeMaintenanceWindowsForTarget(arg0 *ssm.DescribeMaint
 
 // DescribeMaintenanceWindowsForTarget indicates an expected call of DescribeMaintenanceWindowsForTarget
 func (mr *MockSSMAPIMockRecorder) DescribeMaintenanceWindowsForTarget(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeMaintenanceWindowsForTarget", reflect.TypeOf((*MockSSMAPI)(nil).DescribeMaintenanceWindowsForTarget), arg0)
 }
 
 // DescribeMaintenanceWindowsForTargetRequest mocks base method
 func (m *MockSSMAPI) DescribeMaintenanceWindowsForTargetRequest(arg0 *ssm.DescribeMaintenanceWindowsForTargetInput) (*request.Request, *ssm.DescribeMaintenanceWindowsForTargetOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeMaintenanceWindowsForTargetRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ssm.DescribeMaintenanceWindowsForTargetOutput)
@@ -2456,13 +2167,11 @@ func (m *MockSSMAPI) DescribeMaintenanceWindowsForTargetRequest(arg0 *ssm.Descri
 
 // DescribeMaintenanceWindowsForTargetRequest indicates an expected call of DescribeMaintenanceWindowsForTargetRequest
 func (mr *MockSSMAPIMockRecorder) DescribeMaintenanceWindowsForTargetRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeMaintenanceWindowsForTargetRequest", reflect.TypeOf((*MockSSMAPI)(nil).DescribeMaintenanceWindowsForTargetRequest), arg0)
 }
 
 // DescribeMaintenanceWindowsForTargetWithContext mocks base method
 func (m *MockSSMAPI) DescribeMaintenanceWindowsForTargetWithContext(arg0 context.Context, arg1 *ssm.DescribeMaintenanceWindowsForTargetInput, arg2 ...request.Option) (*ssm.DescribeMaintenanceWindowsForTargetOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -2475,14 +2184,12 @@ func (m *MockSSMAPI) DescribeMaintenanceWindowsForTargetWithContext(arg0 context
 
 // DescribeMaintenanceWindowsForTargetWithContext indicates an expected call of DescribeMaintenanceWindowsForTargetWithContext
 func (mr *MockSSMAPIMockRecorder) DescribeMaintenanceWindowsForTargetWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeMaintenanceWindowsForTargetWithContext", reflect.TypeOf((*MockSSMAPI)(nil).DescribeMaintenanceWindowsForTargetWithContext), varargs...)
 }
 
 // DescribeMaintenanceWindowsRequest mocks base method
 func (m *MockSSMAPI) DescribeMaintenanceWindowsRequest(arg0 *ssm.DescribeMaintenanceWindowsInput) (*request.Request, *ssm.DescribeMaintenanceWindowsOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeMaintenanceWindowsRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ssm.DescribeMaintenanceWindowsOutput)
@@ -2491,13 +2198,11 @@ func (m *MockSSMAPI) DescribeMaintenanceWindowsRequest(arg0 *ssm.DescribeMainten
 
 // DescribeMaintenanceWindowsRequest indicates an expected call of DescribeMaintenanceWindowsRequest
 func (mr *MockSSMAPIMockRecorder) DescribeMaintenanceWindowsRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeMaintenanceWindowsRequest", reflect.TypeOf((*MockSSMAPI)(nil).DescribeMaintenanceWindowsRequest), arg0)
 }
 
 // DescribeMaintenanceWindowsWithContext mocks base method
 func (m *MockSSMAPI) DescribeMaintenanceWindowsWithContext(arg0 context.Context, arg1 *ssm.DescribeMaintenanceWindowsInput, arg2 ...request.Option) (*ssm.DescribeMaintenanceWindowsOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -2510,14 +2215,12 @@ func (m *MockSSMAPI) DescribeMaintenanceWindowsWithContext(arg0 context.Context,
 
 // DescribeMaintenanceWindowsWithContext indicates an expected call of DescribeMaintenanceWindowsWithContext
 func (mr *MockSSMAPIMockRecorder) DescribeMaintenanceWindowsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeMaintenanceWindowsWithContext", reflect.TypeOf((*MockSSMAPI)(nil).DescribeMaintenanceWindowsWithContext), varargs...)
 }
 
 // DescribeParameters mocks base method
 func (m *MockSSMAPI) DescribeParameters(arg0 *ssm.DescribeParametersInput) (*ssm.DescribeParametersOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeParameters", arg0)
 	ret0, _ := ret[0].(*ssm.DescribeParametersOutput)
 	ret1, _ := ret[1].(error)
@@ -2526,13 +2229,11 @@ func (m *MockSSMAPI) DescribeParameters(arg0 *ssm.DescribeParametersInput) (*ssm
 
 // DescribeParameters indicates an expected call of DescribeParameters
 func (mr *MockSSMAPIMockRecorder) DescribeParameters(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeParameters", reflect.TypeOf((*MockSSMAPI)(nil).DescribeParameters), arg0)
 }
 
 // DescribeParametersPages mocks base method
 func (m *MockSSMAPI) DescribeParametersPages(arg0 *ssm.DescribeParametersInput, arg1 func(*ssm.DescribeParametersOutput, bool) bool) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeParametersPages", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -2540,13 +2241,11 @@ func (m *MockSSMAPI) DescribeParametersPages(arg0 *ssm.DescribeParametersInput, 
 
 // DescribeParametersPages indicates an expected call of DescribeParametersPages
 func (mr *MockSSMAPIMockRecorder) DescribeParametersPages(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeParametersPages", reflect.TypeOf((*MockSSMAPI)(nil).DescribeParametersPages), arg0, arg1)
 }
 
 // DescribeParametersPagesWithContext mocks base method
 func (m *MockSSMAPI) DescribeParametersPagesWithContext(arg0 context.Context, arg1 *ssm.DescribeParametersInput, arg2 func(*ssm.DescribeParametersOutput, bool) bool, arg3 ...request.Option) error {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1, arg2}
 	for _, a := range arg3 {
 		varargs = append(varargs, a)
@@ -2558,14 +2257,12 @@ func (m *MockSSMAPI) DescribeParametersPagesWithContext(arg0 context.Context, ar
 
 // DescribeParametersPagesWithContext indicates an expected call of DescribeParametersPagesWithContext
 func (mr *MockSSMAPIMockRecorder) DescribeParametersPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeParametersPagesWithContext", reflect.TypeOf((*MockSSMAPI)(nil).DescribeParametersPagesWithContext), varargs...)
 }
 
 // DescribeParametersRequest mocks base method
 func (m *MockSSMAPI) DescribeParametersRequest(arg0 *ssm.DescribeParametersInput) (*request.Request, *ssm.DescribeParametersOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeParametersRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ssm.DescribeParametersOutput)
@@ -2574,13 +2271,11 @@ func (m *MockSSMAPI) DescribeParametersRequest(arg0 *ssm.DescribeParametersInput
 
 // DescribeParametersRequest indicates an expected call of DescribeParametersRequest
 func (mr *MockSSMAPIMockRecorder) DescribeParametersRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeParametersRequest", reflect.TypeOf((*MockSSMAPI)(nil).DescribeParametersRequest), arg0)
 }
 
 // DescribeParametersWithContext mocks base method
 func (m *MockSSMAPI) DescribeParametersWithContext(arg0 context.Context, arg1 *ssm.DescribeParametersInput, arg2 ...request.Option) (*ssm.DescribeParametersOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -2593,14 +2288,12 @@ func (m *MockSSMAPI) DescribeParametersWithContext(arg0 context.Context, arg1 *s
 
 // DescribeParametersWithContext indicates an expected call of DescribeParametersWithContext
 func (mr *MockSSMAPIMockRecorder) DescribeParametersWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeParametersWithContext", reflect.TypeOf((*MockSSMAPI)(nil).DescribeParametersWithContext), varargs...)
 }
 
 // DescribePatchBaselines mocks base method
 func (m *MockSSMAPI) DescribePatchBaselines(arg0 *ssm.DescribePatchBaselinesInput) (*ssm.DescribePatchBaselinesOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribePatchBaselines", arg0)
 	ret0, _ := ret[0].(*ssm.DescribePatchBaselinesOutput)
 	ret1, _ := ret[1].(error)
@@ -2609,13 +2302,11 @@ func (m *MockSSMAPI) DescribePatchBaselines(arg0 *ssm.DescribePatchBaselinesInpu
 
 // DescribePatchBaselines indicates an expected call of DescribePatchBaselines
 func (mr *MockSSMAPIMockRecorder) DescribePatchBaselines(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribePatchBaselines", reflect.TypeOf((*MockSSMAPI)(nil).DescribePatchBaselines), arg0)
 }
 
 // DescribePatchBaselinesRequest mocks base method
 func (m *MockSSMAPI) DescribePatchBaselinesRequest(arg0 *ssm.DescribePatchBaselinesInput) (*request.Request, *ssm.DescribePatchBaselinesOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribePatchBaselinesRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ssm.DescribePatchBaselinesOutput)
@@ -2624,13 +2315,11 @@ func (m *MockSSMAPI) DescribePatchBaselinesRequest(arg0 *ssm.DescribePatchBaseli
 
 // DescribePatchBaselinesRequest indicates an expected call of DescribePatchBaselinesRequest
 func (mr *MockSSMAPIMockRecorder) DescribePatchBaselinesRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribePatchBaselinesRequest", reflect.TypeOf((*MockSSMAPI)(nil).DescribePatchBaselinesRequest), arg0)
 }
 
 // DescribePatchBaselinesWithContext mocks base method
 func (m *MockSSMAPI) DescribePatchBaselinesWithContext(arg0 context.Context, arg1 *ssm.DescribePatchBaselinesInput, arg2 ...request.Option) (*ssm.DescribePatchBaselinesOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -2643,14 +2332,12 @@ func (m *MockSSMAPI) DescribePatchBaselinesWithContext(arg0 context.Context, arg
 
 // DescribePatchBaselinesWithContext indicates an expected call of DescribePatchBaselinesWithContext
 func (mr *MockSSMAPIMockRecorder) DescribePatchBaselinesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribePatchBaselinesWithContext", reflect.TypeOf((*MockSSMAPI)(nil).DescribePatchBaselinesWithContext), varargs...)
 }
 
 // DescribePatchGroupState mocks base method
 func (m *MockSSMAPI) DescribePatchGroupState(arg0 *ssm.DescribePatchGroupStateInput) (*ssm.DescribePatchGroupStateOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribePatchGroupState", arg0)
 	ret0, _ := ret[0].(*ssm.DescribePatchGroupStateOutput)
 	ret1, _ := ret[1].(error)
@@ -2659,13 +2346,11 @@ func (m *MockSSMAPI) DescribePatchGroupState(arg0 *ssm.DescribePatchGroupStateIn
 
 // DescribePatchGroupState indicates an expected call of DescribePatchGroupState
 func (mr *MockSSMAPIMockRecorder) DescribePatchGroupState(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribePatchGroupState", reflect.TypeOf((*MockSSMAPI)(nil).DescribePatchGroupState), arg0)
 }
 
 // DescribePatchGroupStateRequest mocks base method
 func (m *MockSSMAPI) DescribePatchGroupStateRequest(arg0 *ssm.DescribePatchGroupStateInput) (*request.Request, *ssm.DescribePatchGroupStateOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribePatchGroupStateRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ssm.DescribePatchGroupStateOutput)
@@ -2674,13 +2359,11 @@ func (m *MockSSMAPI) DescribePatchGroupStateRequest(arg0 *ssm.DescribePatchGroup
 
 // DescribePatchGroupStateRequest indicates an expected call of DescribePatchGroupStateRequest
 func (mr *MockSSMAPIMockRecorder) DescribePatchGroupStateRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribePatchGroupStateRequest", reflect.TypeOf((*MockSSMAPI)(nil).DescribePatchGroupStateRequest), arg0)
 }
 
 // DescribePatchGroupStateWithContext mocks base method
 func (m *MockSSMAPI) DescribePatchGroupStateWithContext(arg0 context.Context, arg1 *ssm.DescribePatchGroupStateInput, arg2 ...request.Option) (*ssm.DescribePatchGroupStateOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -2693,14 +2376,12 @@ func (m *MockSSMAPI) DescribePatchGroupStateWithContext(arg0 context.Context, ar
 
 // DescribePatchGroupStateWithContext indicates an expected call of DescribePatchGroupStateWithContext
 func (mr *MockSSMAPIMockRecorder) DescribePatchGroupStateWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribePatchGroupStateWithContext", reflect.TypeOf((*MockSSMAPI)(nil).DescribePatchGroupStateWithContext), varargs...)
 }
 
 // DescribePatchGroups mocks base method
 func (m *MockSSMAPI) DescribePatchGroups(arg0 *ssm.DescribePatchGroupsInput) (*ssm.DescribePatchGroupsOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribePatchGroups", arg0)
 	ret0, _ := ret[0].(*ssm.DescribePatchGroupsOutput)
 	ret1, _ := ret[1].(error)
@@ -2709,13 +2390,11 @@ func (m *MockSSMAPI) DescribePatchGroups(arg0 *ssm.DescribePatchGroupsInput) (*s
 
 // DescribePatchGroups indicates an expected call of DescribePatchGroups
 func (mr *MockSSMAPIMockRecorder) DescribePatchGroups(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribePatchGroups", reflect.TypeOf((*MockSSMAPI)(nil).DescribePatchGroups), arg0)
 }
 
 // DescribePatchGroupsRequest mocks base method
 func (m *MockSSMAPI) DescribePatchGroupsRequest(arg0 *ssm.DescribePatchGroupsInput) (*request.Request, *ssm.DescribePatchGroupsOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribePatchGroupsRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ssm.DescribePatchGroupsOutput)
@@ -2724,13 +2403,11 @@ func (m *MockSSMAPI) DescribePatchGroupsRequest(arg0 *ssm.DescribePatchGroupsInp
 
 // DescribePatchGroupsRequest indicates an expected call of DescribePatchGroupsRequest
 func (mr *MockSSMAPIMockRecorder) DescribePatchGroupsRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribePatchGroupsRequest", reflect.TypeOf((*MockSSMAPI)(nil).DescribePatchGroupsRequest), arg0)
 }
 
 // DescribePatchGroupsWithContext mocks base method
 func (m *MockSSMAPI) DescribePatchGroupsWithContext(arg0 context.Context, arg1 *ssm.DescribePatchGroupsInput, arg2 ...request.Option) (*ssm.DescribePatchGroupsOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -2743,14 +2420,12 @@ func (m *MockSSMAPI) DescribePatchGroupsWithContext(arg0 context.Context, arg1 *
 
 // DescribePatchGroupsWithContext indicates an expected call of DescribePatchGroupsWithContext
 func (mr *MockSSMAPIMockRecorder) DescribePatchGroupsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribePatchGroupsWithContext", reflect.TypeOf((*MockSSMAPI)(nil).DescribePatchGroupsWithContext), varargs...)
 }
 
 // DescribeSessions mocks base method
 func (m *MockSSMAPI) DescribeSessions(arg0 *ssm.DescribeSessionsInput) (*ssm.DescribeSessionsOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeSessions", arg0)
 	ret0, _ := ret[0].(*ssm.DescribeSessionsOutput)
 	ret1, _ := ret[1].(error)
@@ -2759,13 +2434,11 @@ func (m *MockSSMAPI) DescribeSessions(arg0 *ssm.DescribeSessionsInput) (*ssm.Des
 
 // DescribeSessions indicates an expected call of DescribeSessions
 func (mr *MockSSMAPIMockRecorder) DescribeSessions(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeSessions", reflect.TypeOf((*MockSSMAPI)(nil).DescribeSessions), arg0)
 }
 
 // DescribeSessionsRequest mocks base method
 func (m *MockSSMAPI) DescribeSessionsRequest(arg0 *ssm.DescribeSessionsInput) (*request.Request, *ssm.DescribeSessionsOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeSessionsRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ssm.DescribeSessionsOutput)
@@ -2774,13 +2447,11 @@ func (m *MockSSMAPI) DescribeSessionsRequest(arg0 *ssm.DescribeSessionsInput) (*
 
 // DescribeSessionsRequest indicates an expected call of DescribeSessionsRequest
 func (mr *MockSSMAPIMockRecorder) DescribeSessionsRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeSessionsRequest", reflect.TypeOf((*MockSSMAPI)(nil).DescribeSessionsRequest), arg0)
 }
 
 // DescribeSessionsWithContext mocks base method
 func (m *MockSSMAPI) DescribeSessionsWithContext(arg0 context.Context, arg1 *ssm.DescribeSessionsInput, arg2 ...request.Option) (*ssm.DescribeSessionsOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -2793,14 +2464,12 @@ func (m *MockSSMAPI) DescribeSessionsWithContext(arg0 context.Context, arg1 *ssm
 
 // DescribeSessionsWithContext indicates an expected call of DescribeSessionsWithContext
 func (mr *MockSSMAPIMockRecorder) DescribeSessionsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeSessionsWithContext", reflect.TypeOf((*MockSSMAPI)(nil).DescribeSessionsWithContext), varargs...)
 }
 
 // GetAutomationExecution mocks base method
 func (m *MockSSMAPI) GetAutomationExecution(arg0 *ssm.GetAutomationExecutionInput) (*ssm.GetAutomationExecutionOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetAutomationExecution", arg0)
 	ret0, _ := ret[0].(*ssm.GetAutomationExecutionOutput)
 	ret1, _ := ret[1].(error)
@@ -2809,13 +2478,11 @@ func (m *MockSSMAPI) GetAutomationExecution(arg0 *ssm.GetAutomationExecutionInpu
 
 // GetAutomationExecution indicates an expected call of GetAutomationExecution
 func (mr *MockSSMAPIMockRecorder) GetAutomationExecution(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAutomationExecution", reflect.TypeOf((*MockSSMAPI)(nil).GetAutomationExecution), arg0)
 }
 
 // GetAutomationExecutionRequest mocks base method
 func (m *MockSSMAPI) GetAutomationExecutionRequest(arg0 *ssm.GetAutomationExecutionInput) (*request.Request, *ssm.GetAutomationExecutionOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetAutomationExecutionRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ssm.GetAutomationExecutionOutput)
@@ -2824,13 +2491,11 @@ func (m *MockSSMAPI) GetAutomationExecutionRequest(arg0 *ssm.GetAutomationExecut
 
 // GetAutomationExecutionRequest indicates an expected call of GetAutomationExecutionRequest
 func (mr *MockSSMAPIMockRecorder) GetAutomationExecutionRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAutomationExecutionRequest", reflect.TypeOf((*MockSSMAPI)(nil).GetAutomationExecutionRequest), arg0)
 }
 
 // GetAutomationExecutionWithContext mocks base method
 func (m *MockSSMAPI) GetAutomationExecutionWithContext(arg0 context.Context, arg1 *ssm.GetAutomationExecutionInput, arg2 ...request.Option) (*ssm.GetAutomationExecutionOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -2843,14 +2508,12 @@ func (m *MockSSMAPI) GetAutomationExecutionWithContext(arg0 context.Context, arg
 
 // GetAutomationExecutionWithContext indicates an expected call of GetAutomationExecutionWithContext
 func (mr *MockSSMAPIMockRecorder) GetAutomationExecutionWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAutomationExecutionWithContext", reflect.TypeOf((*MockSSMAPI)(nil).GetAutomationExecutionWithContext), varargs...)
 }
 
 // GetCommandInvocation mocks base method
 func (m *MockSSMAPI) GetCommandInvocation(arg0 *ssm.GetCommandInvocationInput) (*ssm.GetCommandInvocationOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetCommandInvocation", arg0)
 	ret0, _ := ret[0].(*ssm.GetCommandInvocationOutput)
 	ret1, _ := ret[1].(error)
@@ -2859,13 +2522,11 @@ func (m *MockSSMAPI) GetCommandInvocation(arg0 *ssm.GetCommandInvocationInput) (
 
 // GetCommandInvocation indicates an expected call of GetCommandInvocation
 func (mr *MockSSMAPIMockRecorder) GetCommandInvocation(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCommandInvocation", reflect.TypeOf((*MockSSMAPI)(nil).GetCommandInvocation), arg0)
 }
 
 // GetCommandInvocationRequest mocks base method
 func (m *MockSSMAPI) GetCommandInvocationRequest(arg0 *ssm.GetCommandInvocationInput) (*request.Request, *ssm.GetCommandInvocationOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetCommandInvocationRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ssm.GetCommandInvocationOutput)
@@ -2874,13 +2535,11 @@ func (m *MockSSMAPI) GetCommandInvocationRequest(arg0 *ssm.GetCommandInvocationI
 
 // GetCommandInvocationRequest indicates an expected call of GetCommandInvocationRequest
 func (mr *MockSSMAPIMockRecorder) GetCommandInvocationRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCommandInvocationRequest", reflect.TypeOf((*MockSSMAPI)(nil).GetCommandInvocationRequest), arg0)
 }
 
 // GetCommandInvocationWithContext mocks base method
 func (m *MockSSMAPI) GetCommandInvocationWithContext(arg0 context.Context, arg1 *ssm.GetCommandInvocationInput, arg2 ...request.Option) (*ssm.GetCommandInvocationOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -2893,14 +2552,12 @@ func (m *MockSSMAPI) GetCommandInvocationWithContext(arg0 context.Context, arg1 
 
 // GetCommandInvocationWithContext indicates an expected call of GetCommandInvocationWithContext
 func (mr *MockSSMAPIMockRecorder) GetCommandInvocationWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCommandInvocationWithContext", reflect.TypeOf((*MockSSMAPI)(nil).GetCommandInvocationWithContext), varargs...)
 }
 
 // GetConnectionStatus mocks base method
 func (m *MockSSMAPI) GetConnectionStatus(arg0 *ssm.GetConnectionStatusInput) (*ssm.GetConnectionStatusOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetConnectionStatus", arg0)
 	ret0, _ := ret[0].(*ssm.GetConnectionStatusOutput)
 	ret1, _ := ret[1].(error)
@@ -2909,13 +2566,11 @@ func (m *MockSSMAPI) GetConnectionStatus(arg0 *ssm.GetConnectionStatusInput) (*s
 
 // GetConnectionStatus indicates an expected call of GetConnectionStatus
 func (mr *MockSSMAPIMockRecorder) GetConnectionStatus(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetConnectionStatus", reflect.TypeOf((*MockSSMAPI)(nil).GetConnectionStatus), arg0)
 }
 
 // GetConnectionStatusRequest mocks base method
 func (m *MockSSMAPI) GetConnectionStatusRequest(arg0 *ssm.GetConnectionStatusInput) (*request.Request, *ssm.GetConnectionStatusOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetConnectionStatusRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ssm.GetConnectionStatusOutput)
@@ -2924,13 +2579,11 @@ func (m *MockSSMAPI) GetConnectionStatusRequest(arg0 *ssm.GetConnectionStatusInp
 
 // GetConnectionStatusRequest indicates an expected call of GetConnectionStatusRequest
 func (mr *MockSSMAPIMockRecorder) GetConnectionStatusRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetConnectionStatusRequest", reflect.TypeOf((*MockSSMAPI)(nil).GetConnectionStatusRequest), arg0)
 }
 
 // GetConnectionStatusWithContext mocks base method
 func (m *MockSSMAPI) GetConnectionStatusWithContext(arg0 context.Context, arg1 *ssm.GetConnectionStatusInput, arg2 ...request.Option) (*ssm.GetConnectionStatusOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -2943,14 +2596,12 @@ func (m *MockSSMAPI) GetConnectionStatusWithContext(arg0 context.Context, arg1 *
 
 // GetConnectionStatusWithContext indicates an expected call of GetConnectionStatusWithContext
 func (mr *MockSSMAPIMockRecorder) GetConnectionStatusWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetConnectionStatusWithContext", reflect.TypeOf((*MockSSMAPI)(nil).GetConnectionStatusWithContext), varargs...)
 }
 
 // GetDefaultPatchBaseline mocks base method
 func (m *MockSSMAPI) GetDefaultPatchBaseline(arg0 *ssm.GetDefaultPatchBaselineInput) (*ssm.GetDefaultPatchBaselineOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetDefaultPatchBaseline", arg0)
 	ret0, _ := ret[0].(*ssm.GetDefaultPatchBaselineOutput)
 	ret1, _ := ret[1].(error)
@@ -2959,13 +2610,11 @@ func (m *MockSSMAPI) GetDefaultPatchBaseline(arg0 *ssm.GetDefaultPatchBaselineIn
 
 // GetDefaultPatchBaseline indicates an expected call of GetDefaultPatchBaseline
 func (mr *MockSSMAPIMockRecorder) GetDefaultPatchBaseline(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDefaultPatchBaseline", reflect.TypeOf((*MockSSMAPI)(nil).GetDefaultPatchBaseline), arg0)
 }
 
 // GetDefaultPatchBaselineRequest mocks base method
 func (m *MockSSMAPI) GetDefaultPatchBaselineRequest(arg0 *ssm.GetDefaultPatchBaselineInput) (*request.Request, *ssm.GetDefaultPatchBaselineOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetDefaultPatchBaselineRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ssm.GetDefaultPatchBaselineOutput)
@@ -2974,13 +2623,11 @@ func (m *MockSSMAPI) GetDefaultPatchBaselineRequest(arg0 *ssm.GetDefaultPatchBas
 
 // GetDefaultPatchBaselineRequest indicates an expected call of GetDefaultPatchBaselineRequest
 func (mr *MockSSMAPIMockRecorder) GetDefaultPatchBaselineRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDefaultPatchBaselineRequest", reflect.TypeOf((*MockSSMAPI)(nil).GetDefaultPatchBaselineRequest), arg0)
 }
 
 // GetDefaultPatchBaselineWithContext mocks base method
 func (m *MockSSMAPI) GetDefaultPatchBaselineWithContext(arg0 context.Context, arg1 *ssm.GetDefaultPatchBaselineInput, arg2 ...request.Option) (*ssm.GetDefaultPatchBaselineOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -2993,14 +2640,12 @@ func (m *MockSSMAPI) GetDefaultPatchBaselineWithContext(arg0 context.Context, ar
 
 // GetDefaultPatchBaselineWithContext indicates an expected call of GetDefaultPatchBaselineWithContext
 func (mr *MockSSMAPIMockRecorder) GetDefaultPatchBaselineWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDefaultPatchBaselineWithContext", reflect.TypeOf((*MockSSMAPI)(nil).GetDefaultPatchBaselineWithContext), varargs...)
 }
 
 // GetDeployablePatchSnapshotForInstance mocks base method
 func (m *MockSSMAPI) GetDeployablePatchSnapshotForInstance(arg0 *ssm.GetDeployablePatchSnapshotForInstanceInput) (*ssm.GetDeployablePatchSnapshotForInstanceOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetDeployablePatchSnapshotForInstance", arg0)
 	ret0, _ := ret[0].(*ssm.GetDeployablePatchSnapshotForInstanceOutput)
 	ret1, _ := ret[1].(error)
@@ -3009,13 +2654,11 @@ func (m *MockSSMAPI) GetDeployablePatchSnapshotForInstance(arg0 *ssm.GetDeployab
 
 // GetDeployablePatchSnapshotForInstance indicates an expected call of GetDeployablePatchSnapshotForInstance
 func (mr *MockSSMAPIMockRecorder) GetDeployablePatchSnapshotForInstance(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDeployablePatchSnapshotForInstance", reflect.TypeOf((*MockSSMAPI)(nil).GetDeployablePatchSnapshotForInstance), arg0)
 }
 
 // GetDeployablePatchSnapshotForInstanceRequest mocks base method
 func (m *MockSSMAPI) GetDeployablePatchSnapshotForInstanceRequest(arg0 *ssm.GetDeployablePatchSnapshotForInstanceInput) (*request.Request, *ssm.GetDeployablePatchSnapshotForInstanceOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetDeployablePatchSnapshotForInstanceRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ssm.GetDeployablePatchSnapshotForInstanceOutput)
@@ -3024,13 +2667,11 @@ func (m *MockSSMAPI) GetDeployablePatchSnapshotForInstanceRequest(arg0 *ssm.GetD
 
 // GetDeployablePatchSnapshotForInstanceRequest indicates an expected call of GetDeployablePatchSnapshotForInstanceRequest
 func (mr *MockSSMAPIMockRecorder) GetDeployablePatchSnapshotForInstanceRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDeployablePatchSnapshotForInstanceRequest", reflect.TypeOf((*MockSSMAPI)(nil).GetDeployablePatchSnapshotForInstanceRequest), arg0)
 }
 
 // GetDeployablePatchSnapshotForInstanceWithContext mocks base method
 func (m *MockSSMAPI) GetDeployablePatchSnapshotForInstanceWithContext(arg0 context.Context, arg1 *ssm.GetDeployablePatchSnapshotForInstanceInput, arg2 ...request.Option) (*ssm.GetDeployablePatchSnapshotForInstanceOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -3043,14 +2684,12 @@ func (m *MockSSMAPI) GetDeployablePatchSnapshotForInstanceWithContext(arg0 conte
 
 // GetDeployablePatchSnapshotForInstanceWithContext indicates an expected call of GetDeployablePatchSnapshotForInstanceWithContext
 func (mr *MockSSMAPIMockRecorder) GetDeployablePatchSnapshotForInstanceWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDeployablePatchSnapshotForInstanceWithContext", reflect.TypeOf((*MockSSMAPI)(nil).GetDeployablePatchSnapshotForInstanceWithContext), varargs...)
 }
 
 // GetDocument mocks base method
 func (m *MockSSMAPI) GetDocument(arg0 *ssm.GetDocumentInput) (*ssm.GetDocumentOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetDocument", arg0)
 	ret0, _ := ret[0].(*ssm.GetDocumentOutput)
 	ret1, _ := ret[1].(error)
@@ -3059,13 +2698,11 @@ func (m *MockSSMAPI) GetDocument(arg0 *ssm.GetDocumentInput) (*ssm.GetDocumentOu
 
 // GetDocument indicates an expected call of GetDocument
 func (mr *MockSSMAPIMockRecorder) GetDocument(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDocument", reflect.TypeOf((*MockSSMAPI)(nil).GetDocument), arg0)
 }
 
 // GetDocumentRequest mocks base method
 func (m *MockSSMAPI) GetDocumentRequest(arg0 *ssm.GetDocumentInput) (*request.Request, *ssm.GetDocumentOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetDocumentRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ssm.GetDocumentOutput)
@@ -3074,13 +2711,11 @@ func (m *MockSSMAPI) GetDocumentRequest(arg0 *ssm.GetDocumentInput) (*request.Re
 
 // GetDocumentRequest indicates an expected call of GetDocumentRequest
 func (mr *MockSSMAPIMockRecorder) GetDocumentRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDocumentRequest", reflect.TypeOf((*MockSSMAPI)(nil).GetDocumentRequest), arg0)
 }
 
 // GetDocumentWithContext mocks base method
 func (m *MockSSMAPI) GetDocumentWithContext(arg0 context.Context, arg1 *ssm.GetDocumentInput, arg2 ...request.Option) (*ssm.GetDocumentOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -3093,14 +2728,12 @@ func (m *MockSSMAPI) GetDocumentWithContext(arg0 context.Context, arg1 *ssm.GetD
 
 // GetDocumentWithContext indicates an expected call of GetDocumentWithContext
 func (mr *MockSSMAPIMockRecorder) GetDocumentWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDocumentWithContext", reflect.TypeOf((*MockSSMAPI)(nil).GetDocumentWithContext), varargs...)
 }
 
 // GetInventory mocks base method
 func (m *MockSSMAPI) GetInventory(arg0 *ssm.GetInventoryInput) (*ssm.GetInventoryOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetInventory", arg0)
 	ret0, _ := ret[0].(*ssm.GetInventoryOutput)
 	ret1, _ := ret[1].(error)
@@ -3109,13 +2742,11 @@ func (m *MockSSMAPI) GetInventory(arg0 *ssm.GetInventoryInput) (*ssm.GetInventor
 
 // GetInventory indicates an expected call of GetInventory
 func (mr *MockSSMAPIMockRecorder) GetInventory(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetInventory", reflect.TypeOf((*MockSSMAPI)(nil).GetInventory), arg0)
 }
 
 // GetInventoryRequest mocks base method
 func (m *MockSSMAPI) GetInventoryRequest(arg0 *ssm.GetInventoryInput) (*request.Request, *ssm.GetInventoryOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetInventoryRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ssm.GetInventoryOutput)
@@ -3124,13 +2755,11 @@ func (m *MockSSMAPI) GetInventoryRequest(arg0 *ssm.GetInventoryInput) (*request.
 
 // GetInventoryRequest indicates an expected call of GetInventoryRequest
 func (mr *MockSSMAPIMockRecorder) GetInventoryRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetInventoryRequest", reflect.TypeOf((*MockSSMAPI)(nil).GetInventoryRequest), arg0)
 }
 
 // GetInventorySchema mocks base method
 func (m *MockSSMAPI) GetInventorySchema(arg0 *ssm.GetInventorySchemaInput) (*ssm.GetInventorySchemaOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetInventorySchema", arg0)
 	ret0, _ := ret[0].(*ssm.GetInventorySchemaOutput)
 	ret1, _ := ret[1].(error)
@@ -3139,13 +2768,11 @@ func (m *MockSSMAPI) GetInventorySchema(arg0 *ssm.GetInventorySchemaInput) (*ssm
 
 // GetInventorySchema indicates an expected call of GetInventorySchema
 func (mr *MockSSMAPIMockRecorder) GetInventorySchema(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetInventorySchema", reflect.TypeOf((*MockSSMAPI)(nil).GetInventorySchema), arg0)
 }
 
 // GetInventorySchemaRequest mocks base method
 func (m *MockSSMAPI) GetInventorySchemaRequest(arg0 *ssm.GetInventorySchemaInput) (*request.Request, *ssm.GetInventorySchemaOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetInventorySchemaRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ssm.GetInventorySchemaOutput)
@@ -3154,13 +2781,11 @@ func (m *MockSSMAPI) GetInventorySchemaRequest(arg0 *ssm.GetInventorySchemaInput
 
 // GetInventorySchemaRequest indicates an expected call of GetInventorySchemaRequest
 func (mr *MockSSMAPIMockRecorder) GetInventorySchemaRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetInventorySchemaRequest", reflect.TypeOf((*MockSSMAPI)(nil).GetInventorySchemaRequest), arg0)
 }
 
 // GetInventorySchemaWithContext mocks base method
 func (m *MockSSMAPI) GetInventorySchemaWithContext(arg0 context.Context, arg1 *ssm.GetInventorySchemaInput, arg2 ...request.Option) (*ssm.GetInventorySchemaOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -3173,14 +2798,12 @@ func (m *MockSSMAPI) GetInventorySchemaWithContext(arg0 context.Context, arg1 *s
 
 // GetInventorySchemaWithContext indicates an expected call of GetInventorySchemaWithContext
 func (mr *MockSSMAPIMockRecorder) GetInventorySchemaWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetInventorySchemaWithContext", reflect.TypeOf((*MockSSMAPI)(nil).GetInventorySchemaWithContext), varargs...)
 }
 
 // GetInventoryWithContext mocks base method
 func (m *MockSSMAPI) GetInventoryWithContext(arg0 context.Context, arg1 *ssm.GetInventoryInput, arg2 ...request.Option) (*ssm.GetInventoryOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -3193,14 +2816,12 @@ func (m *MockSSMAPI) GetInventoryWithContext(arg0 context.Context, arg1 *ssm.Get
 
 // GetInventoryWithContext indicates an expected call of GetInventoryWithContext
 func (mr *MockSSMAPIMockRecorder) GetInventoryWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetInventoryWithContext", reflect.TypeOf((*MockSSMAPI)(nil).GetInventoryWithContext), varargs...)
 }
 
 // GetMaintenanceWindow mocks base method
 func (m *MockSSMAPI) GetMaintenanceWindow(arg0 *ssm.GetMaintenanceWindowInput) (*ssm.GetMaintenanceWindowOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetMaintenanceWindow", arg0)
 	ret0, _ := ret[0].(*ssm.GetMaintenanceWindowOutput)
 	ret1, _ := ret[1].(error)
@@ -3209,13 +2830,11 @@ func (m *MockSSMAPI) GetMaintenanceWindow(arg0 *ssm.GetMaintenanceWindowInput) (
 
 // GetMaintenanceWindow indicates an expected call of GetMaintenanceWindow
 func (mr *MockSSMAPIMockRecorder) GetMaintenanceWindow(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMaintenanceWindow", reflect.TypeOf((*MockSSMAPI)(nil).GetMaintenanceWindow), arg0)
 }
 
 // GetMaintenanceWindowExecution mocks base method
 func (m *MockSSMAPI) GetMaintenanceWindowExecution(arg0 *ssm.GetMaintenanceWindowExecutionInput) (*ssm.GetMaintenanceWindowExecutionOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetMaintenanceWindowExecution", arg0)
 	ret0, _ := ret[0].(*ssm.GetMaintenanceWindowExecutionOutput)
 	ret1, _ := ret[1].(error)
@@ -3224,13 +2843,11 @@ func (m *MockSSMAPI) GetMaintenanceWindowExecution(arg0 *ssm.GetMaintenanceWindo
 
 // GetMaintenanceWindowExecution indicates an expected call of GetMaintenanceWindowExecution
 func (mr *MockSSMAPIMockRecorder) GetMaintenanceWindowExecution(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMaintenanceWindowExecution", reflect.TypeOf((*MockSSMAPI)(nil).GetMaintenanceWindowExecution), arg0)
 }
 
 // GetMaintenanceWindowExecutionRequest mocks base method
 func (m *MockSSMAPI) GetMaintenanceWindowExecutionRequest(arg0 *ssm.GetMaintenanceWindowExecutionInput) (*request.Request, *ssm.GetMaintenanceWindowExecutionOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetMaintenanceWindowExecutionRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ssm.GetMaintenanceWindowExecutionOutput)
@@ -3239,13 +2856,11 @@ func (m *MockSSMAPI) GetMaintenanceWindowExecutionRequest(arg0 *ssm.GetMaintenan
 
 // GetMaintenanceWindowExecutionRequest indicates an expected call of GetMaintenanceWindowExecutionRequest
 func (mr *MockSSMAPIMockRecorder) GetMaintenanceWindowExecutionRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMaintenanceWindowExecutionRequest", reflect.TypeOf((*MockSSMAPI)(nil).GetMaintenanceWindowExecutionRequest), arg0)
 }
 
 // GetMaintenanceWindowExecutionTask mocks base method
 func (m *MockSSMAPI) GetMaintenanceWindowExecutionTask(arg0 *ssm.GetMaintenanceWindowExecutionTaskInput) (*ssm.GetMaintenanceWindowExecutionTaskOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetMaintenanceWindowExecutionTask", arg0)
 	ret0, _ := ret[0].(*ssm.GetMaintenanceWindowExecutionTaskOutput)
 	ret1, _ := ret[1].(error)
@@ -3254,13 +2869,11 @@ func (m *MockSSMAPI) GetMaintenanceWindowExecutionTask(arg0 *ssm.GetMaintenanceW
 
 // GetMaintenanceWindowExecutionTask indicates an expected call of GetMaintenanceWindowExecutionTask
 func (mr *MockSSMAPIMockRecorder) GetMaintenanceWindowExecutionTask(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMaintenanceWindowExecutionTask", reflect.TypeOf((*MockSSMAPI)(nil).GetMaintenanceWindowExecutionTask), arg0)
 }
 
 // GetMaintenanceWindowExecutionTaskInvocation mocks base method
 func (m *MockSSMAPI) GetMaintenanceWindowExecutionTaskInvocation(arg0 *ssm.GetMaintenanceWindowExecutionTaskInvocationInput) (*ssm.GetMaintenanceWindowExecutionTaskInvocationOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetMaintenanceWindowExecutionTaskInvocation", arg0)
 	ret0, _ := ret[0].(*ssm.GetMaintenanceWindowExecutionTaskInvocationOutput)
 	ret1, _ := ret[1].(error)
@@ -3269,13 +2882,11 @@ func (m *MockSSMAPI) GetMaintenanceWindowExecutionTaskInvocation(arg0 *ssm.GetMa
 
 // GetMaintenanceWindowExecutionTaskInvocation indicates an expected call of GetMaintenanceWindowExecutionTaskInvocation
 func (mr *MockSSMAPIMockRecorder) GetMaintenanceWindowExecutionTaskInvocation(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMaintenanceWindowExecutionTaskInvocation", reflect.TypeOf((*MockSSMAPI)(nil).GetMaintenanceWindowExecutionTaskInvocation), arg0)
 }
 
 // GetMaintenanceWindowExecutionTaskInvocationRequest mocks base method
 func (m *MockSSMAPI) GetMaintenanceWindowExecutionTaskInvocationRequest(arg0 *ssm.GetMaintenanceWindowExecutionTaskInvocationInput) (*request.Request, *ssm.GetMaintenanceWindowExecutionTaskInvocationOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetMaintenanceWindowExecutionTaskInvocationRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ssm.GetMaintenanceWindowExecutionTaskInvocationOutput)
@@ -3284,13 +2895,11 @@ func (m *MockSSMAPI) GetMaintenanceWindowExecutionTaskInvocationRequest(arg0 *ss
 
 // GetMaintenanceWindowExecutionTaskInvocationRequest indicates an expected call of GetMaintenanceWindowExecutionTaskInvocationRequest
 func (mr *MockSSMAPIMockRecorder) GetMaintenanceWindowExecutionTaskInvocationRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMaintenanceWindowExecutionTaskInvocationRequest", reflect.TypeOf((*MockSSMAPI)(nil).GetMaintenanceWindowExecutionTaskInvocationRequest), arg0)
 }
 
 // GetMaintenanceWindowExecutionTaskInvocationWithContext mocks base method
 func (m *MockSSMAPI) GetMaintenanceWindowExecutionTaskInvocationWithContext(arg0 context.Context, arg1 *ssm.GetMaintenanceWindowExecutionTaskInvocationInput, arg2 ...request.Option) (*ssm.GetMaintenanceWindowExecutionTaskInvocationOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -3303,14 +2912,12 @@ func (m *MockSSMAPI) GetMaintenanceWindowExecutionTaskInvocationWithContext(arg0
 
 // GetMaintenanceWindowExecutionTaskInvocationWithContext indicates an expected call of GetMaintenanceWindowExecutionTaskInvocationWithContext
 func (mr *MockSSMAPIMockRecorder) GetMaintenanceWindowExecutionTaskInvocationWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMaintenanceWindowExecutionTaskInvocationWithContext", reflect.TypeOf((*MockSSMAPI)(nil).GetMaintenanceWindowExecutionTaskInvocationWithContext), varargs...)
 }
 
 // GetMaintenanceWindowExecutionTaskRequest mocks base method
 func (m *MockSSMAPI) GetMaintenanceWindowExecutionTaskRequest(arg0 *ssm.GetMaintenanceWindowExecutionTaskInput) (*request.Request, *ssm.GetMaintenanceWindowExecutionTaskOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetMaintenanceWindowExecutionTaskRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ssm.GetMaintenanceWindowExecutionTaskOutput)
@@ -3319,13 +2926,11 @@ func (m *MockSSMAPI) GetMaintenanceWindowExecutionTaskRequest(arg0 *ssm.GetMaint
 
 // GetMaintenanceWindowExecutionTaskRequest indicates an expected call of GetMaintenanceWindowExecutionTaskRequest
 func (mr *MockSSMAPIMockRecorder) GetMaintenanceWindowExecutionTaskRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMaintenanceWindowExecutionTaskRequest", reflect.TypeOf((*MockSSMAPI)(nil).GetMaintenanceWindowExecutionTaskRequest), arg0)
 }
 
 // GetMaintenanceWindowExecutionTaskWithContext mocks base method
 func (m *MockSSMAPI) GetMaintenanceWindowExecutionTaskWithContext(arg0 context.Context, arg1 *ssm.GetMaintenanceWindowExecutionTaskInput, arg2 ...request.Option) (*ssm.GetMaintenanceWindowExecutionTaskOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -3338,14 +2943,12 @@ func (m *MockSSMAPI) GetMaintenanceWindowExecutionTaskWithContext(arg0 context.C
 
 // GetMaintenanceWindowExecutionTaskWithContext indicates an expected call of GetMaintenanceWindowExecutionTaskWithContext
 func (mr *MockSSMAPIMockRecorder) GetMaintenanceWindowExecutionTaskWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMaintenanceWindowExecutionTaskWithContext", reflect.TypeOf((*MockSSMAPI)(nil).GetMaintenanceWindowExecutionTaskWithContext), varargs...)
 }
 
 // GetMaintenanceWindowExecutionWithContext mocks base method
 func (m *MockSSMAPI) GetMaintenanceWindowExecutionWithContext(arg0 context.Context, arg1 *ssm.GetMaintenanceWindowExecutionInput, arg2 ...request.Option) (*ssm.GetMaintenanceWindowExecutionOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -3358,14 +2961,12 @@ func (m *MockSSMAPI) GetMaintenanceWindowExecutionWithContext(arg0 context.Conte
 
 // GetMaintenanceWindowExecutionWithContext indicates an expected call of GetMaintenanceWindowExecutionWithContext
 func (mr *MockSSMAPIMockRecorder) GetMaintenanceWindowExecutionWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMaintenanceWindowExecutionWithContext", reflect.TypeOf((*MockSSMAPI)(nil).GetMaintenanceWindowExecutionWithContext), varargs...)
 }
 
 // GetMaintenanceWindowRequest mocks base method
 func (m *MockSSMAPI) GetMaintenanceWindowRequest(arg0 *ssm.GetMaintenanceWindowInput) (*request.Request, *ssm.GetMaintenanceWindowOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetMaintenanceWindowRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ssm.GetMaintenanceWindowOutput)
@@ -3374,13 +2975,11 @@ func (m *MockSSMAPI) GetMaintenanceWindowRequest(arg0 *ssm.GetMaintenanceWindowI
 
 // GetMaintenanceWindowRequest indicates an expected call of GetMaintenanceWindowRequest
 func (mr *MockSSMAPIMockRecorder) GetMaintenanceWindowRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMaintenanceWindowRequest", reflect.TypeOf((*MockSSMAPI)(nil).GetMaintenanceWindowRequest), arg0)
 }
 
 // GetMaintenanceWindowTask mocks base method
 func (m *MockSSMAPI) GetMaintenanceWindowTask(arg0 *ssm.GetMaintenanceWindowTaskInput) (*ssm.GetMaintenanceWindowTaskOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetMaintenanceWindowTask", arg0)
 	ret0, _ := ret[0].(*ssm.GetMaintenanceWindowTaskOutput)
 	ret1, _ := ret[1].(error)
@@ -3389,13 +2988,11 @@ func (m *MockSSMAPI) GetMaintenanceWindowTask(arg0 *ssm.GetMaintenanceWindowTask
 
 // GetMaintenanceWindowTask indicates an expected call of GetMaintenanceWindowTask
 func (mr *MockSSMAPIMockRecorder) GetMaintenanceWindowTask(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMaintenanceWindowTask", reflect.TypeOf((*MockSSMAPI)(nil).GetMaintenanceWindowTask), arg0)
 }
 
 // GetMaintenanceWindowTaskRequest mocks base method
 func (m *MockSSMAPI) GetMaintenanceWindowTaskRequest(arg0 *ssm.GetMaintenanceWindowTaskInput) (*request.Request, *ssm.GetMaintenanceWindowTaskOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetMaintenanceWindowTaskRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ssm.GetMaintenanceWindowTaskOutput)
@@ -3404,13 +3001,11 @@ func (m *MockSSMAPI) GetMaintenanceWindowTaskRequest(arg0 *ssm.GetMaintenanceWin
 
 // GetMaintenanceWindowTaskRequest indicates an expected call of GetMaintenanceWindowTaskRequest
 func (mr *MockSSMAPIMockRecorder) GetMaintenanceWindowTaskRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMaintenanceWindowTaskRequest", reflect.TypeOf((*MockSSMAPI)(nil).GetMaintenanceWindowTaskRequest), arg0)
 }
 
 // GetMaintenanceWindowTaskWithContext mocks base method
 func (m *MockSSMAPI) GetMaintenanceWindowTaskWithContext(arg0 context.Context, arg1 *ssm.GetMaintenanceWindowTaskInput, arg2 ...request.Option) (*ssm.GetMaintenanceWindowTaskOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -3423,14 +3018,12 @@ func (m *MockSSMAPI) GetMaintenanceWindowTaskWithContext(arg0 context.Context, a
 
 // GetMaintenanceWindowTaskWithContext indicates an expected call of GetMaintenanceWindowTaskWithContext
 func (mr *MockSSMAPIMockRecorder) GetMaintenanceWindowTaskWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMaintenanceWindowTaskWithContext", reflect.TypeOf((*MockSSMAPI)(nil).GetMaintenanceWindowTaskWithContext), varargs...)
 }
 
 // GetMaintenanceWindowWithContext mocks base method
 func (m *MockSSMAPI) GetMaintenanceWindowWithContext(arg0 context.Context, arg1 *ssm.GetMaintenanceWindowInput, arg2 ...request.Option) (*ssm.GetMaintenanceWindowOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -3443,14 +3036,12 @@ func (m *MockSSMAPI) GetMaintenanceWindowWithContext(arg0 context.Context, arg1 
 
 // GetMaintenanceWindowWithContext indicates an expected call of GetMaintenanceWindowWithContext
 func (mr *MockSSMAPIMockRecorder) GetMaintenanceWindowWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMaintenanceWindowWithContext", reflect.TypeOf((*MockSSMAPI)(nil).GetMaintenanceWindowWithContext), varargs...)
 }
 
 // GetParameter mocks base method
 func (m *MockSSMAPI) GetParameter(arg0 *ssm.GetParameterInput) (*ssm.GetParameterOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetParameter", arg0)
 	ret0, _ := ret[0].(*ssm.GetParameterOutput)
 	ret1, _ := ret[1].(error)
@@ -3459,13 +3050,11 @@ func (m *MockSSMAPI) GetParameter(arg0 *ssm.GetParameterInput) (*ssm.GetParamete
 
 // GetParameter indicates an expected call of GetParameter
 func (mr *MockSSMAPIMockRecorder) GetParameter(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetParameter", reflect.TypeOf((*MockSSMAPI)(nil).GetParameter), arg0)
 }
 
 // GetParameterHistory mocks base method
 func (m *MockSSMAPI) GetParameterHistory(arg0 *ssm.GetParameterHistoryInput) (*ssm.GetParameterHistoryOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetParameterHistory", arg0)
 	ret0, _ := ret[0].(*ssm.GetParameterHistoryOutput)
 	ret1, _ := ret[1].(error)
@@ -3474,13 +3063,11 @@ func (m *MockSSMAPI) GetParameterHistory(arg0 *ssm.GetParameterHistoryInput) (*s
 
 // GetParameterHistory indicates an expected call of GetParameterHistory
 func (mr *MockSSMAPIMockRecorder) GetParameterHistory(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetParameterHistory", reflect.TypeOf((*MockSSMAPI)(nil).GetParameterHistory), arg0)
 }
 
 // GetParameterHistoryPages mocks base method
 func (m *MockSSMAPI) GetParameterHistoryPages(arg0 *ssm.GetParameterHistoryInput, arg1 func(*ssm.GetParameterHistoryOutput, bool) bool) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetParameterHistoryPages", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -3488,13 +3075,11 @@ func (m *MockSSMAPI) GetParameterHistoryPages(arg0 *ssm.GetParameterHistoryInput
 
 // GetParameterHistoryPages indicates an expected call of GetParameterHistoryPages
 func (mr *MockSSMAPIMockRecorder) GetParameterHistoryPages(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetParameterHistoryPages", reflect.TypeOf((*MockSSMAPI)(nil).GetParameterHistoryPages), arg0, arg1)
 }
 
 // GetParameterHistoryPagesWithContext mocks base method
 func (m *MockSSMAPI) GetParameterHistoryPagesWithContext(arg0 context.Context, arg1 *ssm.GetParameterHistoryInput, arg2 func(*ssm.GetParameterHistoryOutput, bool) bool, arg3 ...request.Option) error {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1, arg2}
 	for _, a := range arg3 {
 		varargs = append(varargs, a)
@@ -3506,14 +3091,12 @@ func (m *MockSSMAPI) GetParameterHistoryPagesWithContext(arg0 context.Context, a
 
 // GetParameterHistoryPagesWithContext indicates an expected call of GetParameterHistoryPagesWithContext
 func (mr *MockSSMAPIMockRecorder) GetParameterHistoryPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetParameterHistoryPagesWithContext", reflect.TypeOf((*MockSSMAPI)(nil).GetParameterHistoryPagesWithContext), varargs...)
 }
 
 // GetParameterHistoryRequest mocks base method
 func (m *MockSSMAPI) GetParameterHistoryRequest(arg0 *ssm.GetParameterHistoryInput) (*request.Request, *ssm.GetParameterHistoryOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetParameterHistoryRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ssm.GetParameterHistoryOutput)
@@ -3522,13 +3105,11 @@ func (m *MockSSMAPI) GetParameterHistoryRequest(arg0 *ssm.GetParameterHistoryInp
 
 // GetParameterHistoryRequest indicates an expected call of GetParameterHistoryRequest
 func (mr *MockSSMAPIMockRecorder) GetParameterHistoryRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetParameterHistoryRequest", reflect.TypeOf((*MockSSMAPI)(nil).GetParameterHistoryRequest), arg0)
 }
 
 // GetParameterHistoryWithContext mocks base method
 func (m *MockSSMAPI) GetParameterHistoryWithContext(arg0 context.Context, arg1 *ssm.GetParameterHistoryInput, arg2 ...request.Option) (*ssm.GetParameterHistoryOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -3541,14 +3122,12 @@ func (m *MockSSMAPI) GetParameterHistoryWithContext(arg0 context.Context, arg1 *
 
 // GetParameterHistoryWithContext indicates an expected call of GetParameterHistoryWithContext
 func (mr *MockSSMAPIMockRecorder) GetParameterHistoryWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetParameterHistoryWithContext", reflect.TypeOf((*MockSSMAPI)(nil).GetParameterHistoryWithContext), varargs...)
 }
 
 // GetParameterRequest mocks base method
 func (m *MockSSMAPI) GetParameterRequest(arg0 *ssm.GetParameterInput) (*request.Request, *ssm.GetParameterOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetParameterRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ssm.GetParameterOutput)
@@ -3557,13 +3136,11 @@ func (m *MockSSMAPI) GetParameterRequest(arg0 *ssm.GetParameterInput) (*request.
 
 // GetParameterRequest indicates an expected call of GetParameterRequest
 func (mr *MockSSMAPIMockRecorder) GetParameterRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetParameterRequest", reflect.TypeOf((*MockSSMAPI)(nil).GetParameterRequest), arg0)
 }
 
 // GetParameterWithContext mocks base method
 func (m *MockSSMAPI) GetParameterWithContext(arg0 context.Context, arg1 *ssm.GetParameterInput, arg2 ...request.Option) (*ssm.GetParameterOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -3576,14 +3153,12 @@ func (m *MockSSMAPI) GetParameterWithContext(arg0 context.Context, arg1 *ssm.Get
 
 // GetParameterWithContext indicates an expected call of GetParameterWithContext
 func (mr *MockSSMAPIMockRecorder) GetParameterWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetParameterWithContext", reflect.TypeOf((*MockSSMAPI)(nil).GetParameterWithContext), varargs...)
 }
 
 // GetParameters mocks base method
 func (m *MockSSMAPI) GetParameters(arg0 *ssm.GetParametersInput) (*ssm.GetParametersOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetParameters", arg0)
 	ret0, _ := ret[0].(*ssm.GetParametersOutput)
 	ret1, _ := ret[1].(error)
@@ -3592,13 +3167,11 @@ func (m *MockSSMAPI) GetParameters(arg0 *ssm.GetParametersInput) (*ssm.GetParame
 
 // GetParameters indicates an expected call of GetParameters
 func (mr *MockSSMAPIMockRecorder) GetParameters(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetParameters", reflect.TypeOf((*MockSSMAPI)(nil).GetParameters), arg0)
 }
 
 // GetParametersByPath mocks base method
 func (m *MockSSMAPI) GetParametersByPath(arg0 *ssm.GetParametersByPathInput) (*ssm.GetParametersByPathOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetParametersByPath", arg0)
 	ret0, _ := ret[0].(*ssm.GetParametersByPathOutput)
 	ret1, _ := ret[1].(error)
@@ -3607,13 +3180,11 @@ func (m *MockSSMAPI) GetParametersByPath(arg0 *ssm.GetParametersByPathInput) (*s
 
 // GetParametersByPath indicates an expected call of GetParametersByPath
 func (mr *MockSSMAPIMockRecorder) GetParametersByPath(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetParametersByPath", reflect.TypeOf((*MockSSMAPI)(nil).GetParametersByPath), arg0)
 }
 
 // GetParametersByPathPages mocks base method
 func (m *MockSSMAPI) GetParametersByPathPages(arg0 *ssm.GetParametersByPathInput, arg1 func(*ssm.GetParametersByPathOutput, bool) bool) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetParametersByPathPages", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -3621,13 +3192,11 @@ func (m *MockSSMAPI) GetParametersByPathPages(arg0 *ssm.GetParametersByPathInput
 
 // GetParametersByPathPages indicates an expected call of GetParametersByPathPages
 func (mr *MockSSMAPIMockRecorder) GetParametersByPathPages(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetParametersByPathPages", reflect.TypeOf((*MockSSMAPI)(nil).GetParametersByPathPages), arg0, arg1)
 }
 
 // GetParametersByPathPagesWithContext mocks base method
 func (m *MockSSMAPI) GetParametersByPathPagesWithContext(arg0 context.Context, arg1 *ssm.GetParametersByPathInput, arg2 func(*ssm.GetParametersByPathOutput, bool) bool, arg3 ...request.Option) error {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1, arg2}
 	for _, a := range arg3 {
 		varargs = append(varargs, a)
@@ -3639,14 +3208,12 @@ func (m *MockSSMAPI) GetParametersByPathPagesWithContext(arg0 context.Context, a
 
 // GetParametersByPathPagesWithContext indicates an expected call of GetParametersByPathPagesWithContext
 func (mr *MockSSMAPIMockRecorder) GetParametersByPathPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetParametersByPathPagesWithContext", reflect.TypeOf((*MockSSMAPI)(nil).GetParametersByPathPagesWithContext), varargs...)
 }
 
 // GetParametersByPathRequest mocks base method
 func (m *MockSSMAPI) GetParametersByPathRequest(arg0 *ssm.GetParametersByPathInput) (*request.Request, *ssm.GetParametersByPathOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetParametersByPathRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ssm.GetParametersByPathOutput)
@@ -3655,13 +3222,11 @@ func (m *MockSSMAPI) GetParametersByPathRequest(arg0 *ssm.GetParametersByPathInp
 
 // GetParametersByPathRequest indicates an expected call of GetParametersByPathRequest
 func (mr *MockSSMAPIMockRecorder) GetParametersByPathRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetParametersByPathRequest", reflect.TypeOf((*MockSSMAPI)(nil).GetParametersByPathRequest), arg0)
 }
 
 // GetParametersByPathWithContext mocks base method
 func (m *MockSSMAPI) GetParametersByPathWithContext(arg0 context.Context, arg1 *ssm.GetParametersByPathInput, arg2 ...request.Option) (*ssm.GetParametersByPathOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -3674,14 +3239,12 @@ func (m *MockSSMAPI) GetParametersByPathWithContext(arg0 context.Context, arg1 *
 
 // GetParametersByPathWithContext indicates an expected call of GetParametersByPathWithContext
 func (mr *MockSSMAPIMockRecorder) GetParametersByPathWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetParametersByPathWithContext", reflect.TypeOf((*MockSSMAPI)(nil).GetParametersByPathWithContext), varargs...)
 }
 
 // GetParametersRequest mocks base method
 func (m *MockSSMAPI) GetParametersRequest(arg0 *ssm.GetParametersInput) (*request.Request, *ssm.GetParametersOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetParametersRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ssm.GetParametersOutput)
@@ -3690,13 +3253,11 @@ func (m *MockSSMAPI) GetParametersRequest(arg0 *ssm.GetParametersInput) (*reques
 
 // GetParametersRequest indicates an expected call of GetParametersRequest
 func (mr *MockSSMAPIMockRecorder) GetParametersRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetParametersRequest", reflect.TypeOf((*MockSSMAPI)(nil).GetParametersRequest), arg0)
 }
 
 // GetParametersWithContext mocks base method
 func (m *MockSSMAPI) GetParametersWithContext(arg0 context.Context, arg1 *ssm.GetParametersInput, arg2 ...request.Option) (*ssm.GetParametersOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -3709,14 +3270,12 @@ func (m *MockSSMAPI) GetParametersWithContext(arg0 context.Context, arg1 *ssm.Ge
 
 // GetParametersWithContext indicates an expected call of GetParametersWithContext
 func (mr *MockSSMAPIMockRecorder) GetParametersWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetParametersWithContext", reflect.TypeOf((*MockSSMAPI)(nil).GetParametersWithContext), varargs...)
 }
 
 // GetPatchBaseline mocks base method
 func (m *MockSSMAPI) GetPatchBaseline(arg0 *ssm.GetPatchBaselineInput) (*ssm.GetPatchBaselineOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetPatchBaseline", arg0)
 	ret0, _ := ret[0].(*ssm.GetPatchBaselineOutput)
 	ret1, _ := ret[1].(error)
@@ -3725,13 +3284,11 @@ func (m *MockSSMAPI) GetPatchBaseline(arg0 *ssm.GetPatchBaselineInput) (*ssm.Get
 
 // GetPatchBaseline indicates an expected call of GetPatchBaseline
 func (mr *MockSSMAPIMockRecorder) GetPatchBaseline(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPatchBaseline", reflect.TypeOf((*MockSSMAPI)(nil).GetPatchBaseline), arg0)
 }
 
 // GetPatchBaselineForPatchGroup mocks base method
 func (m *MockSSMAPI) GetPatchBaselineForPatchGroup(arg0 *ssm.GetPatchBaselineForPatchGroupInput) (*ssm.GetPatchBaselineForPatchGroupOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetPatchBaselineForPatchGroup", arg0)
 	ret0, _ := ret[0].(*ssm.GetPatchBaselineForPatchGroupOutput)
 	ret1, _ := ret[1].(error)
@@ -3740,13 +3297,11 @@ func (m *MockSSMAPI) GetPatchBaselineForPatchGroup(arg0 *ssm.GetPatchBaselineFor
 
 // GetPatchBaselineForPatchGroup indicates an expected call of GetPatchBaselineForPatchGroup
 func (mr *MockSSMAPIMockRecorder) GetPatchBaselineForPatchGroup(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPatchBaselineForPatchGroup", reflect.TypeOf((*MockSSMAPI)(nil).GetPatchBaselineForPatchGroup), arg0)
 }
 
 // GetPatchBaselineForPatchGroupRequest mocks base method
 func (m *MockSSMAPI) GetPatchBaselineForPatchGroupRequest(arg0 *ssm.GetPatchBaselineForPatchGroupInput) (*request.Request, *ssm.GetPatchBaselineForPatchGroupOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetPatchBaselineForPatchGroupRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ssm.GetPatchBaselineForPatchGroupOutput)
@@ -3755,13 +3310,11 @@ func (m *MockSSMAPI) GetPatchBaselineForPatchGroupRequest(arg0 *ssm.GetPatchBase
 
 // GetPatchBaselineForPatchGroupRequest indicates an expected call of GetPatchBaselineForPatchGroupRequest
 func (mr *MockSSMAPIMockRecorder) GetPatchBaselineForPatchGroupRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPatchBaselineForPatchGroupRequest", reflect.TypeOf((*MockSSMAPI)(nil).GetPatchBaselineForPatchGroupRequest), arg0)
 }
 
 // GetPatchBaselineForPatchGroupWithContext mocks base method
 func (m *MockSSMAPI) GetPatchBaselineForPatchGroupWithContext(arg0 context.Context, arg1 *ssm.GetPatchBaselineForPatchGroupInput, arg2 ...request.Option) (*ssm.GetPatchBaselineForPatchGroupOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -3774,14 +3327,12 @@ func (m *MockSSMAPI) GetPatchBaselineForPatchGroupWithContext(arg0 context.Conte
 
 // GetPatchBaselineForPatchGroupWithContext indicates an expected call of GetPatchBaselineForPatchGroupWithContext
 func (mr *MockSSMAPIMockRecorder) GetPatchBaselineForPatchGroupWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPatchBaselineForPatchGroupWithContext", reflect.TypeOf((*MockSSMAPI)(nil).GetPatchBaselineForPatchGroupWithContext), varargs...)
 }
 
 // GetPatchBaselineRequest mocks base method
 func (m *MockSSMAPI) GetPatchBaselineRequest(arg0 *ssm.GetPatchBaselineInput) (*request.Request, *ssm.GetPatchBaselineOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetPatchBaselineRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ssm.GetPatchBaselineOutput)
@@ -3790,13 +3341,11 @@ func (m *MockSSMAPI) GetPatchBaselineRequest(arg0 *ssm.GetPatchBaselineInput) (*
 
 // GetPatchBaselineRequest indicates an expected call of GetPatchBaselineRequest
 func (mr *MockSSMAPIMockRecorder) GetPatchBaselineRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPatchBaselineRequest", reflect.TypeOf((*MockSSMAPI)(nil).GetPatchBaselineRequest), arg0)
 }
 
 // GetPatchBaselineWithContext mocks base method
 func (m *MockSSMAPI) GetPatchBaselineWithContext(arg0 context.Context, arg1 *ssm.GetPatchBaselineInput, arg2 ...request.Option) (*ssm.GetPatchBaselineOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -3809,14 +3358,12 @@ func (m *MockSSMAPI) GetPatchBaselineWithContext(arg0 context.Context, arg1 *ssm
 
 // GetPatchBaselineWithContext indicates an expected call of GetPatchBaselineWithContext
 func (mr *MockSSMAPIMockRecorder) GetPatchBaselineWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPatchBaselineWithContext", reflect.TypeOf((*MockSSMAPI)(nil).GetPatchBaselineWithContext), varargs...)
 }
 
 // GetServiceSetting mocks base method
 func (m *MockSSMAPI) GetServiceSetting(arg0 *ssm.GetServiceSettingInput) (*ssm.GetServiceSettingOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetServiceSetting", arg0)
 	ret0, _ := ret[0].(*ssm.GetServiceSettingOutput)
 	ret1, _ := ret[1].(error)
@@ -3825,13 +3372,11 @@ func (m *MockSSMAPI) GetServiceSetting(arg0 *ssm.GetServiceSettingInput) (*ssm.G
 
 // GetServiceSetting indicates an expected call of GetServiceSetting
 func (mr *MockSSMAPIMockRecorder) GetServiceSetting(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetServiceSetting", reflect.TypeOf((*MockSSMAPI)(nil).GetServiceSetting), arg0)
 }
 
 // GetServiceSettingRequest mocks base method
 func (m *MockSSMAPI) GetServiceSettingRequest(arg0 *ssm.GetServiceSettingInput) (*request.Request, *ssm.GetServiceSettingOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetServiceSettingRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ssm.GetServiceSettingOutput)
@@ -3840,13 +3385,11 @@ func (m *MockSSMAPI) GetServiceSettingRequest(arg0 *ssm.GetServiceSettingInput) 
 
 // GetServiceSettingRequest indicates an expected call of GetServiceSettingRequest
 func (mr *MockSSMAPIMockRecorder) GetServiceSettingRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetServiceSettingRequest", reflect.TypeOf((*MockSSMAPI)(nil).GetServiceSettingRequest), arg0)
 }
 
 // GetServiceSettingWithContext mocks base method
 func (m *MockSSMAPI) GetServiceSettingWithContext(arg0 context.Context, arg1 *ssm.GetServiceSettingInput, arg2 ...request.Option) (*ssm.GetServiceSettingOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -3859,14 +3402,12 @@ func (m *MockSSMAPI) GetServiceSettingWithContext(arg0 context.Context, arg1 *ss
 
 // GetServiceSettingWithContext indicates an expected call of GetServiceSettingWithContext
 func (mr *MockSSMAPIMockRecorder) GetServiceSettingWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetServiceSettingWithContext", reflect.TypeOf((*MockSSMAPI)(nil).GetServiceSettingWithContext), varargs...)
 }
 
 // LabelParameterVersion mocks base method
 func (m *MockSSMAPI) LabelParameterVersion(arg0 *ssm.LabelParameterVersionInput) (*ssm.LabelParameterVersionOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "LabelParameterVersion", arg0)
 	ret0, _ := ret[0].(*ssm.LabelParameterVersionOutput)
 	ret1, _ := ret[1].(error)
@@ -3875,13 +3416,11 @@ func (m *MockSSMAPI) LabelParameterVersion(arg0 *ssm.LabelParameterVersionInput)
 
 // LabelParameterVersion indicates an expected call of LabelParameterVersion
 func (mr *MockSSMAPIMockRecorder) LabelParameterVersion(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LabelParameterVersion", reflect.TypeOf((*MockSSMAPI)(nil).LabelParameterVersion), arg0)
 }
 
 // LabelParameterVersionRequest mocks base method
 func (m *MockSSMAPI) LabelParameterVersionRequest(arg0 *ssm.LabelParameterVersionInput) (*request.Request, *ssm.LabelParameterVersionOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "LabelParameterVersionRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ssm.LabelParameterVersionOutput)
@@ -3890,13 +3429,11 @@ func (m *MockSSMAPI) LabelParameterVersionRequest(arg0 *ssm.LabelParameterVersio
 
 // LabelParameterVersionRequest indicates an expected call of LabelParameterVersionRequest
 func (mr *MockSSMAPIMockRecorder) LabelParameterVersionRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LabelParameterVersionRequest", reflect.TypeOf((*MockSSMAPI)(nil).LabelParameterVersionRequest), arg0)
 }
 
 // LabelParameterVersionWithContext mocks base method
 func (m *MockSSMAPI) LabelParameterVersionWithContext(arg0 context.Context, arg1 *ssm.LabelParameterVersionInput, arg2 ...request.Option) (*ssm.LabelParameterVersionOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -3909,14 +3446,12 @@ func (m *MockSSMAPI) LabelParameterVersionWithContext(arg0 context.Context, arg1
 
 // LabelParameterVersionWithContext indicates an expected call of LabelParameterVersionWithContext
 func (mr *MockSSMAPIMockRecorder) LabelParameterVersionWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LabelParameterVersionWithContext", reflect.TypeOf((*MockSSMAPI)(nil).LabelParameterVersionWithContext), varargs...)
 }
 
 // ListAssociationVersions mocks base method
 func (m *MockSSMAPI) ListAssociationVersions(arg0 *ssm.ListAssociationVersionsInput) (*ssm.ListAssociationVersionsOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListAssociationVersions", arg0)
 	ret0, _ := ret[0].(*ssm.ListAssociationVersionsOutput)
 	ret1, _ := ret[1].(error)
@@ -3925,13 +3460,11 @@ func (m *MockSSMAPI) ListAssociationVersions(arg0 *ssm.ListAssociationVersionsIn
 
 // ListAssociationVersions indicates an expected call of ListAssociationVersions
 func (mr *MockSSMAPIMockRecorder) ListAssociationVersions(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAssociationVersions", reflect.TypeOf((*MockSSMAPI)(nil).ListAssociationVersions), arg0)
 }
 
 // ListAssociationVersionsRequest mocks base method
 func (m *MockSSMAPI) ListAssociationVersionsRequest(arg0 *ssm.ListAssociationVersionsInput) (*request.Request, *ssm.ListAssociationVersionsOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListAssociationVersionsRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ssm.ListAssociationVersionsOutput)
@@ -3940,13 +3473,11 @@ func (m *MockSSMAPI) ListAssociationVersionsRequest(arg0 *ssm.ListAssociationVer
 
 // ListAssociationVersionsRequest indicates an expected call of ListAssociationVersionsRequest
 func (mr *MockSSMAPIMockRecorder) ListAssociationVersionsRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAssociationVersionsRequest", reflect.TypeOf((*MockSSMAPI)(nil).ListAssociationVersionsRequest), arg0)
 }
 
 // ListAssociationVersionsWithContext mocks base method
 func (m *MockSSMAPI) ListAssociationVersionsWithContext(arg0 context.Context, arg1 *ssm.ListAssociationVersionsInput, arg2 ...request.Option) (*ssm.ListAssociationVersionsOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -3959,14 +3490,12 @@ func (m *MockSSMAPI) ListAssociationVersionsWithContext(arg0 context.Context, ar
 
 // ListAssociationVersionsWithContext indicates an expected call of ListAssociationVersionsWithContext
 func (mr *MockSSMAPIMockRecorder) ListAssociationVersionsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAssociationVersionsWithContext", reflect.TypeOf((*MockSSMAPI)(nil).ListAssociationVersionsWithContext), varargs...)
 }
 
 // ListAssociations mocks base method
 func (m *MockSSMAPI) ListAssociations(arg0 *ssm.ListAssociationsInput) (*ssm.ListAssociationsOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListAssociations", arg0)
 	ret0, _ := ret[0].(*ssm.ListAssociationsOutput)
 	ret1, _ := ret[1].(error)
@@ -3975,13 +3504,11 @@ func (m *MockSSMAPI) ListAssociations(arg0 *ssm.ListAssociationsInput) (*ssm.Lis
 
 // ListAssociations indicates an expected call of ListAssociations
 func (mr *MockSSMAPIMockRecorder) ListAssociations(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAssociations", reflect.TypeOf((*MockSSMAPI)(nil).ListAssociations), arg0)
 }
 
 // ListAssociationsPages mocks base method
 func (m *MockSSMAPI) ListAssociationsPages(arg0 *ssm.ListAssociationsInput, arg1 func(*ssm.ListAssociationsOutput, bool) bool) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListAssociationsPages", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -3989,13 +3516,11 @@ func (m *MockSSMAPI) ListAssociationsPages(arg0 *ssm.ListAssociationsInput, arg1
 
 // ListAssociationsPages indicates an expected call of ListAssociationsPages
 func (mr *MockSSMAPIMockRecorder) ListAssociationsPages(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAssociationsPages", reflect.TypeOf((*MockSSMAPI)(nil).ListAssociationsPages), arg0, arg1)
 }
 
 // ListAssociationsPagesWithContext mocks base method
 func (m *MockSSMAPI) ListAssociationsPagesWithContext(arg0 context.Context, arg1 *ssm.ListAssociationsInput, arg2 func(*ssm.ListAssociationsOutput, bool) bool, arg3 ...request.Option) error {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1, arg2}
 	for _, a := range arg3 {
 		varargs = append(varargs, a)
@@ -4007,14 +3532,12 @@ func (m *MockSSMAPI) ListAssociationsPagesWithContext(arg0 context.Context, arg1
 
 // ListAssociationsPagesWithContext indicates an expected call of ListAssociationsPagesWithContext
 func (mr *MockSSMAPIMockRecorder) ListAssociationsPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAssociationsPagesWithContext", reflect.TypeOf((*MockSSMAPI)(nil).ListAssociationsPagesWithContext), varargs...)
 }
 
 // ListAssociationsRequest mocks base method
 func (m *MockSSMAPI) ListAssociationsRequest(arg0 *ssm.ListAssociationsInput) (*request.Request, *ssm.ListAssociationsOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListAssociationsRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ssm.ListAssociationsOutput)
@@ -4023,13 +3546,11 @@ func (m *MockSSMAPI) ListAssociationsRequest(arg0 *ssm.ListAssociationsInput) (*
 
 // ListAssociationsRequest indicates an expected call of ListAssociationsRequest
 func (mr *MockSSMAPIMockRecorder) ListAssociationsRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAssociationsRequest", reflect.TypeOf((*MockSSMAPI)(nil).ListAssociationsRequest), arg0)
 }
 
 // ListAssociationsWithContext mocks base method
 func (m *MockSSMAPI) ListAssociationsWithContext(arg0 context.Context, arg1 *ssm.ListAssociationsInput, arg2 ...request.Option) (*ssm.ListAssociationsOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -4042,14 +3563,12 @@ func (m *MockSSMAPI) ListAssociationsWithContext(arg0 context.Context, arg1 *ssm
 
 // ListAssociationsWithContext indicates an expected call of ListAssociationsWithContext
 func (mr *MockSSMAPIMockRecorder) ListAssociationsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAssociationsWithContext", reflect.TypeOf((*MockSSMAPI)(nil).ListAssociationsWithContext), varargs...)
 }
 
 // ListCommandInvocations mocks base method
 func (m *MockSSMAPI) ListCommandInvocations(arg0 *ssm.ListCommandInvocationsInput) (*ssm.ListCommandInvocationsOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListCommandInvocations", arg0)
 	ret0, _ := ret[0].(*ssm.ListCommandInvocationsOutput)
 	ret1, _ := ret[1].(error)
@@ -4058,13 +3577,11 @@ func (m *MockSSMAPI) ListCommandInvocations(arg0 *ssm.ListCommandInvocationsInpu
 
 // ListCommandInvocations indicates an expected call of ListCommandInvocations
 func (mr *MockSSMAPIMockRecorder) ListCommandInvocations(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListCommandInvocations", reflect.TypeOf((*MockSSMAPI)(nil).ListCommandInvocations), arg0)
 }
 
 // ListCommandInvocationsPages mocks base method
 func (m *MockSSMAPI) ListCommandInvocationsPages(arg0 *ssm.ListCommandInvocationsInput, arg1 func(*ssm.ListCommandInvocationsOutput, bool) bool) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListCommandInvocationsPages", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -4072,13 +3589,11 @@ func (m *MockSSMAPI) ListCommandInvocationsPages(arg0 *ssm.ListCommandInvocation
 
 // ListCommandInvocationsPages indicates an expected call of ListCommandInvocationsPages
 func (mr *MockSSMAPIMockRecorder) ListCommandInvocationsPages(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListCommandInvocationsPages", reflect.TypeOf((*MockSSMAPI)(nil).ListCommandInvocationsPages), arg0, arg1)
 }
 
 // ListCommandInvocationsPagesWithContext mocks base method
 func (m *MockSSMAPI) ListCommandInvocationsPagesWithContext(arg0 context.Context, arg1 *ssm.ListCommandInvocationsInput, arg2 func(*ssm.ListCommandInvocationsOutput, bool) bool, arg3 ...request.Option) error {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1, arg2}
 	for _, a := range arg3 {
 		varargs = append(varargs, a)
@@ -4090,14 +3605,12 @@ func (m *MockSSMAPI) ListCommandInvocationsPagesWithContext(arg0 context.Context
 
 // ListCommandInvocationsPagesWithContext indicates an expected call of ListCommandInvocationsPagesWithContext
 func (mr *MockSSMAPIMockRecorder) ListCommandInvocationsPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListCommandInvocationsPagesWithContext", reflect.TypeOf((*MockSSMAPI)(nil).ListCommandInvocationsPagesWithContext), varargs...)
 }
 
 // ListCommandInvocationsRequest mocks base method
 func (m *MockSSMAPI) ListCommandInvocationsRequest(arg0 *ssm.ListCommandInvocationsInput) (*request.Request, *ssm.ListCommandInvocationsOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListCommandInvocationsRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ssm.ListCommandInvocationsOutput)
@@ -4106,13 +3619,11 @@ func (m *MockSSMAPI) ListCommandInvocationsRequest(arg0 *ssm.ListCommandInvocati
 
 // ListCommandInvocationsRequest indicates an expected call of ListCommandInvocationsRequest
 func (mr *MockSSMAPIMockRecorder) ListCommandInvocationsRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListCommandInvocationsRequest", reflect.TypeOf((*MockSSMAPI)(nil).ListCommandInvocationsRequest), arg0)
 }
 
 // ListCommandInvocationsWithContext mocks base method
 func (m *MockSSMAPI) ListCommandInvocationsWithContext(arg0 context.Context, arg1 *ssm.ListCommandInvocationsInput, arg2 ...request.Option) (*ssm.ListCommandInvocationsOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -4125,14 +3636,12 @@ func (m *MockSSMAPI) ListCommandInvocationsWithContext(arg0 context.Context, arg
 
 // ListCommandInvocationsWithContext indicates an expected call of ListCommandInvocationsWithContext
 func (mr *MockSSMAPIMockRecorder) ListCommandInvocationsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListCommandInvocationsWithContext", reflect.TypeOf((*MockSSMAPI)(nil).ListCommandInvocationsWithContext), varargs...)
 }
 
 // ListCommands mocks base method
 func (m *MockSSMAPI) ListCommands(arg0 *ssm.ListCommandsInput) (*ssm.ListCommandsOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListCommands", arg0)
 	ret0, _ := ret[0].(*ssm.ListCommandsOutput)
 	ret1, _ := ret[1].(error)
@@ -4141,13 +3650,11 @@ func (m *MockSSMAPI) ListCommands(arg0 *ssm.ListCommandsInput) (*ssm.ListCommand
 
 // ListCommands indicates an expected call of ListCommands
 func (mr *MockSSMAPIMockRecorder) ListCommands(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListCommands", reflect.TypeOf((*MockSSMAPI)(nil).ListCommands), arg0)
 }
 
 // ListCommandsPages mocks base method
 func (m *MockSSMAPI) ListCommandsPages(arg0 *ssm.ListCommandsInput, arg1 func(*ssm.ListCommandsOutput, bool) bool) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListCommandsPages", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -4155,13 +3662,11 @@ func (m *MockSSMAPI) ListCommandsPages(arg0 *ssm.ListCommandsInput, arg1 func(*s
 
 // ListCommandsPages indicates an expected call of ListCommandsPages
 func (mr *MockSSMAPIMockRecorder) ListCommandsPages(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListCommandsPages", reflect.TypeOf((*MockSSMAPI)(nil).ListCommandsPages), arg0, arg1)
 }
 
 // ListCommandsPagesWithContext mocks base method
 func (m *MockSSMAPI) ListCommandsPagesWithContext(arg0 context.Context, arg1 *ssm.ListCommandsInput, arg2 func(*ssm.ListCommandsOutput, bool) bool, arg3 ...request.Option) error {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1, arg2}
 	for _, a := range arg3 {
 		varargs = append(varargs, a)
@@ -4173,14 +3678,12 @@ func (m *MockSSMAPI) ListCommandsPagesWithContext(arg0 context.Context, arg1 *ss
 
 // ListCommandsPagesWithContext indicates an expected call of ListCommandsPagesWithContext
 func (mr *MockSSMAPIMockRecorder) ListCommandsPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListCommandsPagesWithContext", reflect.TypeOf((*MockSSMAPI)(nil).ListCommandsPagesWithContext), varargs...)
 }
 
 // ListCommandsRequest mocks base method
 func (m *MockSSMAPI) ListCommandsRequest(arg0 *ssm.ListCommandsInput) (*request.Request, *ssm.ListCommandsOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListCommandsRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ssm.ListCommandsOutput)
@@ -4189,13 +3692,11 @@ func (m *MockSSMAPI) ListCommandsRequest(arg0 *ssm.ListCommandsInput) (*request.
 
 // ListCommandsRequest indicates an expected call of ListCommandsRequest
 func (mr *MockSSMAPIMockRecorder) ListCommandsRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListCommandsRequest", reflect.TypeOf((*MockSSMAPI)(nil).ListCommandsRequest), arg0)
 }
 
 // ListCommandsWithContext mocks base method
 func (m *MockSSMAPI) ListCommandsWithContext(arg0 context.Context, arg1 *ssm.ListCommandsInput, arg2 ...request.Option) (*ssm.ListCommandsOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -4208,14 +3709,12 @@ func (m *MockSSMAPI) ListCommandsWithContext(arg0 context.Context, arg1 *ssm.Lis
 
 // ListCommandsWithContext indicates an expected call of ListCommandsWithContext
 func (mr *MockSSMAPIMockRecorder) ListCommandsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListCommandsWithContext", reflect.TypeOf((*MockSSMAPI)(nil).ListCommandsWithContext), varargs...)
 }
 
 // ListComplianceItems mocks base method
 func (m *MockSSMAPI) ListComplianceItems(arg0 *ssm.ListComplianceItemsInput) (*ssm.ListComplianceItemsOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListComplianceItems", arg0)
 	ret0, _ := ret[0].(*ssm.ListComplianceItemsOutput)
 	ret1, _ := ret[1].(error)
@@ -4224,13 +3723,11 @@ func (m *MockSSMAPI) ListComplianceItems(arg0 *ssm.ListComplianceItemsInput) (*s
 
 // ListComplianceItems indicates an expected call of ListComplianceItems
 func (mr *MockSSMAPIMockRecorder) ListComplianceItems(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListComplianceItems", reflect.TypeOf((*MockSSMAPI)(nil).ListComplianceItems), arg0)
 }
 
 // ListComplianceItemsRequest mocks base method
 func (m *MockSSMAPI) ListComplianceItemsRequest(arg0 *ssm.ListComplianceItemsInput) (*request.Request, *ssm.ListComplianceItemsOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListComplianceItemsRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ssm.ListComplianceItemsOutput)
@@ -4239,13 +3736,11 @@ func (m *MockSSMAPI) ListComplianceItemsRequest(arg0 *ssm.ListComplianceItemsInp
 
 // ListComplianceItemsRequest indicates an expected call of ListComplianceItemsRequest
 func (mr *MockSSMAPIMockRecorder) ListComplianceItemsRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListComplianceItemsRequest", reflect.TypeOf((*MockSSMAPI)(nil).ListComplianceItemsRequest), arg0)
 }
 
 // ListComplianceItemsWithContext mocks base method
 func (m *MockSSMAPI) ListComplianceItemsWithContext(arg0 context.Context, arg1 *ssm.ListComplianceItemsInput, arg2 ...request.Option) (*ssm.ListComplianceItemsOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -4258,14 +3753,12 @@ func (m *MockSSMAPI) ListComplianceItemsWithContext(arg0 context.Context, arg1 *
 
 // ListComplianceItemsWithContext indicates an expected call of ListComplianceItemsWithContext
 func (mr *MockSSMAPIMockRecorder) ListComplianceItemsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListComplianceItemsWithContext", reflect.TypeOf((*MockSSMAPI)(nil).ListComplianceItemsWithContext), varargs...)
 }
 
 // ListComplianceSummaries mocks base method
 func (m *MockSSMAPI) ListComplianceSummaries(arg0 *ssm.ListComplianceSummariesInput) (*ssm.ListComplianceSummariesOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListComplianceSummaries", arg0)
 	ret0, _ := ret[0].(*ssm.ListComplianceSummariesOutput)
 	ret1, _ := ret[1].(error)
@@ -4274,13 +3767,11 @@ func (m *MockSSMAPI) ListComplianceSummaries(arg0 *ssm.ListComplianceSummariesIn
 
 // ListComplianceSummaries indicates an expected call of ListComplianceSummaries
 func (mr *MockSSMAPIMockRecorder) ListComplianceSummaries(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListComplianceSummaries", reflect.TypeOf((*MockSSMAPI)(nil).ListComplianceSummaries), arg0)
 }
 
 // ListComplianceSummariesRequest mocks base method
 func (m *MockSSMAPI) ListComplianceSummariesRequest(arg0 *ssm.ListComplianceSummariesInput) (*request.Request, *ssm.ListComplianceSummariesOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListComplianceSummariesRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ssm.ListComplianceSummariesOutput)
@@ -4289,13 +3780,11 @@ func (m *MockSSMAPI) ListComplianceSummariesRequest(arg0 *ssm.ListComplianceSumm
 
 // ListComplianceSummariesRequest indicates an expected call of ListComplianceSummariesRequest
 func (mr *MockSSMAPIMockRecorder) ListComplianceSummariesRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListComplianceSummariesRequest", reflect.TypeOf((*MockSSMAPI)(nil).ListComplianceSummariesRequest), arg0)
 }
 
 // ListComplianceSummariesWithContext mocks base method
 func (m *MockSSMAPI) ListComplianceSummariesWithContext(arg0 context.Context, arg1 *ssm.ListComplianceSummariesInput, arg2 ...request.Option) (*ssm.ListComplianceSummariesOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -4308,14 +3797,12 @@ func (m *MockSSMAPI) ListComplianceSummariesWithContext(arg0 context.Context, ar
 
 // ListComplianceSummariesWithContext indicates an expected call of ListComplianceSummariesWithContext
 func (mr *MockSSMAPIMockRecorder) ListComplianceSummariesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListComplianceSummariesWithContext", reflect.TypeOf((*MockSSMAPI)(nil).ListComplianceSummariesWithContext), varargs...)
 }
 
 // ListDocumentVersions mocks base method
 func (m *MockSSMAPI) ListDocumentVersions(arg0 *ssm.ListDocumentVersionsInput) (*ssm.ListDocumentVersionsOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListDocumentVersions", arg0)
 	ret0, _ := ret[0].(*ssm.ListDocumentVersionsOutput)
 	ret1, _ := ret[1].(error)
@@ -4324,13 +3811,11 @@ func (m *MockSSMAPI) ListDocumentVersions(arg0 *ssm.ListDocumentVersionsInput) (
 
 // ListDocumentVersions indicates an expected call of ListDocumentVersions
 func (mr *MockSSMAPIMockRecorder) ListDocumentVersions(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListDocumentVersions", reflect.TypeOf((*MockSSMAPI)(nil).ListDocumentVersions), arg0)
 }
 
 // ListDocumentVersionsRequest mocks base method
 func (m *MockSSMAPI) ListDocumentVersionsRequest(arg0 *ssm.ListDocumentVersionsInput) (*request.Request, *ssm.ListDocumentVersionsOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListDocumentVersionsRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ssm.ListDocumentVersionsOutput)
@@ -4339,13 +3824,11 @@ func (m *MockSSMAPI) ListDocumentVersionsRequest(arg0 *ssm.ListDocumentVersionsI
 
 // ListDocumentVersionsRequest indicates an expected call of ListDocumentVersionsRequest
 func (mr *MockSSMAPIMockRecorder) ListDocumentVersionsRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListDocumentVersionsRequest", reflect.TypeOf((*MockSSMAPI)(nil).ListDocumentVersionsRequest), arg0)
 }
 
 // ListDocumentVersionsWithContext mocks base method
 func (m *MockSSMAPI) ListDocumentVersionsWithContext(arg0 context.Context, arg1 *ssm.ListDocumentVersionsInput, arg2 ...request.Option) (*ssm.ListDocumentVersionsOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -4358,14 +3841,12 @@ func (m *MockSSMAPI) ListDocumentVersionsWithContext(arg0 context.Context, arg1 
 
 // ListDocumentVersionsWithContext indicates an expected call of ListDocumentVersionsWithContext
 func (mr *MockSSMAPIMockRecorder) ListDocumentVersionsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListDocumentVersionsWithContext", reflect.TypeOf((*MockSSMAPI)(nil).ListDocumentVersionsWithContext), varargs...)
 }
 
 // ListDocuments mocks base method
 func (m *MockSSMAPI) ListDocuments(arg0 *ssm.ListDocumentsInput) (*ssm.ListDocumentsOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListDocuments", arg0)
 	ret0, _ := ret[0].(*ssm.ListDocumentsOutput)
 	ret1, _ := ret[1].(error)
@@ -4374,13 +3855,11 @@ func (m *MockSSMAPI) ListDocuments(arg0 *ssm.ListDocumentsInput) (*ssm.ListDocum
 
 // ListDocuments indicates an expected call of ListDocuments
 func (mr *MockSSMAPIMockRecorder) ListDocuments(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListDocuments", reflect.TypeOf((*MockSSMAPI)(nil).ListDocuments), arg0)
 }
 
 // ListDocumentsPages mocks base method
 func (m *MockSSMAPI) ListDocumentsPages(arg0 *ssm.ListDocumentsInput, arg1 func(*ssm.ListDocumentsOutput, bool) bool) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListDocumentsPages", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -4388,13 +3867,11 @@ func (m *MockSSMAPI) ListDocumentsPages(arg0 *ssm.ListDocumentsInput, arg1 func(
 
 // ListDocumentsPages indicates an expected call of ListDocumentsPages
 func (mr *MockSSMAPIMockRecorder) ListDocumentsPages(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListDocumentsPages", reflect.TypeOf((*MockSSMAPI)(nil).ListDocumentsPages), arg0, arg1)
 }
 
 // ListDocumentsPagesWithContext mocks base method
 func (m *MockSSMAPI) ListDocumentsPagesWithContext(arg0 context.Context, arg1 *ssm.ListDocumentsInput, arg2 func(*ssm.ListDocumentsOutput, bool) bool, arg3 ...request.Option) error {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1, arg2}
 	for _, a := range arg3 {
 		varargs = append(varargs, a)
@@ -4406,14 +3883,12 @@ func (m *MockSSMAPI) ListDocumentsPagesWithContext(arg0 context.Context, arg1 *s
 
 // ListDocumentsPagesWithContext indicates an expected call of ListDocumentsPagesWithContext
 func (mr *MockSSMAPIMockRecorder) ListDocumentsPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListDocumentsPagesWithContext", reflect.TypeOf((*MockSSMAPI)(nil).ListDocumentsPagesWithContext), varargs...)
 }
 
 // ListDocumentsRequest mocks base method
 func (m *MockSSMAPI) ListDocumentsRequest(arg0 *ssm.ListDocumentsInput) (*request.Request, *ssm.ListDocumentsOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListDocumentsRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ssm.ListDocumentsOutput)
@@ -4422,13 +3897,11 @@ func (m *MockSSMAPI) ListDocumentsRequest(arg0 *ssm.ListDocumentsInput) (*reques
 
 // ListDocumentsRequest indicates an expected call of ListDocumentsRequest
 func (mr *MockSSMAPIMockRecorder) ListDocumentsRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListDocumentsRequest", reflect.TypeOf((*MockSSMAPI)(nil).ListDocumentsRequest), arg0)
 }
 
 // ListDocumentsWithContext mocks base method
 func (m *MockSSMAPI) ListDocumentsWithContext(arg0 context.Context, arg1 *ssm.ListDocumentsInput, arg2 ...request.Option) (*ssm.ListDocumentsOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -4441,14 +3914,12 @@ func (m *MockSSMAPI) ListDocumentsWithContext(arg0 context.Context, arg1 *ssm.Li
 
 // ListDocumentsWithContext indicates an expected call of ListDocumentsWithContext
 func (mr *MockSSMAPIMockRecorder) ListDocumentsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListDocumentsWithContext", reflect.TypeOf((*MockSSMAPI)(nil).ListDocumentsWithContext), varargs...)
 }
 
 // ListInventoryEntries mocks base method
 func (m *MockSSMAPI) ListInventoryEntries(arg0 *ssm.ListInventoryEntriesInput) (*ssm.ListInventoryEntriesOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListInventoryEntries", arg0)
 	ret0, _ := ret[0].(*ssm.ListInventoryEntriesOutput)
 	ret1, _ := ret[1].(error)
@@ -4457,13 +3928,11 @@ func (m *MockSSMAPI) ListInventoryEntries(arg0 *ssm.ListInventoryEntriesInput) (
 
 // ListInventoryEntries indicates an expected call of ListInventoryEntries
 func (mr *MockSSMAPIMockRecorder) ListInventoryEntries(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListInventoryEntries", reflect.TypeOf((*MockSSMAPI)(nil).ListInventoryEntries), arg0)
 }
 
 // ListInventoryEntriesRequest mocks base method
 func (m *MockSSMAPI) ListInventoryEntriesRequest(arg0 *ssm.ListInventoryEntriesInput) (*request.Request, *ssm.ListInventoryEntriesOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListInventoryEntriesRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ssm.ListInventoryEntriesOutput)
@@ -4472,13 +3941,11 @@ func (m *MockSSMAPI) ListInventoryEntriesRequest(arg0 *ssm.ListInventoryEntriesI
 
 // ListInventoryEntriesRequest indicates an expected call of ListInventoryEntriesRequest
 func (mr *MockSSMAPIMockRecorder) ListInventoryEntriesRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListInventoryEntriesRequest", reflect.TypeOf((*MockSSMAPI)(nil).ListInventoryEntriesRequest), arg0)
 }
 
 // ListInventoryEntriesWithContext mocks base method
 func (m *MockSSMAPI) ListInventoryEntriesWithContext(arg0 context.Context, arg1 *ssm.ListInventoryEntriesInput, arg2 ...request.Option) (*ssm.ListInventoryEntriesOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -4491,14 +3958,12 @@ func (m *MockSSMAPI) ListInventoryEntriesWithContext(arg0 context.Context, arg1 
 
 // ListInventoryEntriesWithContext indicates an expected call of ListInventoryEntriesWithContext
 func (mr *MockSSMAPIMockRecorder) ListInventoryEntriesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListInventoryEntriesWithContext", reflect.TypeOf((*MockSSMAPI)(nil).ListInventoryEntriesWithContext), varargs...)
 }
 
 // ListResourceComplianceSummaries mocks base method
 func (m *MockSSMAPI) ListResourceComplianceSummaries(arg0 *ssm.ListResourceComplianceSummariesInput) (*ssm.ListResourceComplianceSummariesOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListResourceComplianceSummaries", arg0)
 	ret0, _ := ret[0].(*ssm.ListResourceComplianceSummariesOutput)
 	ret1, _ := ret[1].(error)
@@ -4507,13 +3972,11 @@ func (m *MockSSMAPI) ListResourceComplianceSummaries(arg0 *ssm.ListResourceCompl
 
 // ListResourceComplianceSummaries indicates an expected call of ListResourceComplianceSummaries
 func (mr *MockSSMAPIMockRecorder) ListResourceComplianceSummaries(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListResourceComplianceSummaries", reflect.TypeOf((*MockSSMAPI)(nil).ListResourceComplianceSummaries), arg0)
 }
 
 // ListResourceComplianceSummariesRequest mocks base method
 func (m *MockSSMAPI) ListResourceComplianceSummariesRequest(arg0 *ssm.ListResourceComplianceSummariesInput) (*request.Request, *ssm.ListResourceComplianceSummariesOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListResourceComplianceSummariesRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ssm.ListResourceComplianceSummariesOutput)
@@ -4522,13 +3985,11 @@ func (m *MockSSMAPI) ListResourceComplianceSummariesRequest(arg0 *ssm.ListResour
 
 // ListResourceComplianceSummariesRequest indicates an expected call of ListResourceComplianceSummariesRequest
 func (mr *MockSSMAPIMockRecorder) ListResourceComplianceSummariesRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListResourceComplianceSummariesRequest", reflect.TypeOf((*MockSSMAPI)(nil).ListResourceComplianceSummariesRequest), arg0)
 }
 
 // ListResourceComplianceSummariesWithContext mocks base method
 func (m *MockSSMAPI) ListResourceComplianceSummariesWithContext(arg0 context.Context, arg1 *ssm.ListResourceComplianceSummariesInput, arg2 ...request.Option) (*ssm.ListResourceComplianceSummariesOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -4541,14 +4002,12 @@ func (m *MockSSMAPI) ListResourceComplianceSummariesWithContext(arg0 context.Con
 
 // ListResourceComplianceSummariesWithContext indicates an expected call of ListResourceComplianceSummariesWithContext
 func (mr *MockSSMAPIMockRecorder) ListResourceComplianceSummariesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListResourceComplianceSummariesWithContext", reflect.TypeOf((*MockSSMAPI)(nil).ListResourceComplianceSummariesWithContext), varargs...)
 }
 
 // ListResourceDataSync mocks base method
 func (m *MockSSMAPI) ListResourceDataSync(arg0 *ssm.ListResourceDataSyncInput) (*ssm.ListResourceDataSyncOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListResourceDataSync", arg0)
 	ret0, _ := ret[0].(*ssm.ListResourceDataSyncOutput)
 	ret1, _ := ret[1].(error)
@@ -4557,13 +4016,11 @@ func (m *MockSSMAPI) ListResourceDataSync(arg0 *ssm.ListResourceDataSyncInput) (
 
 // ListResourceDataSync indicates an expected call of ListResourceDataSync
 func (mr *MockSSMAPIMockRecorder) ListResourceDataSync(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListResourceDataSync", reflect.TypeOf((*MockSSMAPI)(nil).ListResourceDataSync), arg0)
 }
 
 // ListResourceDataSyncRequest mocks base method
 func (m *MockSSMAPI) ListResourceDataSyncRequest(arg0 *ssm.ListResourceDataSyncInput) (*request.Request, *ssm.ListResourceDataSyncOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListResourceDataSyncRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ssm.ListResourceDataSyncOutput)
@@ -4572,13 +4029,11 @@ func (m *MockSSMAPI) ListResourceDataSyncRequest(arg0 *ssm.ListResourceDataSyncI
 
 // ListResourceDataSyncRequest indicates an expected call of ListResourceDataSyncRequest
 func (mr *MockSSMAPIMockRecorder) ListResourceDataSyncRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListResourceDataSyncRequest", reflect.TypeOf((*MockSSMAPI)(nil).ListResourceDataSyncRequest), arg0)
 }
 
 // ListResourceDataSyncWithContext mocks base method
 func (m *MockSSMAPI) ListResourceDataSyncWithContext(arg0 context.Context, arg1 *ssm.ListResourceDataSyncInput, arg2 ...request.Option) (*ssm.ListResourceDataSyncOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -4591,14 +4046,12 @@ func (m *MockSSMAPI) ListResourceDataSyncWithContext(arg0 context.Context, arg1 
 
 // ListResourceDataSyncWithContext indicates an expected call of ListResourceDataSyncWithContext
 func (mr *MockSSMAPIMockRecorder) ListResourceDataSyncWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListResourceDataSyncWithContext", reflect.TypeOf((*MockSSMAPI)(nil).ListResourceDataSyncWithContext), varargs...)
 }
 
 // ListTagsForResource mocks base method
 func (m *MockSSMAPI) ListTagsForResource(arg0 *ssm.ListTagsForResourceInput) (*ssm.ListTagsForResourceOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListTagsForResource", arg0)
 	ret0, _ := ret[0].(*ssm.ListTagsForResourceOutput)
 	ret1, _ := ret[1].(error)
@@ -4607,13 +4060,11 @@ func (m *MockSSMAPI) ListTagsForResource(arg0 *ssm.ListTagsForResourceInput) (*s
 
 // ListTagsForResource indicates an expected call of ListTagsForResource
 func (mr *MockSSMAPIMockRecorder) ListTagsForResource(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListTagsForResource", reflect.TypeOf((*MockSSMAPI)(nil).ListTagsForResource), arg0)
 }
 
 // ListTagsForResourceRequest mocks base method
 func (m *MockSSMAPI) ListTagsForResourceRequest(arg0 *ssm.ListTagsForResourceInput) (*request.Request, *ssm.ListTagsForResourceOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListTagsForResourceRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ssm.ListTagsForResourceOutput)
@@ -4622,13 +4073,11 @@ func (m *MockSSMAPI) ListTagsForResourceRequest(arg0 *ssm.ListTagsForResourceInp
 
 // ListTagsForResourceRequest indicates an expected call of ListTagsForResourceRequest
 func (mr *MockSSMAPIMockRecorder) ListTagsForResourceRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListTagsForResourceRequest", reflect.TypeOf((*MockSSMAPI)(nil).ListTagsForResourceRequest), arg0)
 }
 
 // ListTagsForResourceWithContext mocks base method
 func (m *MockSSMAPI) ListTagsForResourceWithContext(arg0 context.Context, arg1 *ssm.ListTagsForResourceInput, arg2 ...request.Option) (*ssm.ListTagsForResourceOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -4641,14 +4090,12 @@ func (m *MockSSMAPI) ListTagsForResourceWithContext(arg0 context.Context, arg1 *
 
 // ListTagsForResourceWithContext indicates an expected call of ListTagsForResourceWithContext
 func (mr *MockSSMAPIMockRecorder) ListTagsForResourceWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListTagsForResourceWithContext", reflect.TypeOf((*MockSSMAPI)(nil).ListTagsForResourceWithContext), varargs...)
 }
 
 // ModifyDocumentPermission mocks base method
 func (m *MockSSMAPI) ModifyDocumentPermission(arg0 *ssm.ModifyDocumentPermissionInput) (*ssm.ModifyDocumentPermissionOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ModifyDocumentPermission", arg0)
 	ret0, _ := ret[0].(*ssm.ModifyDocumentPermissionOutput)
 	ret1, _ := ret[1].(error)
@@ -4657,13 +4104,11 @@ func (m *MockSSMAPI) ModifyDocumentPermission(arg0 *ssm.ModifyDocumentPermission
 
 // ModifyDocumentPermission indicates an expected call of ModifyDocumentPermission
 func (mr *MockSSMAPIMockRecorder) ModifyDocumentPermission(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyDocumentPermission", reflect.TypeOf((*MockSSMAPI)(nil).ModifyDocumentPermission), arg0)
 }
 
 // ModifyDocumentPermissionRequest mocks base method
 func (m *MockSSMAPI) ModifyDocumentPermissionRequest(arg0 *ssm.ModifyDocumentPermissionInput) (*request.Request, *ssm.ModifyDocumentPermissionOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ModifyDocumentPermissionRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ssm.ModifyDocumentPermissionOutput)
@@ -4672,13 +4117,11 @@ func (m *MockSSMAPI) ModifyDocumentPermissionRequest(arg0 *ssm.ModifyDocumentPer
 
 // ModifyDocumentPermissionRequest indicates an expected call of ModifyDocumentPermissionRequest
 func (mr *MockSSMAPIMockRecorder) ModifyDocumentPermissionRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyDocumentPermissionRequest", reflect.TypeOf((*MockSSMAPI)(nil).ModifyDocumentPermissionRequest), arg0)
 }
 
 // ModifyDocumentPermissionWithContext mocks base method
 func (m *MockSSMAPI) ModifyDocumentPermissionWithContext(arg0 context.Context, arg1 *ssm.ModifyDocumentPermissionInput, arg2 ...request.Option) (*ssm.ModifyDocumentPermissionOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -4691,14 +4134,12 @@ func (m *MockSSMAPI) ModifyDocumentPermissionWithContext(arg0 context.Context, a
 
 // ModifyDocumentPermissionWithContext indicates an expected call of ModifyDocumentPermissionWithContext
 func (mr *MockSSMAPIMockRecorder) ModifyDocumentPermissionWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyDocumentPermissionWithContext", reflect.TypeOf((*MockSSMAPI)(nil).ModifyDocumentPermissionWithContext), varargs...)
 }
 
 // PutComplianceItems mocks base method
 func (m *MockSSMAPI) PutComplianceItems(arg0 *ssm.PutComplianceItemsInput) (*ssm.PutComplianceItemsOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PutComplianceItems", arg0)
 	ret0, _ := ret[0].(*ssm.PutComplianceItemsOutput)
 	ret1, _ := ret[1].(error)
@@ -4707,13 +4148,11 @@ func (m *MockSSMAPI) PutComplianceItems(arg0 *ssm.PutComplianceItemsInput) (*ssm
 
 // PutComplianceItems indicates an expected call of PutComplianceItems
 func (mr *MockSSMAPIMockRecorder) PutComplianceItems(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutComplianceItems", reflect.TypeOf((*MockSSMAPI)(nil).PutComplianceItems), arg0)
 }
 
 // PutComplianceItemsRequest mocks base method
 func (m *MockSSMAPI) PutComplianceItemsRequest(arg0 *ssm.PutComplianceItemsInput) (*request.Request, *ssm.PutComplianceItemsOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PutComplianceItemsRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ssm.PutComplianceItemsOutput)
@@ -4722,13 +4161,11 @@ func (m *MockSSMAPI) PutComplianceItemsRequest(arg0 *ssm.PutComplianceItemsInput
 
 // PutComplianceItemsRequest indicates an expected call of PutComplianceItemsRequest
 func (mr *MockSSMAPIMockRecorder) PutComplianceItemsRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutComplianceItemsRequest", reflect.TypeOf((*MockSSMAPI)(nil).PutComplianceItemsRequest), arg0)
 }
 
 // PutComplianceItemsWithContext mocks base method
 func (m *MockSSMAPI) PutComplianceItemsWithContext(arg0 context.Context, arg1 *ssm.PutComplianceItemsInput, arg2 ...request.Option) (*ssm.PutComplianceItemsOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -4741,14 +4178,12 @@ func (m *MockSSMAPI) PutComplianceItemsWithContext(arg0 context.Context, arg1 *s
 
 // PutComplianceItemsWithContext indicates an expected call of PutComplianceItemsWithContext
 func (mr *MockSSMAPIMockRecorder) PutComplianceItemsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutComplianceItemsWithContext", reflect.TypeOf((*MockSSMAPI)(nil).PutComplianceItemsWithContext), varargs...)
 }
 
 // PutInventory mocks base method
 func (m *MockSSMAPI) PutInventory(arg0 *ssm.PutInventoryInput) (*ssm.PutInventoryOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PutInventory", arg0)
 	ret0, _ := ret[0].(*ssm.PutInventoryOutput)
 	ret1, _ := ret[1].(error)
@@ -4757,13 +4192,11 @@ func (m *MockSSMAPI) PutInventory(arg0 *ssm.PutInventoryInput) (*ssm.PutInventor
 
 // PutInventory indicates an expected call of PutInventory
 func (mr *MockSSMAPIMockRecorder) PutInventory(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutInventory", reflect.TypeOf((*MockSSMAPI)(nil).PutInventory), arg0)
 }
 
 // PutInventoryRequest mocks base method
 func (m *MockSSMAPI) PutInventoryRequest(arg0 *ssm.PutInventoryInput) (*request.Request, *ssm.PutInventoryOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PutInventoryRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ssm.PutInventoryOutput)
@@ -4772,13 +4205,11 @@ func (m *MockSSMAPI) PutInventoryRequest(arg0 *ssm.PutInventoryInput) (*request.
 
 // PutInventoryRequest indicates an expected call of PutInventoryRequest
 func (mr *MockSSMAPIMockRecorder) PutInventoryRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutInventoryRequest", reflect.TypeOf((*MockSSMAPI)(nil).PutInventoryRequest), arg0)
 }
 
 // PutInventoryWithContext mocks base method
 func (m *MockSSMAPI) PutInventoryWithContext(arg0 context.Context, arg1 *ssm.PutInventoryInput, arg2 ...request.Option) (*ssm.PutInventoryOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -4791,14 +4222,12 @@ func (m *MockSSMAPI) PutInventoryWithContext(arg0 context.Context, arg1 *ssm.Put
 
 // PutInventoryWithContext indicates an expected call of PutInventoryWithContext
 func (mr *MockSSMAPIMockRecorder) PutInventoryWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutInventoryWithContext", reflect.TypeOf((*MockSSMAPI)(nil).PutInventoryWithContext), varargs...)
 }
 
 // PutParameter mocks base method
 func (m *MockSSMAPI) PutParameter(arg0 *ssm.PutParameterInput) (*ssm.PutParameterOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PutParameter", arg0)
 	ret0, _ := ret[0].(*ssm.PutParameterOutput)
 	ret1, _ := ret[1].(error)
@@ -4807,13 +4236,11 @@ func (m *MockSSMAPI) PutParameter(arg0 *ssm.PutParameterInput) (*ssm.PutParamete
 
 // PutParameter indicates an expected call of PutParameter
 func (mr *MockSSMAPIMockRecorder) PutParameter(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutParameter", reflect.TypeOf((*MockSSMAPI)(nil).PutParameter), arg0)
 }
 
 // PutParameterRequest mocks base method
 func (m *MockSSMAPI) PutParameterRequest(arg0 *ssm.PutParameterInput) (*request.Request, *ssm.PutParameterOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PutParameterRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ssm.PutParameterOutput)
@@ -4822,13 +4249,11 @@ func (m *MockSSMAPI) PutParameterRequest(arg0 *ssm.PutParameterInput) (*request.
 
 // PutParameterRequest indicates an expected call of PutParameterRequest
 func (mr *MockSSMAPIMockRecorder) PutParameterRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutParameterRequest", reflect.TypeOf((*MockSSMAPI)(nil).PutParameterRequest), arg0)
 }
 
 // PutParameterWithContext mocks base method
 func (m *MockSSMAPI) PutParameterWithContext(arg0 context.Context, arg1 *ssm.PutParameterInput, arg2 ...request.Option) (*ssm.PutParameterOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -4841,14 +4266,12 @@ func (m *MockSSMAPI) PutParameterWithContext(arg0 context.Context, arg1 *ssm.Put
 
 // PutParameterWithContext indicates an expected call of PutParameterWithContext
 func (mr *MockSSMAPIMockRecorder) PutParameterWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutParameterWithContext", reflect.TypeOf((*MockSSMAPI)(nil).PutParameterWithContext), varargs...)
 }
 
 // RegisterDefaultPatchBaseline mocks base method
 func (m *MockSSMAPI) RegisterDefaultPatchBaseline(arg0 *ssm.RegisterDefaultPatchBaselineInput) (*ssm.RegisterDefaultPatchBaselineOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RegisterDefaultPatchBaseline", arg0)
 	ret0, _ := ret[0].(*ssm.RegisterDefaultPatchBaselineOutput)
 	ret1, _ := ret[1].(error)
@@ -4857,13 +4280,11 @@ func (m *MockSSMAPI) RegisterDefaultPatchBaseline(arg0 *ssm.RegisterDefaultPatch
 
 // RegisterDefaultPatchBaseline indicates an expected call of RegisterDefaultPatchBaseline
 func (mr *MockSSMAPIMockRecorder) RegisterDefaultPatchBaseline(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterDefaultPatchBaseline", reflect.TypeOf((*MockSSMAPI)(nil).RegisterDefaultPatchBaseline), arg0)
 }
 
 // RegisterDefaultPatchBaselineRequest mocks base method
 func (m *MockSSMAPI) RegisterDefaultPatchBaselineRequest(arg0 *ssm.RegisterDefaultPatchBaselineInput) (*request.Request, *ssm.RegisterDefaultPatchBaselineOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RegisterDefaultPatchBaselineRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ssm.RegisterDefaultPatchBaselineOutput)
@@ -4872,13 +4293,11 @@ func (m *MockSSMAPI) RegisterDefaultPatchBaselineRequest(arg0 *ssm.RegisterDefau
 
 // RegisterDefaultPatchBaselineRequest indicates an expected call of RegisterDefaultPatchBaselineRequest
 func (mr *MockSSMAPIMockRecorder) RegisterDefaultPatchBaselineRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterDefaultPatchBaselineRequest", reflect.TypeOf((*MockSSMAPI)(nil).RegisterDefaultPatchBaselineRequest), arg0)
 }
 
 // RegisterDefaultPatchBaselineWithContext mocks base method
 func (m *MockSSMAPI) RegisterDefaultPatchBaselineWithContext(arg0 context.Context, arg1 *ssm.RegisterDefaultPatchBaselineInput, arg2 ...request.Option) (*ssm.RegisterDefaultPatchBaselineOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -4891,14 +4310,12 @@ func (m *MockSSMAPI) RegisterDefaultPatchBaselineWithContext(arg0 context.Contex
 
 // RegisterDefaultPatchBaselineWithContext indicates an expected call of RegisterDefaultPatchBaselineWithContext
 func (mr *MockSSMAPIMockRecorder) RegisterDefaultPatchBaselineWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterDefaultPatchBaselineWithContext", reflect.TypeOf((*MockSSMAPI)(nil).RegisterDefaultPatchBaselineWithContext), varargs...)
 }
 
 // RegisterPatchBaselineForPatchGroup mocks base method
 func (m *MockSSMAPI) RegisterPatchBaselineForPatchGroup(arg0 *ssm.RegisterPatchBaselineForPatchGroupInput) (*ssm.RegisterPatchBaselineForPatchGroupOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RegisterPatchBaselineForPatchGroup", arg0)
 	ret0, _ := ret[0].(*ssm.RegisterPatchBaselineForPatchGroupOutput)
 	ret1, _ := ret[1].(error)
@@ -4907,13 +4324,11 @@ func (m *MockSSMAPI) RegisterPatchBaselineForPatchGroup(arg0 *ssm.RegisterPatchB
 
 // RegisterPatchBaselineForPatchGroup indicates an expected call of RegisterPatchBaselineForPatchGroup
 func (mr *MockSSMAPIMockRecorder) RegisterPatchBaselineForPatchGroup(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterPatchBaselineForPatchGroup", reflect.TypeOf((*MockSSMAPI)(nil).RegisterPatchBaselineForPatchGroup), arg0)
 }
 
 // RegisterPatchBaselineForPatchGroupRequest mocks base method
 func (m *MockSSMAPI) RegisterPatchBaselineForPatchGroupRequest(arg0 *ssm.RegisterPatchBaselineForPatchGroupInput) (*request.Request, *ssm.RegisterPatchBaselineForPatchGroupOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RegisterPatchBaselineForPatchGroupRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ssm.RegisterPatchBaselineForPatchGroupOutput)
@@ -4922,13 +4337,11 @@ func (m *MockSSMAPI) RegisterPatchBaselineForPatchGroupRequest(arg0 *ssm.Registe
 
 // RegisterPatchBaselineForPatchGroupRequest indicates an expected call of RegisterPatchBaselineForPatchGroupRequest
 func (mr *MockSSMAPIMockRecorder) RegisterPatchBaselineForPatchGroupRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterPatchBaselineForPatchGroupRequest", reflect.TypeOf((*MockSSMAPI)(nil).RegisterPatchBaselineForPatchGroupRequest), arg0)
 }
 
 // RegisterPatchBaselineForPatchGroupWithContext mocks base method
 func (m *MockSSMAPI) RegisterPatchBaselineForPatchGroupWithContext(arg0 context.Context, arg1 *ssm.RegisterPatchBaselineForPatchGroupInput, arg2 ...request.Option) (*ssm.RegisterPatchBaselineForPatchGroupOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -4941,14 +4354,12 @@ func (m *MockSSMAPI) RegisterPatchBaselineForPatchGroupWithContext(arg0 context.
 
 // RegisterPatchBaselineForPatchGroupWithContext indicates an expected call of RegisterPatchBaselineForPatchGroupWithContext
 func (mr *MockSSMAPIMockRecorder) RegisterPatchBaselineForPatchGroupWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterPatchBaselineForPatchGroupWithContext", reflect.TypeOf((*MockSSMAPI)(nil).RegisterPatchBaselineForPatchGroupWithContext), varargs...)
 }
 
 // RegisterTargetWithMaintenanceWindow mocks base method
 func (m *MockSSMAPI) RegisterTargetWithMaintenanceWindow(arg0 *ssm.RegisterTargetWithMaintenanceWindowInput) (*ssm.RegisterTargetWithMaintenanceWindowOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RegisterTargetWithMaintenanceWindow", arg0)
 	ret0, _ := ret[0].(*ssm.RegisterTargetWithMaintenanceWindowOutput)
 	ret1, _ := ret[1].(error)
@@ -4957,13 +4368,11 @@ func (m *MockSSMAPI) RegisterTargetWithMaintenanceWindow(arg0 *ssm.RegisterTarge
 
 // RegisterTargetWithMaintenanceWindow indicates an expected call of RegisterTargetWithMaintenanceWindow
 func (mr *MockSSMAPIMockRecorder) RegisterTargetWithMaintenanceWindow(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterTargetWithMaintenanceWindow", reflect.TypeOf((*MockSSMAPI)(nil).RegisterTargetWithMaintenanceWindow), arg0)
 }
 
 // RegisterTargetWithMaintenanceWindowRequest mocks base method
 func (m *MockSSMAPI) RegisterTargetWithMaintenanceWindowRequest(arg0 *ssm.RegisterTargetWithMaintenanceWindowInput) (*request.Request, *ssm.RegisterTargetWithMaintenanceWindowOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RegisterTargetWithMaintenanceWindowRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ssm.RegisterTargetWithMaintenanceWindowOutput)
@@ -4972,13 +4381,11 @@ func (m *MockSSMAPI) RegisterTargetWithMaintenanceWindowRequest(arg0 *ssm.Regist
 
 // RegisterTargetWithMaintenanceWindowRequest indicates an expected call of RegisterTargetWithMaintenanceWindowRequest
 func (mr *MockSSMAPIMockRecorder) RegisterTargetWithMaintenanceWindowRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterTargetWithMaintenanceWindowRequest", reflect.TypeOf((*MockSSMAPI)(nil).RegisterTargetWithMaintenanceWindowRequest), arg0)
 }
 
 // RegisterTargetWithMaintenanceWindowWithContext mocks base method
 func (m *MockSSMAPI) RegisterTargetWithMaintenanceWindowWithContext(arg0 context.Context, arg1 *ssm.RegisterTargetWithMaintenanceWindowInput, arg2 ...request.Option) (*ssm.RegisterTargetWithMaintenanceWindowOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -4991,14 +4398,12 @@ func (m *MockSSMAPI) RegisterTargetWithMaintenanceWindowWithContext(arg0 context
 
 // RegisterTargetWithMaintenanceWindowWithContext indicates an expected call of RegisterTargetWithMaintenanceWindowWithContext
 func (mr *MockSSMAPIMockRecorder) RegisterTargetWithMaintenanceWindowWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterTargetWithMaintenanceWindowWithContext", reflect.TypeOf((*MockSSMAPI)(nil).RegisterTargetWithMaintenanceWindowWithContext), varargs...)
 }
 
 // RegisterTaskWithMaintenanceWindow mocks base method
 func (m *MockSSMAPI) RegisterTaskWithMaintenanceWindow(arg0 *ssm.RegisterTaskWithMaintenanceWindowInput) (*ssm.RegisterTaskWithMaintenanceWindowOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RegisterTaskWithMaintenanceWindow", arg0)
 	ret0, _ := ret[0].(*ssm.RegisterTaskWithMaintenanceWindowOutput)
 	ret1, _ := ret[1].(error)
@@ -5007,13 +4412,11 @@ func (m *MockSSMAPI) RegisterTaskWithMaintenanceWindow(arg0 *ssm.RegisterTaskWit
 
 // RegisterTaskWithMaintenanceWindow indicates an expected call of RegisterTaskWithMaintenanceWindow
 func (mr *MockSSMAPIMockRecorder) RegisterTaskWithMaintenanceWindow(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterTaskWithMaintenanceWindow", reflect.TypeOf((*MockSSMAPI)(nil).RegisterTaskWithMaintenanceWindow), arg0)
 }
 
 // RegisterTaskWithMaintenanceWindowRequest mocks base method
 func (m *MockSSMAPI) RegisterTaskWithMaintenanceWindowRequest(arg0 *ssm.RegisterTaskWithMaintenanceWindowInput) (*request.Request, *ssm.RegisterTaskWithMaintenanceWindowOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RegisterTaskWithMaintenanceWindowRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ssm.RegisterTaskWithMaintenanceWindowOutput)
@@ -5022,13 +4425,11 @@ func (m *MockSSMAPI) RegisterTaskWithMaintenanceWindowRequest(arg0 *ssm.Register
 
 // RegisterTaskWithMaintenanceWindowRequest indicates an expected call of RegisterTaskWithMaintenanceWindowRequest
 func (mr *MockSSMAPIMockRecorder) RegisterTaskWithMaintenanceWindowRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterTaskWithMaintenanceWindowRequest", reflect.TypeOf((*MockSSMAPI)(nil).RegisterTaskWithMaintenanceWindowRequest), arg0)
 }
 
 // RegisterTaskWithMaintenanceWindowWithContext mocks base method
 func (m *MockSSMAPI) RegisterTaskWithMaintenanceWindowWithContext(arg0 context.Context, arg1 *ssm.RegisterTaskWithMaintenanceWindowInput, arg2 ...request.Option) (*ssm.RegisterTaskWithMaintenanceWindowOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -5041,14 +4442,12 @@ func (m *MockSSMAPI) RegisterTaskWithMaintenanceWindowWithContext(arg0 context.C
 
 // RegisterTaskWithMaintenanceWindowWithContext indicates an expected call of RegisterTaskWithMaintenanceWindowWithContext
 func (mr *MockSSMAPIMockRecorder) RegisterTaskWithMaintenanceWindowWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterTaskWithMaintenanceWindowWithContext", reflect.TypeOf((*MockSSMAPI)(nil).RegisterTaskWithMaintenanceWindowWithContext), varargs...)
 }
 
 // RemoveTagsFromResource mocks base method
 func (m *MockSSMAPI) RemoveTagsFromResource(arg0 *ssm.RemoveTagsFromResourceInput) (*ssm.RemoveTagsFromResourceOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RemoveTagsFromResource", arg0)
 	ret0, _ := ret[0].(*ssm.RemoveTagsFromResourceOutput)
 	ret1, _ := ret[1].(error)
@@ -5057,13 +4456,11 @@ func (m *MockSSMAPI) RemoveTagsFromResource(arg0 *ssm.RemoveTagsFromResourceInpu
 
 // RemoveTagsFromResource indicates an expected call of RemoveTagsFromResource
 func (mr *MockSSMAPIMockRecorder) RemoveTagsFromResource(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveTagsFromResource", reflect.TypeOf((*MockSSMAPI)(nil).RemoveTagsFromResource), arg0)
 }
 
 // RemoveTagsFromResourceRequest mocks base method
 func (m *MockSSMAPI) RemoveTagsFromResourceRequest(arg0 *ssm.RemoveTagsFromResourceInput) (*request.Request, *ssm.RemoveTagsFromResourceOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RemoveTagsFromResourceRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ssm.RemoveTagsFromResourceOutput)
@@ -5072,13 +4469,11 @@ func (m *MockSSMAPI) RemoveTagsFromResourceRequest(arg0 *ssm.RemoveTagsFromResou
 
 // RemoveTagsFromResourceRequest indicates an expected call of RemoveTagsFromResourceRequest
 func (mr *MockSSMAPIMockRecorder) RemoveTagsFromResourceRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveTagsFromResourceRequest", reflect.TypeOf((*MockSSMAPI)(nil).RemoveTagsFromResourceRequest), arg0)
 }
 
 // RemoveTagsFromResourceWithContext mocks base method
 func (m *MockSSMAPI) RemoveTagsFromResourceWithContext(arg0 context.Context, arg1 *ssm.RemoveTagsFromResourceInput, arg2 ...request.Option) (*ssm.RemoveTagsFromResourceOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -5091,14 +4486,12 @@ func (m *MockSSMAPI) RemoveTagsFromResourceWithContext(arg0 context.Context, arg
 
 // RemoveTagsFromResourceWithContext indicates an expected call of RemoveTagsFromResourceWithContext
 func (mr *MockSSMAPIMockRecorder) RemoveTagsFromResourceWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveTagsFromResourceWithContext", reflect.TypeOf((*MockSSMAPI)(nil).RemoveTagsFromResourceWithContext), varargs...)
 }
 
 // ResetServiceSetting mocks base method
 func (m *MockSSMAPI) ResetServiceSetting(arg0 *ssm.ResetServiceSettingInput) (*ssm.ResetServiceSettingOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ResetServiceSetting", arg0)
 	ret0, _ := ret[0].(*ssm.ResetServiceSettingOutput)
 	ret1, _ := ret[1].(error)
@@ -5107,13 +4500,11 @@ func (m *MockSSMAPI) ResetServiceSetting(arg0 *ssm.ResetServiceSettingInput) (*s
 
 // ResetServiceSetting indicates an expected call of ResetServiceSetting
 func (mr *MockSSMAPIMockRecorder) ResetServiceSetting(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResetServiceSetting", reflect.TypeOf((*MockSSMAPI)(nil).ResetServiceSetting), arg0)
 }
 
 // ResetServiceSettingRequest mocks base method
 func (m *MockSSMAPI) ResetServiceSettingRequest(arg0 *ssm.ResetServiceSettingInput) (*request.Request, *ssm.ResetServiceSettingOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ResetServiceSettingRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ssm.ResetServiceSettingOutput)
@@ -5122,13 +4513,11 @@ func (m *MockSSMAPI) ResetServiceSettingRequest(arg0 *ssm.ResetServiceSettingInp
 
 // ResetServiceSettingRequest indicates an expected call of ResetServiceSettingRequest
 func (mr *MockSSMAPIMockRecorder) ResetServiceSettingRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResetServiceSettingRequest", reflect.TypeOf((*MockSSMAPI)(nil).ResetServiceSettingRequest), arg0)
 }
 
 // ResetServiceSettingWithContext mocks base method
 func (m *MockSSMAPI) ResetServiceSettingWithContext(arg0 context.Context, arg1 *ssm.ResetServiceSettingInput, arg2 ...request.Option) (*ssm.ResetServiceSettingOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -5141,14 +4530,12 @@ func (m *MockSSMAPI) ResetServiceSettingWithContext(arg0 context.Context, arg1 *
 
 // ResetServiceSettingWithContext indicates an expected call of ResetServiceSettingWithContext
 func (mr *MockSSMAPIMockRecorder) ResetServiceSettingWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResetServiceSettingWithContext", reflect.TypeOf((*MockSSMAPI)(nil).ResetServiceSettingWithContext), varargs...)
 }
 
 // ResumeSession mocks base method
 func (m *MockSSMAPI) ResumeSession(arg0 *ssm.ResumeSessionInput) (*ssm.ResumeSessionOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ResumeSession", arg0)
 	ret0, _ := ret[0].(*ssm.ResumeSessionOutput)
 	ret1, _ := ret[1].(error)
@@ -5157,13 +4544,11 @@ func (m *MockSSMAPI) ResumeSession(arg0 *ssm.ResumeSessionInput) (*ssm.ResumeSes
 
 // ResumeSession indicates an expected call of ResumeSession
 func (mr *MockSSMAPIMockRecorder) ResumeSession(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResumeSession", reflect.TypeOf((*MockSSMAPI)(nil).ResumeSession), arg0)
 }
 
 // ResumeSessionRequest mocks base method
 func (m *MockSSMAPI) ResumeSessionRequest(arg0 *ssm.ResumeSessionInput) (*request.Request, *ssm.ResumeSessionOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ResumeSessionRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ssm.ResumeSessionOutput)
@@ -5172,13 +4557,11 @@ func (m *MockSSMAPI) ResumeSessionRequest(arg0 *ssm.ResumeSessionInput) (*reques
 
 // ResumeSessionRequest indicates an expected call of ResumeSessionRequest
 func (mr *MockSSMAPIMockRecorder) ResumeSessionRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResumeSessionRequest", reflect.TypeOf((*MockSSMAPI)(nil).ResumeSessionRequest), arg0)
 }
 
 // ResumeSessionWithContext mocks base method
 func (m *MockSSMAPI) ResumeSessionWithContext(arg0 context.Context, arg1 *ssm.ResumeSessionInput, arg2 ...request.Option) (*ssm.ResumeSessionOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -5191,14 +4574,12 @@ func (m *MockSSMAPI) ResumeSessionWithContext(arg0 context.Context, arg1 *ssm.Re
 
 // ResumeSessionWithContext indicates an expected call of ResumeSessionWithContext
 func (mr *MockSSMAPIMockRecorder) ResumeSessionWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResumeSessionWithContext", reflect.TypeOf((*MockSSMAPI)(nil).ResumeSessionWithContext), varargs...)
 }
 
 // SendAutomationSignal mocks base method
 func (m *MockSSMAPI) SendAutomationSignal(arg0 *ssm.SendAutomationSignalInput) (*ssm.SendAutomationSignalOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SendAutomationSignal", arg0)
 	ret0, _ := ret[0].(*ssm.SendAutomationSignalOutput)
 	ret1, _ := ret[1].(error)
@@ -5207,13 +4588,11 @@ func (m *MockSSMAPI) SendAutomationSignal(arg0 *ssm.SendAutomationSignalInput) (
 
 // SendAutomationSignal indicates an expected call of SendAutomationSignal
 func (mr *MockSSMAPIMockRecorder) SendAutomationSignal(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendAutomationSignal", reflect.TypeOf((*MockSSMAPI)(nil).SendAutomationSignal), arg0)
 }
 
 // SendAutomationSignalRequest mocks base method
 func (m *MockSSMAPI) SendAutomationSignalRequest(arg0 *ssm.SendAutomationSignalInput) (*request.Request, *ssm.SendAutomationSignalOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SendAutomationSignalRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ssm.SendAutomationSignalOutput)
@@ -5222,13 +4601,11 @@ func (m *MockSSMAPI) SendAutomationSignalRequest(arg0 *ssm.SendAutomationSignalI
 
 // SendAutomationSignalRequest indicates an expected call of SendAutomationSignalRequest
 func (mr *MockSSMAPIMockRecorder) SendAutomationSignalRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendAutomationSignalRequest", reflect.TypeOf((*MockSSMAPI)(nil).SendAutomationSignalRequest), arg0)
 }
 
 // SendAutomationSignalWithContext mocks base method
 func (m *MockSSMAPI) SendAutomationSignalWithContext(arg0 context.Context, arg1 *ssm.SendAutomationSignalInput, arg2 ...request.Option) (*ssm.SendAutomationSignalOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -5241,14 +4618,12 @@ func (m *MockSSMAPI) SendAutomationSignalWithContext(arg0 context.Context, arg1 
 
 // SendAutomationSignalWithContext indicates an expected call of SendAutomationSignalWithContext
 func (mr *MockSSMAPIMockRecorder) SendAutomationSignalWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendAutomationSignalWithContext", reflect.TypeOf((*MockSSMAPI)(nil).SendAutomationSignalWithContext), varargs...)
 }
 
 // SendCommand mocks base method
 func (m *MockSSMAPI) SendCommand(arg0 *ssm.SendCommandInput) (*ssm.SendCommandOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SendCommand", arg0)
 	ret0, _ := ret[0].(*ssm.SendCommandOutput)
 	ret1, _ := ret[1].(error)
@@ -5257,13 +4632,11 @@ func (m *MockSSMAPI) SendCommand(arg0 *ssm.SendCommandInput) (*ssm.SendCommandOu
 
 // SendCommand indicates an expected call of SendCommand
 func (mr *MockSSMAPIMockRecorder) SendCommand(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendCommand", reflect.TypeOf((*MockSSMAPI)(nil).SendCommand), arg0)
 }
 
 // SendCommandRequest mocks base method
 func (m *MockSSMAPI) SendCommandRequest(arg0 *ssm.SendCommandInput) (*request.Request, *ssm.SendCommandOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SendCommandRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ssm.SendCommandOutput)
@@ -5272,13 +4645,11 @@ func (m *MockSSMAPI) SendCommandRequest(arg0 *ssm.SendCommandInput) (*request.Re
 
 // SendCommandRequest indicates an expected call of SendCommandRequest
 func (mr *MockSSMAPIMockRecorder) SendCommandRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendCommandRequest", reflect.TypeOf((*MockSSMAPI)(nil).SendCommandRequest), arg0)
 }
 
 // SendCommandWithContext mocks base method
 func (m *MockSSMAPI) SendCommandWithContext(arg0 context.Context, arg1 *ssm.SendCommandInput, arg2 ...request.Option) (*ssm.SendCommandOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -5291,14 +4662,12 @@ func (m *MockSSMAPI) SendCommandWithContext(arg0 context.Context, arg1 *ssm.Send
 
 // SendCommandWithContext indicates an expected call of SendCommandWithContext
 func (mr *MockSSMAPIMockRecorder) SendCommandWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendCommandWithContext", reflect.TypeOf((*MockSSMAPI)(nil).SendCommandWithContext), varargs...)
 }
 
 // StartAssociationsOnce mocks base method
 func (m *MockSSMAPI) StartAssociationsOnce(arg0 *ssm.StartAssociationsOnceInput) (*ssm.StartAssociationsOnceOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StartAssociationsOnce", arg0)
 	ret0, _ := ret[0].(*ssm.StartAssociationsOnceOutput)
 	ret1, _ := ret[1].(error)
@@ -5307,13 +4676,11 @@ func (m *MockSSMAPI) StartAssociationsOnce(arg0 *ssm.StartAssociationsOnceInput)
 
 // StartAssociationsOnce indicates an expected call of StartAssociationsOnce
 func (mr *MockSSMAPIMockRecorder) StartAssociationsOnce(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartAssociationsOnce", reflect.TypeOf((*MockSSMAPI)(nil).StartAssociationsOnce), arg0)
 }
 
 // StartAssociationsOnceRequest mocks base method
 func (m *MockSSMAPI) StartAssociationsOnceRequest(arg0 *ssm.StartAssociationsOnceInput) (*request.Request, *ssm.StartAssociationsOnceOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StartAssociationsOnceRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ssm.StartAssociationsOnceOutput)
@@ -5322,13 +4689,11 @@ func (m *MockSSMAPI) StartAssociationsOnceRequest(arg0 *ssm.StartAssociationsOnc
 
 // StartAssociationsOnceRequest indicates an expected call of StartAssociationsOnceRequest
 func (mr *MockSSMAPIMockRecorder) StartAssociationsOnceRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartAssociationsOnceRequest", reflect.TypeOf((*MockSSMAPI)(nil).StartAssociationsOnceRequest), arg0)
 }
 
 // StartAssociationsOnceWithContext mocks base method
 func (m *MockSSMAPI) StartAssociationsOnceWithContext(arg0 context.Context, arg1 *ssm.StartAssociationsOnceInput, arg2 ...request.Option) (*ssm.StartAssociationsOnceOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -5341,14 +4706,12 @@ func (m *MockSSMAPI) StartAssociationsOnceWithContext(arg0 context.Context, arg1
 
 // StartAssociationsOnceWithContext indicates an expected call of StartAssociationsOnceWithContext
 func (mr *MockSSMAPIMockRecorder) StartAssociationsOnceWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartAssociationsOnceWithContext", reflect.TypeOf((*MockSSMAPI)(nil).StartAssociationsOnceWithContext), varargs...)
 }
 
 // StartAutomationExecution mocks base method
 func (m *MockSSMAPI) StartAutomationExecution(arg0 *ssm.StartAutomationExecutionInput) (*ssm.StartAutomationExecutionOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StartAutomationExecution", arg0)
 	ret0, _ := ret[0].(*ssm.StartAutomationExecutionOutput)
 	ret1, _ := ret[1].(error)
@@ -5357,13 +4720,11 @@ func (m *MockSSMAPI) StartAutomationExecution(arg0 *ssm.StartAutomationExecution
 
 // StartAutomationExecution indicates an expected call of StartAutomationExecution
 func (mr *MockSSMAPIMockRecorder) StartAutomationExecution(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartAutomationExecution", reflect.TypeOf((*MockSSMAPI)(nil).StartAutomationExecution), arg0)
 }
 
 // StartAutomationExecutionRequest mocks base method
 func (m *MockSSMAPI) StartAutomationExecutionRequest(arg0 *ssm.StartAutomationExecutionInput) (*request.Request, *ssm.StartAutomationExecutionOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StartAutomationExecutionRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ssm.StartAutomationExecutionOutput)
@@ -5372,13 +4733,11 @@ func (m *MockSSMAPI) StartAutomationExecutionRequest(arg0 *ssm.StartAutomationEx
 
 // StartAutomationExecutionRequest indicates an expected call of StartAutomationExecutionRequest
 func (mr *MockSSMAPIMockRecorder) StartAutomationExecutionRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartAutomationExecutionRequest", reflect.TypeOf((*MockSSMAPI)(nil).StartAutomationExecutionRequest), arg0)
 }
 
 // StartAutomationExecutionWithContext mocks base method
 func (m *MockSSMAPI) StartAutomationExecutionWithContext(arg0 context.Context, arg1 *ssm.StartAutomationExecutionInput, arg2 ...request.Option) (*ssm.StartAutomationExecutionOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -5391,14 +4750,12 @@ func (m *MockSSMAPI) StartAutomationExecutionWithContext(arg0 context.Context, a
 
 // StartAutomationExecutionWithContext indicates an expected call of StartAutomationExecutionWithContext
 func (mr *MockSSMAPIMockRecorder) StartAutomationExecutionWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartAutomationExecutionWithContext", reflect.TypeOf((*MockSSMAPI)(nil).StartAutomationExecutionWithContext), varargs...)
 }
 
 // StartSession mocks base method
 func (m *MockSSMAPI) StartSession(arg0 *ssm.StartSessionInput) (*ssm.StartSessionOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StartSession", arg0)
 	ret0, _ := ret[0].(*ssm.StartSessionOutput)
 	ret1, _ := ret[1].(error)
@@ -5407,13 +4764,11 @@ func (m *MockSSMAPI) StartSession(arg0 *ssm.StartSessionInput) (*ssm.StartSessio
 
 // StartSession indicates an expected call of StartSession
 func (mr *MockSSMAPIMockRecorder) StartSession(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartSession", reflect.TypeOf((*MockSSMAPI)(nil).StartSession), arg0)
 }
 
 // StartSessionRequest mocks base method
 func (m *MockSSMAPI) StartSessionRequest(arg0 *ssm.StartSessionInput) (*request.Request, *ssm.StartSessionOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StartSessionRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ssm.StartSessionOutput)
@@ -5422,13 +4777,11 @@ func (m *MockSSMAPI) StartSessionRequest(arg0 *ssm.StartSessionInput) (*request.
 
 // StartSessionRequest indicates an expected call of StartSessionRequest
 func (mr *MockSSMAPIMockRecorder) StartSessionRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartSessionRequest", reflect.TypeOf((*MockSSMAPI)(nil).StartSessionRequest), arg0)
 }
 
 // StartSessionWithContext mocks base method
 func (m *MockSSMAPI) StartSessionWithContext(arg0 context.Context, arg1 *ssm.StartSessionInput, arg2 ...request.Option) (*ssm.StartSessionOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -5441,14 +4794,12 @@ func (m *MockSSMAPI) StartSessionWithContext(arg0 context.Context, arg1 *ssm.Sta
 
 // StartSessionWithContext indicates an expected call of StartSessionWithContext
 func (mr *MockSSMAPIMockRecorder) StartSessionWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartSessionWithContext", reflect.TypeOf((*MockSSMAPI)(nil).StartSessionWithContext), varargs...)
 }
 
 // StopAutomationExecution mocks base method
 func (m *MockSSMAPI) StopAutomationExecution(arg0 *ssm.StopAutomationExecutionInput) (*ssm.StopAutomationExecutionOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StopAutomationExecution", arg0)
 	ret0, _ := ret[0].(*ssm.StopAutomationExecutionOutput)
 	ret1, _ := ret[1].(error)
@@ -5457,13 +4808,11 @@ func (m *MockSSMAPI) StopAutomationExecution(arg0 *ssm.StopAutomationExecutionIn
 
 // StopAutomationExecution indicates an expected call of StopAutomationExecution
 func (mr *MockSSMAPIMockRecorder) StopAutomationExecution(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StopAutomationExecution", reflect.TypeOf((*MockSSMAPI)(nil).StopAutomationExecution), arg0)
 }
 
 // StopAutomationExecutionRequest mocks base method
 func (m *MockSSMAPI) StopAutomationExecutionRequest(arg0 *ssm.StopAutomationExecutionInput) (*request.Request, *ssm.StopAutomationExecutionOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StopAutomationExecutionRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ssm.StopAutomationExecutionOutput)
@@ -5472,13 +4821,11 @@ func (m *MockSSMAPI) StopAutomationExecutionRequest(arg0 *ssm.StopAutomationExec
 
 // StopAutomationExecutionRequest indicates an expected call of StopAutomationExecutionRequest
 func (mr *MockSSMAPIMockRecorder) StopAutomationExecutionRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StopAutomationExecutionRequest", reflect.TypeOf((*MockSSMAPI)(nil).StopAutomationExecutionRequest), arg0)
 }
 
 // StopAutomationExecutionWithContext mocks base method
 func (m *MockSSMAPI) StopAutomationExecutionWithContext(arg0 context.Context, arg1 *ssm.StopAutomationExecutionInput, arg2 ...request.Option) (*ssm.StopAutomationExecutionOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -5491,14 +4838,12 @@ func (m *MockSSMAPI) StopAutomationExecutionWithContext(arg0 context.Context, ar
 
 // StopAutomationExecutionWithContext indicates an expected call of StopAutomationExecutionWithContext
 func (mr *MockSSMAPIMockRecorder) StopAutomationExecutionWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StopAutomationExecutionWithContext", reflect.TypeOf((*MockSSMAPI)(nil).StopAutomationExecutionWithContext), varargs...)
 }
 
 // TerminateSession mocks base method
 func (m *MockSSMAPI) TerminateSession(arg0 *ssm.TerminateSessionInput) (*ssm.TerminateSessionOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "TerminateSession", arg0)
 	ret0, _ := ret[0].(*ssm.TerminateSessionOutput)
 	ret1, _ := ret[1].(error)
@@ -5507,13 +4852,11 @@ func (m *MockSSMAPI) TerminateSession(arg0 *ssm.TerminateSessionInput) (*ssm.Ter
 
 // TerminateSession indicates an expected call of TerminateSession
 func (mr *MockSSMAPIMockRecorder) TerminateSession(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TerminateSession", reflect.TypeOf((*MockSSMAPI)(nil).TerminateSession), arg0)
 }
 
 // TerminateSessionRequest mocks base method
 func (m *MockSSMAPI) TerminateSessionRequest(arg0 *ssm.TerminateSessionInput) (*request.Request, *ssm.TerminateSessionOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "TerminateSessionRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ssm.TerminateSessionOutput)
@@ -5522,13 +4865,11 @@ func (m *MockSSMAPI) TerminateSessionRequest(arg0 *ssm.TerminateSessionInput) (*
 
 // TerminateSessionRequest indicates an expected call of TerminateSessionRequest
 func (mr *MockSSMAPIMockRecorder) TerminateSessionRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TerminateSessionRequest", reflect.TypeOf((*MockSSMAPI)(nil).TerminateSessionRequest), arg0)
 }
 
 // TerminateSessionWithContext mocks base method
 func (m *MockSSMAPI) TerminateSessionWithContext(arg0 context.Context, arg1 *ssm.TerminateSessionInput, arg2 ...request.Option) (*ssm.TerminateSessionOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -5541,14 +4882,12 @@ func (m *MockSSMAPI) TerminateSessionWithContext(arg0 context.Context, arg1 *ssm
 
 // TerminateSessionWithContext indicates an expected call of TerminateSessionWithContext
 func (mr *MockSSMAPIMockRecorder) TerminateSessionWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TerminateSessionWithContext", reflect.TypeOf((*MockSSMAPI)(nil).TerminateSessionWithContext), varargs...)
 }
 
 // UpdateAssociation mocks base method
 func (m *MockSSMAPI) UpdateAssociation(arg0 *ssm.UpdateAssociationInput) (*ssm.UpdateAssociationOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateAssociation", arg0)
 	ret0, _ := ret[0].(*ssm.UpdateAssociationOutput)
 	ret1, _ := ret[1].(error)
@@ -5557,13 +4896,11 @@ func (m *MockSSMAPI) UpdateAssociation(arg0 *ssm.UpdateAssociationInput) (*ssm.U
 
 // UpdateAssociation indicates an expected call of UpdateAssociation
 func (mr *MockSSMAPIMockRecorder) UpdateAssociation(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateAssociation", reflect.TypeOf((*MockSSMAPI)(nil).UpdateAssociation), arg0)
 }
 
 // UpdateAssociationRequest mocks base method
 func (m *MockSSMAPI) UpdateAssociationRequest(arg0 *ssm.UpdateAssociationInput) (*request.Request, *ssm.UpdateAssociationOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateAssociationRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ssm.UpdateAssociationOutput)
@@ -5572,13 +4909,11 @@ func (m *MockSSMAPI) UpdateAssociationRequest(arg0 *ssm.UpdateAssociationInput) 
 
 // UpdateAssociationRequest indicates an expected call of UpdateAssociationRequest
 func (mr *MockSSMAPIMockRecorder) UpdateAssociationRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateAssociationRequest", reflect.TypeOf((*MockSSMAPI)(nil).UpdateAssociationRequest), arg0)
 }
 
 // UpdateAssociationStatus mocks base method
 func (m *MockSSMAPI) UpdateAssociationStatus(arg0 *ssm.UpdateAssociationStatusInput) (*ssm.UpdateAssociationStatusOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateAssociationStatus", arg0)
 	ret0, _ := ret[0].(*ssm.UpdateAssociationStatusOutput)
 	ret1, _ := ret[1].(error)
@@ -5587,13 +4922,11 @@ func (m *MockSSMAPI) UpdateAssociationStatus(arg0 *ssm.UpdateAssociationStatusIn
 
 // UpdateAssociationStatus indicates an expected call of UpdateAssociationStatus
 func (mr *MockSSMAPIMockRecorder) UpdateAssociationStatus(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateAssociationStatus", reflect.TypeOf((*MockSSMAPI)(nil).UpdateAssociationStatus), arg0)
 }
 
 // UpdateAssociationStatusRequest mocks base method
 func (m *MockSSMAPI) UpdateAssociationStatusRequest(arg0 *ssm.UpdateAssociationStatusInput) (*request.Request, *ssm.UpdateAssociationStatusOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateAssociationStatusRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ssm.UpdateAssociationStatusOutput)
@@ -5602,13 +4935,11 @@ func (m *MockSSMAPI) UpdateAssociationStatusRequest(arg0 *ssm.UpdateAssociationS
 
 // UpdateAssociationStatusRequest indicates an expected call of UpdateAssociationStatusRequest
 func (mr *MockSSMAPIMockRecorder) UpdateAssociationStatusRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateAssociationStatusRequest", reflect.TypeOf((*MockSSMAPI)(nil).UpdateAssociationStatusRequest), arg0)
 }
 
 // UpdateAssociationStatusWithContext mocks base method
 func (m *MockSSMAPI) UpdateAssociationStatusWithContext(arg0 context.Context, arg1 *ssm.UpdateAssociationStatusInput, arg2 ...request.Option) (*ssm.UpdateAssociationStatusOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -5621,14 +4952,12 @@ func (m *MockSSMAPI) UpdateAssociationStatusWithContext(arg0 context.Context, ar
 
 // UpdateAssociationStatusWithContext indicates an expected call of UpdateAssociationStatusWithContext
 func (mr *MockSSMAPIMockRecorder) UpdateAssociationStatusWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateAssociationStatusWithContext", reflect.TypeOf((*MockSSMAPI)(nil).UpdateAssociationStatusWithContext), varargs...)
 }
 
 // UpdateAssociationWithContext mocks base method
 func (m *MockSSMAPI) UpdateAssociationWithContext(arg0 context.Context, arg1 *ssm.UpdateAssociationInput, arg2 ...request.Option) (*ssm.UpdateAssociationOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -5641,14 +4970,12 @@ func (m *MockSSMAPI) UpdateAssociationWithContext(arg0 context.Context, arg1 *ss
 
 // UpdateAssociationWithContext indicates an expected call of UpdateAssociationWithContext
 func (mr *MockSSMAPIMockRecorder) UpdateAssociationWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateAssociationWithContext", reflect.TypeOf((*MockSSMAPI)(nil).UpdateAssociationWithContext), varargs...)
 }
 
 // UpdateDocument mocks base method
 func (m *MockSSMAPI) UpdateDocument(arg0 *ssm.UpdateDocumentInput) (*ssm.UpdateDocumentOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateDocument", arg0)
 	ret0, _ := ret[0].(*ssm.UpdateDocumentOutput)
 	ret1, _ := ret[1].(error)
@@ -5657,13 +4984,11 @@ func (m *MockSSMAPI) UpdateDocument(arg0 *ssm.UpdateDocumentInput) (*ssm.UpdateD
 
 // UpdateDocument indicates an expected call of UpdateDocument
 func (mr *MockSSMAPIMockRecorder) UpdateDocument(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateDocument", reflect.TypeOf((*MockSSMAPI)(nil).UpdateDocument), arg0)
 }
 
 // UpdateDocumentDefaultVersion mocks base method
 func (m *MockSSMAPI) UpdateDocumentDefaultVersion(arg0 *ssm.UpdateDocumentDefaultVersionInput) (*ssm.UpdateDocumentDefaultVersionOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateDocumentDefaultVersion", arg0)
 	ret0, _ := ret[0].(*ssm.UpdateDocumentDefaultVersionOutput)
 	ret1, _ := ret[1].(error)
@@ -5672,13 +4997,11 @@ func (m *MockSSMAPI) UpdateDocumentDefaultVersion(arg0 *ssm.UpdateDocumentDefaul
 
 // UpdateDocumentDefaultVersion indicates an expected call of UpdateDocumentDefaultVersion
 func (mr *MockSSMAPIMockRecorder) UpdateDocumentDefaultVersion(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateDocumentDefaultVersion", reflect.TypeOf((*MockSSMAPI)(nil).UpdateDocumentDefaultVersion), arg0)
 }
 
 // UpdateDocumentDefaultVersionRequest mocks base method
 func (m *MockSSMAPI) UpdateDocumentDefaultVersionRequest(arg0 *ssm.UpdateDocumentDefaultVersionInput) (*request.Request, *ssm.UpdateDocumentDefaultVersionOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateDocumentDefaultVersionRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ssm.UpdateDocumentDefaultVersionOutput)
@@ -5687,13 +5010,11 @@ func (m *MockSSMAPI) UpdateDocumentDefaultVersionRequest(arg0 *ssm.UpdateDocumen
 
 // UpdateDocumentDefaultVersionRequest indicates an expected call of UpdateDocumentDefaultVersionRequest
 func (mr *MockSSMAPIMockRecorder) UpdateDocumentDefaultVersionRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateDocumentDefaultVersionRequest", reflect.TypeOf((*MockSSMAPI)(nil).UpdateDocumentDefaultVersionRequest), arg0)
 }
 
 // UpdateDocumentDefaultVersionWithContext mocks base method
 func (m *MockSSMAPI) UpdateDocumentDefaultVersionWithContext(arg0 context.Context, arg1 *ssm.UpdateDocumentDefaultVersionInput, arg2 ...request.Option) (*ssm.UpdateDocumentDefaultVersionOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -5706,14 +5027,12 @@ func (m *MockSSMAPI) UpdateDocumentDefaultVersionWithContext(arg0 context.Contex
 
 // UpdateDocumentDefaultVersionWithContext indicates an expected call of UpdateDocumentDefaultVersionWithContext
 func (mr *MockSSMAPIMockRecorder) UpdateDocumentDefaultVersionWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateDocumentDefaultVersionWithContext", reflect.TypeOf((*MockSSMAPI)(nil).UpdateDocumentDefaultVersionWithContext), varargs...)
 }
 
 // UpdateDocumentRequest mocks base method
 func (m *MockSSMAPI) UpdateDocumentRequest(arg0 *ssm.UpdateDocumentInput) (*request.Request, *ssm.UpdateDocumentOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateDocumentRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ssm.UpdateDocumentOutput)
@@ -5722,13 +5041,11 @@ func (m *MockSSMAPI) UpdateDocumentRequest(arg0 *ssm.UpdateDocumentInput) (*requ
 
 // UpdateDocumentRequest indicates an expected call of UpdateDocumentRequest
 func (mr *MockSSMAPIMockRecorder) UpdateDocumentRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateDocumentRequest", reflect.TypeOf((*MockSSMAPI)(nil).UpdateDocumentRequest), arg0)
 }
 
 // UpdateDocumentWithContext mocks base method
 func (m *MockSSMAPI) UpdateDocumentWithContext(arg0 context.Context, arg1 *ssm.UpdateDocumentInput, arg2 ...request.Option) (*ssm.UpdateDocumentOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -5741,14 +5058,12 @@ func (m *MockSSMAPI) UpdateDocumentWithContext(arg0 context.Context, arg1 *ssm.U
 
 // UpdateDocumentWithContext indicates an expected call of UpdateDocumentWithContext
 func (mr *MockSSMAPIMockRecorder) UpdateDocumentWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateDocumentWithContext", reflect.TypeOf((*MockSSMAPI)(nil).UpdateDocumentWithContext), varargs...)
 }
 
 // UpdateMaintenanceWindow mocks base method
 func (m *MockSSMAPI) UpdateMaintenanceWindow(arg0 *ssm.UpdateMaintenanceWindowInput) (*ssm.UpdateMaintenanceWindowOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateMaintenanceWindow", arg0)
 	ret0, _ := ret[0].(*ssm.UpdateMaintenanceWindowOutput)
 	ret1, _ := ret[1].(error)
@@ -5757,13 +5072,11 @@ func (m *MockSSMAPI) UpdateMaintenanceWindow(arg0 *ssm.UpdateMaintenanceWindowIn
 
 // UpdateMaintenanceWindow indicates an expected call of UpdateMaintenanceWindow
 func (mr *MockSSMAPIMockRecorder) UpdateMaintenanceWindow(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateMaintenanceWindow", reflect.TypeOf((*MockSSMAPI)(nil).UpdateMaintenanceWindow), arg0)
 }
 
 // UpdateMaintenanceWindowRequest mocks base method
 func (m *MockSSMAPI) UpdateMaintenanceWindowRequest(arg0 *ssm.UpdateMaintenanceWindowInput) (*request.Request, *ssm.UpdateMaintenanceWindowOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateMaintenanceWindowRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ssm.UpdateMaintenanceWindowOutput)
@@ -5772,13 +5085,11 @@ func (m *MockSSMAPI) UpdateMaintenanceWindowRequest(arg0 *ssm.UpdateMaintenanceW
 
 // UpdateMaintenanceWindowRequest indicates an expected call of UpdateMaintenanceWindowRequest
 func (mr *MockSSMAPIMockRecorder) UpdateMaintenanceWindowRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateMaintenanceWindowRequest", reflect.TypeOf((*MockSSMAPI)(nil).UpdateMaintenanceWindowRequest), arg0)
 }
 
 // UpdateMaintenanceWindowTarget mocks base method
 func (m *MockSSMAPI) UpdateMaintenanceWindowTarget(arg0 *ssm.UpdateMaintenanceWindowTargetInput) (*ssm.UpdateMaintenanceWindowTargetOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateMaintenanceWindowTarget", arg0)
 	ret0, _ := ret[0].(*ssm.UpdateMaintenanceWindowTargetOutput)
 	ret1, _ := ret[1].(error)
@@ -5787,13 +5098,11 @@ func (m *MockSSMAPI) UpdateMaintenanceWindowTarget(arg0 *ssm.UpdateMaintenanceWi
 
 // UpdateMaintenanceWindowTarget indicates an expected call of UpdateMaintenanceWindowTarget
 func (mr *MockSSMAPIMockRecorder) UpdateMaintenanceWindowTarget(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateMaintenanceWindowTarget", reflect.TypeOf((*MockSSMAPI)(nil).UpdateMaintenanceWindowTarget), arg0)
 }
 
 // UpdateMaintenanceWindowTargetRequest mocks base method
 func (m *MockSSMAPI) UpdateMaintenanceWindowTargetRequest(arg0 *ssm.UpdateMaintenanceWindowTargetInput) (*request.Request, *ssm.UpdateMaintenanceWindowTargetOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateMaintenanceWindowTargetRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ssm.UpdateMaintenanceWindowTargetOutput)
@@ -5802,13 +5111,11 @@ func (m *MockSSMAPI) UpdateMaintenanceWindowTargetRequest(arg0 *ssm.UpdateMainte
 
 // UpdateMaintenanceWindowTargetRequest indicates an expected call of UpdateMaintenanceWindowTargetRequest
 func (mr *MockSSMAPIMockRecorder) UpdateMaintenanceWindowTargetRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateMaintenanceWindowTargetRequest", reflect.TypeOf((*MockSSMAPI)(nil).UpdateMaintenanceWindowTargetRequest), arg0)
 }
 
 // UpdateMaintenanceWindowTargetWithContext mocks base method
 func (m *MockSSMAPI) UpdateMaintenanceWindowTargetWithContext(arg0 context.Context, arg1 *ssm.UpdateMaintenanceWindowTargetInput, arg2 ...request.Option) (*ssm.UpdateMaintenanceWindowTargetOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -5821,14 +5128,12 @@ func (m *MockSSMAPI) UpdateMaintenanceWindowTargetWithContext(arg0 context.Conte
 
 // UpdateMaintenanceWindowTargetWithContext indicates an expected call of UpdateMaintenanceWindowTargetWithContext
 func (mr *MockSSMAPIMockRecorder) UpdateMaintenanceWindowTargetWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateMaintenanceWindowTargetWithContext", reflect.TypeOf((*MockSSMAPI)(nil).UpdateMaintenanceWindowTargetWithContext), varargs...)
 }
 
 // UpdateMaintenanceWindowTask mocks base method
 func (m *MockSSMAPI) UpdateMaintenanceWindowTask(arg0 *ssm.UpdateMaintenanceWindowTaskInput) (*ssm.UpdateMaintenanceWindowTaskOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateMaintenanceWindowTask", arg0)
 	ret0, _ := ret[0].(*ssm.UpdateMaintenanceWindowTaskOutput)
 	ret1, _ := ret[1].(error)
@@ -5837,13 +5142,11 @@ func (m *MockSSMAPI) UpdateMaintenanceWindowTask(arg0 *ssm.UpdateMaintenanceWind
 
 // UpdateMaintenanceWindowTask indicates an expected call of UpdateMaintenanceWindowTask
 func (mr *MockSSMAPIMockRecorder) UpdateMaintenanceWindowTask(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateMaintenanceWindowTask", reflect.TypeOf((*MockSSMAPI)(nil).UpdateMaintenanceWindowTask), arg0)
 }
 
 // UpdateMaintenanceWindowTaskRequest mocks base method
 func (m *MockSSMAPI) UpdateMaintenanceWindowTaskRequest(arg0 *ssm.UpdateMaintenanceWindowTaskInput) (*request.Request, *ssm.UpdateMaintenanceWindowTaskOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateMaintenanceWindowTaskRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ssm.UpdateMaintenanceWindowTaskOutput)
@@ -5852,13 +5155,11 @@ func (m *MockSSMAPI) UpdateMaintenanceWindowTaskRequest(arg0 *ssm.UpdateMaintena
 
 // UpdateMaintenanceWindowTaskRequest indicates an expected call of UpdateMaintenanceWindowTaskRequest
 func (mr *MockSSMAPIMockRecorder) UpdateMaintenanceWindowTaskRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateMaintenanceWindowTaskRequest", reflect.TypeOf((*MockSSMAPI)(nil).UpdateMaintenanceWindowTaskRequest), arg0)
 }
 
 // UpdateMaintenanceWindowTaskWithContext mocks base method
 func (m *MockSSMAPI) UpdateMaintenanceWindowTaskWithContext(arg0 context.Context, arg1 *ssm.UpdateMaintenanceWindowTaskInput, arg2 ...request.Option) (*ssm.UpdateMaintenanceWindowTaskOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -5871,14 +5172,12 @@ func (m *MockSSMAPI) UpdateMaintenanceWindowTaskWithContext(arg0 context.Context
 
 // UpdateMaintenanceWindowTaskWithContext indicates an expected call of UpdateMaintenanceWindowTaskWithContext
 func (mr *MockSSMAPIMockRecorder) UpdateMaintenanceWindowTaskWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateMaintenanceWindowTaskWithContext", reflect.TypeOf((*MockSSMAPI)(nil).UpdateMaintenanceWindowTaskWithContext), varargs...)
 }
 
 // UpdateMaintenanceWindowWithContext mocks base method
 func (m *MockSSMAPI) UpdateMaintenanceWindowWithContext(arg0 context.Context, arg1 *ssm.UpdateMaintenanceWindowInput, arg2 ...request.Option) (*ssm.UpdateMaintenanceWindowOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -5891,14 +5190,12 @@ func (m *MockSSMAPI) UpdateMaintenanceWindowWithContext(arg0 context.Context, ar
 
 // UpdateMaintenanceWindowWithContext indicates an expected call of UpdateMaintenanceWindowWithContext
 func (mr *MockSSMAPIMockRecorder) UpdateMaintenanceWindowWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateMaintenanceWindowWithContext", reflect.TypeOf((*MockSSMAPI)(nil).UpdateMaintenanceWindowWithContext), varargs...)
 }
 
 // UpdateManagedInstanceRole mocks base method
 func (m *MockSSMAPI) UpdateManagedInstanceRole(arg0 *ssm.UpdateManagedInstanceRoleInput) (*ssm.UpdateManagedInstanceRoleOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateManagedInstanceRole", arg0)
 	ret0, _ := ret[0].(*ssm.UpdateManagedInstanceRoleOutput)
 	ret1, _ := ret[1].(error)
@@ -5907,13 +5204,11 @@ func (m *MockSSMAPI) UpdateManagedInstanceRole(arg0 *ssm.UpdateManagedInstanceRo
 
 // UpdateManagedInstanceRole indicates an expected call of UpdateManagedInstanceRole
 func (mr *MockSSMAPIMockRecorder) UpdateManagedInstanceRole(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateManagedInstanceRole", reflect.TypeOf((*MockSSMAPI)(nil).UpdateManagedInstanceRole), arg0)
 }
 
 // UpdateManagedInstanceRoleRequest mocks base method
 func (m *MockSSMAPI) UpdateManagedInstanceRoleRequest(arg0 *ssm.UpdateManagedInstanceRoleInput) (*request.Request, *ssm.UpdateManagedInstanceRoleOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateManagedInstanceRoleRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ssm.UpdateManagedInstanceRoleOutput)
@@ -5922,13 +5217,11 @@ func (m *MockSSMAPI) UpdateManagedInstanceRoleRequest(arg0 *ssm.UpdateManagedIns
 
 // UpdateManagedInstanceRoleRequest indicates an expected call of UpdateManagedInstanceRoleRequest
 func (mr *MockSSMAPIMockRecorder) UpdateManagedInstanceRoleRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateManagedInstanceRoleRequest", reflect.TypeOf((*MockSSMAPI)(nil).UpdateManagedInstanceRoleRequest), arg0)
 }
 
 // UpdateManagedInstanceRoleWithContext mocks base method
 func (m *MockSSMAPI) UpdateManagedInstanceRoleWithContext(arg0 context.Context, arg1 *ssm.UpdateManagedInstanceRoleInput, arg2 ...request.Option) (*ssm.UpdateManagedInstanceRoleOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -5941,14 +5234,12 @@ func (m *MockSSMAPI) UpdateManagedInstanceRoleWithContext(arg0 context.Context, 
 
 // UpdateManagedInstanceRoleWithContext indicates an expected call of UpdateManagedInstanceRoleWithContext
 func (mr *MockSSMAPIMockRecorder) UpdateManagedInstanceRoleWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateManagedInstanceRoleWithContext", reflect.TypeOf((*MockSSMAPI)(nil).UpdateManagedInstanceRoleWithContext), varargs...)
 }
 
 // UpdatePatchBaseline mocks base method
 func (m *MockSSMAPI) UpdatePatchBaseline(arg0 *ssm.UpdatePatchBaselineInput) (*ssm.UpdatePatchBaselineOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdatePatchBaseline", arg0)
 	ret0, _ := ret[0].(*ssm.UpdatePatchBaselineOutput)
 	ret1, _ := ret[1].(error)
@@ -5957,13 +5248,11 @@ func (m *MockSSMAPI) UpdatePatchBaseline(arg0 *ssm.UpdatePatchBaselineInput) (*s
 
 // UpdatePatchBaseline indicates an expected call of UpdatePatchBaseline
 func (mr *MockSSMAPIMockRecorder) UpdatePatchBaseline(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdatePatchBaseline", reflect.TypeOf((*MockSSMAPI)(nil).UpdatePatchBaseline), arg0)
 }
 
 // UpdatePatchBaselineRequest mocks base method
 func (m *MockSSMAPI) UpdatePatchBaselineRequest(arg0 *ssm.UpdatePatchBaselineInput) (*request.Request, *ssm.UpdatePatchBaselineOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdatePatchBaselineRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ssm.UpdatePatchBaselineOutput)
@@ -5972,13 +5261,11 @@ func (m *MockSSMAPI) UpdatePatchBaselineRequest(arg0 *ssm.UpdatePatchBaselineInp
 
 // UpdatePatchBaselineRequest indicates an expected call of UpdatePatchBaselineRequest
 func (mr *MockSSMAPIMockRecorder) UpdatePatchBaselineRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdatePatchBaselineRequest", reflect.TypeOf((*MockSSMAPI)(nil).UpdatePatchBaselineRequest), arg0)
 }
 
 // UpdatePatchBaselineWithContext mocks base method
 func (m *MockSSMAPI) UpdatePatchBaselineWithContext(arg0 context.Context, arg1 *ssm.UpdatePatchBaselineInput, arg2 ...request.Option) (*ssm.UpdatePatchBaselineOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -5991,14 +5278,12 @@ func (m *MockSSMAPI) UpdatePatchBaselineWithContext(arg0 context.Context, arg1 *
 
 // UpdatePatchBaselineWithContext indicates an expected call of UpdatePatchBaselineWithContext
 func (mr *MockSSMAPIMockRecorder) UpdatePatchBaselineWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdatePatchBaselineWithContext", reflect.TypeOf((*MockSSMAPI)(nil).UpdatePatchBaselineWithContext), varargs...)
 }
 
 // UpdateServiceSetting mocks base method
 func (m *MockSSMAPI) UpdateServiceSetting(arg0 *ssm.UpdateServiceSettingInput) (*ssm.UpdateServiceSettingOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateServiceSetting", arg0)
 	ret0, _ := ret[0].(*ssm.UpdateServiceSettingOutput)
 	ret1, _ := ret[1].(error)
@@ -6007,13 +5292,11 @@ func (m *MockSSMAPI) UpdateServiceSetting(arg0 *ssm.UpdateServiceSettingInput) (
 
 // UpdateServiceSetting indicates an expected call of UpdateServiceSetting
 func (mr *MockSSMAPIMockRecorder) UpdateServiceSetting(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateServiceSetting", reflect.TypeOf((*MockSSMAPI)(nil).UpdateServiceSetting), arg0)
 }
 
 // UpdateServiceSettingRequest mocks base method
 func (m *MockSSMAPI) UpdateServiceSettingRequest(arg0 *ssm.UpdateServiceSettingInput) (*request.Request, *ssm.UpdateServiceSettingOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateServiceSettingRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ssm.UpdateServiceSettingOutput)
@@ -6022,13 +5305,11 @@ func (m *MockSSMAPI) UpdateServiceSettingRequest(arg0 *ssm.UpdateServiceSettingI
 
 // UpdateServiceSettingRequest indicates an expected call of UpdateServiceSettingRequest
 func (mr *MockSSMAPIMockRecorder) UpdateServiceSettingRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateServiceSettingRequest", reflect.TypeOf((*MockSSMAPI)(nil).UpdateServiceSettingRequest), arg0)
 }
 
 // UpdateServiceSettingWithContext mocks base method
 func (m *MockSSMAPI) UpdateServiceSettingWithContext(arg0 context.Context, arg1 *ssm.UpdateServiceSettingInput, arg2 ...request.Option) (*ssm.UpdateServiceSettingOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -6041,7 +5322,6 @@ func (m *MockSSMAPI) UpdateServiceSettingWithContext(arg0 context.Context, arg1 
 
 // UpdateServiceSettingWithContext indicates an expected call of UpdateServiceSettingWithContext
 func (mr *MockSSMAPIMockRecorder) UpdateServiceSettingWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateServiceSettingWithContext", reflect.TypeOf((*MockSSMAPI)(nil).UpdateServiceSettingWithContext), varargs...)
 }

--- a/ecs-cli/modules/clients/aws/cloudformation/mock/client.go
+++ b/ecs-cli/modules/clients/aws/cloudformation/mock/client.go
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2015-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the
@@ -50,7 +50,6 @@ func (m *MockCloudformationClient) EXPECT() *MockCloudformationClientMockRecorde
 
 // CreateStack mocks base method
 func (m *MockCloudformationClient) CreateStack(arg0, arg1 string, arg2 bool, arg3 *cloudformation.CfnStackParams, arg4 []*cloudformation0.Tag) (string, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateStack", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
@@ -59,13 +58,11 @@ func (m *MockCloudformationClient) CreateStack(arg0, arg1 string, arg2 bool, arg
 
 // CreateStack indicates an expected call of CreateStack
 func (mr *MockCloudformationClientMockRecorder) CreateStack(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateStack", reflect.TypeOf((*MockCloudformationClient)(nil).CreateStack), arg0, arg1, arg2, arg3, arg4)
 }
 
 // DeleteStack mocks base method
 func (m *MockCloudformationClient) DeleteStack(arg0 string) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteStack", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -73,13 +70,11 @@ func (m *MockCloudformationClient) DeleteStack(arg0 string) error {
 
 // DeleteStack indicates an expected call of DeleteStack
 func (mr *MockCloudformationClientMockRecorder) DeleteStack(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteStack", reflect.TypeOf((*MockCloudformationClient)(nil).DeleteStack), arg0)
 }
 
 // DescribeNetworkResources mocks base method
 func (m *MockCloudformationClient) DescribeNetworkResources(arg0 string) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeNetworkResources", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -87,13 +82,11 @@ func (m *MockCloudformationClient) DescribeNetworkResources(arg0 string) error {
 
 // DescribeNetworkResources indicates an expected call of DescribeNetworkResources
 func (mr *MockCloudformationClientMockRecorder) DescribeNetworkResources(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeNetworkResources", reflect.TypeOf((*MockCloudformationClient)(nil).DescribeNetworkResources), arg0)
 }
 
 // DescribeStacks mocks base method
 func (m *MockCloudformationClient) DescribeStacks(arg0 string) (*cloudformation0.DescribeStacksOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeStacks", arg0)
 	ret0, _ := ret[0].(*cloudformation0.DescribeStacksOutput)
 	ret1, _ := ret[1].(error)
@@ -102,13 +95,11 @@ func (m *MockCloudformationClient) DescribeStacks(arg0 string) (*cloudformation0
 
 // DescribeStacks indicates an expected call of DescribeStacks
 func (mr *MockCloudformationClientMockRecorder) DescribeStacks(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeStacks", reflect.TypeOf((*MockCloudformationClient)(nil).DescribeStacks), arg0)
 }
 
 // GetStackParameters mocks base method
 func (m *MockCloudformationClient) GetStackParameters(arg0 string) ([]*cloudformation0.Parameter, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetStackParameters", arg0)
 	ret0, _ := ret[0].([]*cloudformation0.Parameter)
 	ret1, _ := ret[1].(error)
@@ -117,13 +108,11 @@ func (m *MockCloudformationClient) GetStackParameters(arg0 string) ([]*cloudform
 
 // GetStackParameters indicates an expected call of GetStackParameters
 func (mr *MockCloudformationClientMockRecorder) GetStackParameters(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetStackParameters", reflect.TypeOf((*MockCloudformationClient)(nil).GetStackParameters), arg0)
 }
 
 // UpdateStack mocks base method
 func (m *MockCloudformationClient) UpdateStack(arg0 string, arg1 *cloudformation.CfnStackParams) (string, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateStack", arg0, arg1)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
@@ -132,13 +121,11 @@ func (m *MockCloudformationClient) UpdateStack(arg0 string, arg1 *cloudformation
 
 // UpdateStack indicates an expected call of UpdateStack
 func (mr *MockCloudformationClientMockRecorder) UpdateStack(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateStack", reflect.TypeOf((*MockCloudformationClient)(nil).UpdateStack), arg0, arg1)
 }
 
 // ValidateStackExists mocks base method
 func (m *MockCloudformationClient) ValidateStackExists(arg0 string) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ValidateStackExists", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -146,13 +133,11 @@ func (m *MockCloudformationClient) ValidateStackExists(arg0 string) error {
 
 // ValidateStackExists indicates an expected call of ValidateStackExists
 func (mr *MockCloudformationClientMockRecorder) ValidateStackExists(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateStackExists", reflect.TypeOf((*MockCloudformationClient)(nil).ValidateStackExists), arg0)
 }
 
 // WaitUntilCreateComplete mocks base method
 func (m *MockCloudformationClient) WaitUntilCreateComplete(arg0 string) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WaitUntilCreateComplete", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -160,13 +145,11 @@ func (m *MockCloudformationClient) WaitUntilCreateComplete(arg0 string) error {
 
 // WaitUntilCreateComplete indicates an expected call of WaitUntilCreateComplete
 func (mr *MockCloudformationClientMockRecorder) WaitUntilCreateComplete(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitUntilCreateComplete", reflect.TypeOf((*MockCloudformationClient)(nil).WaitUntilCreateComplete), arg0)
 }
 
 // WaitUntilDeleteComplete mocks base method
 func (m *MockCloudformationClient) WaitUntilDeleteComplete(arg0 string) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WaitUntilDeleteComplete", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -174,13 +157,11 @@ func (m *MockCloudformationClient) WaitUntilDeleteComplete(arg0 string) error {
 
 // WaitUntilDeleteComplete indicates an expected call of WaitUntilDeleteComplete
 func (mr *MockCloudformationClientMockRecorder) WaitUntilDeleteComplete(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitUntilDeleteComplete", reflect.TypeOf((*MockCloudformationClient)(nil).WaitUntilDeleteComplete), arg0)
 }
 
 // WaitUntilUpdateComplete mocks base method
 func (m *MockCloudformationClient) WaitUntilUpdateComplete(arg0 string) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WaitUntilUpdateComplete", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -188,6 +169,5 @@ func (m *MockCloudformationClient) WaitUntilUpdateComplete(arg0 string) error {
 
 // WaitUntilUpdateComplete indicates an expected call of WaitUntilUpdateComplete
 func (mr *MockCloudformationClientMockRecorder) WaitUntilUpdateComplete(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitUntilUpdateComplete", reflect.TypeOf((*MockCloudformationClient)(nil).WaitUntilUpdateComplete), arg0)
 }

--- a/ecs-cli/modules/clients/aws/cloudformation/mock/sdk/cloudformationiface_mock.go
+++ b/ecs-cli/modules/clients/aws/cloudformation/mock/sdk/cloudformationiface_mock.go
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2015-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the
@@ -51,7 +51,6 @@ func (m *MockCloudFormationAPI) EXPECT() *MockCloudFormationAPIMockRecorder {
 
 // CancelUpdateStack mocks base method
 func (m *MockCloudFormationAPI) CancelUpdateStack(arg0 *cloudformation.CancelUpdateStackInput) (*cloudformation.CancelUpdateStackOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CancelUpdateStack", arg0)
 	ret0, _ := ret[0].(*cloudformation.CancelUpdateStackOutput)
 	ret1, _ := ret[1].(error)
@@ -60,13 +59,11 @@ func (m *MockCloudFormationAPI) CancelUpdateStack(arg0 *cloudformation.CancelUpd
 
 // CancelUpdateStack indicates an expected call of CancelUpdateStack
 func (mr *MockCloudFormationAPIMockRecorder) CancelUpdateStack(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CancelUpdateStack", reflect.TypeOf((*MockCloudFormationAPI)(nil).CancelUpdateStack), arg0)
 }
 
 // CancelUpdateStackRequest mocks base method
 func (m *MockCloudFormationAPI) CancelUpdateStackRequest(arg0 *cloudformation.CancelUpdateStackInput) (*request.Request, *cloudformation.CancelUpdateStackOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CancelUpdateStackRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*cloudformation.CancelUpdateStackOutput)
@@ -75,13 +72,11 @@ func (m *MockCloudFormationAPI) CancelUpdateStackRequest(arg0 *cloudformation.Ca
 
 // CancelUpdateStackRequest indicates an expected call of CancelUpdateStackRequest
 func (mr *MockCloudFormationAPIMockRecorder) CancelUpdateStackRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CancelUpdateStackRequest", reflect.TypeOf((*MockCloudFormationAPI)(nil).CancelUpdateStackRequest), arg0)
 }
 
 // CancelUpdateStackWithContext mocks base method
 func (m *MockCloudFormationAPI) CancelUpdateStackWithContext(arg0 context.Context, arg1 *cloudformation.CancelUpdateStackInput, arg2 ...request.Option) (*cloudformation.CancelUpdateStackOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -94,14 +89,12 @@ func (m *MockCloudFormationAPI) CancelUpdateStackWithContext(arg0 context.Contex
 
 // CancelUpdateStackWithContext indicates an expected call of CancelUpdateStackWithContext
 func (mr *MockCloudFormationAPIMockRecorder) CancelUpdateStackWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CancelUpdateStackWithContext", reflect.TypeOf((*MockCloudFormationAPI)(nil).CancelUpdateStackWithContext), varargs...)
 }
 
 // ContinueUpdateRollback mocks base method
 func (m *MockCloudFormationAPI) ContinueUpdateRollback(arg0 *cloudformation.ContinueUpdateRollbackInput) (*cloudformation.ContinueUpdateRollbackOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ContinueUpdateRollback", arg0)
 	ret0, _ := ret[0].(*cloudformation.ContinueUpdateRollbackOutput)
 	ret1, _ := ret[1].(error)
@@ -110,13 +103,11 @@ func (m *MockCloudFormationAPI) ContinueUpdateRollback(arg0 *cloudformation.Cont
 
 // ContinueUpdateRollback indicates an expected call of ContinueUpdateRollback
 func (mr *MockCloudFormationAPIMockRecorder) ContinueUpdateRollback(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContinueUpdateRollback", reflect.TypeOf((*MockCloudFormationAPI)(nil).ContinueUpdateRollback), arg0)
 }
 
 // ContinueUpdateRollbackRequest mocks base method
 func (m *MockCloudFormationAPI) ContinueUpdateRollbackRequest(arg0 *cloudformation.ContinueUpdateRollbackInput) (*request.Request, *cloudformation.ContinueUpdateRollbackOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ContinueUpdateRollbackRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*cloudformation.ContinueUpdateRollbackOutput)
@@ -125,13 +116,11 @@ func (m *MockCloudFormationAPI) ContinueUpdateRollbackRequest(arg0 *cloudformati
 
 // ContinueUpdateRollbackRequest indicates an expected call of ContinueUpdateRollbackRequest
 func (mr *MockCloudFormationAPIMockRecorder) ContinueUpdateRollbackRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContinueUpdateRollbackRequest", reflect.TypeOf((*MockCloudFormationAPI)(nil).ContinueUpdateRollbackRequest), arg0)
 }
 
 // ContinueUpdateRollbackWithContext mocks base method
 func (m *MockCloudFormationAPI) ContinueUpdateRollbackWithContext(arg0 context.Context, arg1 *cloudformation.ContinueUpdateRollbackInput, arg2 ...request.Option) (*cloudformation.ContinueUpdateRollbackOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -144,14 +133,12 @@ func (m *MockCloudFormationAPI) ContinueUpdateRollbackWithContext(arg0 context.C
 
 // ContinueUpdateRollbackWithContext indicates an expected call of ContinueUpdateRollbackWithContext
 func (mr *MockCloudFormationAPIMockRecorder) ContinueUpdateRollbackWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContinueUpdateRollbackWithContext", reflect.TypeOf((*MockCloudFormationAPI)(nil).ContinueUpdateRollbackWithContext), varargs...)
 }
 
 // CreateChangeSet mocks base method
 func (m *MockCloudFormationAPI) CreateChangeSet(arg0 *cloudformation.CreateChangeSetInput) (*cloudformation.CreateChangeSetOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateChangeSet", arg0)
 	ret0, _ := ret[0].(*cloudformation.CreateChangeSetOutput)
 	ret1, _ := ret[1].(error)
@@ -160,13 +147,11 @@ func (m *MockCloudFormationAPI) CreateChangeSet(arg0 *cloudformation.CreateChang
 
 // CreateChangeSet indicates an expected call of CreateChangeSet
 func (mr *MockCloudFormationAPIMockRecorder) CreateChangeSet(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateChangeSet", reflect.TypeOf((*MockCloudFormationAPI)(nil).CreateChangeSet), arg0)
 }
 
 // CreateChangeSetRequest mocks base method
 func (m *MockCloudFormationAPI) CreateChangeSetRequest(arg0 *cloudformation.CreateChangeSetInput) (*request.Request, *cloudformation.CreateChangeSetOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateChangeSetRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*cloudformation.CreateChangeSetOutput)
@@ -175,13 +160,11 @@ func (m *MockCloudFormationAPI) CreateChangeSetRequest(arg0 *cloudformation.Crea
 
 // CreateChangeSetRequest indicates an expected call of CreateChangeSetRequest
 func (mr *MockCloudFormationAPIMockRecorder) CreateChangeSetRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateChangeSetRequest", reflect.TypeOf((*MockCloudFormationAPI)(nil).CreateChangeSetRequest), arg0)
 }
 
 // CreateChangeSetWithContext mocks base method
 func (m *MockCloudFormationAPI) CreateChangeSetWithContext(arg0 context.Context, arg1 *cloudformation.CreateChangeSetInput, arg2 ...request.Option) (*cloudformation.CreateChangeSetOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -194,14 +177,12 @@ func (m *MockCloudFormationAPI) CreateChangeSetWithContext(arg0 context.Context,
 
 // CreateChangeSetWithContext indicates an expected call of CreateChangeSetWithContext
 func (mr *MockCloudFormationAPIMockRecorder) CreateChangeSetWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateChangeSetWithContext", reflect.TypeOf((*MockCloudFormationAPI)(nil).CreateChangeSetWithContext), varargs...)
 }
 
 // CreateStack mocks base method
 func (m *MockCloudFormationAPI) CreateStack(arg0 *cloudformation.CreateStackInput) (*cloudformation.CreateStackOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateStack", arg0)
 	ret0, _ := ret[0].(*cloudformation.CreateStackOutput)
 	ret1, _ := ret[1].(error)
@@ -210,13 +191,11 @@ func (m *MockCloudFormationAPI) CreateStack(arg0 *cloudformation.CreateStackInpu
 
 // CreateStack indicates an expected call of CreateStack
 func (mr *MockCloudFormationAPIMockRecorder) CreateStack(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateStack", reflect.TypeOf((*MockCloudFormationAPI)(nil).CreateStack), arg0)
 }
 
 // CreateStackInstances mocks base method
 func (m *MockCloudFormationAPI) CreateStackInstances(arg0 *cloudformation.CreateStackInstancesInput) (*cloudformation.CreateStackInstancesOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateStackInstances", arg0)
 	ret0, _ := ret[0].(*cloudformation.CreateStackInstancesOutput)
 	ret1, _ := ret[1].(error)
@@ -225,13 +204,11 @@ func (m *MockCloudFormationAPI) CreateStackInstances(arg0 *cloudformation.Create
 
 // CreateStackInstances indicates an expected call of CreateStackInstances
 func (mr *MockCloudFormationAPIMockRecorder) CreateStackInstances(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateStackInstances", reflect.TypeOf((*MockCloudFormationAPI)(nil).CreateStackInstances), arg0)
 }
 
 // CreateStackInstancesRequest mocks base method
 func (m *MockCloudFormationAPI) CreateStackInstancesRequest(arg0 *cloudformation.CreateStackInstancesInput) (*request.Request, *cloudformation.CreateStackInstancesOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateStackInstancesRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*cloudformation.CreateStackInstancesOutput)
@@ -240,13 +217,11 @@ func (m *MockCloudFormationAPI) CreateStackInstancesRequest(arg0 *cloudformation
 
 // CreateStackInstancesRequest indicates an expected call of CreateStackInstancesRequest
 func (mr *MockCloudFormationAPIMockRecorder) CreateStackInstancesRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateStackInstancesRequest", reflect.TypeOf((*MockCloudFormationAPI)(nil).CreateStackInstancesRequest), arg0)
 }
 
 // CreateStackInstancesWithContext mocks base method
 func (m *MockCloudFormationAPI) CreateStackInstancesWithContext(arg0 context.Context, arg1 *cloudformation.CreateStackInstancesInput, arg2 ...request.Option) (*cloudformation.CreateStackInstancesOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -259,14 +234,12 @@ func (m *MockCloudFormationAPI) CreateStackInstancesWithContext(arg0 context.Con
 
 // CreateStackInstancesWithContext indicates an expected call of CreateStackInstancesWithContext
 func (mr *MockCloudFormationAPIMockRecorder) CreateStackInstancesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateStackInstancesWithContext", reflect.TypeOf((*MockCloudFormationAPI)(nil).CreateStackInstancesWithContext), varargs...)
 }
 
 // CreateStackRequest mocks base method
 func (m *MockCloudFormationAPI) CreateStackRequest(arg0 *cloudformation.CreateStackInput) (*request.Request, *cloudformation.CreateStackOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateStackRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*cloudformation.CreateStackOutput)
@@ -275,13 +248,11 @@ func (m *MockCloudFormationAPI) CreateStackRequest(arg0 *cloudformation.CreateSt
 
 // CreateStackRequest indicates an expected call of CreateStackRequest
 func (mr *MockCloudFormationAPIMockRecorder) CreateStackRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateStackRequest", reflect.TypeOf((*MockCloudFormationAPI)(nil).CreateStackRequest), arg0)
 }
 
 // CreateStackSet mocks base method
 func (m *MockCloudFormationAPI) CreateStackSet(arg0 *cloudformation.CreateStackSetInput) (*cloudformation.CreateStackSetOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateStackSet", arg0)
 	ret0, _ := ret[0].(*cloudformation.CreateStackSetOutput)
 	ret1, _ := ret[1].(error)
@@ -290,13 +261,11 @@ func (m *MockCloudFormationAPI) CreateStackSet(arg0 *cloudformation.CreateStackS
 
 // CreateStackSet indicates an expected call of CreateStackSet
 func (mr *MockCloudFormationAPIMockRecorder) CreateStackSet(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateStackSet", reflect.TypeOf((*MockCloudFormationAPI)(nil).CreateStackSet), arg0)
 }
 
 // CreateStackSetRequest mocks base method
 func (m *MockCloudFormationAPI) CreateStackSetRequest(arg0 *cloudformation.CreateStackSetInput) (*request.Request, *cloudformation.CreateStackSetOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateStackSetRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*cloudformation.CreateStackSetOutput)
@@ -305,13 +274,11 @@ func (m *MockCloudFormationAPI) CreateStackSetRequest(arg0 *cloudformation.Creat
 
 // CreateStackSetRequest indicates an expected call of CreateStackSetRequest
 func (mr *MockCloudFormationAPIMockRecorder) CreateStackSetRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateStackSetRequest", reflect.TypeOf((*MockCloudFormationAPI)(nil).CreateStackSetRequest), arg0)
 }
 
 // CreateStackSetWithContext mocks base method
 func (m *MockCloudFormationAPI) CreateStackSetWithContext(arg0 context.Context, arg1 *cloudformation.CreateStackSetInput, arg2 ...request.Option) (*cloudformation.CreateStackSetOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -324,14 +291,12 @@ func (m *MockCloudFormationAPI) CreateStackSetWithContext(arg0 context.Context, 
 
 // CreateStackSetWithContext indicates an expected call of CreateStackSetWithContext
 func (mr *MockCloudFormationAPIMockRecorder) CreateStackSetWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateStackSetWithContext", reflect.TypeOf((*MockCloudFormationAPI)(nil).CreateStackSetWithContext), varargs...)
 }
 
 // CreateStackWithContext mocks base method
 func (m *MockCloudFormationAPI) CreateStackWithContext(arg0 context.Context, arg1 *cloudformation.CreateStackInput, arg2 ...request.Option) (*cloudformation.CreateStackOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -344,14 +309,12 @@ func (m *MockCloudFormationAPI) CreateStackWithContext(arg0 context.Context, arg
 
 // CreateStackWithContext indicates an expected call of CreateStackWithContext
 func (mr *MockCloudFormationAPIMockRecorder) CreateStackWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateStackWithContext", reflect.TypeOf((*MockCloudFormationAPI)(nil).CreateStackWithContext), varargs...)
 }
 
 // DeleteChangeSet mocks base method
 func (m *MockCloudFormationAPI) DeleteChangeSet(arg0 *cloudformation.DeleteChangeSetInput) (*cloudformation.DeleteChangeSetOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteChangeSet", arg0)
 	ret0, _ := ret[0].(*cloudformation.DeleteChangeSetOutput)
 	ret1, _ := ret[1].(error)
@@ -360,13 +323,11 @@ func (m *MockCloudFormationAPI) DeleteChangeSet(arg0 *cloudformation.DeleteChang
 
 // DeleteChangeSet indicates an expected call of DeleteChangeSet
 func (mr *MockCloudFormationAPIMockRecorder) DeleteChangeSet(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteChangeSet", reflect.TypeOf((*MockCloudFormationAPI)(nil).DeleteChangeSet), arg0)
 }
 
 // DeleteChangeSetRequest mocks base method
 func (m *MockCloudFormationAPI) DeleteChangeSetRequest(arg0 *cloudformation.DeleteChangeSetInput) (*request.Request, *cloudformation.DeleteChangeSetOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteChangeSetRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*cloudformation.DeleteChangeSetOutput)
@@ -375,13 +336,11 @@ func (m *MockCloudFormationAPI) DeleteChangeSetRequest(arg0 *cloudformation.Dele
 
 // DeleteChangeSetRequest indicates an expected call of DeleteChangeSetRequest
 func (mr *MockCloudFormationAPIMockRecorder) DeleteChangeSetRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteChangeSetRequest", reflect.TypeOf((*MockCloudFormationAPI)(nil).DeleteChangeSetRequest), arg0)
 }
 
 // DeleteChangeSetWithContext mocks base method
 func (m *MockCloudFormationAPI) DeleteChangeSetWithContext(arg0 context.Context, arg1 *cloudformation.DeleteChangeSetInput, arg2 ...request.Option) (*cloudformation.DeleteChangeSetOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -394,14 +353,12 @@ func (m *MockCloudFormationAPI) DeleteChangeSetWithContext(arg0 context.Context,
 
 // DeleteChangeSetWithContext indicates an expected call of DeleteChangeSetWithContext
 func (mr *MockCloudFormationAPIMockRecorder) DeleteChangeSetWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteChangeSetWithContext", reflect.TypeOf((*MockCloudFormationAPI)(nil).DeleteChangeSetWithContext), varargs...)
 }
 
 // DeleteStack mocks base method
 func (m *MockCloudFormationAPI) DeleteStack(arg0 *cloudformation.DeleteStackInput) (*cloudformation.DeleteStackOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteStack", arg0)
 	ret0, _ := ret[0].(*cloudformation.DeleteStackOutput)
 	ret1, _ := ret[1].(error)
@@ -410,13 +367,11 @@ func (m *MockCloudFormationAPI) DeleteStack(arg0 *cloudformation.DeleteStackInpu
 
 // DeleteStack indicates an expected call of DeleteStack
 func (mr *MockCloudFormationAPIMockRecorder) DeleteStack(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteStack", reflect.TypeOf((*MockCloudFormationAPI)(nil).DeleteStack), arg0)
 }
 
 // DeleteStackInstances mocks base method
 func (m *MockCloudFormationAPI) DeleteStackInstances(arg0 *cloudformation.DeleteStackInstancesInput) (*cloudformation.DeleteStackInstancesOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteStackInstances", arg0)
 	ret0, _ := ret[0].(*cloudformation.DeleteStackInstancesOutput)
 	ret1, _ := ret[1].(error)
@@ -425,13 +380,11 @@ func (m *MockCloudFormationAPI) DeleteStackInstances(arg0 *cloudformation.Delete
 
 // DeleteStackInstances indicates an expected call of DeleteStackInstances
 func (mr *MockCloudFormationAPIMockRecorder) DeleteStackInstances(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteStackInstances", reflect.TypeOf((*MockCloudFormationAPI)(nil).DeleteStackInstances), arg0)
 }
 
 // DeleteStackInstancesRequest mocks base method
 func (m *MockCloudFormationAPI) DeleteStackInstancesRequest(arg0 *cloudformation.DeleteStackInstancesInput) (*request.Request, *cloudformation.DeleteStackInstancesOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteStackInstancesRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*cloudformation.DeleteStackInstancesOutput)
@@ -440,13 +393,11 @@ func (m *MockCloudFormationAPI) DeleteStackInstancesRequest(arg0 *cloudformation
 
 // DeleteStackInstancesRequest indicates an expected call of DeleteStackInstancesRequest
 func (mr *MockCloudFormationAPIMockRecorder) DeleteStackInstancesRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteStackInstancesRequest", reflect.TypeOf((*MockCloudFormationAPI)(nil).DeleteStackInstancesRequest), arg0)
 }
 
 // DeleteStackInstancesWithContext mocks base method
 func (m *MockCloudFormationAPI) DeleteStackInstancesWithContext(arg0 context.Context, arg1 *cloudformation.DeleteStackInstancesInput, arg2 ...request.Option) (*cloudformation.DeleteStackInstancesOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -459,14 +410,12 @@ func (m *MockCloudFormationAPI) DeleteStackInstancesWithContext(arg0 context.Con
 
 // DeleteStackInstancesWithContext indicates an expected call of DeleteStackInstancesWithContext
 func (mr *MockCloudFormationAPIMockRecorder) DeleteStackInstancesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteStackInstancesWithContext", reflect.TypeOf((*MockCloudFormationAPI)(nil).DeleteStackInstancesWithContext), varargs...)
 }
 
 // DeleteStackRequest mocks base method
 func (m *MockCloudFormationAPI) DeleteStackRequest(arg0 *cloudformation.DeleteStackInput) (*request.Request, *cloudformation.DeleteStackOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteStackRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*cloudformation.DeleteStackOutput)
@@ -475,13 +424,11 @@ func (m *MockCloudFormationAPI) DeleteStackRequest(arg0 *cloudformation.DeleteSt
 
 // DeleteStackRequest indicates an expected call of DeleteStackRequest
 func (mr *MockCloudFormationAPIMockRecorder) DeleteStackRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteStackRequest", reflect.TypeOf((*MockCloudFormationAPI)(nil).DeleteStackRequest), arg0)
 }
 
 // DeleteStackSet mocks base method
 func (m *MockCloudFormationAPI) DeleteStackSet(arg0 *cloudformation.DeleteStackSetInput) (*cloudformation.DeleteStackSetOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteStackSet", arg0)
 	ret0, _ := ret[0].(*cloudformation.DeleteStackSetOutput)
 	ret1, _ := ret[1].(error)
@@ -490,13 +437,11 @@ func (m *MockCloudFormationAPI) DeleteStackSet(arg0 *cloudformation.DeleteStackS
 
 // DeleteStackSet indicates an expected call of DeleteStackSet
 func (mr *MockCloudFormationAPIMockRecorder) DeleteStackSet(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteStackSet", reflect.TypeOf((*MockCloudFormationAPI)(nil).DeleteStackSet), arg0)
 }
 
 // DeleteStackSetRequest mocks base method
 func (m *MockCloudFormationAPI) DeleteStackSetRequest(arg0 *cloudformation.DeleteStackSetInput) (*request.Request, *cloudformation.DeleteStackSetOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteStackSetRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*cloudformation.DeleteStackSetOutput)
@@ -505,13 +450,11 @@ func (m *MockCloudFormationAPI) DeleteStackSetRequest(arg0 *cloudformation.Delet
 
 // DeleteStackSetRequest indicates an expected call of DeleteStackSetRequest
 func (mr *MockCloudFormationAPIMockRecorder) DeleteStackSetRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteStackSetRequest", reflect.TypeOf((*MockCloudFormationAPI)(nil).DeleteStackSetRequest), arg0)
 }
 
 // DeleteStackSetWithContext mocks base method
 func (m *MockCloudFormationAPI) DeleteStackSetWithContext(arg0 context.Context, arg1 *cloudformation.DeleteStackSetInput, arg2 ...request.Option) (*cloudformation.DeleteStackSetOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -524,14 +467,12 @@ func (m *MockCloudFormationAPI) DeleteStackSetWithContext(arg0 context.Context, 
 
 // DeleteStackSetWithContext indicates an expected call of DeleteStackSetWithContext
 func (mr *MockCloudFormationAPIMockRecorder) DeleteStackSetWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteStackSetWithContext", reflect.TypeOf((*MockCloudFormationAPI)(nil).DeleteStackSetWithContext), varargs...)
 }
 
 // DeleteStackWithContext mocks base method
 func (m *MockCloudFormationAPI) DeleteStackWithContext(arg0 context.Context, arg1 *cloudformation.DeleteStackInput, arg2 ...request.Option) (*cloudformation.DeleteStackOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -544,14 +485,12 @@ func (m *MockCloudFormationAPI) DeleteStackWithContext(arg0 context.Context, arg
 
 // DeleteStackWithContext indicates an expected call of DeleteStackWithContext
 func (mr *MockCloudFormationAPIMockRecorder) DeleteStackWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteStackWithContext", reflect.TypeOf((*MockCloudFormationAPI)(nil).DeleteStackWithContext), varargs...)
 }
 
 // DescribeAccountLimits mocks base method
 func (m *MockCloudFormationAPI) DescribeAccountLimits(arg0 *cloudformation.DescribeAccountLimitsInput) (*cloudformation.DescribeAccountLimitsOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeAccountLimits", arg0)
 	ret0, _ := ret[0].(*cloudformation.DescribeAccountLimitsOutput)
 	ret1, _ := ret[1].(error)
@@ -560,13 +499,11 @@ func (m *MockCloudFormationAPI) DescribeAccountLimits(arg0 *cloudformation.Descr
 
 // DescribeAccountLimits indicates an expected call of DescribeAccountLimits
 func (mr *MockCloudFormationAPIMockRecorder) DescribeAccountLimits(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeAccountLimits", reflect.TypeOf((*MockCloudFormationAPI)(nil).DescribeAccountLimits), arg0)
 }
 
 // DescribeAccountLimitsRequest mocks base method
 func (m *MockCloudFormationAPI) DescribeAccountLimitsRequest(arg0 *cloudformation.DescribeAccountLimitsInput) (*request.Request, *cloudformation.DescribeAccountLimitsOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeAccountLimitsRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*cloudformation.DescribeAccountLimitsOutput)
@@ -575,13 +512,11 @@ func (m *MockCloudFormationAPI) DescribeAccountLimitsRequest(arg0 *cloudformatio
 
 // DescribeAccountLimitsRequest indicates an expected call of DescribeAccountLimitsRequest
 func (mr *MockCloudFormationAPIMockRecorder) DescribeAccountLimitsRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeAccountLimitsRequest", reflect.TypeOf((*MockCloudFormationAPI)(nil).DescribeAccountLimitsRequest), arg0)
 }
 
 // DescribeAccountLimitsWithContext mocks base method
 func (m *MockCloudFormationAPI) DescribeAccountLimitsWithContext(arg0 context.Context, arg1 *cloudformation.DescribeAccountLimitsInput, arg2 ...request.Option) (*cloudformation.DescribeAccountLimitsOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -594,14 +529,12 @@ func (m *MockCloudFormationAPI) DescribeAccountLimitsWithContext(arg0 context.Co
 
 // DescribeAccountLimitsWithContext indicates an expected call of DescribeAccountLimitsWithContext
 func (mr *MockCloudFormationAPIMockRecorder) DescribeAccountLimitsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeAccountLimitsWithContext", reflect.TypeOf((*MockCloudFormationAPI)(nil).DescribeAccountLimitsWithContext), varargs...)
 }
 
 // DescribeChangeSet mocks base method
 func (m *MockCloudFormationAPI) DescribeChangeSet(arg0 *cloudformation.DescribeChangeSetInput) (*cloudformation.DescribeChangeSetOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeChangeSet", arg0)
 	ret0, _ := ret[0].(*cloudformation.DescribeChangeSetOutput)
 	ret1, _ := ret[1].(error)
@@ -610,13 +543,11 @@ func (m *MockCloudFormationAPI) DescribeChangeSet(arg0 *cloudformation.DescribeC
 
 // DescribeChangeSet indicates an expected call of DescribeChangeSet
 func (mr *MockCloudFormationAPIMockRecorder) DescribeChangeSet(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeChangeSet", reflect.TypeOf((*MockCloudFormationAPI)(nil).DescribeChangeSet), arg0)
 }
 
 // DescribeChangeSetRequest mocks base method
 func (m *MockCloudFormationAPI) DescribeChangeSetRequest(arg0 *cloudformation.DescribeChangeSetInput) (*request.Request, *cloudformation.DescribeChangeSetOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeChangeSetRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*cloudformation.DescribeChangeSetOutput)
@@ -625,13 +556,11 @@ func (m *MockCloudFormationAPI) DescribeChangeSetRequest(arg0 *cloudformation.De
 
 // DescribeChangeSetRequest indicates an expected call of DescribeChangeSetRequest
 func (mr *MockCloudFormationAPIMockRecorder) DescribeChangeSetRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeChangeSetRequest", reflect.TypeOf((*MockCloudFormationAPI)(nil).DescribeChangeSetRequest), arg0)
 }
 
 // DescribeChangeSetWithContext mocks base method
 func (m *MockCloudFormationAPI) DescribeChangeSetWithContext(arg0 context.Context, arg1 *cloudformation.DescribeChangeSetInput, arg2 ...request.Option) (*cloudformation.DescribeChangeSetOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -644,14 +573,12 @@ func (m *MockCloudFormationAPI) DescribeChangeSetWithContext(arg0 context.Contex
 
 // DescribeChangeSetWithContext indicates an expected call of DescribeChangeSetWithContext
 func (mr *MockCloudFormationAPIMockRecorder) DescribeChangeSetWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeChangeSetWithContext", reflect.TypeOf((*MockCloudFormationAPI)(nil).DescribeChangeSetWithContext), varargs...)
 }
 
 // DescribeStackDriftDetectionStatus mocks base method
 func (m *MockCloudFormationAPI) DescribeStackDriftDetectionStatus(arg0 *cloudformation.DescribeStackDriftDetectionStatusInput) (*cloudformation.DescribeStackDriftDetectionStatusOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeStackDriftDetectionStatus", arg0)
 	ret0, _ := ret[0].(*cloudformation.DescribeStackDriftDetectionStatusOutput)
 	ret1, _ := ret[1].(error)
@@ -660,13 +587,11 @@ func (m *MockCloudFormationAPI) DescribeStackDriftDetectionStatus(arg0 *cloudfor
 
 // DescribeStackDriftDetectionStatus indicates an expected call of DescribeStackDriftDetectionStatus
 func (mr *MockCloudFormationAPIMockRecorder) DescribeStackDriftDetectionStatus(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeStackDriftDetectionStatus", reflect.TypeOf((*MockCloudFormationAPI)(nil).DescribeStackDriftDetectionStatus), arg0)
 }
 
 // DescribeStackDriftDetectionStatusRequest mocks base method
 func (m *MockCloudFormationAPI) DescribeStackDriftDetectionStatusRequest(arg0 *cloudformation.DescribeStackDriftDetectionStatusInput) (*request.Request, *cloudformation.DescribeStackDriftDetectionStatusOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeStackDriftDetectionStatusRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*cloudformation.DescribeStackDriftDetectionStatusOutput)
@@ -675,13 +600,11 @@ func (m *MockCloudFormationAPI) DescribeStackDriftDetectionStatusRequest(arg0 *c
 
 // DescribeStackDriftDetectionStatusRequest indicates an expected call of DescribeStackDriftDetectionStatusRequest
 func (mr *MockCloudFormationAPIMockRecorder) DescribeStackDriftDetectionStatusRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeStackDriftDetectionStatusRequest", reflect.TypeOf((*MockCloudFormationAPI)(nil).DescribeStackDriftDetectionStatusRequest), arg0)
 }
 
 // DescribeStackDriftDetectionStatusWithContext mocks base method
 func (m *MockCloudFormationAPI) DescribeStackDriftDetectionStatusWithContext(arg0 context.Context, arg1 *cloudformation.DescribeStackDriftDetectionStatusInput, arg2 ...request.Option) (*cloudformation.DescribeStackDriftDetectionStatusOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -694,14 +617,12 @@ func (m *MockCloudFormationAPI) DescribeStackDriftDetectionStatusWithContext(arg
 
 // DescribeStackDriftDetectionStatusWithContext indicates an expected call of DescribeStackDriftDetectionStatusWithContext
 func (mr *MockCloudFormationAPIMockRecorder) DescribeStackDriftDetectionStatusWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeStackDriftDetectionStatusWithContext", reflect.TypeOf((*MockCloudFormationAPI)(nil).DescribeStackDriftDetectionStatusWithContext), varargs...)
 }
 
 // DescribeStackEvents mocks base method
 func (m *MockCloudFormationAPI) DescribeStackEvents(arg0 *cloudformation.DescribeStackEventsInput) (*cloudformation.DescribeStackEventsOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeStackEvents", arg0)
 	ret0, _ := ret[0].(*cloudformation.DescribeStackEventsOutput)
 	ret1, _ := ret[1].(error)
@@ -710,13 +631,11 @@ func (m *MockCloudFormationAPI) DescribeStackEvents(arg0 *cloudformation.Describ
 
 // DescribeStackEvents indicates an expected call of DescribeStackEvents
 func (mr *MockCloudFormationAPIMockRecorder) DescribeStackEvents(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeStackEvents", reflect.TypeOf((*MockCloudFormationAPI)(nil).DescribeStackEvents), arg0)
 }
 
 // DescribeStackEventsPages mocks base method
 func (m *MockCloudFormationAPI) DescribeStackEventsPages(arg0 *cloudformation.DescribeStackEventsInput, arg1 func(*cloudformation.DescribeStackEventsOutput, bool) bool) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeStackEventsPages", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -724,13 +643,11 @@ func (m *MockCloudFormationAPI) DescribeStackEventsPages(arg0 *cloudformation.De
 
 // DescribeStackEventsPages indicates an expected call of DescribeStackEventsPages
 func (mr *MockCloudFormationAPIMockRecorder) DescribeStackEventsPages(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeStackEventsPages", reflect.TypeOf((*MockCloudFormationAPI)(nil).DescribeStackEventsPages), arg0, arg1)
 }
 
 // DescribeStackEventsPagesWithContext mocks base method
 func (m *MockCloudFormationAPI) DescribeStackEventsPagesWithContext(arg0 context.Context, arg1 *cloudformation.DescribeStackEventsInput, arg2 func(*cloudformation.DescribeStackEventsOutput, bool) bool, arg3 ...request.Option) error {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1, arg2}
 	for _, a := range arg3 {
 		varargs = append(varargs, a)
@@ -742,14 +659,12 @@ func (m *MockCloudFormationAPI) DescribeStackEventsPagesWithContext(arg0 context
 
 // DescribeStackEventsPagesWithContext indicates an expected call of DescribeStackEventsPagesWithContext
 func (mr *MockCloudFormationAPIMockRecorder) DescribeStackEventsPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeStackEventsPagesWithContext", reflect.TypeOf((*MockCloudFormationAPI)(nil).DescribeStackEventsPagesWithContext), varargs...)
 }
 
 // DescribeStackEventsRequest mocks base method
 func (m *MockCloudFormationAPI) DescribeStackEventsRequest(arg0 *cloudformation.DescribeStackEventsInput) (*request.Request, *cloudformation.DescribeStackEventsOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeStackEventsRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*cloudformation.DescribeStackEventsOutput)
@@ -758,13 +673,11 @@ func (m *MockCloudFormationAPI) DescribeStackEventsRequest(arg0 *cloudformation.
 
 // DescribeStackEventsRequest indicates an expected call of DescribeStackEventsRequest
 func (mr *MockCloudFormationAPIMockRecorder) DescribeStackEventsRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeStackEventsRequest", reflect.TypeOf((*MockCloudFormationAPI)(nil).DescribeStackEventsRequest), arg0)
 }
 
 // DescribeStackEventsWithContext mocks base method
 func (m *MockCloudFormationAPI) DescribeStackEventsWithContext(arg0 context.Context, arg1 *cloudformation.DescribeStackEventsInput, arg2 ...request.Option) (*cloudformation.DescribeStackEventsOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -777,14 +690,12 @@ func (m *MockCloudFormationAPI) DescribeStackEventsWithContext(arg0 context.Cont
 
 // DescribeStackEventsWithContext indicates an expected call of DescribeStackEventsWithContext
 func (mr *MockCloudFormationAPIMockRecorder) DescribeStackEventsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeStackEventsWithContext", reflect.TypeOf((*MockCloudFormationAPI)(nil).DescribeStackEventsWithContext), varargs...)
 }
 
 // DescribeStackInstance mocks base method
 func (m *MockCloudFormationAPI) DescribeStackInstance(arg0 *cloudformation.DescribeStackInstanceInput) (*cloudformation.DescribeStackInstanceOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeStackInstance", arg0)
 	ret0, _ := ret[0].(*cloudformation.DescribeStackInstanceOutput)
 	ret1, _ := ret[1].(error)
@@ -793,13 +704,11 @@ func (m *MockCloudFormationAPI) DescribeStackInstance(arg0 *cloudformation.Descr
 
 // DescribeStackInstance indicates an expected call of DescribeStackInstance
 func (mr *MockCloudFormationAPIMockRecorder) DescribeStackInstance(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeStackInstance", reflect.TypeOf((*MockCloudFormationAPI)(nil).DescribeStackInstance), arg0)
 }
 
 // DescribeStackInstanceRequest mocks base method
 func (m *MockCloudFormationAPI) DescribeStackInstanceRequest(arg0 *cloudformation.DescribeStackInstanceInput) (*request.Request, *cloudformation.DescribeStackInstanceOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeStackInstanceRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*cloudformation.DescribeStackInstanceOutput)
@@ -808,13 +717,11 @@ func (m *MockCloudFormationAPI) DescribeStackInstanceRequest(arg0 *cloudformatio
 
 // DescribeStackInstanceRequest indicates an expected call of DescribeStackInstanceRequest
 func (mr *MockCloudFormationAPIMockRecorder) DescribeStackInstanceRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeStackInstanceRequest", reflect.TypeOf((*MockCloudFormationAPI)(nil).DescribeStackInstanceRequest), arg0)
 }
 
 // DescribeStackInstanceWithContext mocks base method
 func (m *MockCloudFormationAPI) DescribeStackInstanceWithContext(arg0 context.Context, arg1 *cloudformation.DescribeStackInstanceInput, arg2 ...request.Option) (*cloudformation.DescribeStackInstanceOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -827,14 +734,12 @@ func (m *MockCloudFormationAPI) DescribeStackInstanceWithContext(arg0 context.Co
 
 // DescribeStackInstanceWithContext indicates an expected call of DescribeStackInstanceWithContext
 func (mr *MockCloudFormationAPIMockRecorder) DescribeStackInstanceWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeStackInstanceWithContext", reflect.TypeOf((*MockCloudFormationAPI)(nil).DescribeStackInstanceWithContext), varargs...)
 }
 
 // DescribeStackResource mocks base method
 func (m *MockCloudFormationAPI) DescribeStackResource(arg0 *cloudformation.DescribeStackResourceInput) (*cloudformation.DescribeStackResourceOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeStackResource", arg0)
 	ret0, _ := ret[0].(*cloudformation.DescribeStackResourceOutput)
 	ret1, _ := ret[1].(error)
@@ -843,13 +748,11 @@ func (m *MockCloudFormationAPI) DescribeStackResource(arg0 *cloudformation.Descr
 
 // DescribeStackResource indicates an expected call of DescribeStackResource
 func (mr *MockCloudFormationAPIMockRecorder) DescribeStackResource(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeStackResource", reflect.TypeOf((*MockCloudFormationAPI)(nil).DescribeStackResource), arg0)
 }
 
 // DescribeStackResourceDrifts mocks base method
 func (m *MockCloudFormationAPI) DescribeStackResourceDrifts(arg0 *cloudformation.DescribeStackResourceDriftsInput) (*cloudformation.DescribeStackResourceDriftsOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeStackResourceDrifts", arg0)
 	ret0, _ := ret[0].(*cloudformation.DescribeStackResourceDriftsOutput)
 	ret1, _ := ret[1].(error)
@@ -858,13 +761,11 @@ func (m *MockCloudFormationAPI) DescribeStackResourceDrifts(arg0 *cloudformation
 
 // DescribeStackResourceDrifts indicates an expected call of DescribeStackResourceDrifts
 func (mr *MockCloudFormationAPIMockRecorder) DescribeStackResourceDrifts(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeStackResourceDrifts", reflect.TypeOf((*MockCloudFormationAPI)(nil).DescribeStackResourceDrifts), arg0)
 }
 
 // DescribeStackResourceDriftsPages mocks base method
 func (m *MockCloudFormationAPI) DescribeStackResourceDriftsPages(arg0 *cloudformation.DescribeStackResourceDriftsInput, arg1 func(*cloudformation.DescribeStackResourceDriftsOutput, bool) bool) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeStackResourceDriftsPages", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -872,13 +773,11 @@ func (m *MockCloudFormationAPI) DescribeStackResourceDriftsPages(arg0 *cloudform
 
 // DescribeStackResourceDriftsPages indicates an expected call of DescribeStackResourceDriftsPages
 func (mr *MockCloudFormationAPIMockRecorder) DescribeStackResourceDriftsPages(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeStackResourceDriftsPages", reflect.TypeOf((*MockCloudFormationAPI)(nil).DescribeStackResourceDriftsPages), arg0, arg1)
 }
 
 // DescribeStackResourceDriftsPagesWithContext mocks base method
 func (m *MockCloudFormationAPI) DescribeStackResourceDriftsPagesWithContext(arg0 context.Context, arg1 *cloudformation.DescribeStackResourceDriftsInput, arg2 func(*cloudformation.DescribeStackResourceDriftsOutput, bool) bool, arg3 ...request.Option) error {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1, arg2}
 	for _, a := range arg3 {
 		varargs = append(varargs, a)
@@ -890,14 +789,12 @@ func (m *MockCloudFormationAPI) DescribeStackResourceDriftsPagesWithContext(arg0
 
 // DescribeStackResourceDriftsPagesWithContext indicates an expected call of DescribeStackResourceDriftsPagesWithContext
 func (mr *MockCloudFormationAPIMockRecorder) DescribeStackResourceDriftsPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeStackResourceDriftsPagesWithContext", reflect.TypeOf((*MockCloudFormationAPI)(nil).DescribeStackResourceDriftsPagesWithContext), varargs...)
 }
 
 // DescribeStackResourceDriftsRequest mocks base method
 func (m *MockCloudFormationAPI) DescribeStackResourceDriftsRequest(arg0 *cloudformation.DescribeStackResourceDriftsInput) (*request.Request, *cloudformation.DescribeStackResourceDriftsOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeStackResourceDriftsRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*cloudformation.DescribeStackResourceDriftsOutput)
@@ -906,13 +803,11 @@ func (m *MockCloudFormationAPI) DescribeStackResourceDriftsRequest(arg0 *cloudfo
 
 // DescribeStackResourceDriftsRequest indicates an expected call of DescribeStackResourceDriftsRequest
 func (mr *MockCloudFormationAPIMockRecorder) DescribeStackResourceDriftsRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeStackResourceDriftsRequest", reflect.TypeOf((*MockCloudFormationAPI)(nil).DescribeStackResourceDriftsRequest), arg0)
 }
 
 // DescribeStackResourceDriftsWithContext mocks base method
 func (m *MockCloudFormationAPI) DescribeStackResourceDriftsWithContext(arg0 context.Context, arg1 *cloudformation.DescribeStackResourceDriftsInput, arg2 ...request.Option) (*cloudformation.DescribeStackResourceDriftsOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -925,14 +820,12 @@ func (m *MockCloudFormationAPI) DescribeStackResourceDriftsWithContext(arg0 cont
 
 // DescribeStackResourceDriftsWithContext indicates an expected call of DescribeStackResourceDriftsWithContext
 func (mr *MockCloudFormationAPIMockRecorder) DescribeStackResourceDriftsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeStackResourceDriftsWithContext", reflect.TypeOf((*MockCloudFormationAPI)(nil).DescribeStackResourceDriftsWithContext), varargs...)
 }
 
 // DescribeStackResourceRequest mocks base method
 func (m *MockCloudFormationAPI) DescribeStackResourceRequest(arg0 *cloudformation.DescribeStackResourceInput) (*request.Request, *cloudformation.DescribeStackResourceOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeStackResourceRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*cloudformation.DescribeStackResourceOutput)
@@ -941,13 +834,11 @@ func (m *MockCloudFormationAPI) DescribeStackResourceRequest(arg0 *cloudformatio
 
 // DescribeStackResourceRequest indicates an expected call of DescribeStackResourceRequest
 func (mr *MockCloudFormationAPIMockRecorder) DescribeStackResourceRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeStackResourceRequest", reflect.TypeOf((*MockCloudFormationAPI)(nil).DescribeStackResourceRequest), arg0)
 }
 
 // DescribeStackResourceWithContext mocks base method
 func (m *MockCloudFormationAPI) DescribeStackResourceWithContext(arg0 context.Context, arg1 *cloudformation.DescribeStackResourceInput, arg2 ...request.Option) (*cloudformation.DescribeStackResourceOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -960,14 +851,12 @@ func (m *MockCloudFormationAPI) DescribeStackResourceWithContext(arg0 context.Co
 
 // DescribeStackResourceWithContext indicates an expected call of DescribeStackResourceWithContext
 func (mr *MockCloudFormationAPIMockRecorder) DescribeStackResourceWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeStackResourceWithContext", reflect.TypeOf((*MockCloudFormationAPI)(nil).DescribeStackResourceWithContext), varargs...)
 }
 
 // DescribeStackResources mocks base method
 func (m *MockCloudFormationAPI) DescribeStackResources(arg0 *cloudformation.DescribeStackResourcesInput) (*cloudformation.DescribeStackResourcesOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeStackResources", arg0)
 	ret0, _ := ret[0].(*cloudformation.DescribeStackResourcesOutput)
 	ret1, _ := ret[1].(error)
@@ -976,13 +865,11 @@ func (m *MockCloudFormationAPI) DescribeStackResources(arg0 *cloudformation.Desc
 
 // DescribeStackResources indicates an expected call of DescribeStackResources
 func (mr *MockCloudFormationAPIMockRecorder) DescribeStackResources(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeStackResources", reflect.TypeOf((*MockCloudFormationAPI)(nil).DescribeStackResources), arg0)
 }
 
 // DescribeStackResourcesRequest mocks base method
 func (m *MockCloudFormationAPI) DescribeStackResourcesRequest(arg0 *cloudformation.DescribeStackResourcesInput) (*request.Request, *cloudformation.DescribeStackResourcesOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeStackResourcesRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*cloudformation.DescribeStackResourcesOutput)
@@ -991,13 +878,11 @@ func (m *MockCloudFormationAPI) DescribeStackResourcesRequest(arg0 *cloudformati
 
 // DescribeStackResourcesRequest indicates an expected call of DescribeStackResourcesRequest
 func (mr *MockCloudFormationAPIMockRecorder) DescribeStackResourcesRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeStackResourcesRequest", reflect.TypeOf((*MockCloudFormationAPI)(nil).DescribeStackResourcesRequest), arg0)
 }
 
 // DescribeStackResourcesWithContext mocks base method
 func (m *MockCloudFormationAPI) DescribeStackResourcesWithContext(arg0 context.Context, arg1 *cloudformation.DescribeStackResourcesInput, arg2 ...request.Option) (*cloudformation.DescribeStackResourcesOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -1010,14 +895,12 @@ func (m *MockCloudFormationAPI) DescribeStackResourcesWithContext(arg0 context.C
 
 // DescribeStackResourcesWithContext indicates an expected call of DescribeStackResourcesWithContext
 func (mr *MockCloudFormationAPIMockRecorder) DescribeStackResourcesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeStackResourcesWithContext", reflect.TypeOf((*MockCloudFormationAPI)(nil).DescribeStackResourcesWithContext), varargs...)
 }
 
 // DescribeStackSet mocks base method
 func (m *MockCloudFormationAPI) DescribeStackSet(arg0 *cloudformation.DescribeStackSetInput) (*cloudformation.DescribeStackSetOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeStackSet", arg0)
 	ret0, _ := ret[0].(*cloudformation.DescribeStackSetOutput)
 	ret1, _ := ret[1].(error)
@@ -1026,13 +909,11 @@ func (m *MockCloudFormationAPI) DescribeStackSet(arg0 *cloudformation.DescribeSt
 
 // DescribeStackSet indicates an expected call of DescribeStackSet
 func (mr *MockCloudFormationAPIMockRecorder) DescribeStackSet(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeStackSet", reflect.TypeOf((*MockCloudFormationAPI)(nil).DescribeStackSet), arg0)
 }
 
 // DescribeStackSetOperation mocks base method
 func (m *MockCloudFormationAPI) DescribeStackSetOperation(arg0 *cloudformation.DescribeStackSetOperationInput) (*cloudformation.DescribeStackSetOperationOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeStackSetOperation", arg0)
 	ret0, _ := ret[0].(*cloudformation.DescribeStackSetOperationOutput)
 	ret1, _ := ret[1].(error)
@@ -1041,13 +922,11 @@ func (m *MockCloudFormationAPI) DescribeStackSetOperation(arg0 *cloudformation.D
 
 // DescribeStackSetOperation indicates an expected call of DescribeStackSetOperation
 func (mr *MockCloudFormationAPIMockRecorder) DescribeStackSetOperation(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeStackSetOperation", reflect.TypeOf((*MockCloudFormationAPI)(nil).DescribeStackSetOperation), arg0)
 }
 
 // DescribeStackSetOperationRequest mocks base method
 func (m *MockCloudFormationAPI) DescribeStackSetOperationRequest(arg0 *cloudformation.DescribeStackSetOperationInput) (*request.Request, *cloudformation.DescribeStackSetOperationOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeStackSetOperationRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*cloudformation.DescribeStackSetOperationOutput)
@@ -1056,13 +935,11 @@ func (m *MockCloudFormationAPI) DescribeStackSetOperationRequest(arg0 *cloudform
 
 // DescribeStackSetOperationRequest indicates an expected call of DescribeStackSetOperationRequest
 func (mr *MockCloudFormationAPIMockRecorder) DescribeStackSetOperationRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeStackSetOperationRequest", reflect.TypeOf((*MockCloudFormationAPI)(nil).DescribeStackSetOperationRequest), arg0)
 }
 
 // DescribeStackSetOperationWithContext mocks base method
 func (m *MockCloudFormationAPI) DescribeStackSetOperationWithContext(arg0 context.Context, arg1 *cloudformation.DescribeStackSetOperationInput, arg2 ...request.Option) (*cloudformation.DescribeStackSetOperationOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -1075,14 +952,12 @@ func (m *MockCloudFormationAPI) DescribeStackSetOperationWithContext(arg0 contex
 
 // DescribeStackSetOperationWithContext indicates an expected call of DescribeStackSetOperationWithContext
 func (mr *MockCloudFormationAPIMockRecorder) DescribeStackSetOperationWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeStackSetOperationWithContext", reflect.TypeOf((*MockCloudFormationAPI)(nil).DescribeStackSetOperationWithContext), varargs...)
 }
 
 // DescribeStackSetRequest mocks base method
 func (m *MockCloudFormationAPI) DescribeStackSetRequest(arg0 *cloudformation.DescribeStackSetInput) (*request.Request, *cloudformation.DescribeStackSetOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeStackSetRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*cloudformation.DescribeStackSetOutput)
@@ -1091,13 +966,11 @@ func (m *MockCloudFormationAPI) DescribeStackSetRequest(arg0 *cloudformation.Des
 
 // DescribeStackSetRequest indicates an expected call of DescribeStackSetRequest
 func (mr *MockCloudFormationAPIMockRecorder) DescribeStackSetRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeStackSetRequest", reflect.TypeOf((*MockCloudFormationAPI)(nil).DescribeStackSetRequest), arg0)
 }
 
 // DescribeStackSetWithContext mocks base method
 func (m *MockCloudFormationAPI) DescribeStackSetWithContext(arg0 context.Context, arg1 *cloudformation.DescribeStackSetInput, arg2 ...request.Option) (*cloudformation.DescribeStackSetOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -1110,14 +983,12 @@ func (m *MockCloudFormationAPI) DescribeStackSetWithContext(arg0 context.Context
 
 // DescribeStackSetWithContext indicates an expected call of DescribeStackSetWithContext
 func (mr *MockCloudFormationAPIMockRecorder) DescribeStackSetWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeStackSetWithContext", reflect.TypeOf((*MockCloudFormationAPI)(nil).DescribeStackSetWithContext), varargs...)
 }
 
 // DescribeStacks mocks base method
 func (m *MockCloudFormationAPI) DescribeStacks(arg0 *cloudformation.DescribeStacksInput) (*cloudformation.DescribeStacksOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeStacks", arg0)
 	ret0, _ := ret[0].(*cloudformation.DescribeStacksOutput)
 	ret1, _ := ret[1].(error)
@@ -1126,13 +997,11 @@ func (m *MockCloudFormationAPI) DescribeStacks(arg0 *cloudformation.DescribeStac
 
 // DescribeStacks indicates an expected call of DescribeStacks
 func (mr *MockCloudFormationAPIMockRecorder) DescribeStacks(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeStacks", reflect.TypeOf((*MockCloudFormationAPI)(nil).DescribeStacks), arg0)
 }
 
 // DescribeStacksPages mocks base method
 func (m *MockCloudFormationAPI) DescribeStacksPages(arg0 *cloudformation.DescribeStacksInput, arg1 func(*cloudformation.DescribeStacksOutput, bool) bool) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeStacksPages", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -1140,13 +1009,11 @@ func (m *MockCloudFormationAPI) DescribeStacksPages(arg0 *cloudformation.Describ
 
 // DescribeStacksPages indicates an expected call of DescribeStacksPages
 func (mr *MockCloudFormationAPIMockRecorder) DescribeStacksPages(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeStacksPages", reflect.TypeOf((*MockCloudFormationAPI)(nil).DescribeStacksPages), arg0, arg1)
 }
 
 // DescribeStacksPagesWithContext mocks base method
 func (m *MockCloudFormationAPI) DescribeStacksPagesWithContext(arg0 context.Context, arg1 *cloudformation.DescribeStacksInput, arg2 func(*cloudformation.DescribeStacksOutput, bool) bool, arg3 ...request.Option) error {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1, arg2}
 	for _, a := range arg3 {
 		varargs = append(varargs, a)
@@ -1158,14 +1025,12 @@ func (m *MockCloudFormationAPI) DescribeStacksPagesWithContext(arg0 context.Cont
 
 // DescribeStacksPagesWithContext indicates an expected call of DescribeStacksPagesWithContext
 func (mr *MockCloudFormationAPIMockRecorder) DescribeStacksPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeStacksPagesWithContext", reflect.TypeOf((*MockCloudFormationAPI)(nil).DescribeStacksPagesWithContext), varargs...)
 }
 
 // DescribeStacksRequest mocks base method
 func (m *MockCloudFormationAPI) DescribeStacksRequest(arg0 *cloudformation.DescribeStacksInput) (*request.Request, *cloudformation.DescribeStacksOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeStacksRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*cloudformation.DescribeStacksOutput)
@@ -1174,13 +1039,11 @@ func (m *MockCloudFormationAPI) DescribeStacksRequest(arg0 *cloudformation.Descr
 
 // DescribeStacksRequest indicates an expected call of DescribeStacksRequest
 func (mr *MockCloudFormationAPIMockRecorder) DescribeStacksRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeStacksRequest", reflect.TypeOf((*MockCloudFormationAPI)(nil).DescribeStacksRequest), arg0)
 }
 
 // DescribeStacksWithContext mocks base method
 func (m *MockCloudFormationAPI) DescribeStacksWithContext(arg0 context.Context, arg1 *cloudformation.DescribeStacksInput, arg2 ...request.Option) (*cloudformation.DescribeStacksOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -1193,14 +1056,12 @@ func (m *MockCloudFormationAPI) DescribeStacksWithContext(arg0 context.Context, 
 
 // DescribeStacksWithContext indicates an expected call of DescribeStacksWithContext
 func (mr *MockCloudFormationAPIMockRecorder) DescribeStacksWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeStacksWithContext", reflect.TypeOf((*MockCloudFormationAPI)(nil).DescribeStacksWithContext), varargs...)
 }
 
 // DetectStackDrift mocks base method
 func (m *MockCloudFormationAPI) DetectStackDrift(arg0 *cloudformation.DetectStackDriftInput) (*cloudformation.DetectStackDriftOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DetectStackDrift", arg0)
 	ret0, _ := ret[0].(*cloudformation.DetectStackDriftOutput)
 	ret1, _ := ret[1].(error)
@@ -1209,13 +1070,11 @@ func (m *MockCloudFormationAPI) DetectStackDrift(arg0 *cloudformation.DetectStac
 
 // DetectStackDrift indicates an expected call of DetectStackDrift
 func (mr *MockCloudFormationAPIMockRecorder) DetectStackDrift(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DetectStackDrift", reflect.TypeOf((*MockCloudFormationAPI)(nil).DetectStackDrift), arg0)
 }
 
 // DetectStackDriftRequest mocks base method
 func (m *MockCloudFormationAPI) DetectStackDriftRequest(arg0 *cloudformation.DetectStackDriftInput) (*request.Request, *cloudformation.DetectStackDriftOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DetectStackDriftRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*cloudformation.DetectStackDriftOutput)
@@ -1224,13 +1083,11 @@ func (m *MockCloudFormationAPI) DetectStackDriftRequest(arg0 *cloudformation.Det
 
 // DetectStackDriftRequest indicates an expected call of DetectStackDriftRequest
 func (mr *MockCloudFormationAPIMockRecorder) DetectStackDriftRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DetectStackDriftRequest", reflect.TypeOf((*MockCloudFormationAPI)(nil).DetectStackDriftRequest), arg0)
 }
 
 // DetectStackDriftWithContext mocks base method
 func (m *MockCloudFormationAPI) DetectStackDriftWithContext(arg0 context.Context, arg1 *cloudformation.DetectStackDriftInput, arg2 ...request.Option) (*cloudformation.DetectStackDriftOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -1243,14 +1100,12 @@ func (m *MockCloudFormationAPI) DetectStackDriftWithContext(arg0 context.Context
 
 // DetectStackDriftWithContext indicates an expected call of DetectStackDriftWithContext
 func (mr *MockCloudFormationAPIMockRecorder) DetectStackDriftWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DetectStackDriftWithContext", reflect.TypeOf((*MockCloudFormationAPI)(nil).DetectStackDriftWithContext), varargs...)
 }
 
 // DetectStackResourceDrift mocks base method
 func (m *MockCloudFormationAPI) DetectStackResourceDrift(arg0 *cloudformation.DetectStackResourceDriftInput) (*cloudformation.DetectStackResourceDriftOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DetectStackResourceDrift", arg0)
 	ret0, _ := ret[0].(*cloudformation.DetectStackResourceDriftOutput)
 	ret1, _ := ret[1].(error)
@@ -1259,13 +1114,11 @@ func (m *MockCloudFormationAPI) DetectStackResourceDrift(arg0 *cloudformation.De
 
 // DetectStackResourceDrift indicates an expected call of DetectStackResourceDrift
 func (mr *MockCloudFormationAPIMockRecorder) DetectStackResourceDrift(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DetectStackResourceDrift", reflect.TypeOf((*MockCloudFormationAPI)(nil).DetectStackResourceDrift), arg0)
 }
 
 // DetectStackResourceDriftRequest mocks base method
 func (m *MockCloudFormationAPI) DetectStackResourceDriftRequest(arg0 *cloudformation.DetectStackResourceDriftInput) (*request.Request, *cloudformation.DetectStackResourceDriftOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DetectStackResourceDriftRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*cloudformation.DetectStackResourceDriftOutput)
@@ -1274,13 +1127,11 @@ func (m *MockCloudFormationAPI) DetectStackResourceDriftRequest(arg0 *cloudforma
 
 // DetectStackResourceDriftRequest indicates an expected call of DetectStackResourceDriftRequest
 func (mr *MockCloudFormationAPIMockRecorder) DetectStackResourceDriftRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DetectStackResourceDriftRequest", reflect.TypeOf((*MockCloudFormationAPI)(nil).DetectStackResourceDriftRequest), arg0)
 }
 
 // DetectStackResourceDriftWithContext mocks base method
 func (m *MockCloudFormationAPI) DetectStackResourceDriftWithContext(arg0 context.Context, arg1 *cloudformation.DetectStackResourceDriftInput, arg2 ...request.Option) (*cloudformation.DetectStackResourceDriftOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -1293,14 +1144,12 @@ func (m *MockCloudFormationAPI) DetectStackResourceDriftWithContext(arg0 context
 
 // DetectStackResourceDriftWithContext indicates an expected call of DetectStackResourceDriftWithContext
 func (mr *MockCloudFormationAPIMockRecorder) DetectStackResourceDriftWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DetectStackResourceDriftWithContext", reflect.TypeOf((*MockCloudFormationAPI)(nil).DetectStackResourceDriftWithContext), varargs...)
 }
 
 // EstimateTemplateCost mocks base method
 func (m *MockCloudFormationAPI) EstimateTemplateCost(arg0 *cloudformation.EstimateTemplateCostInput) (*cloudformation.EstimateTemplateCostOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "EstimateTemplateCost", arg0)
 	ret0, _ := ret[0].(*cloudformation.EstimateTemplateCostOutput)
 	ret1, _ := ret[1].(error)
@@ -1309,13 +1158,11 @@ func (m *MockCloudFormationAPI) EstimateTemplateCost(arg0 *cloudformation.Estima
 
 // EstimateTemplateCost indicates an expected call of EstimateTemplateCost
 func (mr *MockCloudFormationAPIMockRecorder) EstimateTemplateCost(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EstimateTemplateCost", reflect.TypeOf((*MockCloudFormationAPI)(nil).EstimateTemplateCost), arg0)
 }
 
 // EstimateTemplateCostRequest mocks base method
 func (m *MockCloudFormationAPI) EstimateTemplateCostRequest(arg0 *cloudformation.EstimateTemplateCostInput) (*request.Request, *cloudformation.EstimateTemplateCostOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "EstimateTemplateCostRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*cloudformation.EstimateTemplateCostOutput)
@@ -1324,13 +1171,11 @@ func (m *MockCloudFormationAPI) EstimateTemplateCostRequest(arg0 *cloudformation
 
 // EstimateTemplateCostRequest indicates an expected call of EstimateTemplateCostRequest
 func (mr *MockCloudFormationAPIMockRecorder) EstimateTemplateCostRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EstimateTemplateCostRequest", reflect.TypeOf((*MockCloudFormationAPI)(nil).EstimateTemplateCostRequest), arg0)
 }
 
 // EstimateTemplateCostWithContext mocks base method
 func (m *MockCloudFormationAPI) EstimateTemplateCostWithContext(arg0 context.Context, arg1 *cloudformation.EstimateTemplateCostInput, arg2 ...request.Option) (*cloudformation.EstimateTemplateCostOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -1343,14 +1188,12 @@ func (m *MockCloudFormationAPI) EstimateTemplateCostWithContext(arg0 context.Con
 
 // EstimateTemplateCostWithContext indicates an expected call of EstimateTemplateCostWithContext
 func (mr *MockCloudFormationAPIMockRecorder) EstimateTemplateCostWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EstimateTemplateCostWithContext", reflect.TypeOf((*MockCloudFormationAPI)(nil).EstimateTemplateCostWithContext), varargs...)
 }
 
 // ExecuteChangeSet mocks base method
 func (m *MockCloudFormationAPI) ExecuteChangeSet(arg0 *cloudformation.ExecuteChangeSetInput) (*cloudformation.ExecuteChangeSetOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ExecuteChangeSet", arg0)
 	ret0, _ := ret[0].(*cloudformation.ExecuteChangeSetOutput)
 	ret1, _ := ret[1].(error)
@@ -1359,13 +1202,11 @@ func (m *MockCloudFormationAPI) ExecuteChangeSet(arg0 *cloudformation.ExecuteCha
 
 // ExecuteChangeSet indicates an expected call of ExecuteChangeSet
 func (mr *MockCloudFormationAPIMockRecorder) ExecuteChangeSet(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExecuteChangeSet", reflect.TypeOf((*MockCloudFormationAPI)(nil).ExecuteChangeSet), arg0)
 }
 
 // ExecuteChangeSetRequest mocks base method
 func (m *MockCloudFormationAPI) ExecuteChangeSetRequest(arg0 *cloudformation.ExecuteChangeSetInput) (*request.Request, *cloudformation.ExecuteChangeSetOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ExecuteChangeSetRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*cloudformation.ExecuteChangeSetOutput)
@@ -1374,13 +1215,11 @@ func (m *MockCloudFormationAPI) ExecuteChangeSetRequest(arg0 *cloudformation.Exe
 
 // ExecuteChangeSetRequest indicates an expected call of ExecuteChangeSetRequest
 func (mr *MockCloudFormationAPIMockRecorder) ExecuteChangeSetRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExecuteChangeSetRequest", reflect.TypeOf((*MockCloudFormationAPI)(nil).ExecuteChangeSetRequest), arg0)
 }
 
 // ExecuteChangeSetWithContext mocks base method
 func (m *MockCloudFormationAPI) ExecuteChangeSetWithContext(arg0 context.Context, arg1 *cloudformation.ExecuteChangeSetInput, arg2 ...request.Option) (*cloudformation.ExecuteChangeSetOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -1393,14 +1232,12 @@ func (m *MockCloudFormationAPI) ExecuteChangeSetWithContext(arg0 context.Context
 
 // ExecuteChangeSetWithContext indicates an expected call of ExecuteChangeSetWithContext
 func (mr *MockCloudFormationAPIMockRecorder) ExecuteChangeSetWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExecuteChangeSetWithContext", reflect.TypeOf((*MockCloudFormationAPI)(nil).ExecuteChangeSetWithContext), varargs...)
 }
 
 // GetStackPolicy mocks base method
 func (m *MockCloudFormationAPI) GetStackPolicy(arg0 *cloudformation.GetStackPolicyInput) (*cloudformation.GetStackPolicyOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetStackPolicy", arg0)
 	ret0, _ := ret[0].(*cloudformation.GetStackPolicyOutput)
 	ret1, _ := ret[1].(error)
@@ -1409,13 +1246,11 @@ func (m *MockCloudFormationAPI) GetStackPolicy(arg0 *cloudformation.GetStackPoli
 
 // GetStackPolicy indicates an expected call of GetStackPolicy
 func (mr *MockCloudFormationAPIMockRecorder) GetStackPolicy(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetStackPolicy", reflect.TypeOf((*MockCloudFormationAPI)(nil).GetStackPolicy), arg0)
 }
 
 // GetStackPolicyRequest mocks base method
 func (m *MockCloudFormationAPI) GetStackPolicyRequest(arg0 *cloudformation.GetStackPolicyInput) (*request.Request, *cloudformation.GetStackPolicyOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetStackPolicyRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*cloudformation.GetStackPolicyOutput)
@@ -1424,13 +1259,11 @@ func (m *MockCloudFormationAPI) GetStackPolicyRequest(arg0 *cloudformation.GetSt
 
 // GetStackPolicyRequest indicates an expected call of GetStackPolicyRequest
 func (mr *MockCloudFormationAPIMockRecorder) GetStackPolicyRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetStackPolicyRequest", reflect.TypeOf((*MockCloudFormationAPI)(nil).GetStackPolicyRequest), arg0)
 }
 
 // GetStackPolicyWithContext mocks base method
 func (m *MockCloudFormationAPI) GetStackPolicyWithContext(arg0 context.Context, arg1 *cloudformation.GetStackPolicyInput, arg2 ...request.Option) (*cloudformation.GetStackPolicyOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -1443,14 +1276,12 @@ func (m *MockCloudFormationAPI) GetStackPolicyWithContext(arg0 context.Context, 
 
 // GetStackPolicyWithContext indicates an expected call of GetStackPolicyWithContext
 func (mr *MockCloudFormationAPIMockRecorder) GetStackPolicyWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetStackPolicyWithContext", reflect.TypeOf((*MockCloudFormationAPI)(nil).GetStackPolicyWithContext), varargs...)
 }
 
 // GetTemplate mocks base method
 func (m *MockCloudFormationAPI) GetTemplate(arg0 *cloudformation.GetTemplateInput) (*cloudformation.GetTemplateOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetTemplate", arg0)
 	ret0, _ := ret[0].(*cloudformation.GetTemplateOutput)
 	ret1, _ := ret[1].(error)
@@ -1459,13 +1290,11 @@ func (m *MockCloudFormationAPI) GetTemplate(arg0 *cloudformation.GetTemplateInpu
 
 // GetTemplate indicates an expected call of GetTemplate
 func (mr *MockCloudFormationAPIMockRecorder) GetTemplate(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTemplate", reflect.TypeOf((*MockCloudFormationAPI)(nil).GetTemplate), arg0)
 }
 
 // GetTemplateRequest mocks base method
 func (m *MockCloudFormationAPI) GetTemplateRequest(arg0 *cloudformation.GetTemplateInput) (*request.Request, *cloudformation.GetTemplateOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetTemplateRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*cloudformation.GetTemplateOutput)
@@ -1474,13 +1303,11 @@ func (m *MockCloudFormationAPI) GetTemplateRequest(arg0 *cloudformation.GetTempl
 
 // GetTemplateRequest indicates an expected call of GetTemplateRequest
 func (mr *MockCloudFormationAPIMockRecorder) GetTemplateRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTemplateRequest", reflect.TypeOf((*MockCloudFormationAPI)(nil).GetTemplateRequest), arg0)
 }
 
 // GetTemplateSummary mocks base method
 func (m *MockCloudFormationAPI) GetTemplateSummary(arg0 *cloudformation.GetTemplateSummaryInput) (*cloudformation.GetTemplateSummaryOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetTemplateSummary", arg0)
 	ret0, _ := ret[0].(*cloudformation.GetTemplateSummaryOutput)
 	ret1, _ := ret[1].(error)
@@ -1489,13 +1316,11 @@ func (m *MockCloudFormationAPI) GetTemplateSummary(arg0 *cloudformation.GetTempl
 
 // GetTemplateSummary indicates an expected call of GetTemplateSummary
 func (mr *MockCloudFormationAPIMockRecorder) GetTemplateSummary(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTemplateSummary", reflect.TypeOf((*MockCloudFormationAPI)(nil).GetTemplateSummary), arg0)
 }
 
 // GetTemplateSummaryRequest mocks base method
 func (m *MockCloudFormationAPI) GetTemplateSummaryRequest(arg0 *cloudformation.GetTemplateSummaryInput) (*request.Request, *cloudformation.GetTemplateSummaryOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetTemplateSummaryRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*cloudformation.GetTemplateSummaryOutput)
@@ -1504,13 +1329,11 @@ func (m *MockCloudFormationAPI) GetTemplateSummaryRequest(arg0 *cloudformation.G
 
 // GetTemplateSummaryRequest indicates an expected call of GetTemplateSummaryRequest
 func (mr *MockCloudFormationAPIMockRecorder) GetTemplateSummaryRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTemplateSummaryRequest", reflect.TypeOf((*MockCloudFormationAPI)(nil).GetTemplateSummaryRequest), arg0)
 }
 
 // GetTemplateSummaryWithContext mocks base method
 func (m *MockCloudFormationAPI) GetTemplateSummaryWithContext(arg0 context.Context, arg1 *cloudformation.GetTemplateSummaryInput, arg2 ...request.Option) (*cloudformation.GetTemplateSummaryOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -1523,14 +1346,12 @@ func (m *MockCloudFormationAPI) GetTemplateSummaryWithContext(arg0 context.Conte
 
 // GetTemplateSummaryWithContext indicates an expected call of GetTemplateSummaryWithContext
 func (mr *MockCloudFormationAPIMockRecorder) GetTemplateSummaryWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTemplateSummaryWithContext", reflect.TypeOf((*MockCloudFormationAPI)(nil).GetTemplateSummaryWithContext), varargs...)
 }
 
 // GetTemplateWithContext mocks base method
 func (m *MockCloudFormationAPI) GetTemplateWithContext(arg0 context.Context, arg1 *cloudformation.GetTemplateInput, arg2 ...request.Option) (*cloudformation.GetTemplateOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -1543,14 +1364,12 @@ func (m *MockCloudFormationAPI) GetTemplateWithContext(arg0 context.Context, arg
 
 // GetTemplateWithContext indicates an expected call of GetTemplateWithContext
 func (mr *MockCloudFormationAPIMockRecorder) GetTemplateWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTemplateWithContext", reflect.TypeOf((*MockCloudFormationAPI)(nil).GetTemplateWithContext), varargs...)
 }
 
 // ListChangeSets mocks base method
 func (m *MockCloudFormationAPI) ListChangeSets(arg0 *cloudformation.ListChangeSetsInput) (*cloudformation.ListChangeSetsOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListChangeSets", arg0)
 	ret0, _ := ret[0].(*cloudformation.ListChangeSetsOutput)
 	ret1, _ := ret[1].(error)
@@ -1559,13 +1378,11 @@ func (m *MockCloudFormationAPI) ListChangeSets(arg0 *cloudformation.ListChangeSe
 
 // ListChangeSets indicates an expected call of ListChangeSets
 func (mr *MockCloudFormationAPIMockRecorder) ListChangeSets(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListChangeSets", reflect.TypeOf((*MockCloudFormationAPI)(nil).ListChangeSets), arg0)
 }
 
 // ListChangeSetsRequest mocks base method
 func (m *MockCloudFormationAPI) ListChangeSetsRequest(arg0 *cloudformation.ListChangeSetsInput) (*request.Request, *cloudformation.ListChangeSetsOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListChangeSetsRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*cloudformation.ListChangeSetsOutput)
@@ -1574,13 +1391,11 @@ func (m *MockCloudFormationAPI) ListChangeSetsRequest(arg0 *cloudformation.ListC
 
 // ListChangeSetsRequest indicates an expected call of ListChangeSetsRequest
 func (mr *MockCloudFormationAPIMockRecorder) ListChangeSetsRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListChangeSetsRequest", reflect.TypeOf((*MockCloudFormationAPI)(nil).ListChangeSetsRequest), arg0)
 }
 
 // ListChangeSetsWithContext mocks base method
 func (m *MockCloudFormationAPI) ListChangeSetsWithContext(arg0 context.Context, arg1 *cloudformation.ListChangeSetsInput, arg2 ...request.Option) (*cloudformation.ListChangeSetsOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -1593,14 +1408,12 @@ func (m *MockCloudFormationAPI) ListChangeSetsWithContext(arg0 context.Context, 
 
 // ListChangeSetsWithContext indicates an expected call of ListChangeSetsWithContext
 func (mr *MockCloudFormationAPIMockRecorder) ListChangeSetsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListChangeSetsWithContext", reflect.TypeOf((*MockCloudFormationAPI)(nil).ListChangeSetsWithContext), varargs...)
 }
 
 // ListExports mocks base method
 func (m *MockCloudFormationAPI) ListExports(arg0 *cloudformation.ListExportsInput) (*cloudformation.ListExportsOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListExports", arg0)
 	ret0, _ := ret[0].(*cloudformation.ListExportsOutput)
 	ret1, _ := ret[1].(error)
@@ -1609,13 +1422,11 @@ func (m *MockCloudFormationAPI) ListExports(arg0 *cloudformation.ListExportsInpu
 
 // ListExports indicates an expected call of ListExports
 func (mr *MockCloudFormationAPIMockRecorder) ListExports(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListExports", reflect.TypeOf((*MockCloudFormationAPI)(nil).ListExports), arg0)
 }
 
 // ListExportsPages mocks base method
 func (m *MockCloudFormationAPI) ListExportsPages(arg0 *cloudformation.ListExportsInput, arg1 func(*cloudformation.ListExportsOutput, bool) bool) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListExportsPages", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -1623,13 +1434,11 @@ func (m *MockCloudFormationAPI) ListExportsPages(arg0 *cloudformation.ListExport
 
 // ListExportsPages indicates an expected call of ListExportsPages
 func (mr *MockCloudFormationAPIMockRecorder) ListExportsPages(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListExportsPages", reflect.TypeOf((*MockCloudFormationAPI)(nil).ListExportsPages), arg0, arg1)
 }
 
 // ListExportsPagesWithContext mocks base method
 func (m *MockCloudFormationAPI) ListExportsPagesWithContext(arg0 context.Context, arg1 *cloudformation.ListExportsInput, arg2 func(*cloudformation.ListExportsOutput, bool) bool, arg3 ...request.Option) error {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1, arg2}
 	for _, a := range arg3 {
 		varargs = append(varargs, a)
@@ -1641,14 +1450,12 @@ func (m *MockCloudFormationAPI) ListExportsPagesWithContext(arg0 context.Context
 
 // ListExportsPagesWithContext indicates an expected call of ListExportsPagesWithContext
 func (mr *MockCloudFormationAPIMockRecorder) ListExportsPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListExportsPagesWithContext", reflect.TypeOf((*MockCloudFormationAPI)(nil).ListExportsPagesWithContext), varargs...)
 }
 
 // ListExportsRequest mocks base method
 func (m *MockCloudFormationAPI) ListExportsRequest(arg0 *cloudformation.ListExportsInput) (*request.Request, *cloudformation.ListExportsOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListExportsRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*cloudformation.ListExportsOutput)
@@ -1657,13 +1464,11 @@ func (m *MockCloudFormationAPI) ListExportsRequest(arg0 *cloudformation.ListExpo
 
 // ListExportsRequest indicates an expected call of ListExportsRequest
 func (mr *MockCloudFormationAPIMockRecorder) ListExportsRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListExportsRequest", reflect.TypeOf((*MockCloudFormationAPI)(nil).ListExportsRequest), arg0)
 }
 
 // ListExportsWithContext mocks base method
 func (m *MockCloudFormationAPI) ListExportsWithContext(arg0 context.Context, arg1 *cloudformation.ListExportsInput, arg2 ...request.Option) (*cloudformation.ListExportsOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -1676,14 +1481,12 @@ func (m *MockCloudFormationAPI) ListExportsWithContext(arg0 context.Context, arg
 
 // ListExportsWithContext indicates an expected call of ListExportsWithContext
 func (mr *MockCloudFormationAPIMockRecorder) ListExportsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListExportsWithContext", reflect.TypeOf((*MockCloudFormationAPI)(nil).ListExportsWithContext), varargs...)
 }
 
 // ListImports mocks base method
 func (m *MockCloudFormationAPI) ListImports(arg0 *cloudformation.ListImportsInput) (*cloudformation.ListImportsOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListImports", arg0)
 	ret0, _ := ret[0].(*cloudformation.ListImportsOutput)
 	ret1, _ := ret[1].(error)
@@ -1692,13 +1495,11 @@ func (m *MockCloudFormationAPI) ListImports(arg0 *cloudformation.ListImportsInpu
 
 // ListImports indicates an expected call of ListImports
 func (mr *MockCloudFormationAPIMockRecorder) ListImports(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListImports", reflect.TypeOf((*MockCloudFormationAPI)(nil).ListImports), arg0)
 }
 
 // ListImportsPages mocks base method
 func (m *MockCloudFormationAPI) ListImportsPages(arg0 *cloudformation.ListImportsInput, arg1 func(*cloudformation.ListImportsOutput, bool) bool) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListImportsPages", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -1706,13 +1507,11 @@ func (m *MockCloudFormationAPI) ListImportsPages(arg0 *cloudformation.ListImport
 
 // ListImportsPages indicates an expected call of ListImportsPages
 func (mr *MockCloudFormationAPIMockRecorder) ListImportsPages(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListImportsPages", reflect.TypeOf((*MockCloudFormationAPI)(nil).ListImportsPages), arg0, arg1)
 }
 
 // ListImportsPagesWithContext mocks base method
 func (m *MockCloudFormationAPI) ListImportsPagesWithContext(arg0 context.Context, arg1 *cloudformation.ListImportsInput, arg2 func(*cloudformation.ListImportsOutput, bool) bool, arg3 ...request.Option) error {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1, arg2}
 	for _, a := range arg3 {
 		varargs = append(varargs, a)
@@ -1724,14 +1523,12 @@ func (m *MockCloudFormationAPI) ListImportsPagesWithContext(arg0 context.Context
 
 // ListImportsPagesWithContext indicates an expected call of ListImportsPagesWithContext
 func (mr *MockCloudFormationAPIMockRecorder) ListImportsPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListImportsPagesWithContext", reflect.TypeOf((*MockCloudFormationAPI)(nil).ListImportsPagesWithContext), varargs...)
 }
 
 // ListImportsRequest mocks base method
 func (m *MockCloudFormationAPI) ListImportsRequest(arg0 *cloudformation.ListImportsInput) (*request.Request, *cloudformation.ListImportsOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListImportsRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*cloudformation.ListImportsOutput)
@@ -1740,13 +1537,11 @@ func (m *MockCloudFormationAPI) ListImportsRequest(arg0 *cloudformation.ListImpo
 
 // ListImportsRequest indicates an expected call of ListImportsRequest
 func (mr *MockCloudFormationAPIMockRecorder) ListImportsRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListImportsRequest", reflect.TypeOf((*MockCloudFormationAPI)(nil).ListImportsRequest), arg0)
 }
 
 // ListImportsWithContext mocks base method
 func (m *MockCloudFormationAPI) ListImportsWithContext(arg0 context.Context, arg1 *cloudformation.ListImportsInput, arg2 ...request.Option) (*cloudformation.ListImportsOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -1759,14 +1554,12 @@ func (m *MockCloudFormationAPI) ListImportsWithContext(arg0 context.Context, arg
 
 // ListImportsWithContext indicates an expected call of ListImportsWithContext
 func (mr *MockCloudFormationAPIMockRecorder) ListImportsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListImportsWithContext", reflect.TypeOf((*MockCloudFormationAPI)(nil).ListImportsWithContext), varargs...)
 }
 
 // ListStackInstances mocks base method
 func (m *MockCloudFormationAPI) ListStackInstances(arg0 *cloudformation.ListStackInstancesInput) (*cloudformation.ListStackInstancesOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListStackInstances", arg0)
 	ret0, _ := ret[0].(*cloudformation.ListStackInstancesOutput)
 	ret1, _ := ret[1].(error)
@@ -1775,13 +1568,11 @@ func (m *MockCloudFormationAPI) ListStackInstances(arg0 *cloudformation.ListStac
 
 // ListStackInstances indicates an expected call of ListStackInstances
 func (mr *MockCloudFormationAPIMockRecorder) ListStackInstances(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListStackInstances", reflect.TypeOf((*MockCloudFormationAPI)(nil).ListStackInstances), arg0)
 }
 
 // ListStackInstancesRequest mocks base method
 func (m *MockCloudFormationAPI) ListStackInstancesRequest(arg0 *cloudformation.ListStackInstancesInput) (*request.Request, *cloudformation.ListStackInstancesOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListStackInstancesRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*cloudformation.ListStackInstancesOutput)
@@ -1790,13 +1581,11 @@ func (m *MockCloudFormationAPI) ListStackInstancesRequest(arg0 *cloudformation.L
 
 // ListStackInstancesRequest indicates an expected call of ListStackInstancesRequest
 func (mr *MockCloudFormationAPIMockRecorder) ListStackInstancesRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListStackInstancesRequest", reflect.TypeOf((*MockCloudFormationAPI)(nil).ListStackInstancesRequest), arg0)
 }
 
 // ListStackInstancesWithContext mocks base method
 func (m *MockCloudFormationAPI) ListStackInstancesWithContext(arg0 context.Context, arg1 *cloudformation.ListStackInstancesInput, arg2 ...request.Option) (*cloudformation.ListStackInstancesOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -1809,14 +1598,12 @@ func (m *MockCloudFormationAPI) ListStackInstancesWithContext(arg0 context.Conte
 
 // ListStackInstancesWithContext indicates an expected call of ListStackInstancesWithContext
 func (mr *MockCloudFormationAPIMockRecorder) ListStackInstancesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListStackInstancesWithContext", reflect.TypeOf((*MockCloudFormationAPI)(nil).ListStackInstancesWithContext), varargs...)
 }
 
 // ListStackResources mocks base method
 func (m *MockCloudFormationAPI) ListStackResources(arg0 *cloudformation.ListStackResourcesInput) (*cloudformation.ListStackResourcesOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListStackResources", arg0)
 	ret0, _ := ret[0].(*cloudformation.ListStackResourcesOutput)
 	ret1, _ := ret[1].(error)
@@ -1825,13 +1612,11 @@ func (m *MockCloudFormationAPI) ListStackResources(arg0 *cloudformation.ListStac
 
 // ListStackResources indicates an expected call of ListStackResources
 func (mr *MockCloudFormationAPIMockRecorder) ListStackResources(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListStackResources", reflect.TypeOf((*MockCloudFormationAPI)(nil).ListStackResources), arg0)
 }
 
 // ListStackResourcesPages mocks base method
 func (m *MockCloudFormationAPI) ListStackResourcesPages(arg0 *cloudformation.ListStackResourcesInput, arg1 func(*cloudformation.ListStackResourcesOutput, bool) bool) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListStackResourcesPages", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -1839,13 +1624,11 @@ func (m *MockCloudFormationAPI) ListStackResourcesPages(arg0 *cloudformation.Lis
 
 // ListStackResourcesPages indicates an expected call of ListStackResourcesPages
 func (mr *MockCloudFormationAPIMockRecorder) ListStackResourcesPages(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListStackResourcesPages", reflect.TypeOf((*MockCloudFormationAPI)(nil).ListStackResourcesPages), arg0, arg1)
 }
 
 // ListStackResourcesPagesWithContext mocks base method
 func (m *MockCloudFormationAPI) ListStackResourcesPagesWithContext(arg0 context.Context, arg1 *cloudformation.ListStackResourcesInput, arg2 func(*cloudformation.ListStackResourcesOutput, bool) bool, arg3 ...request.Option) error {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1, arg2}
 	for _, a := range arg3 {
 		varargs = append(varargs, a)
@@ -1857,14 +1640,12 @@ func (m *MockCloudFormationAPI) ListStackResourcesPagesWithContext(arg0 context.
 
 // ListStackResourcesPagesWithContext indicates an expected call of ListStackResourcesPagesWithContext
 func (mr *MockCloudFormationAPIMockRecorder) ListStackResourcesPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListStackResourcesPagesWithContext", reflect.TypeOf((*MockCloudFormationAPI)(nil).ListStackResourcesPagesWithContext), varargs...)
 }
 
 // ListStackResourcesRequest mocks base method
 func (m *MockCloudFormationAPI) ListStackResourcesRequest(arg0 *cloudformation.ListStackResourcesInput) (*request.Request, *cloudformation.ListStackResourcesOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListStackResourcesRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*cloudformation.ListStackResourcesOutput)
@@ -1873,13 +1654,11 @@ func (m *MockCloudFormationAPI) ListStackResourcesRequest(arg0 *cloudformation.L
 
 // ListStackResourcesRequest indicates an expected call of ListStackResourcesRequest
 func (mr *MockCloudFormationAPIMockRecorder) ListStackResourcesRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListStackResourcesRequest", reflect.TypeOf((*MockCloudFormationAPI)(nil).ListStackResourcesRequest), arg0)
 }
 
 // ListStackResourcesWithContext mocks base method
 func (m *MockCloudFormationAPI) ListStackResourcesWithContext(arg0 context.Context, arg1 *cloudformation.ListStackResourcesInput, arg2 ...request.Option) (*cloudformation.ListStackResourcesOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -1892,14 +1671,12 @@ func (m *MockCloudFormationAPI) ListStackResourcesWithContext(arg0 context.Conte
 
 // ListStackResourcesWithContext indicates an expected call of ListStackResourcesWithContext
 func (mr *MockCloudFormationAPIMockRecorder) ListStackResourcesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListStackResourcesWithContext", reflect.TypeOf((*MockCloudFormationAPI)(nil).ListStackResourcesWithContext), varargs...)
 }
 
 // ListStackSetOperationResults mocks base method
 func (m *MockCloudFormationAPI) ListStackSetOperationResults(arg0 *cloudformation.ListStackSetOperationResultsInput) (*cloudformation.ListStackSetOperationResultsOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListStackSetOperationResults", arg0)
 	ret0, _ := ret[0].(*cloudformation.ListStackSetOperationResultsOutput)
 	ret1, _ := ret[1].(error)
@@ -1908,13 +1685,11 @@ func (m *MockCloudFormationAPI) ListStackSetOperationResults(arg0 *cloudformatio
 
 // ListStackSetOperationResults indicates an expected call of ListStackSetOperationResults
 func (mr *MockCloudFormationAPIMockRecorder) ListStackSetOperationResults(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListStackSetOperationResults", reflect.TypeOf((*MockCloudFormationAPI)(nil).ListStackSetOperationResults), arg0)
 }
 
 // ListStackSetOperationResultsRequest mocks base method
 func (m *MockCloudFormationAPI) ListStackSetOperationResultsRequest(arg0 *cloudformation.ListStackSetOperationResultsInput) (*request.Request, *cloudformation.ListStackSetOperationResultsOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListStackSetOperationResultsRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*cloudformation.ListStackSetOperationResultsOutput)
@@ -1923,13 +1698,11 @@ func (m *MockCloudFormationAPI) ListStackSetOperationResultsRequest(arg0 *cloudf
 
 // ListStackSetOperationResultsRequest indicates an expected call of ListStackSetOperationResultsRequest
 func (mr *MockCloudFormationAPIMockRecorder) ListStackSetOperationResultsRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListStackSetOperationResultsRequest", reflect.TypeOf((*MockCloudFormationAPI)(nil).ListStackSetOperationResultsRequest), arg0)
 }
 
 // ListStackSetOperationResultsWithContext mocks base method
 func (m *MockCloudFormationAPI) ListStackSetOperationResultsWithContext(arg0 context.Context, arg1 *cloudformation.ListStackSetOperationResultsInput, arg2 ...request.Option) (*cloudformation.ListStackSetOperationResultsOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -1942,14 +1715,12 @@ func (m *MockCloudFormationAPI) ListStackSetOperationResultsWithContext(arg0 con
 
 // ListStackSetOperationResultsWithContext indicates an expected call of ListStackSetOperationResultsWithContext
 func (mr *MockCloudFormationAPIMockRecorder) ListStackSetOperationResultsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListStackSetOperationResultsWithContext", reflect.TypeOf((*MockCloudFormationAPI)(nil).ListStackSetOperationResultsWithContext), varargs...)
 }
 
 // ListStackSetOperations mocks base method
 func (m *MockCloudFormationAPI) ListStackSetOperations(arg0 *cloudformation.ListStackSetOperationsInput) (*cloudformation.ListStackSetOperationsOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListStackSetOperations", arg0)
 	ret0, _ := ret[0].(*cloudformation.ListStackSetOperationsOutput)
 	ret1, _ := ret[1].(error)
@@ -1958,13 +1729,11 @@ func (m *MockCloudFormationAPI) ListStackSetOperations(arg0 *cloudformation.List
 
 // ListStackSetOperations indicates an expected call of ListStackSetOperations
 func (mr *MockCloudFormationAPIMockRecorder) ListStackSetOperations(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListStackSetOperations", reflect.TypeOf((*MockCloudFormationAPI)(nil).ListStackSetOperations), arg0)
 }
 
 // ListStackSetOperationsRequest mocks base method
 func (m *MockCloudFormationAPI) ListStackSetOperationsRequest(arg0 *cloudformation.ListStackSetOperationsInput) (*request.Request, *cloudformation.ListStackSetOperationsOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListStackSetOperationsRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*cloudformation.ListStackSetOperationsOutput)
@@ -1973,13 +1742,11 @@ func (m *MockCloudFormationAPI) ListStackSetOperationsRequest(arg0 *cloudformati
 
 // ListStackSetOperationsRequest indicates an expected call of ListStackSetOperationsRequest
 func (mr *MockCloudFormationAPIMockRecorder) ListStackSetOperationsRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListStackSetOperationsRequest", reflect.TypeOf((*MockCloudFormationAPI)(nil).ListStackSetOperationsRequest), arg0)
 }
 
 // ListStackSetOperationsWithContext mocks base method
 func (m *MockCloudFormationAPI) ListStackSetOperationsWithContext(arg0 context.Context, arg1 *cloudformation.ListStackSetOperationsInput, arg2 ...request.Option) (*cloudformation.ListStackSetOperationsOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -1992,14 +1759,12 @@ func (m *MockCloudFormationAPI) ListStackSetOperationsWithContext(arg0 context.C
 
 // ListStackSetOperationsWithContext indicates an expected call of ListStackSetOperationsWithContext
 func (mr *MockCloudFormationAPIMockRecorder) ListStackSetOperationsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListStackSetOperationsWithContext", reflect.TypeOf((*MockCloudFormationAPI)(nil).ListStackSetOperationsWithContext), varargs...)
 }
 
 // ListStackSets mocks base method
 func (m *MockCloudFormationAPI) ListStackSets(arg0 *cloudformation.ListStackSetsInput) (*cloudformation.ListStackSetsOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListStackSets", arg0)
 	ret0, _ := ret[0].(*cloudformation.ListStackSetsOutput)
 	ret1, _ := ret[1].(error)
@@ -2008,13 +1773,11 @@ func (m *MockCloudFormationAPI) ListStackSets(arg0 *cloudformation.ListStackSets
 
 // ListStackSets indicates an expected call of ListStackSets
 func (mr *MockCloudFormationAPIMockRecorder) ListStackSets(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListStackSets", reflect.TypeOf((*MockCloudFormationAPI)(nil).ListStackSets), arg0)
 }
 
 // ListStackSetsRequest mocks base method
 func (m *MockCloudFormationAPI) ListStackSetsRequest(arg0 *cloudformation.ListStackSetsInput) (*request.Request, *cloudformation.ListStackSetsOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListStackSetsRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*cloudformation.ListStackSetsOutput)
@@ -2023,13 +1786,11 @@ func (m *MockCloudFormationAPI) ListStackSetsRequest(arg0 *cloudformation.ListSt
 
 // ListStackSetsRequest indicates an expected call of ListStackSetsRequest
 func (mr *MockCloudFormationAPIMockRecorder) ListStackSetsRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListStackSetsRequest", reflect.TypeOf((*MockCloudFormationAPI)(nil).ListStackSetsRequest), arg0)
 }
 
 // ListStackSetsWithContext mocks base method
 func (m *MockCloudFormationAPI) ListStackSetsWithContext(arg0 context.Context, arg1 *cloudformation.ListStackSetsInput, arg2 ...request.Option) (*cloudformation.ListStackSetsOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -2042,14 +1803,12 @@ func (m *MockCloudFormationAPI) ListStackSetsWithContext(arg0 context.Context, a
 
 // ListStackSetsWithContext indicates an expected call of ListStackSetsWithContext
 func (mr *MockCloudFormationAPIMockRecorder) ListStackSetsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListStackSetsWithContext", reflect.TypeOf((*MockCloudFormationAPI)(nil).ListStackSetsWithContext), varargs...)
 }
 
 // ListStacks mocks base method
 func (m *MockCloudFormationAPI) ListStacks(arg0 *cloudformation.ListStacksInput) (*cloudformation.ListStacksOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListStacks", arg0)
 	ret0, _ := ret[0].(*cloudformation.ListStacksOutput)
 	ret1, _ := ret[1].(error)
@@ -2058,13 +1817,11 @@ func (m *MockCloudFormationAPI) ListStacks(arg0 *cloudformation.ListStacksInput)
 
 // ListStacks indicates an expected call of ListStacks
 func (mr *MockCloudFormationAPIMockRecorder) ListStacks(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListStacks", reflect.TypeOf((*MockCloudFormationAPI)(nil).ListStacks), arg0)
 }
 
 // ListStacksPages mocks base method
 func (m *MockCloudFormationAPI) ListStacksPages(arg0 *cloudformation.ListStacksInput, arg1 func(*cloudformation.ListStacksOutput, bool) bool) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListStacksPages", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -2072,13 +1829,11 @@ func (m *MockCloudFormationAPI) ListStacksPages(arg0 *cloudformation.ListStacksI
 
 // ListStacksPages indicates an expected call of ListStacksPages
 func (mr *MockCloudFormationAPIMockRecorder) ListStacksPages(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListStacksPages", reflect.TypeOf((*MockCloudFormationAPI)(nil).ListStacksPages), arg0, arg1)
 }
 
 // ListStacksPagesWithContext mocks base method
 func (m *MockCloudFormationAPI) ListStacksPagesWithContext(arg0 context.Context, arg1 *cloudformation.ListStacksInput, arg2 func(*cloudformation.ListStacksOutput, bool) bool, arg3 ...request.Option) error {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1, arg2}
 	for _, a := range arg3 {
 		varargs = append(varargs, a)
@@ -2090,14 +1845,12 @@ func (m *MockCloudFormationAPI) ListStacksPagesWithContext(arg0 context.Context,
 
 // ListStacksPagesWithContext indicates an expected call of ListStacksPagesWithContext
 func (mr *MockCloudFormationAPIMockRecorder) ListStacksPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListStacksPagesWithContext", reflect.TypeOf((*MockCloudFormationAPI)(nil).ListStacksPagesWithContext), varargs...)
 }
 
 // ListStacksRequest mocks base method
 func (m *MockCloudFormationAPI) ListStacksRequest(arg0 *cloudformation.ListStacksInput) (*request.Request, *cloudformation.ListStacksOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListStacksRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*cloudformation.ListStacksOutput)
@@ -2106,13 +1859,11 @@ func (m *MockCloudFormationAPI) ListStacksRequest(arg0 *cloudformation.ListStack
 
 // ListStacksRequest indicates an expected call of ListStacksRequest
 func (mr *MockCloudFormationAPIMockRecorder) ListStacksRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListStacksRequest", reflect.TypeOf((*MockCloudFormationAPI)(nil).ListStacksRequest), arg0)
 }
 
 // ListStacksWithContext mocks base method
 func (m *MockCloudFormationAPI) ListStacksWithContext(arg0 context.Context, arg1 *cloudformation.ListStacksInput, arg2 ...request.Option) (*cloudformation.ListStacksOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -2125,14 +1876,12 @@ func (m *MockCloudFormationAPI) ListStacksWithContext(arg0 context.Context, arg1
 
 // ListStacksWithContext indicates an expected call of ListStacksWithContext
 func (mr *MockCloudFormationAPIMockRecorder) ListStacksWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListStacksWithContext", reflect.TypeOf((*MockCloudFormationAPI)(nil).ListStacksWithContext), varargs...)
 }
 
 // SetStackPolicy mocks base method
 func (m *MockCloudFormationAPI) SetStackPolicy(arg0 *cloudformation.SetStackPolicyInput) (*cloudformation.SetStackPolicyOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetStackPolicy", arg0)
 	ret0, _ := ret[0].(*cloudformation.SetStackPolicyOutput)
 	ret1, _ := ret[1].(error)
@@ -2141,13 +1890,11 @@ func (m *MockCloudFormationAPI) SetStackPolicy(arg0 *cloudformation.SetStackPoli
 
 // SetStackPolicy indicates an expected call of SetStackPolicy
 func (mr *MockCloudFormationAPIMockRecorder) SetStackPolicy(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetStackPolicy", reflect.TypeOf((*MockCloudFormationAPI)(nil).SetStackPolicy), arg0)
 }
 
 // SetStackPolicyRequest mocks base method
 func (m *MockCloudFormationAPI) SetStackPolicyRequest(arg0 *cloudformation.SetStackPolicyInput) (*request.Request, *cloudformation.SetStackPolicyOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetStackPolicyRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*cloudformation.SetStackPolicyOutput)
@@ -2156,13 +1903,11 @@ func (m *MockCloudFormationAPI) SetStackPolicyRequest(arg0 *cloudformation.SetSt
 
 // SetStackPolicyRequest indicates an expected call of SetStackPolicyRequest
 func (mr *MockCloudFormationAPIMockRecorder) SetStackPolicyRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetStackPolicyRequest", reflect.TypeOf((*MockCloudFormationAPI)(nil).SetStackPolicyRequest), arg0)
 }
 
 // SetStackPolicyWithContext mocks base method
 func (m *MockCloudFormationAPI) SetStackPolicyWithContext(arg0 context.Context, arg1 *cloudformation.SetStackPolicyInput, arg2 ...request.Option) (*cloudformation.SetStackPolicyOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -2175,14 +1920,12 @@ func (m *MockCloudFormationAPI) SetStackPolicyWithContext(arg0 context.Context, 
 
 // SetStackPolicyWithContext indicates an expected call of SetStackPolicyWithContext
 func (mr *MockCloudFormationAPIMockRecorder) SetStackPolicyWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetStackPolicyWithContext", reflect.TypeOf((*MockCloudFormationAPI)(nil).SetStackPolicyWithContext), varargs...)
 }
 
 // SignalResource mocks base method
 func (m *MockCloudFormationAPI) SignalResource(arg0 *cloudformation.SignalResourceInput) (*cloudformation.SignalResourceOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SignalResource", arg0)
 	ret0, _ := ret[0].(*cloudformation.SignalResourceOutput)
 	ret1, _ := ret[1].(error)
@@ -2191,13 +1934,11 @@ func (m *MockCloudFormationAPI) SignalResource(arg0 *cloudformation.SignalResour
 
 // SignalResource indicates an expected call of SignalResource
 func (mr *MockCloudFormationAPIMockRecorder) SignalResource(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SignalResource", reflect.TypeOf((*MockCloudFormationAPI)(nil).SignalResource), arg0)
 }
 
 // SignalResourceRequest mocks base method
 func (m *MockCloudFormationAPI) SignalResourceRequest(arg0 *cloudformation.SignalResourceInput) (*request.Request, *cloudformation.SignalResourceOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SignalResourceRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*cloudformation.SignalResourceOutput)
@@ -2206,13 +1947,11 @@ func (m *MockCloudFormationAPI) SignalResourceRequest(arg0 *cloudformation.Signa
 
 // SignalResourceRequest indicates an expected call of SignalResourceRequest
 func (mr *MockCloudFormationAPIMockRecorder) SignalResourceRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SignalResourceRequest", reflect.TypeOf((*MockCloudFormationAPI)(nil).SignalResourceRequest), arg0)
 }
 
 // SignalResourceWithContext mocks base method
 func (m *MockCloudFormationAPI) SignalResourceWithContext(arg0 context.Context, arg1 *cloudformation.SignalResourceInput, arg2 ...request.Option) (*cloudformation.SignalResourceOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -2225,14 +1964,12 @@ func (m *MockCloudFormationAPI) SignalResourceWithContext(arg0 context.Context, 
 
 // SignalResourceWithContext indicates an expected call of SignalResourceWithContext
 func (mr *MockCloudFormationAPIMockRecorder) SignalResourceWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SignalResourceWithContext", reflect.TypeOf((*MockCloudFormationAPI)(nil).SignalResourceWithContext), varargs...)
 }
 
 // StopStackSetOperation mocks base method
 func (m *MockCloudFormationAPI) StopStackSetOperation(arg0 *cloudformation.StopStackSetOperationInput) (*cloudformation.StopStackSetOperationOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StopStackSetOperation", arg0)
 	ret0, _ := ret[0].(*cloudformation.StopStackSetOperationOutput)
 	ret1, _ := ret[1].(error)
@@ -2241,13 +1978,11 @@ func (m *MockCloudFormationAPI) StopStackSetOperation(arg0 *cloudformation.StopS
 
 // StopStackSetOperation indicates an expected call of StopStackSetOperation
 func (mr *MockCloudFormationAPIMockRecorder) StopStackSetOperation(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StopStackSetOperation", reflect.TypeOf((*MockCloudFormationAPI)(nil).StopStackSetOperation), arg0)
 }
 
 // StopStackSetOperationRequest mocks base method
 func (m *MockCloudFormationAPI) StopStackSetOperationRequest(arg0 *cloudformation.StopStackSetOperationInput) (*request.Request, *cloudformation.StopStackSetOperationOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StopStackSetOperationRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*cloudformation.StopStackSetOperationOutput)
@@ -2256,13 +1991,11 @@ func (m *MockCloudFormationAPI) StopStackSetOperationRequest(arg0 *cloudformatio
 
 // StopStackSetOperationRequest indicates an expected call of StopStackSetOperationRequest
 func (mr *MockCloudFormationAPIMockRecorder) StopStackSetOperationRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StopStackSetOperationRequest", reflect.TypeOf((*MockCloudFormationAPI)(nil).StopStackSetOperationRequest), arg0)
 }
 
 // StopStackSetOperationWithContext mocks base method
 func (m *MockCloudFormationAPI) StopStackSetOperationWithContext(arg0 context.Context, arg1 *cloudformation.StopStackSetOperationInput, arg2 ...request.Option) (*cloudformation.StopStackSetOperationOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -2275,14 +2008,12 @@ func (m *MockCloudFormationAPI) StopStackSetOperationWithContext(arg0 context.Co
 
 // StopStackSetOperationWithContext indicates an expected call of StopStackSetOperationWithContext
 func (mr *MockCloudFormationAPIMockRecorder) StopStackSetOperationWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StopStackSetOperationWithContext", reflect.TypeOf((*MockCloudFormationAPI)(nil).StopStackSetOperationWithContext), varargs...)
 }
 
 // UpdateStack mocks base method
 func (m *MockCloudFormationAPI) UpdateStack(arg0 *cloudformation.UpdateStackInput) (*cloudformation.UpdateStackOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateStack", arg0)
 	ret0, _ := ret[0].(*cloudformation.UpdateStackOutput)
 	ret1, _ := ret[1].(error)
@@ -2291,13 +2022,11 @@ func (m *MockCloudFormationAPI) UpdateStack(arg0 *cloudformation.UpdateStackInpu
 
 // UpdateStack indicates an expected call of UpdateStack
 func (mr *MockCloudFormationAPIMockRecorder) UpdateStack(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateStack", reflect.TypeOf((*MockCloudFormationAPI)(nil).UpdateStack), arg0)
 }
 
 // UpdateStackInstances mocks base method
 func (m *MockCloudFormationAPI) UpdateStackInstances(arg0 *cloudformation.UpdateStackInstancesInput) (*cloudformation.UpdateStackInstancesOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateStackInstances", arg0)
 	ret0, _ := ret[0].(*cloudformation.UpdateStackInstancesOutput)
 	ret1, _ := ret[1].(error)
@@ -2306,13 +2035,11 @@ func (m *MockCloudFormationAPI) UpdateStackInstances(arg0 *cloudformation.Update
 
 // UpdateStackInstances indicates an expected call of UpdateStackInstances
 func (mr *MockCloudFormationAPIMockRecorder) UpdateStackInstances(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateStackInstances", reflect.TypeOf((*MockCloudFormationAPI)(nil).UpdateStackInstances), arg0)
 }
 
 // UpdateStackInstancesRequest mocks base method
 func (m *MockCloudFormationAPI) UpdateStackInstancesRequest(arg0 *cloudformation.UpdateStackInstancesInput) (*request.Request, *cloudformation.UpdateStackInstancesOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateStackInstancesRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*cloudformation.UpdateStackInstancesOutput)
@@ -2321,13 +2048,11 @@ func (m *MockCloudFormationAPI) UpdateStackInstancesRequest(arg0 *cloudformation
 
 // UpdateStackInstancesRequest indicates an expected call of UpdateStackInstancesRequest
 func (mr *MockCloudFormationAPIMockRecorder) UpdateStackInstancesRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateStackInstancesRequest", reflect.TypeOf((*MockCloudFormationAPI)(nil).UpdateStackInstancesRequest), arg0)
 }
 
 // UpdateStackInstancesWithContext mocks base method
 func (m *MockCloudFormationAPI) UpdateStackInstancesWithContext(arg0 context.Context, arg1 *cloudformation.UpdateStackInstancesInput, arg2 ...request.Option) (*cloudformation.UpdateStackInstancesOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -2340,14 +2065,12 @@ func (m *MockCloudFormationAPI) UpdateStackInstancesWithContext(arg0 context.Con
 
 // UpdateStackInstancesWithContext indicates an expected call of UpdateStackInstancesWithContext
 func (mr *MockCloudFormationAPIMockRecorder) UpdateStackInstancesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateStackInstancesWithContext", reflect.TypeOf((*MockCloudFormationAPI)(nil).UpdateStackInstancesWithContext), varargs...)
 }
 
 // UpdateStackRequest mocks base method
 func (m *MockCloudFormationAPI) UpdateStackRequest(arg0 *cloudformation.UpdateStackInput) (*request.Request, *cloudformation.UpdateStackOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateStackRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*cloudformation.UpdateStackOutput)
@@ -2356,13 +2079,11 @@ func (m *MockCloudFormationAPI) UpdateStackRequest(arg0 *cloudformation.UpdateSt
 
 // UpdateStackRequest indicates an expected call of UpdateStackRequest
 func (mr *MockCloudFormationAPIMockRecorder) UpdateStackRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateStackRequest", reflect.TypeOf((*MockCloudFormationAPI)(nil).UpdateStackRequest), arg0)
 }
 
 // UpdateStackSet mocks base method
 func (m *MockCloudFormationAPI) UpdateStackSet(arg0 *cloudformation.UpdateStackSetInput) (*cloudformation.UpdateStackSetOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateStackSet", arg0)
 	ret0, _ := ret[0].(*cloudformation.UpdateStackSetOutput)
 	ret1, _ := ret[1].(error)
@@ -2371,13 +2092,11 @@ func (m *MockCloudFormationAPI) UpdateStackSet(arg0 *cloudformation.UpdateStackS
 
 // UpdateStackSet indicates an expected call of UpdateStackSet
 func (mr *MockCloudFormationAPIMockRecorder) UpdateStackSet(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateStackSet", reflect.TypeOf((*MockCloudFormationAPI)(nil).UpdateStackSet), arg0)
 }
 
 // UpdateStackSetRequest mocks base method
 func (m *MockCloudFormationAPI) UpdateStackSetRequest(arg0 *cloudformation.UpdateStackSetInput) (*request.Request, *cloudformation.UpdateStackSetOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateStackSetRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*cloudformation.UpdateStackSetOutput)
@@ -2386,13 +2105,11 @@ func (m *MockCloudFormationAPI) UpdateStackSetRequest(arg0 *cloudformation.Updat
 
 // UpdateStackSetRequest indicates an expected call of UpdateStackSetRequest
 func (mr *MockCloudFormationAPIMockRecorder) UpdateStackSetRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateStackSetRequest", reflect.TypeOf((*MockCloudFormationAPI)(nil).UpdateStackSetRequest), arg0)
 }
 
 // UpdateStackSetWithContext mocks base method
 func (m *MockCloudFormationAPI) UpdateStackSetWithContext(arg0 context.Context, arg1 *cloudformation.UpdateStackSetInput, arg2 ...request.Option) (*cloudformation.UpdateStackSetOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -2405,14 +2122,12 @@ func (m *MockCloudFormationAPI) UpdateStackSetWithContext(arg0 context.Context, 
 
 // UpdateStackSetWithContext indicates an expected call of UpdateStackSetWithContext
 func (mr *MockCloudFormationAPIMockRecorder) UpdateStackSetWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateStackSetWithContext", reflect.TypeOf((*MockCloudFormationAPI)(nil).UpdateStackSetWithContext), varargs...)
 }
 
 // UpdateStackWithContext mocks base method
 func (m *MockCloudFormationAPI) UpdateStackWithContext(arg0 context.Context, arg1 *cloudformation.UpdateStackInput, arg2 ...request.Option) (*cloudformation.UpdateStackOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -2425,14 +2140,12 @@ func (m *MockCloudFormationAPI) UpdateStackWithContext(arg0 context.Context, arg
 
 // UpdateStackWithContext indicates an expected call of UpdateStackWithContext
 func (mr *MockCloudFormationAPIMockRecorder) UpdateStackWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateStackWithContext", reflect.TypeOf((*MockCloudFormationAPI)(nil).UpdateStackWithContext), varargs...)
 }
 
 // UpdateTerminationProtection mocks base method
 func (m *MockCloudFormationAPI) UpdateTerminationProtection(arg0 *cloudformation.UpdateTerminationProtectionInput) (*cloudformation.UpdateTerminationProtectionOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateTerminationProtection", arg0)
 	ret0, _ := ret[0].(*cloudformation.UpdateTerminationProtectionOutput)
 	ret1, _ := ret[1].(error)
@@ -2441,13 +2154,11 @@ func (m *MockCloudFormationAPI) UpdateTerminationProtection(arg0 *cloudformation
 
 // UpdateTerminationProtection indicates an expected call of UpdateTerminationProtection
 func (mr *MockCloudFormationAPIMockRecorder) UpdateTerminationProtection(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateTerminationProtection", reflect.TypeOf((*MockCloudFormationAPI)(nil).UpdateTerminationProtection), arg0)
 }
 
 // UpdateTerminationProtectionRequest mocks base method
 func (m *MockCloudFormationAPI) UpdateTerminationProtectionRequest(arg0 *cloudformation.UpdateTerminationProtectionInput) (*request.Request, *cloudformation.UpdateTerminationProtectionOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateTerminationProtectionRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*cloudformation.UpdateTerminationProtectionOutput)
@@ -2456,13 +2167,11 @@ func (m *MockCloudFormationAPI) UpdateTerminationProtectionRequest(arg0 *cloudfo
 
 // UpdateTerminationProtectionRequest indicates an expected call of UpdateTerminationProtectionRequest
 func (mr *MockCloudFormationAPIMockRecorder) UpdateTerminationProtectionRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateTerminationProtectionRequest", reflect.TypeOf((*MockCloudFormationAPI)(nil).UpdateTerminationProtectionRequest), arg0)
 }
 
 // UpdateTerminationProtectionWithContext mocks base method
 func (m *MockCloudFormationAPI) UpdateTerminationProtectionWithContext(arg0 context.Context, arg1 *cloudformation.UpdateTerminationProtectionInput, arg2 ...request.Option) (*cloudformation.UpdateTerminationProtectionOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -2475,14 +2184,12 @@ func (m *MockCloudFormationAPI) UpdateTerminationProtectionWithContext(arg0 cont
 
 // UpdateTerminationProtectionWithContext indicates an expected call of UpdateTerminationProtectionWithContext
 func (mr *MockCloudFormationAPIMockRecorder) UpdateTerminationProtectionWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateTerminationProtectionWithContext", reflect.TypeOf((*MockCloudFormationAPI)(nil).UpdateTerminationProtectionWithContext), varargs...)
 }
 
 // ValidateTemplate mocks base method
 func (m *MockCloudFormationAPI) ValidateTemplate(arg0 *cloudformation.ValidateTemplateInput) (*cloudformation.ValidateTemplateOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ValidateTemplate", arg0)
 	ret0, _ := ret[0].(*cloudformation.ValidateTemplateOutput)
 	ret1, _ := ret[1].(error)
@@ -2491,13 +2198,11 @@ func (m *MockCloudFormationAPI) ValidateTemplate(arg0 *cloudformation.ValidateTe
 
 // ValidateTemplate indicates an expected call of ValidateTemplate
 func (mr *MockCloudFormationAPIMockRecorder) ValidateTemplate(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateTemplate", reflect.TypeOf((*MockCloudFormationAPI)(nil).ValidateTemplate), arg0)
 }
 
 // ValidateTemplateRequest mocks base method
 func (m *MockCloudFormationAPI) ValidateTemplateRequest(arg0 *cloudformation.ValidateTemplateInput) (*request.Request, *cloudformation.ValidateTemplateOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ValidateTemplateRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*cloudformation.ValidateTemplateOutput)
@@ -2506,13 +2211,11 @@ func (m *MockCloudFormationAPI) ValidateTemplateRequest(arg0 *cloudformation.Val
 
 // ValidateTemplateRequest indicates an expected call of ValidateTemplateRequest
 func (mr *MockCloudFormationAPIMockRecorder) ValidateTemplateRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateTemplateRequest", reflect.TypeOf((*MockCloudFormationAPI)(nil).ValidateTemplateRequest), arg0)
 }
 
 // ValidateTemplateWithContext mocks base method
 func (m *MockCloudFormationAPI) ValidateTemplateWithContext(arg0 context.Context, arg1 *cloudformation.ValidateTemplateInput, arg2 ...request.Option) (*cloudformation.ValidateTemplateOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -2525,14 +2228,12 @@ func (m *MockCloudFormationAPI) ValidateTemplateWithContext(arg0 context.Context
 
 // ValidateTemplateWithContext indicates an expected call of ValidateTemplateWithContext
 func (mr *MockCloudFormationAPIMockRecorder) ValidateTemplateWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateTemplateWithContext", reflect.TypeOf((*MockCloudFormationAPI)(nil).ValidateTemplateWithContext), varargs...)
 }
 
 // WaitUntilChangeSetCreateComplete mocks base method
 func (m *MockCloudFormationAPI) WaitUntilChangeSetCreateComplete(arg0 *cloudformation.DescribeChangeSetInput) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WaitUntilChangeSetCreateComplete", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -2540,13 +2241,11 @@ func (m *MockCloudFormationAPI) WaitUntilChangeSetCreateComplete(arg0 *cloudform
 
 // WaitUntilChangeSetCreateComplete indicates an expected call of WaitUntilChangeSetCreateComplete
 func (mr *MockCloudFormationAPIMockRecorder) WaitUntilChangeSetCreateComplete(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitUntilChangeSetCreateComplete", reflect.TypeOf((*MockCloudFormationAPI)(nil).WaitUntilChangeSetCreateComplete), arg0)
 }
 
 // WaitUntilChangeSetCreateCompleteWithContext mocks base method
 func (m *MockCloudFormationAPI) WaitUntilChangeSetCreateCompleteWithContext(arg0 context.Context, arg1 *cloudformation.DescribeChangeSetInput, arg2 ...request.WaiterOption) error {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -2558,14 +2257,12 @@ func (m *MockCloudFormationAPI) WaitUntilChangeSetCreateCompleteWithContext(arg0
 
 // WaitUntilChangeSetCreateCompleteWithContext indicates an expected call of WaitUntilChangeSetCreateCompleteWithContext
 func (mr *MockCloudFormationAPIMockRecorder) WaitUntilChangeSetCreateCompleteWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitUntilChangeSetCreateCompleteWithContext", reflect.TypeOf((*MockCloudFormationAPI)(nil).WaitUntilChangeSetCreateCompleteWithContext), varargs...)
 }
 
 // WaitUntilStackCreateComplete mocks base method
 func (m *MockCloudFormationAPI) WaitUntilStackCreateComplete(arg0 *cloudformation.DescribeStacksInput) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WaitUntilStackCreateComplete", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -2573,13 +2270,11 @@ func (m *MockCloudFormationAPI) WaitUntilStackCreateComplete(arg0 *cloudformatio
 
 // WaitUntilStackCreateComplete indicates an expected call of WaitUntilStackCreateComplete
 func (mr *MockCloudFormationAPIMockRecorder) WaitUntilStackCreateComplete(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitUntilStackCreateComplete", reflect.TypeOf((*MockCloudFormationAPI)(nil).WaitUntilStackCreateComplete), arg0)
 }
 
 // WaitUntilStackCreateCompleteWithContext mocks base method
 func (m *MockCloudFormationAPI) WaitUntilStackCreateCompleteWithContext(arg0 context.Context, arg1 *cloudformation.DescribeStacksInput, arg2 ...request.WaiterOption) error {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -2591,14 +2286,12 @@ func (m *MockCloudFormationAPI) WaitUntilStackCreateCompleteWithContext(arg0 con
 
 // WaitUntilStackCreateCompleteWithContext indicates an expected call of WaitUntilStackCreateCompleteWithContext
 func (mr *MockCloudFormationAPIMockRecorder) WaitUntilStackCreateCompleteWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitUntilStackCreateCompleteWithContext", reflect.TypeOf((*MockCloudFormationAPI)(nil).WaitUntilStackCreateCompleteWithContext), varargs...)
 }
 
 // WaitUntilStackDeleteComplete mocks base method
 func (m *MockCloudFormationAPI) WaitUntilStackDeleteComplete(arg0 *cloudformation.DescribeStacksInput) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WaitUntilStackDeleteComplete", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -2606,13 +2299,11 @@ func (m *MockCloudFormationAPI) WaitUntilStackDeleteComplete(arg0 *cloudformatio
 
 // WaitUntilStackDeleteComplete indicates an expected call of WaitUntilStackDeleteComplete
 func (mr *MockCloudFormationAPIMockRecorder) WaitUntilStackDeleteComplete(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitUntilStackDeleteComplete", reflect.TypeOf((*MockCloudFormationAPI)(nil).WaitUntilStackDeleteComplete), arg0)
 }
 
 // WaitUntilStackDeleteCompleteWithContext mocks base method
 func (m *MockCloudFormationAPI) WaitUntilStackDeleteCompleteWithContext(arg0 context.Context, arg1 *cloudformation.DescribeStacksInput, arg2 ...request.WaiterOption) error {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -2624,14 +2315,12 @@ func (m *MockCloudFormationAPI) WaitUntilStackDeleteCompleteWithContext(arg0 con
 
 // WaitUntilStackDeleteCompleteWithContext indicates an expected call of WaitUntilStackDeleteCompleteWithContext
 func (mr *MockCloudFormationAPIMockRecorder) WaitUntilStackDeleteCompleteWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitUntilStackDeleteCompleteWithContext", reflect.TypeOf((*MockCloudFormationAPI)(nil).WaitUntilStackDeleteCompleteWithContext), varargs...)
 }
 
 // WaitUntilStackExists mocks base method
 func (m *MockCloudFormationAPI) WaitUntilStackExists(arg0 *cloudformation.DescribeStacksInput) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WaitUntilStackExists", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -2639,13 +2328,11 @@ func (m *MockCloudFormationAPI) WaitUntilStackExists(arg0 *cloudformation.Descri
 
 // WaitUntilStackExists indicates an expected call of WaitUntilStackExists
 func (mr *MockCloudFormationAPIMockRecorder) WaitUntilStackExists(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitUntilStackExists", reflect.TypeOf((*MockCloudFormationAPI)(nil).WaitUntilStackExists), arg0)
 }
 
 // WaitUntilStackExistsWithContext mocks base method
 func (m *MockCloudFormationAPI) WaitUntilStackExistsWithContext(arg0 context.Context, arg1 *cloudformation.DescribeStacksInput, arg2 ...request.WaiterOption) error {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -2657,14 +2344,12 @@ func (m *MockCloudFormationAPI) WaitUntilStackExistsWithContext(arg0 context.Con
 
 // WaitUntilStackExistsWithContext indicates an expected call of WaitUntilStackExistsWithContext
 func (mr *MockCloudFormationAPIMockRecorder) WaitUntilStackExistsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitUntilStackExistsWithContext", reflect.TypeOf((*MockCloudFormationAPI)(nil).WaitUntilStackExistsWithContext), varargs...)
 }
 
 // WaitUntilStackUpdateComplete mocks base method
 func (m *MockCloudFormationAPI) WaitUntilStackUpdateComplete(arg0 *cloudformation.DescribeStacksInput) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WaitUntilStackUpdateComplete", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -2672,13 +2357,11 @@ func (m *MockCloudFormationAPI) WaitUntilStackUpdateComplete(arg0 *cloudformatio
 
 // WaitUntilStackUpdateComplete indicates an expected call of WaitUntilStackUpdateComplete
 func (mr *MockCloudFormationAPIMockRecorder) WaitUntilStackUpdateComplete(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitUntilStackUpdateComplete", reflect.TypeOf((*MockCloudFormationAPI)(nil).WaitUntilStackUpdateComplete), arg0)
 }
 
 // WaitUntilStackUpdateCompleteWithContext mocks base method
 func (m *MockCloudFormationAPI) WaitUntilStackUpdateCompleteWithContext(arg0 context.Context, arg1 *cloudformation.DescribeStacksInput, arg2 ...request.WaiterOption) error {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -2690,7 +2373,6 @@ func (m *MockCloudFormationAPI) WaitUntilStackUpdateCompleteWithContext(arg0 con
 
 // WaitUntilStackUpdateCompleteWithContext indicates an expected call of WaitUntilStackUpdateCompleteWithContext
 func (mr *MockCloudFormationAPIMockRecorder) WaitUntilStackUpdateCompleteWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitUntilStackUpdateCompleteWithContext", reflect.TypeOf((*MockCloudFormationAPI)(nil).WaitUntilStackUpdateCompleteWithContext), varargs...)
 }

--- a/ecs-cli/modules/clients/aws/cloudwatchlogs/mock/client.go
+++ b/ecs-cli/modules/clients/aws/cloudwatchlogs/mock/client.go
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2015-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the
@@ -49,7 +49,6 @@ func (m *MockClient) EXPECT() *MockClientMockRecorder {
 
 // CreateLogGroup mocks base method
 func (m *MockClient) CreateLogGroup(arg0 *string) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateLogGroup", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -57,13 +56,11 @@ func (m *MockClient) CreateLogGroup(arg0 *string) error {
 
 // CreateLogGroup indicates an expected call of CreateLogGroup
 func (mr *MockClientMockRecorder) CreateLogGroup(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateLogGroup", reflect.TypeOf((*MockClient)(nil).CreateLogGroup), arg0)
 }
 
 // FilterAllLogEvents mocks base method
 func (m *MockClient) FilterAllLogEvents(arg0 *cloudwatchlogs.FilterLogEventsInput, arg1 func([]*cloudwatchlogs.FilteredLogEvent)) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "FilterAllLogEvents", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -71,6 +68,5 @@ func (m *MockClient) FilterAllLogEvents(arg0 *cloudwatchlogs.FilterLogEventsInpu
 
 // FilterAllLogEvents indicates an expected call of FilterAllLogEvents
 func (mr *MockClientMockRecorder) FilterAllLogEvents(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FilterAllLogEvents", reflect.TypeOf((*MockClient)(nil).FilterAllLogEvents), arg0, arg1)
 }

--- a/ecs-cli/modules/clients/aws/cloudwatchlogs/mock/factory.go
+++ b/ecs-cli/modules/clients/aws/cloudwatchlogs/mock/factory.go
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2015-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the
@@ -49,7 +49,6 @@ func (m *MockLogClientFactory) EXPECT() *MockLogClientFactoryMockRecorder {
 
 // Get mocks base method
 func (m *MockLogClientFactory) Get(arg0 string) cloudwatchlogs.Client {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Get", arg0)
 	ret0, _ := ret[0].(cloudwatchlogs.Client)
 	return ret0
@@ -57,6 +56,5 @@ func (m *MockLogClientFactory) Get(arg0 string) cloudwatchlogs.Client {
 
 // Get indicates an expected call of Get
 func (mr *MockLogClientFactoryMockRecorder) Get(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockLogClientFactory)(nil).Get), arg0)
 }

--- a/ecs-cli/modules/clients/aws/cloudwatchlogs/mock/sdk/cloudwatchlogsiface.go
+++ b/ecs-cli/modules/clients/aws/cloudwatchlogs/mock/sdk/cloudwatchlogsiface.go
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2015-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the
@@ -51,7 +51,6 @@ func (m *MockCloudWatchLogsAPI) EXPECT() *MockCloudWatchLogsAPIMockRecorder {
 
 // AssociateKmsKey mocks base method
 func (m *MockCloudWatchLogsAPI) AssociateKmsKey(arg0 *cloudwatchlogs.AssociateKmsKeyInput) (*cloudwatchlogs.AssociateKmsKeyOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AssociateKmsKey", arg0)
 	ret0, _ := ret[0].(*cloudwatchlogs.AssociateKmsKeyOutput)
 	ret1, _ := ret[1].(error)
@@ -60,13 +59,11 @@ func (m *MockCloudWatchLogsAPI) AssociateKmsKey(arg0 *cloudwatchlogs.AssociateKm
 
 // AssociateKmsKey indicates an expected call of AssociateKmsKey
 func (mr *MockCloudWatchLogsAPIMockRecorder) AssociateKmsKey(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AssociateKmsKey", reflect.TypeOf((*MockCloudWatchLogsAPI)(nil).AssociateKmsKey), arg0)
 }
 
 // AssociateKmsKeyRequest mocks base method
 func (m *MockCloudWatchLogsAPI) AssociateKmsKeyRequest(arg0 *cloudwatchlogs.AssociateKmsKeyInput) (*request.Request, *cloudwatchlogs.AssociateKmsKeyOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AssociateKmsKeyRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*cloudwatchlogs.AssociateKmsKeyOutput)
@@ -75,13 +72,11 @@ func (m *MockCloudWatchLogsAPI) AssociateKmsKeyRequest(arg0 *cloudwatchlogs.Asso
 
 // AssociateKmsKeyRequest indicates an expected call of AssociateKmsKeyRequest
 func (mr *MockCloudWatchLogsAPIMockRecorder) AssociateKmsKeyRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AssociateKmsKeyRequest", reflect.TypeOf((*MockCloudWatchLogsAPI)(nil).AssociateKmsKeyRequest), arg0)
 }
 
 // AssociateKmsKeyWithContext mocks base method
 func (m *MockCloudWatchLogsAPI) AssociateKmsKeyWithContext(arg0 context.Context, arg1 *cloudwatchlogs.AssociateKmsKeyInput, arg2 ...request.Option) (*cloudwatchlogs.AssociateKmsKeyOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -94,14 +89,12 @@ func (m *MockCloudWatchLogsAPI) AssociateKmsKeyWithContext(arg0 context.Context,
 
 // AssociateKmsKeyWithContext indicates an expected call of AssociateKmsKeyWithContext
 func (mr *MockCloudWatchLogsAPIMockRecorder) AssociateKmsKeyWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AssociateKmsKeyWithContext", reflect.TypeOf((*MockCloudWatchLogsAPI)(nil).AssociateKmsKeyWithContext), varargs...)
 }
 
 // CancelExportTask mocks base method
 func (m *MockCloudWatchLogsAPI) CancelExportTask(arg0 *cloudwatchlogs.CancelExportTaskInput) (*cloudwatchlogs.CancelExportTaskOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CancelExportTask", arg0)
 	ret0, _ := ret[0].(*cloudwatchlogs.CancelExportTaskOutput)
 	ret1, _ := ret[1].(error)
@@ -110,13 +103,11 @@ func (m *MockCloudWatchLogsAPI) CancelExportTask(arg0 *cloudwatchlogs.CancelExpo
 
 // CancelExportTask indicates an expected call of CancelExportTask
 func (mr *MockCloudWatchLogsAPIMockRecorder) CancelExportTask(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CancelExportTask", reflect.TypeOf((*MockCloudWatchLogsAPI)(nil).CancelExportTask), arg0)
 }
 
 // CancelExportTaskRequest mocks base method
 func (m *MockCloudWatchLogsAPI) CancelExportTaskRequest(arg0 *cloudwatchlogs.CancelExportTaskInput) (*request.Request, *cloudwatchlogs.CancelExportTaskOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CancelExportTaskRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*cloudwatchlogs.CancelExportTaskOutput)
@@ -125,13 +116,11 @@ func (m *MockCloudWatchLogsAPI) CancelExportTaskRequest(arg0 *cloudwatchlogs.Can
 
 // CancelExportTaskRequest indicates an expected call of CancelExportTaskRequest
 func (mr *MockCloudWatchLogsAPIMockRecorder) CancelExportTaskRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CancelExportTaskRequest", reflect.TypeOf((*MockCloudWatchLogsAPI)(nil).CancelExportTaskRequest), arg0)
 }
 
 // CancelExportTaskWithContext mocks base method
 func (m *MockCloudWatchLogsAPI) CancelExportTaskWithContext(arg0 context.Context, arg1 *cloudwatchlogs.CancelExportTaskInput, arg2 ...request.Option) (*cloudwatchlogs.CancelExportTaskOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -144,14 +133,12 @@ func (m *MockCloudWatchLogsAPI) CancelExportTaskWithContext(arg0 context.Context
 
 // CancelExportTaskWithContext indicates an expected call of CancelExportTaskWithContext
 func (mr *MockCloudWatchLogsAPIMockRecorder) CancelExportTaskWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CancelExportTaskWithContext", reflect.TypeOf((*MockCloudWatchLogsAPI)(nil).CancelExportTaskWithContext), varargs...)
 }
 
 // CreateExportTask mocks base method
 func (m *MockCloudWatchLogsAPI) CreateExportTask(arg0 *cloudwatchlogs.CreateExportTaskInput) (*cloudwatchlogs.CreateExportTaskOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateExportTask", arg0)
 	ret0, _ := ret[0].(*cloudwatchlogs.CreateExportTaskOutput)
 	ret1, _ := ret[1].(error)
@@ -160,13 +147,11 @@ func (m *MockCloudWatchLogsAPI) CreateExportTask(arg0 *cloudwatchlogs.CreateExpo
 
 // CreateExportTask indicates an expected call of CreateExportTask
 func (mr *MockCloudWatchLogsAPIMockRecorder) CreateExportTask(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateExportTask", reflect.TypeOf((*MockCloudWatchLogsAPI)(nil).CreateExportTask), arg0)
 }
 
 // CreateExportTaskRequest mocks base method
 func (m *MockCloudWatchLogsAPI) CreateExportTaskRequest(arg0 *cloudwatchlogs.CreateExportTaskInput) (*request.Request, *cloudwatchlogs.CreateExportTaskOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateExportTaskRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*cloudwatchlogs.CreateExportTaskOutput)
@@ -175,13 +160,11 @@ func (m *MockCloudWatchLogsAPI) CreateExportTaskRequest(arg0 *cloudwatchlogs.Cre
 
 // CreateExportTaskRequest indicates an expected call of CreateExportTaskRequest
 func (mr *MockCloudWatchLogsAPIMockRecorder) CreateExportTaskRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateExportTaskRequest", reflect.TypeOf((*MockCloudWatchLogsAPI)(nil).CreateExportTaskRequest), arg0)
 }
 
 // CreateExportTaskWithContext mocks base method
 func (m *MockCloudWatchLogsAPI) CreateExportTaskWithContext(arg0 context.Context, arg1 *cloudwatchlogs.CreateExportTaskInput, arg2 ...request.Option) (*cloudwatchlogs.CreateExportTaskOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -194,14 +177,12 @@ func (m *MockCloudWatchLogsAPI) CreateExportTaskWithContext(arg0 context.Context
 
 // CreateExportTaskWithContext indicates an expected call of CreateExportTaskWithContext
 func (mr *MockCloudWatchLogsAPIMockRecorder) CreateExportTaskWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateExportTaskWithContext", reflect.TypeOf((*MockCloudWatchLogsAPI)(nil).CreateExportTaskWithContext), varargs...)
 }
 
 // CreateLogGroup mocks base method
 func (m *MockCloudWatchLogsAPI) CreateLogGroup(arg0 *cloudwatchlogs.CreateLogGroupInput) (*cloudwatchlogs.CreateLogGroupOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateLogGroup", arg0)
 	ret0, _ := ret[0].(*cloudwatchlogs.CreateLogGroupOutput)
 	ret1, _ := ret[1].(error)
@@ -210,13 +191,11 @@ func (m *MockCloudWatchLogsAPI) CreateLogGroup(arg0 *cloudwatchlogs.CreateLogGro
 
 // CreateLogGroup indicates an expected call of CreateLogGroup
 func (mr *MockCloudWatchLogsAPIMockRecorder) CreateLogGroup(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateLogGroup", reflect.TypeOf((*MockCloudWatchLogsAPI)(nil).CreateLogGroup), arg0)
 }
 
 // CreateLogGroupRequest mocks base method
 func (m *MockCloudWatchLogsAPI) CreateLogGroupRequest(arg0 *cloudwatchlogs.CreateLogGroupInput) (*request.Request, *cloudwatchlogs.CreateLogGroupOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateLogGroupRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*cloudwatchlogs.CreateLogGroupOutput)
@@ -225,13 +204,11 @@ func (m *MockCloudWatchLogsAPI) CreateLogGroupRequest(arg0 *cloudwatchlogs.Creat
 
 // CreateLogGroupRequest indicates an expected call of CreateLogGroupRequest
 func (mr *MockCloudWatchLogsAPIMockRecorder) CreateLogGroupRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateLogGroupRequest", reflect.TypeOf((*MockCloudWatchLogsAPI)(nil).CreateLogGroupRequest), arg0)
 }
 
 // CreateLogGroupWithContext mocks base method
 func (m *MockCloudWatchLogsAPI) CreateLogGroupWithContext(arg0 context.Context, arg1 *cloudwatchlogs.CreateLogGroupInput, arg2 ...request.Option) (*cloudwatchlogs.CreateLogGroupOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -244,14 +221,12 @@ func (m *MockCloudWatchLogsAPI) CreateLogGroupWithContext(arg0 context.Context, 
 
 // CreateLogGroupWithContext indicates an expected call of CreateLogGroupWithContext
 func (mr *MockCloudWatchLogsAPIMockRecorder) CreateLogGroupWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateLogGroupWithContext", reflect.TypeOf((*MockCloudWatchLogsAPI)(nil).CreateLogGroupWithContext), varargs...)
 }
 
 // CreateLogStream mocks base method
 func (m *MockCloudWatchLogsAPI) CreateLogStream(arg0 *cloudwatchlogs.CreateLogStreamInput) (*cloudwatchlogs.CreateLogStreamOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateLogStream", arg0)
 	ret0, _ := ret[0].(*cloudwatchlogs.CreateLogStreamOutput)
 	ret1, _ := ret[1].(error)
@@ -260,13 +235,11 @@ func (m *MockCloudWatchLogsAPI) CreateLogStream(arg0 *cloudwatchlogs.CreateLogSt
 
 // CreateLogStream indicates an expected call of CreateLogStream
 func (mr *MockCloudWatchLogsAPIMockRecorder) CreateLogStream(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateLogStream", reflect.TypeOf((*MockCloudWatchLogsAPI)(nil).CreateLogStream), arg0)
 }
 
 // CreateLogStreamRequest mocks base method
 func (m *MockCloudWatchLogsAPI) CreateLogStreamRequest(arg0 *cloudwatchlogs.CreateLogStreamInput) (*request.Request, *cloudwatchlogs.CreateLogStreamOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateLogStreamRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*cloudwatchlogs.CreateLogStreamOutput)
@@ -275,13 +248,11 @@ func (m *MockCloudWatchLogsAPI) CreateLogStreamRequest(arg0 *cloudwatchlogs.Crea
 
 // CreateLogStreamRequest indicates an expected call of CreateLogStreamRequest
 func (mr *MockCloudWatchLogsAPIMockRecorder) CreateLogStreamRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateLogStreamRequest", reflect.TypeOf((*MockCloudWatchLogsAPI)(nil).CreateLogStreamRequest), arg0)
 }
 
 // CreateLogStreamWithContext mocks base method
 func (m *MockCloudWatchLogsAPI) CreateLogStreamWithContext(arg0 context.Context, arg1 *cloudwatchlogs.CreateLogStreamInput, arg2 ...request.Option) (*cloudwatchlogs.CreateLogStreamOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -294,14 +265,12 @@ func (m *MockCloudWatchLogsAPI) CreateLogStreamWithContext(arg0 context.Context,
 
 // CreateLogStreamWithContext indicates an expected call of CreateLogStreamWithContext
 func (mr *MockCloudWatchLogsAPIMockRecorder) CreateLogStreamWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateLogStreamWithContext", reflect.TypeOf((*MockCloudWatchLogsAPI)(nil).CreateLogStreamWithContext), varargs...)
 }
 
 // DeleteDestination mocks base method
 func (m *MockCloudWatchLogsAPI) DeleteDestination(arg0 *cloudwatchlogs.DeleteDestinationInput) (*cloudwatchlogs.DeleteDestinationOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteDestination", arg0)
 	ret0, _ := ret[0].(*cloudwatchlogs.DeleteDestinationOutput)
 	ret1, _ := ret[1].(error)
@@ -310,13 +279,11 @@ func (m *MockCloudWatchLogsAPI) DeleteDestination(arg0 *cloudwatchlogs.DeleteDes
 
 // DeleteDestination indicates an expected call of DeleteDestination
 func (mr *MockCloudWatchLogsAPIMockRecorder) DeleteDestination(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteDestination", reflect.TypeOf((*MockCloudWatchLogsAPI)(nil).DeleteDestination), arg0)
 }
 
 // DeleteDestinationRequest mocks base method
 func (m *MockCloudWatchLogsAPI) DeleteDestinationRequest(arg0 *cloudwatchlogs.DeleteDestinationInput) (*request.Request, *cloudwatchlogs.DeleteDestinationOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteDestinationRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*cloudwatchlogs.DeleteDestinationOutput)
@@ -325,13 +292,11 @@ func (m *MockCloudWatchLogsAPI) DeleteDestinationRequest(arg0 *cloudwatchlogs.De
 
 // DeleteDestinationRequest indicates an expected call of DeleteDestinationRequest
 func (mr *MockCloudWatchLogsAPIMockRecorder) DeleteDestinationRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteDestinationRequest", reflect.TypeOf((*MockCloudWatchLogsAPI)(nil).DeleteDestinationRequest), arg0)
 }
 
 // DeleteDestinationWithContext mocks base method
 func (m *MockCloudWatchLogsAPI) DeleteDestinationWithContext(arg0 context.Context, arg1 *cloudwatchlogs.DeleteDestinationInput, arg2 ...request.Option) (*cloudwatchlogs.DeleteDestinationOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -344,14 +309,12 @@ func (m *MockCloudWatchLogsAPI) DeleteDestinationWithContext(arg0 context.Contex
 
 // DeleteDestinationWithContext indicates an expected call of DeleteDestinationWithContext
 func (mr *MockCloudWatchLogsAPIMockRecorder) DeleteDestinationWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteDestinationWithContext", reflect.TypeOf((*MockCloudWatchLogsAPI)(nil).DeleteDestinationWithContext), varargs...)
 }
 
 // DeleteLogGroup mocks base method
 func (m *MockCloudWatchLogsAPI) DeleteLogGroup(arg0 *cloudwatchlogs.DeleteLogGroupInput) (*cloudwatchlogs.DeleteLogGroupOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteLogGroup", arg0)
 	ret0, _ := ret[0].(*cloudwatchlogs.DeleteLogGroupOutput)
 	ret1, _ := ret[1].(error)
@@ -360,13 +323,11 @@ func (m *MockCloudWatchLogsAPI) DeleteLogGroup(arg0 *cloudwatchlogs.DeleteLogGro
 
 // DeleteLogGroup indicates an expected call of DeleteLogGroup
 func (mr *MockCloudWatchLogsAPIMockRecorder) DeleteLogGroup(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteLogGroup", reflect.TypeOf((*MockCloudWatchLogsAPI)(nil).DeleteLogGroup), arg0)
 }
 
 // DeleteLogGroupRequest mocks base method
 func (m *MockCloudWatchLogsAPI) DeleteLogGroupRequest(arg0 *cloudwatchlogs.DeleteLogGroupInput) (*request.Request, *cloudwatchlogs.DeleteLogGroupOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteLogGroupRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*cloudwatchlogs.DeleteLogGroupOutput)
@@ -375,13 +336,11 @@ func (m *MockCloudWatchLogsAPI) DeleteLogGroupRequest(arg0 *cloudwatchlogs.Delet
 
 // DeleteLogGroupRequest indicates an expected call of DeleteLogGroupRequest
 func (mr *MockCloudWatchLogsAPIMockRecorder) DeleteLogGroupRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteLogGroupRequest", reflect.TypeOf((*MockCloudWatchLogsAPI)(nil).DeleteLogGroupRequest), arg0)
 }
 
 // DeleteLogGroupWithContext mocks base method
 func (m *MockCloudWatchLogsAPI) DeleteLogGroupWithContext(arg0 context.Context, arg1 *cloudwatchlogs.DeleteLogGroupInput, arg2 ...request.Option) (*cloudwatchlogs.DeleteLogGroupOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -394,14 +353,12 @@ func (m *MockCloudWatchLogsAPI) DeleteLogGroupWithContext(arg0 context.Context, 
 
 // DeleteLogGroupWithContext indicates an expected call of DeleteLogGroupWithContext
 func (mr *MockCloudWatchLogsAPIMockRecorder) DeleteLogGroupWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteLogGroupWithContext", reflect.TypeOf((*MockCloudWatchLogsAPI)(nil).DeleteLogGroupWithContext), varargs...)
 }
 
 // DeleteLogStream mocks base method
 func (m *MockCloudWatchLogsAPI) DeleteLogStream(arg0 *cloudwatchlogs.DeleteLogStreamInput) (*cloudwatchlogs.DeleteLogStreamOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteLogStream", arg0)
 	ret0, _ := ret[0].(*cloudwatchlogs.DeleteLogStreamOutput)
 	ret1, _ := ret[1].(error)
@@ -410,13 +367,11 @@ func (m *MockCloudWatchLogsAPI) DeleteLogStream(arg0 *cloudwatchlogs.DeleteLogSt
 
 // DeleteLogStream indicates an expected call of DeleteLogStream
 func (mr *MockCloudWatchLogsAPIMockRecorder) DeleteLogStream(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteLogStream", reflect.TypeOf((*MockCloudWatchLogsAPI)(nil).DeleteLogStream), arg0)
 }
 
 // DeleteLogStreamRequest mocks base method
 func (m *MockCloudWatchLogsAPI) DeleteLogStreamRequest(arg0 *cloudwatchlogs.DeleteLogStreamInput) (*request.Request, *cloudwatchlogs.DeleteLogStreamOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteLogStreamRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*cloudwatchlogs.DeleteLogStreamOutput)
@@ -425,13 +380,11 @@ func (m *MockCloudWatchLogsAPI) DeleteLogStreamRequest(arg0 *cloudwatchlogs.Dele
 
 // DeleteLogStreamRequest indicates an expected call of DeleteLogStreamRequest
 func (mr *MockCloudWatchLogsAPIMockRecorder) DeleteLogStreamRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteLogStreamRequest", reflect.TypeOf((*MockCloudWatchLogsAPI)(nil).DeleteLogStreamRequest), arg0)
 }
 
 // DeleteLogStreamWithContext mocks base method
 func (m *MockCloudWatchLogsAPI) DeleteLogStreamWithContext(arg0 context.Context, arg1 *cloudwatchlogs.DeleteLogStreamInput, arg2 ...request.Option) (*cloudwatchlogs.DeleteLogStreamOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -444,14 +397,12 @@ func (m *MockCloudWatchLogsAPI) DeleteLogStreamWithContext(arg0 context.Context,
 
 // DeleteLogStreamWithContext indicates an expected call of DeleteLogStreamWithContext
 func (mr *MockCloudWatchLogsAPIMockRecorder) DeleteLogStreamWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteLogStreamWithContext", reflect.TypeOf((*MockCloudWatchLogsAPI)(nil).DeleteLogStreamWithContext), varargs...)
 }
 
 // DeleteMetricFilter mocks base method
 func (m *MockCloudWatchLogsAPI) DeleteMetricFilter(arg0 *cloudwatchlogs.DeleteMetricFilterInput) (*cloudwatchlogs.DeleteMetricFilterOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteMetricFilter", arg0)
 	ret0, _ := ret[0].(*cloudwatchlogs.DeleteMetricFilterOutput)
 	ret1, _ := ret[1].(error)
@@ -460,13 +411,11 @@ func (m *MockCloudWatchLogsAPI) DeleteMetricFilter(arg0 *cloudwatchlogs.DeleteMe
 
 // DeleteMetricFilter indicates an expected call of DeleteMetricFilter
 func (mr *MockCloudWatchLogsAPIMockRecorder) DeleteMetricFilter(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteMetricFilter", reflect.TypeOf((*MockCloudWatchLogsAPI)(nil).DeleteMetricFilter), arg0)
 }
 
 // DeleteMetricFilterRequest mocks base method
 func (m *MockCloudWatchLogsAPI) DeleteMetricFilterRequest(arg0 *cloudwatchlogs.DeleteMetricFilterInput) (*request.Request, *cloudwatchlogs.DeleteMetricFilterOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteMetricFilterRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*cloudwatchlogs.DeleteMetricFilterOutput)
@@ -475,13 +424,11 @@ func (m *MockCloudWatchLogsAPI) DeleteMetricFilterRequest(arg0 *cloudwatchlogs.D
 
 // DeleteMetricFilterRequest indicates an expected call of DeleteMetricFilterRequest
 func (mr *MockCloudWatchLogsAPIMockRecorder) DeleteMetricFilterRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteMetricFilterRequest", reflect.TypeOf((*MockCloudWatchLogsAPI)(nil).DeleteMetricFilterRequest), arg0)
 }
 
 // DeleteMetricFilterWithContext mocks base method
 func (m *MockCloudWatchLogsAPI) DeleteMetricFilterWithContext(arg0 context.Context, arg1 *cloudwatchlogs.DeleteMetricFilterInput, arg2 ...request.Option) (*cloudwatchlogs.DeleteMetricFilterOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -494,14 +441,12 @@ func (m *MockCloudWatchLogsAPI) DeleteMetricFilterWithContext(arg0 context.Conte
 
 // DeleteMetricFilterWithContext indicates an expected call of DeleteMetricFilterWithContext
 func (mr *MockCloudWatchLogsAPIMockRecorder) DeleteMetricFilterWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteMetricFilterWithContext", reflect.TypeOf((*MockCloudWatchLogsAPI)(nil).DeleteMetricFilterWithContext), varargs...)
 }
 
 // DeleteResourcePolicy mocks base method
 func (m *MockCloudWatchLogsAPI) DeleteResourcePolicy(arg0 *cloudwatchlogs.DeleteResourcePolicyInput) (*cloudwatchlogs.DeleteResourcePolicyOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteResourcePolicy", arg0)
 	ret0, _ := ret[0].(*cloudwatchlogs.DeleteResourcePolicyOutput)
 	ret1, _ := ret[1].(error)
@@ -510,13 +455,11 @@ func (m *MockCloudWatchLogsAPI) DeleteResourcePolicy(arg0 *cloudwatchlogs.Delete
 
 // DeleteResourcePolicy indicates an expected call of DeleteResourcePolicy
 func (mr *MockCloudWatchLogsAPIMockRecorder) DeleteResourcePolicy(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteResourcePolicy", reflect.TypeOf((*MockCloudWatchLogsAPI)(nil).DeleteResourcePolicy), arg0)
 }
 
 // DeleteResourcePolicyRequest mocks base method
 func (m *MockCloudWatchLogsAPI) DeleteResourcePolicyRequest(arg0 *cloudwatchlogs.DeleteResourcePolicyInput) (*request.Request, *cloudwatchlogs.DeleteResourcePolicyOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteResourcePolicyRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*cloudwatchlogs.DeleteResourcePolicyOutput)
@@ -525,13 +468,11 @@ func (m *MockCloudWatchLogsAPI) DeleteResourcePolicyRequest(arg0 *cloudwatchlogs
 
 // DeleteResourcePolicyRequest indicates an expected call of DeleteResourcePolicyRequest
 func (mr *MockCloudWatchLogsAPIMockRecorder) DeleteResourcePolicyRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteResourcePolicyRequest", reflect.TypeOf((*MockCloudWatchLogsAPI)(nil).DeleteResourcePolicyRequest), arg0)
 }
 
 // DeleteResourcePolicyWithContext mocks base method
 func (m *MockCloudWatchLogsAPI) DeleteResourcePolicyWithContext(arg0 context.Context, arg1 *cloudwatchlogs.DeleteResourcePolicyInput, arg2 ...request.Option) (*cloudwatchlogs.DeleteResourcePolicyOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -544,14 +485,12 @@ func (m *MockCloudWatchLogsAPI) DeleteResourcePolicyWithContext(arg0 context.Con
 
 // DeleteResourcePolicyWithContext indicates an expected call of DeleteResourcePolicyWithContext
 func (mr *MockCloudWatchLogsAPIMockRecorder) DeleteResourcePolicyWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteResourcePolicyWithContext", reflect.TypeOf((*MockCloudWatchLogsAPI)(nil).DeleteResourcePolicyWithContext), varargs...)
 }
 
 // DeleteRetentionPolicy mocks base method
 func (m *MockCloudWatchLogsAPI) DeleteRetentionPolicy(arg0 *cloudwatchlogs.DeleteRetentionPolicyInput) (*cloudwatchlogs.DeleteRetentionPolicyOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteRetentionPolicy", arg0)
 	ret0, _ := ret[0].(*cloudwatchlogs.DeleteRetentionPolicyOutput)
 	ret1, _ := ret[1].(error)
@@ -560,13 +499,11 @@ func (m *MockCloudWatchLogsAPI) DeleteRetentionPolicy(arg0 *cloudwatchlogs.Delet
 
 // DeleteRetentionPolicy indicates an expected call of DeleteRetentionPolicy
 func (mr *MockCloudWatchLogsAPIMockRecorder) DeleteRetentionPolicy(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteRetentionPolicy", reflect.TypeOf((*MockCloudWatchLogsAPI)(nil).DeleteRetentionPolicy), arg0)
 }
 
 // DeleteRetentionPolicyRequest mocks base method
 func (m *MockCloudWatchLogsAPI) DeleteRetentionPolicyRequest(arg0 *cloudwatchlogs.DeleteRetentionPolicyInput) (*request.Request, *cloudwatchlogs.DeleteRetentionPolicyOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteRetentionPolicyRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*cloudwatchlogs.DeleteRetentionPolicyOutput)
@@ -575,13 +512,11 @@ func (m *MockCloudWatchLogsAPI) DeleteRetentionPolicyRequest(arg0 *cloudwatchlog
 
 // DeleteRetentionPolicyRequest indicates an expected call of DeleteRetentionPolicyRequest
 func (mr *MockCloudWatchLogsAPIMockRecorder) DeleteRetentionPolicyRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteRetentionPolicyRequest", reflect.TypeOf((*MockCloudWatchLogsAPI)(nil).DeleteRetentionPolicyRequest), arg0)
 }
 
 // DeleteRetentionPolicyWithContext mocks base method
 func (m *MockCloudWatchLogsAPI) DeleteRetentionPolicyWithContext(arg0 context.Context, arg1 *cloudwatchlogs.DeleteRetentionPolicyInput, arg2 ...request.Option) (*cloudwatchlogs.DeleteRetentionPolicyOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -594,14 +529,12 @@ func (m *MockCloudWatchLogsAPI) DeleteRetentionPolicyWithContext(arg0 context.Co
 
 // DeleteRetentionPolicyWithContext indicates an expected call of DeleteRetentionPolicyWithContext
 func (mr *MockCloudWatchLogsAPIMockRecorder) DeleteRetentionPolicyWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteRetentionPolicyWithContext", reflect.TypeOf((*MockCloudWatchLogsAPI)(nil).DeleteRetentionPolicyWithContext), varargs...)
 }
 
 // DeleteSubscriptionFilter mocks base method
 func (m *MockCloudWatchLogsAPI) DeleteSubscriptionFilter(arg0 *cloudwatchlogs.DeleteSubscriptionFilterInput) (*cloudwatchlogs.DeleteSubscriptionFilterOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteSubscriptionFilter", arg0)
 	ret0, _ := ret[0].(*cloudwatchlogs.DeleteSubscriptionFilterOutput)
 	ret1, _ := ret[1].(error)
@@ -610,13 +543,11 @@ func (m *MockCloudWatchLogsAPI) DeleteSubscriptionFilter(arg0 *cloudwatchlogs.De
 
 // DeleteSubscriptionFilter indicates an expected call of DeleteSubscriptionFilter
 func (mr *MockCloudWatchLogsAPIMockRecorder) DeleteSubscriptionFilter(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteSubscriptionFilter", reflect.TypeOf((*MockCloudWatchLogsAPI)(nil).DeleteSubscriptionFilter), arg0)
 }
 
 // DeleteSubscriptionFilterRequest mocks base method
 func (m *MockCloudWatchLogsAPI) DeleteSubscriptionFilterRequest(arg0 *cloudwatchlogs.DeleteSubscriptionFilterInput) (*request.Request, *cloudwatchlogs.DeleteSubscriptionFilterOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteSubscriptionFilterRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*cloudwatchlogs.DeleteSubscriptionFilterOutput)
@@ -625,13 +556,11 @@ func (m *MockCloudWatchLogsAPI) DeleteSubscriptionFilterRequest(arg0 *cloudwatch
 
 // DeleteSubscriptionFilterRequest indicates an expected call of DeleteSubscriptionFilterRequest
 func (mr *MockCloudWatchLogsAPIMockRecorder) DeleteSubscriptionFilterRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteSubscriptionFilterRequest", reflect.TypeOf((*MockCloudWatchLogsAPI)(nil).DeleteSubscriptionFilterRequest), arg0)
 }
 
 // DeleteSubscriptionFilterWithContext mocks base method
 func (m *MockCloudWatchLogsAPI) DeleteSubscriptionFilterWithContext(arg0 context.Context, arg1 *cloudwatchlogs.DeleteSubscriptionFilterInput, arg2 ...request.Option) (*cloudwatchlogs.DeleteSubscriptionFilterOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -644,14 +573,12 @@ func (m *MockCloudWatchLogsAPI) DeleteSubscriptionFilterWithContext(arg0 context
 
 // DeleteSubscriptionFilterWithContext indicates an expected call of DeleteSubscriptionFilterWithContext
 func (mr *MockCloudWatchLogsAPIMockRecorder) DeleteSubscriptionFilterWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteSubscriptionFilterWithContext", reflect.TypeOf((*MockCloudWatchLogsAPI)(nil).DeleteSubscriptionFilterWithContext), varargs...)
 }
 
 // DescribeDestinations mocks base method
 func (m *MockCloudWatchLogsAPI) DescribeDestinations(arg0 *cloudwatchlogs.DescribeDestinationsInput) (*cloudwatchlogs.DescribeDestinationsOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeDestinations", arg0)
 	ret0, _ := ret[0].(*cloudwatchlogs.DescribeDestinationsOutput)
 	ret1, _ := ret[1].(error)
@@ -660,13 +587,11 @@ func (m *MockCloudWatchLogsAPI) DescribeDestinations(arg0 *cloudwatchlogs.Descri
 
 // DescribeDestinations indicates an expected call of DescribeDestinations
 func (mr *MockCloudWatchLogsAPIMockRecorder) DescribeDestinations(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeDestinations", reflect.TypeOf((*MockCloudWatchLogsAPI)(nil).DescribeDestinations), arg0)
 }
 
 // DescribeDestinationsPages mocks base method
 func (m *MockCloudWatchLogsAPI) DescribeDestinationsPages(arg0 *cloudwatchlogs.DescribeDestinationsInput, arg1 func(*cloudwatchlogs.DescribeDestinationsOutput, bool) bool) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeDestinationsPages", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -674,13 +599,11 @@ func (m *MockCloudWatchLogsAPI) DescribeDestinationsPages(arg0 *cloudwatchlogs.D
 
 // DescribeDestinationsPages indicates an expected call of DescribeDestinationsPages
 func (mr *MockCloudWatchLogsAPIMockRecorder) DescribeDestinationsPages(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeDestinationsPages", reflect.TypeOf((*MockCloudWatchLogsAPI)(nil).DescribeDestinationsPages), arg0, arg1)
 }
 
 // DescribeDestinationsPagesWithContext mocks base method
 func (m *MockCloudWatchLogsAPI) DescribeDestinationsPagesWithContext(arg0 context.Context, arg1 *cloudwatchlogs.DescribeDestinationsInput, arg2 func(*cloudwatchlogs.DescribeDestinationsOutput, bool) bool, arg3 ...request.Option) error {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1, arg2}
 	for _, a := range arg3 {
 		varargs = append(varargs, a)
@@ -692,14 +615,12 @@ func (m *MockCloudWatchLogsAPI) DescribeDestinationsPagesWithContext(arg0 contex
 
 // DescribeDestinationsPagesWithContext indicates an expected call of DescribeDestinationsPagesWithContext
 func (mr *MockCloudWatchLogsAPIMockRecorder) DescribeDestinationsPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeDestinationsPagesWithContext", reflect.TypeOf((*MockCloudWatchLogsAPI)(nil).DescribeDestinationsPagesWithContext), varargs...)
 }
 
 // DescribeDestinationsRequest mocks base method
 func (m *MockCloudWatchLogsAPI) DescribeDestinationsRequest(arg0 *cloudwatchlogs.DescribeDestinationsInput) (*request.Request, *cloudwatchlogs.DescribeDestinationsOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeDestinationsRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*cloudwatchlogs.DescribeDestinationsOutput)
@@ -708,13 +629,11 @@ func (m *MockCloudWatchLogsAPI) DescribeDestinationsRequest(arg0 *cloudwatchlogs
 
 // DescribeDestinationsRequest indicates an expected call of DescribeDestinationsRequest
 func (mr *MockCloudWatchLogsAPIMockRecorder) DescribeDestinationsRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeDestinationsRequest", reflect.TypeOf((*MockCloudWatchLogsAPI)(nil).DescribeDestinationsRequest), arg0)
 }
 
 // DescribeDestinationsWithContext mocks base method
 func (m *MockCloudWatchLogsAPI) DescribeDestinationsWithContext(arg0 context.Context, arg1 *cloudwatchlogs.DescribeDestinationsInput, arg2 ...request.Option) (*cloudwatchlogs.DescribeDestinationsOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -727,14 +646,12 @@ func (m *MockCloudWatchLogsAPI) DescribeDestinationsWithContext(arg0 context.Con
 
 // DescribeDestinationsWithContext indicates an expected call of DescribeDestinationsWithContext
 func (mr *MockCloudWatchLogsAPIMockRecorder) DescribeDestinationsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeDestinationsWithContext", reflect.TypeOf((*MockCloudWatchLogsAPI)(nil).DescribeDestinationsWithContext), varargs...)
 }
 
 // DescribeExportTasks mocks base method
 func (m *MockCloudWatchLogsAPI) DescribeExportTasks(arg0 *cloudwatchlogs.DescribeExportTasksInput) (*cloudwatchlogs.DescribeExportTasksOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeExportTasks", arg0)
 	ret0, _ := ret[0].(*cloudwatchlogs.DescribeExportTasksOutput)
 	ret1, _ := ret[1].(error)
@@ -743,13 +660,11 @@ func (m *MockCloudWatchLogsAPI) DescribeExportTasks(arg0 *cloudwatchlogs.Describ
 
 // DescribeExportTasks indicates an expected call of DescribeExportTasks
 func (mr *MockCloudWatchLogsAPIMockRecorder) DescribeExportTasks(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeExportTasks", reflect.TypeOf((*MockCloudWatchLogsAPI)(nil).DescribeExportTasks), arg0)
 }
 
 // DescribeExportTasksRequest mocks base method
 func (m *MockCloudWatchLogsAPI) DescribeExportTasksRequest(arg0 *cloudwatchlogs.DescribeExportTasksInput) (*request.Request, *cloudwatchlogs.DescribeExportTasksOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeExportTasksRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*cloudwatchlogs.DescribeExportTasksOutput)
@@ -758,13 +673,11 @@ func (m *MockCloudWatchLogsAPI) DescribeExportTasksRequest(arg0 *cloudwatchlogs.
 
 // DescribeExportTasksRequest indicates an expected call of DescribeExportTasksRequest
 func (mr *MockCloudWatchLogsAPIMockRecorder) DescribeExportTasksRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeExportTasksRequest", reflect.TypeOf((*MockCloudWatchLogsAPI)(nil).DescribeExportTasksRequest), arg0)
 }
 
 // DescribeExportTasksWithContext mocks base method
 func (m *MockCloudWatchLogsAPI) DescribeExportTasksWithContext(arg0 context.Context, arg1 *cloudwatchlogs.DescribeExportTasksInput, arg2 ...request.Option) (*cloudwatchlogs.DescribeExportTasksOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -777,14 +690,12 @@ func (m *MockCloudWatchLogsAPI) DescribeExportTasksWithContext(arg0 context.Cont
 
 // DescribeExportTasksWithContext indicates an expected call of DescribeExportTasksWithContext
 func (mr *MockCloudWatchLogsAPIMockRecorder) DescribeExportTasksWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeExportTasksWithContext", reflect.TypeOf((*MockCloudWatchLogsAPI)(nil).DescribeExportTasksWithContext), varargs...)
 }
 
 // DescribeLogGroups mocks base method
 func (m *MockCloudWatchLogsAPI) DescribeLogGroups(arg0 *cloudwatchlogs.DescribeLogGroupsInput) (*cloudwatchlogs.DescribeLogGroupsOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeLogGroups", arg0)
 	ret0, _ := ret[0].(*cloudwatchlogs.DescribeLogGroupsOutput)
 	ret1, _ := ret[1].(error)
@@ -793,13 +704,11 @@ func (m *MockCloudWatchLogsAPI) DescribeLogGroups(arg0 *cloudwatchlogs.DescribeL
 
 // DescribeLogGroups indicates an expected call of DescribeLogGroups
 func (mr *MockCloudWatchLogsAPIMockRecorder) DescribeLogGroups(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeLogGroups", reflect.TypeOf((*MockCloudWatchLogsAPI)(nil).DescribeLogGroups), arg0)
 }
 
 // DescribeLogGroupsPages mocks base method
 func (m *MockCloudWatchLogsAPI) DescribeLogGroupsPages(arg0 *cloudwatchlogs.DescribeLogGroupsInput, arg1 func(*cloudwatchlogs.DescribeLogGroupsOutput, bool) bool) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeLogGroupsPages", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -807,13 +716,11 @@ func (m *MockCloudWatchLogsAPI) DescribeLogGroupsPages(arg0 *cloudwatchlogs.Desc
 
 // DescribeLogGroupsPages indicates an expected call of DescribeLogGroupsPages
 func (mr *MockCloudWatchLogsAPIMockRecorder) DescribeLogGroupsPages(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeLogGroupsPages", reflect.TypeOf((*MockCloudWatchLogsAPI)(nil).DescribeLogGroupsPages), arg0, arg1)
 }
 
 // DescribeLogGroupsPagesWithContext mocks base method
 func (m *MockCloudWatchLogsAPI) DescribeLogGroupsPagesWithContext(arg0 context.Context, arg1 *cloudwatchlogs.DescribeLogGroupsInput, arg2 func(*cloudwatchlogs.DescribeLogGroupsOutput, bool) bool, arg3 ...request.Option) error {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1, arg2}
 	for _, a := range arg3 {
 		varargs = append(varargs, a)
@@ -825,14 +732,12 @@ func (m *MockCloudWatchLogsAPI) DescribeLogGroupsPagesWithContext(arg0 context.C
 
 // DescribeLogGroupsPagesWithContext indicates an expected call of DescribeLogGroupsPagesWithContext
 func (mr *MockCloudWatchLogsAPIMockRecorder) DescribeLogGroupsPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeLogGroupsPagesWithContext", reflect.TypeOf((*MockCloudWatchLogsAPI)(nil).DescribeLogGroupsPagesWithContext), varargs...)
 }
 
 // DescribeLogGroupsRequest mocks base method
 func (m *MockCloudWatchLogsAPI) DescribeLogGroupsRequest(arg0 *cloudwatchlogs.DescribeLogGroupsInput) (*request.Request, *cloudwatchlogs.DescribeLogGroupsOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeLogGroupsRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*cloudwatchlogs.DescribeLogGroupsOutput)
@@ -841,13 +746,11 @@ func (m *MockCloudWatchLogsAPI) DescribeLogGroupsRequest(arg0 *cloudwatchlogs.De
 
 // DescribeLogGroupsRequest indicates an expected call of DescribeLogGroupsRequest
 func (mr *MockCloudWatchLogsAPIMockRecorder) DescribeLogGroupsRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeLogGroupsRequest", reflect.TypeOf((*MockCloudWatchLogsAPI)(nil).DescribeLogGroupsRequest), arg0)
 }
 
 // DescribeLogGroupsWithContext mocks base method
 func (m *MockCloudWatchLogsAPI) DescribeLogGroupsWithContext(arg0 context.Context, arg1 *cloudwatchlogs.DescribeLogGroupsInput, arg2 ...request.Option) (*cloudwatchlogs.DescribeLogGroupsOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -860,14 +763,12 @@ func (m *MockCloudWatchLogsAPI) DescribeLogGroupsWithContext(arg0 context.Contex
 
 // DescribeLogGroupsWithContext indicates an expected call of DescribeLogGroupsWithContext
 func (mr *MockCloudWatchLogsAPIMockRecorder) DescribeLogGroupsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeLogGroupsWithContext", reflect.TypeOf((*MockCloudWatchLogsAPI)(nil).DescribeLogGroupsWithContext), varargs...)
 }
 
 // DescribeLogStreams mocks base method
 func (m *MockCloudWatchLogsAPI) DescribeLogStreams(arg0 *cloudwatchlogs.DescribeLogStreamsInput) (*cloudwatchlogs.DescribeLogStreamsOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeLogStreams", arg0)
 	ret0, _ := ret[0].(*cloudwatchlogs.DescribeLogStreamsOutput)
 	ret1, _ := ret[1].(error)
@@ -876,13 +777,11 @@ func (m *MockCloudWatchLogsAPI) DescribeLogStreams(arg0 *cloudwatchlogs.Describe
 
 // DescribeLogStreams indicates an expected call of DescribeLogStreams
 func (mr *MockCloudWatchLogsAPIMockRecorder) DescribeLogStreams(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeLogStreams", reflect.TypeOf((*MockCloudWatchLogsAPI)(nil).DescribeLogStreams), arg0)
 }
 
 // DescribeLogStreamsPages mocks base method
 func (m *MockCloudWatchLogsAPI) DescribeLogStreamsPages(arg0 *cloudwatchlogs.DescribeLogStreamsInput, arg1 func(*cloudwatchlogs.DescribeLogStreamsOutput, bool) bool) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeLogStreamsPages", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -890,13 +789,11 @@ func (m *MockCloudWatchLogsAPI) DescribeLogStreamsPages(arg0 *cloudwatchlogs.Des
 
 // DescribeLogStreamsPages indicates an expected call of DescribeLogStreamsPages
 func (mr *MockCloudWatchLogsAPIMockRecorder) DescribeLogStreamsPages(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeLogStreamsPages", reflect.TypeOf((*MockCloudWatchLogsAPI)(nil).DescribeLogStreamsPages), arg0, arg1)
 }
 
 // DescribeLogStreamsPagesWithContext mocks base method
 func (m *MockCloudWatchLogsAPI) DescribeLogStreamsPagesWithContext(arg0 context.Context, arg1 *cloudwatchlogs.DescribeLogStreamsInput, arg2 func(*cloudwatchlogs.DescribeLogStreamsOutput, bool) bool, arg3 ...request.Option) error {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1, arg2}
 	for _, a := range arg3 {
 		varargs = append(varargs, a)
@@ -908,14 +805,12 @@ func (m *MockCloudWatchLogsAPI) DescribeLogStreamsPagesWithContext(arg0 context.
 
 // DescribeLogStreamsPagesWithContext indicates an expected call of DescribeLogStreamsPagesWithContext
 func (mr *MockCloudWatchLogsAPIMockRecorder) DescribeLogStreamsPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeLogStreamsPagesWithContext", reflect.TypeOf((*MockCloudWatchLogsAPI)(nil).DescribeLogStreamsPagesWithContext), varargs...)
 }
 
 // DescribeLogStreamsRequest mocks base method
 func (m *MockCloudWatchLogsAPI) DescribeLogStreamsRequest(arg0 *cloudwatchlogs.DescribeLogStreamsInput) (*request.Request, *cloudwatchlogs.DescribeLogStreamsOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeLogStreamsRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*cloudwatchlogs.DescribeLogStreamsOutput)
@@ -924,13 +819,11 @@ func (m *MockCloudWatchLogsAPI) DescribeLogStreamsRequest(arg0 *cloudwatchlogs.D
 
 // DescribeLogStreamsRequest indicates an expected call of DescribeLogStreamsRequest
 func (mr *MockCloudWatchLogsAPIMockRecorder) DescribeLogStreamsRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeLogStreamsRequest", reflect.TypeOf((*MockCloudWatchLogsAPI)(nil).DescribeLogStreamsRequest), arg0)
 }
 
 // DescribeLogStreamsWithContext mocks base method
 func (m *MockCloudWatchLogsAPI) DescribeLogStreamsWithContext(arg0 context.Context, arg1 *cloudwatchlogs.DescribeLogStreamsInput, arg2 ...request.Option) (*cloudwatchlogs.DescribeLogStreamsOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -943,14 +836,12 @@ func (m *MockCloudWatchLogsAPI) DescribeLogStreamsWithContext(arg0 context.Conte
 
 // DescribeLogStreamsWithContext indicates an expected call of DescribeLogStreamsWithContext
 func (mr *MockCloudWatchLogsAPIMockRecorder) DescribeLogStreamsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeLogStreamsWithContext", reflect.TypeOf((*MockCloudWatchLogsAPI)(nil).DescribeLogStreamsWithContext), varargs...)
 }
 
 // DescribeMetricFilters mocks base method
 func (m *MockCloudWatchLogsAPI) DescribeMetricFilters(arg0 *cloudwatchlogs.DescribeMetricFiltersInput) (*cloudwatchlogs.DescribeMetricFiltersOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeMetricFilters", arg0)
 	ret0, _ := ret[0].(*cloudwatchlogs.DescribeMetricFiltersOutput)
 	ret1, _ := ret[1].(error)
@@ -959,13 +850,11 @@ func (m *MockCloudWatchLogsAPI) DescribeMetricFilters(arg0 *cloudwatchlogs.Descr
 
 // DescribeMetricFilters indicates an expected call of DescribeMetricFilters
 func (mr *MockCloudWatchLogsAPIMockRecorder) DescribeMetricFilters(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeMetricFilters", reflect.TypeOf((*MockCloudWatchLogsAPI)(nil).DescribeMetricFilters), arg0)
 }
 
 // DescribeMetricFiltersPages mocks base method
 func (m *MockCloudWatchLogsAPI) DescribeMetricFiltersPages(arg0 *cloudwatchlogs.DescribeMetricFiltersInput, arg1 func(*cloudwatchlogs.DescribeMetricFiltersOutput, bool) bool) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeMetricFiltersPages", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -973,13 +862,11 @@ func (m *MockCloudWatchLogsAPI) DescribeMetricFiltersPages(arg0 *cloudwatchlogs.
 
 // DescribeMetricFiltersPages indicates an expected call of DescribeMetricFiltersPages
 func (mr *MockCloudWatchLogsAPIMockRecorder) DescribeMetricFiltersPages(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeMetricFiltersPages", reflect.TypeOf((*MockCloudWatchLogsAPI)(nil).DescribeMetricFiltersPages), arg0, arg1)
 }
 
 // DescribeMetricFiltersPagesWithContext mocks base method
 func (m *MockCloudWatchLogsAPI) DescribeMetricFiltersPagesWithContext(arg0 context.Context, arg1 *cloudwatchlogs.DescribeMetricFiltersInput, arg2 func(*cloudwatchlogs.DescribeMetricFiltersOutput, bool) bool, arg3 ...request.Option) error {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1, arg2}
 	for _, a := range arg3 {
 		varargs = append(varargs, a)
@@ -991,14 +878,12 @@ func (m *MockCloudWatchLogsAPI) DescribeMetricFiltersPagesWithContext(arg0 conte
 
 // DescribeMetricFiltersPagesWithContext indicates an expected call of DescribeMetricFiltersPagesWithContext
 func (mr *MockCloudWatchLogsAPIMockRecorder) DescribeMetricFiltersPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeMetricFiltersPagesWithContext", reflect.TypeOf((*MockCloudWatchLogsAPI)(nil).DescribeMetricFiltersPagesWithContext), varargs...)
 }
 
 // DescribeMetricFiltersRequest mocks base method
 func (m *MockCloudWatchLogsAPI) DescribeMetricFiltersRequest(arg0 *cloudwatchlogs.DescribeMetricFiltersInput) (*request.Request, *cloudwatchlogs.DescribeMetricFiltersOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeMetricFiltersRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*cloudwatchlogs.DescribeMetricFiltersOutput)
@@ -1007,13 +892,11 @@ func (m *MockCloudWatchLogsAPI) DescribeMetricFiltersRequest(arg0 *cloudwatchlog
 
 // DescribeMetricFiltersRequest indicates an expected call of DescribeMetricFiltersRequest
 func (mr *MockCloudWatchLogsAPIMockRecorder) DescribeMetricFiltersRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeMetricFiltersRequest", reflect.TypeOf((*MockCloudWatchLogsAPI)(nil).DescribeMetricFiltersRequest), arg0)
 }
 
 // DescribeMetricFiltersWithContext mocks base method
 func (m *MockCloudWatchLogsAPI) DescribeMetricFiltersWithContext(arg0 context.Context, arg1 *cloudwatchlogs.DescribeMetricFiltersInput, arg2 ...request.Option) (*cloudwatchlogs.DescribeMetricFiltersOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -1026,14 +909,12 @@ func (m *MockCloudWatchLogsAPI) DescribeMetricFiltersWithContext(arg0 context.Co
 
 // DescribeMetricFiltersWithContext indicates an expected call of DescribeMetricFiltersWithContext
 func (mr *MockCloudWatchLogsAPIMockRecorder) DescribeMetricFiltersWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeMetricFiltersWithContext", reflect.TypeOf((*MockCloudWatchLogsAPI)(nil).DescribeMetricFiltersWithContext), varargs...)
 }
 
 // DescribeQueries mocks base method
 func (m *MockCloudWatchLogsAPI) DescribeQueries(arg0 *cloudwatchlogs.DescribeQueriesInput) (*cloudwatchlogs.DescribeQueriesOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeQueries", arg0)
 	ret0, _ := ret[0].(*cloudwatchlogs.DescribeQueriesOutput)
 	ret1, _ := ret[1].(error)
@@ -1042,13 +923,11 @@ func (m *MockCloudWatchLogsAPI) DescribeQueries(arg0 *cloudwatchlogs.DescribeQue
 
 // DescribeQueries indicates an expected call of DescribeQueries
 func (mr *MockCloudWatchLogsAPIMockRecorder) DescribeQueries(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeQueries", reflect.TypeOf((*MockCloudWatchLogsAPI)(nil).DescribeQueries), arg0)
 }
 
 // DescribeQueriesRequest mocks base method
 func (m *MockCloudWatchLogsAPI) DescribeQueriesRequest(arg0 *cloudwatchlogs.DescribeQueriesInput) (*request.Request, *cloudwatchlogs.DescribeQueriesOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeQueriesRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*cloudwatchlogs.DescribeQueriesOutput)
@@ -1057,13 +936,11 @@ func (m *MockCloudWatchLogsAPI) DescribeQueriesRequest(arg0 *cloudwatchlogs.Desc
 
 // DescribeQueriesRequest indicates an expected call of DescribeQueriesRequest
 func (mr *MockCloudWatchLogsAPIMockRecorder) DescribeQueriesRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeQueriesRequest", reflect.TypeOf((*MockCloudWatchLogsAPI)(nil).DescribeQueriesRequest), arg0)
 }
 
 // DescribeQueriesWithContext mocks base method
 func (m *MockCloudWatchLogsAPI) DescribeQueriesWithContext(arg0 context.Context, arg1 *cloudwatchlogs.DescribeQueriesInput, arg2 ...request.Option) (*cloudwatchlogs.DescribeQueriesOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -1076,14 +953,12 @@ func (m *MockCloudWatchLogsAPI) DescribeQueriesWithContext(arg0 context.Context,
 
 // DescribeQueriesWithContext indicates an expected call of DescribeQueriesWithContext
 func (mr *MockCloudWatchLogsAPIMockRecorder) DescribeQueriesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeQueriesWithContext", reflect.TypeOf((*MockCloudWatchLogsAPI)(nil).DescribeQueriesWithContext), varargs...)
 }
 
 // DescribeResourcePolicies mocks base method
 func (m *MockCloudWatchLogsAPI) DescribeResourcePolicies(arg0 *cloudwatchlogs.DescribeResourcePoliciesInput) (*cloudwatchlogs.DescribeResourcePoliciesOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeResourcePolicies", arg0)
 	ret0, _ := ret[0].(*cloudwatchlogs.DescribeResourcePoliciesOutput)
 	ret1, _ := ret[1].(error)
@@ -1092,13 +967,11 @@ func (m *MockCloudWatchLogsAPI) DescribeResourcePolicies(arg0 *cloudwatchlogs.De
 
 // DescribeResourcePolicies indicates an expected call of DescribeResourcePolicies
 func (mr *MockCloudWatchLogsAPIMockRecorder) DescribeResourcePolicies(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeResourcePolicies", reflect.TypeOf((*MockCloudWatchLogsAPI)(nil).DescribeResourcePolicies), arg0)
 }
 
 // DescribeResourcePoliciesRequest mocks base method
 func (m *MockCloudWatchLogsAPI) DescribeResourcePoliciesRequest(arg0 *cloudwatchlogs.DescribeResourcePoliciesInput) (*request.Request, *cloudwatchlogs.DescribeResourcePoliciesOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeResourcePoliciesRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*cloudwatchlogs.DescribeResourcePoliciesOutput)
@@ -1107,13 +980,11 @@ func (m *MockCloudWatchLogsAPI) DescribeResourcePoliciesRequest(arg0 *cloudwatch
 
 // DescribeResourcePoliciesRequest indicates an expected call of DescribeResourcePoliciesRequest
 func (mr *MockCloudWatchLogsAPIMockRecorder) DescribeResourcePoliciesRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeResourcePoliciesRequest", reflect.TypeOf((*MockCloudWatchLogsAPI)(nil).DescribeResourcePoliciesRequest), arg0)
 }
 
 // DescribeResourcePoliciesWithContext mocks base method
 func (m *MockCloudWatchLogsAPI) DescribeResourcePoliciesWithContext(arg0 context.Context, arg1 *cloudwatchlogs.DescribeResourcePoliciesInput, arg2 ...request.Option) (*cloudwatchlogs.DescribeResourcePoliciesOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -1126,14 +997,12 @@ func (m *MockCloudWatchLogsAPI) DescribeResourcePoliciesWithContext(arg0 context
 
 // DescribeResourcePoliciesWithContext indicates an expected call of DescribeResourcePoliciesWithContext
 func (mr *MockCloudWatchLogsAPIMockRecorder) DescribeResourcePoliciesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeResourcePoliciesWithContext", reflect.TypeOf((*MockCloudWatchLogsAPI)(nil).DescribeResourcePoliciesWithContext), varargs...)
 }
 
 // DescribeSubscriptionFilters mocks base method
 func (m *MockCloudWatchLogsAPI) DescribeSubscriptionFilters(arg0 *cloudwatchlogs.DescribeSubscriptionFiltersInput) (*cloudwatchlogs.DescribeSubscriptionFiltersOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeSubscriptionFilters", arg0)
 	ret0, _ := ret[0].(*cloudwatchlogs.DescribeSubscriptionFiltersOutput)
 	ret1, _ := ret[1].(error)
@@ -1142,13 +1011,11 @@ func (m *MockCloudWatchLogsAPI) DescribeSubscriptionFilters(arg0 *cloudwatchlogs
 
 // DescribeSubscriptionFilters indicates an expected call of DescribeSubscriptionFilters
 func (mr *MockCloudWatchLogsAPIMockRecorder) DescribeSubscriptionFilters(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeSubscriptionFilters", reflect.TypeOf((*MockCloudWatchLogsAPI)(nil).DescribeSubscriptionFilters), arg0)
 }
 
 // DescribeSubscriptionFiltersPages mocks base method
 func (m *MockCloudWatchLogsAPI) DescribeSubscriptionFiltersPages(arg0 *cloudwatchlogs.DescribeSubscriptionFiltersInput, arg1 func(*cloudwatchlogs.DescribeSubscriptionFiltersOutput, bool) bool) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeSubscriptionFiltersPages", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -1156,13 +1023,11 @@ func (m *MockCloudWatchLogsAPI) DescribeSubscriptionFiltersPages(arg0 *cloudwatc
 
 // DescribeSubscriptionFiltersPages indicates an expected call of DescribeSubscriptionFiltersPages
 func (mr *MockCloudWatchLogsAPIMockRecorder) DescribeSubscriptionFiltersPages(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeSubscriptionFiltersPages", reflect.TypeOf((*MockCloudWatchLogsAPI)(nil).DescribeSubscriptionFiltersPages), arg0, arg1)
 }
 
 // DescribeSubscriptionFiltersPagesWithContext mocks base method
 func (m *MockCloudWatchLogsAPI) DescribeSubscriptionFiltersPagesWithContext(arg0 context.Context, arg1 *cloudwatchlogs.DescribeSubscriptionFiltersInput, arg2 func(*cloudwatchlogs.DescribeSubscriptionFiltersOutput, bool) bool, arg3 ...request.Option) error {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1, arg2}
 	for _, a := range arg3 {
 		varargs = append(varargs, a)
@@ -1174,14 +1039,12 @@ func (m *MockCloudWatchLogsAPI) DescribeSubscriptionFiltersPagesWithContext(arg0
 
 // DescribeSubscriptionFiltersPagesWithContext indicates an expected call of DescribeSubscriptionFiltersPagesWithContext
 func (mr *MockCloudWatchLogsAPIMockRecorder) DescribeSubscriptionFiltersPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeSubscriptionFiltersPagesWithContext", reflect.TypeOf((*MockCloudWatchLogsAPI)(nil).DescribeSubscriptionFiltersPagesWithContext), varargs...)
 }
 
 // DescribeSubscriptionFiltersRequest mocks base method
 func (m *MockCloudWatchLogsAPI) DescribeSubscriptionFiltersRequest(arg0 *cloudwatchlogs.DescribeSubscriptionFiltersInput) (*request.Request, *cloudwatchlogs.DescribeSubscriptionFiltersOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeSubscriptionFiltersRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*cloudwatchlogs.DescribeSubscriptionFiltersOutput)
@@ -1190,13 +1053,11 @@ func (m *MockCloudWatchLogsAPI) DescribeSubscriptionFiltersRequest(arg0 *cloudwa
 
 // DescribeSubscriptionFiltersRequest indicates an expected call of DescribeSubscriptionFiltersRequest
 func (mr *MockCloudWatchLogsAPIMockRecorder) DescribeSubscriptionFiltersRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeSubscriptionFiltersRequest", reflect.TypeOf((*MockCloudWatchLogsAPI)(nil).DescribeSubscriptionFiltersRequest), arg0)
 }
 
 // DescribeSubscriptionFiltersWithContext mocks base method
 func (m *MockCloudWatchLogsAPI) DescribeSubscriptionFiltersWithContext(arg0 context.Context, arg1 *cloudwatchlogs.DescribeSubscriptionFiltersInput, arg2 ...request.Option) (*cloudwatchlogs.DescribeSubscriptionFiltersOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -1209,14 +1070,12 @@ func (m *MockCloudWatchLogsAPI) DescribeSubscriptionFiltersWithContext(arg0 cont
 
 // DescribeSubscriptionFiltersWithContext indicates an expected call of DescribeSubscriptionFiltersWithContext
 func (mr *MockCloudWatchLogsAPIMockRecorder) DescribeSubscriptionFiltersWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeSubscriptionFiltersWithContext", reflect.TypeOf((*MockCloudWatchLogsAPI)(nil).DescribeSubscriptionFiltersWithContext), varargs...)
 }
 
 // DisassociateKmsKey mocks base method
 func (m *MockCloudWatchLogsAPI) DisassociateKmsKey(arg0 *cloudwatchlogs.DisassociateKmsKeyInput) (*cloudwatchlogs.DisassociateKmsKeyOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DisassociateKmsKey", arg0)
 	ret0, _ := ret[0].(*cloudwatchlogs.DisassociateKmsKeyOutput)
 	ret1, _ := ret[1].(error)
@@ -1225,13 +1084,11 @@ func (m *MockCloudWatchLogsAPI) DisassociateKmsKey(arg0 *cloudwatchlogs.Disassoc
 
 // DisassociateKmsKey indicates an expected call of DisassociateKmsKey
 func (mr *MockCloudWatchLogsAPIMockRecorder) DisassociateKmsKey(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DisassociateKmsKey", reflect.TypeOf((*MockCloudWatchLogsAPI)(nil).DisassociateKmsKey), arg0)
 }
 
 // DisassociateKmsKeyRequest mocks base method
 func (m *MockCloudWatchLogsAPI) DisassociateKmsKeyRequest(arg0 *cloudwatchlogs.DisassociateKmsKeyInput) (*request.Request, *cloudwatchlogs.DisassociateKmsKeyOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DisassociateKmsKeyRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*cloudwatchlogs.DisassociateKmsKeyOutput)
@@ -1240,13 +1097,11 @@ func (m *MockCloudWatchLogsAPI) DisassociateKmsKeyRequest(arg0 *cloudwatchlogs.D
 
 // DisassociateKmsKeyRequest indicates an expected call of DisassociateKmsKeyRequest
 func (mr *MockCloudWatchLogsAPIMockRecorder) DisassociateKmsKeyRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DisassociateKmsKeyRequest", reflect.TypeOf((*MockCloudWatchLogsAPI)(nil).DisassociateKmsKeyRequest), arg0)
 }
 
 // DisassociateKmsKeyWithContext mocks base method
 func (m *MockCloudWatchLogsAPI) DisassociateKmsKeyWithContext(arg0 context.Context, arg1 *cloudwatchlogs.DisassociateKmsKeyInput, arg2 ...request.Option) (*cloudwatchlogs.DisassociateKmsKeyOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -1259,14 +1114,12 @@ func (m *MockCloudWatchLogsAPI) DisassociateKmsKeyWithContext(arg0 context.Conte
 
 // DisassociateKmsKeyWithContext indicates an expected call of DisassociateKmsKeyWithContext
 func (mr *MockCloudWatchLogsAPIMockRecorder) DisassociateKmsKeyWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DisassociateKmsKeyWithContext", reflect.TypeOf((*MockCloudWatchLogsAPI)(nil).DisassociateKmsKeyWithContext), varargs...)
 }
 
 // FilterLogEvents mocks base method
 func (m *MockCloudWatchLogsAPI) FilterLogEvents(arg0 *cloudwatchlogs.FilterLogEventsInput) (*cloudwatchlogs.FilterLogEventsOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "FilterLogEvents", arg0)
 	ret0, _ := ret[0].(*cloudwatchlogs.FilterLogEventsOutput)
 	ret1, _ := ret[1].(error)
@@ -1275,13 +1128,11 @@ func (m *MockCloudWatchLogsAPI) FilterLogEvents(arg0 *cloudwatchlogs.FilterLogEv
 
 // FilterLogEvents indicates an expected call of FilterLogEvents
 func (mr *MockCloudWatchLogsAPIMockRecorder) FilterLogEvents(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FilterLogEvents", reflect.TypeOf((*MockCloudWatchLogsAPI)(nil).FilterLogEvents), arg0)
 }
 
 // FilterLogEventsPages mocks base method
 func (m *MockCloudWatchLogsAPI) FilterLogEventsPages(arg0 *cloudwatchlogs.FilterLogEventsInput, arg1 func(*cloudwatchlogs.FilterLogEventsOutput, bool) bool) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "FilterLogEventsPages", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -1289,13 +1140,11 @@ func (m *MockCloudWatchLogsAPI) FilterLogEventsPages(arg0 *cloudwatchlogs.Filter
 
 // FilterLogEventsPages indicates an expected call of FilterLogEventsPages
 func (mr *MockCloudWatchLogsAPIMockRecorder) FilterLogEventsPages(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FilterLogEventsPages", reflect.TypeOf((*MockCloudWatchLogsAPI)(nil).FilterLogEventsPages), arg0, arg1)
 }
 
 // FilterLogEventsPagesWithContext mocks base method
 func (m *MockCloudWatchLogsAPI) FilterLogEventsPagesWithContext(arg0 context.Context, arg1 *cloudwatchlogs.FilterLogEventsInput, arg2 func(*cloudwatchlogs.FilterLogEventsOutput, bool) bool, arg3 ...request.Option) error {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1, arg2}
 	for _, a := range arg3 {
 		varargs = append(varargs, a)
@@ -1307,14 +1156,12 @@ func (m *MockCloudWatchLogsAPI) FilterLogEventsPagesWithContext(arg0 context.Con
 
 // FilterLogEventsPagesWithContext indicates an expected call of FilterLogEventsPagesWithContext
 func (mr *MockCloudWatchLogsAPIMockRecorder) FilterLogEventsPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FilterLogEventsPagesWithContext", reflect.TypeOf((*MockCloudWatchLogsAPI)(nil).FilterLogEventsPagesWithContext), varargs...)
 }
 
 // FilterLogEventsRequest mocks base method
 func (m *MockCloudWatchLogsAPI) FilterLogEventsRequest(arg0 *cloudwatchlogs.FilterLogEventsInput) (*request.Request, *cloudwatchlogs.FilterLogEventsOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "FilterLogEventsRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*cloudwatchlogs.FilterLogEventsOutput)
@@ -1323,13 +1170,11 @@ func (m *MockCloudWatchLogsAPI) FilterLogEventsRequest(arg0 *cloudwatchlogs.Filt
 
 // FilterLogEventsRequest indicates an expected call of FilterLogEventsRequest
 func (mr *MockCloudWatchLogsAPIMockRecorder) FilterLogEventsRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FilterLogEventsRequest", reflect.TypeOf((*MockCloudWatchLogsAPI)(nil).FilterLogEventsRequest), arg0)
 }
 
 // FilterLogEventsWithContext mocks base method
 func (m *MockCloudWatchLogsAPI) FilterLogEventsWithContext(arg0 context.Context, arg1 *cloudwatchlogs.FilterLogEventsInput, arg2 ...request.Option) (*cloudwatchlogs.FilterLogEventsOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -1342,14 +1187,12 @@ func (m *MockCloudWatchLogsAPI) FilterLogEventsWithContext(arg0 context.Context,
 
 // FilterLogEventsWithContext indicates an expected call of FilterLogEventsWithContext
 func (mr *MockCloudWatchLogsAPIMockRecorder) FilterLogEventsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FilterLogEventsWithContext", reflect.TypeOf((*MockCloudWatchLogsAPI)(nil).FilterLogEventsWithContext), varargs...)
 }
 
 // GetLogEvents mocks base method
 func (m *MockCloudWatchLogsAPI) GetLogEvents(arg0 *cloudwatchlogs.GetLogEventsInput) (*cloudwatchlogs.GetLogEventsOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetLogEvents", arg0)
 	ret0, _ := ret[0].(*cloudwatchlogs.GetLogEventsOutput)
 	ret1, _ := ret[1].(error)
@@ -1358,13 +1201,11 @@ func (m *MockCloudWatchLogsAPI) GetLogEvents(arg0 *cloudwatchlogs.GetLogEventsIn
 
 // GetLogEvents indicates an expected call of GetLogEvents
 func (mr *MockCloudWatchLogsAPIMockRecorder) GetLogEvents(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLogEvents", reflect.TypeOf((*MockCloudWatchLogsAPI)(nil).GetLogEvents), arg0)
 }
 
 // GetLogEventsPages mocks base method
 func (m *MockCloudWatchLogsAPI) GetLogEventsPages(arg0 *cloudwatchlogs.GetLogEventsInput, arg1 func(*cloudwatchlogs.GetLogEventsOutput, bool) bool) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetLogEventsPages", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -1372,13 +1213,11 @@ func (m *MockCloudWatchLogsAPI) GetLogEventsPages(arg0 *cloudwatchlogs.GetLogEve
 
 // GetLogEventsPages indicates an expected call of GetLogEventsPages
 func (mr *MockCloudWatchLogsAPIMockRecorder) GetLogEventsPages(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLogEventsPages", reflect.TypeOf((*MockCloudWatchLogsAPI)(nil).GetLogEventsPages), arg0, arg1)
 }
 
 // GetLogEventsPagesWithContext mocks base method
 func (m *MockCloudWatchLogsAPI) GetLogEventsPagesWithContext(arg0 context.Context, arg1 *cloudwatchlogs.GetLogEventsInput, arg2 func(*cloudwatchlogs.GetLogEventsOutput, bool) bool, arg3 ...request.Option) error {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1, arg2}
 	for _, a := range arg3 {
 		varargs = append(varargs, a)
@@ -1390,14 +1229,12 @@ func (m *MockCloudWatchLogsAPI) GetLogEventsPagesWithContext(arg0 context.Contex
 
 // GetLogEventsPagesWithContext indicates an expected call of GetLogEventsPagesWithContext
 func (mr *MockCloudWatchLogsAPIMockRecorder) GetLogEventsPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLogEventsPagesWithContext", reflect.TypeOf((*MockCloudWatchLogsAPI)(nil).GetLogEventsPagesWithContext), varargs...)
 }
 
 // GetLogEventsRequest mocks base method
 func (m *MockCloudWatchLogsAPI) GetLogEventsRequest(arg0 *cloudwatchlogs.GetLogEventsInput) (*request.Request, *cloudwatchlogs.GetLogEventsOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetLogEventsRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*cloudwatchlogs.GetLogEventsOutput)
@@ -1406,13 +1243,11 @@ func (m *MockCloudWatchLogsAPI) GetLogEventsRequest(arg0 *cloudwatchlogs.GetLogE
 
 // GetLogEventsRequest indicates an expected call of GetLogEventsRequest
 func (mr *MockCloudWatchLogsAPIMockRecorder) GetLogEventsRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLogEventsRequest", reflect.TypeOf((*MockCloudWatchLogsAPI)(nil).GetLogEventsRequest), arg0)
 }
 
 // GetLogEventsWithContext mocks base method
 func (m *MockCloudWatchLogsAPI) GetLogEventsWithContext(arg0 context.Context, arg1 *cloudwatchlogs.GetLogEventsInput, arg2 ...request.Option) (*cloudwatchlogs.GetLogEventsOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -1425,14 +1260,12 @@ func (m *MockCloudWatchLogsAPI) GetLogEventsWithContext(arg0 context.Context, ar
 
 // GetLogEventsWithContext indicates an expected call of GetLogEventsWithContext
 func (mr *MockCloudWatchLogsAPIMockRecorder) GetLogEventsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLogEventsWithContext", reflect.TypeOf((*MockCloudWatchLogsAPI)(nil).GetLogEventsWithContext), varargs...)
 }
 
 // GetLogGroupFields mocks base method
 func (m *MockCloudWatchLogsAPI) GetLogGroupFields(arg0 *cloudwatchlogs.GetLogGroupFieldsInput) (*cloudwatchlogs.GetLogGroupFieldsOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetLogGroupFields", arg0)
 	ret0, _ := ret[0].(*cloudwatchlogs.GetLogGroupFieldsOutput)
 	ret1, _ := ret[1].(error)
@@ -1441,13 +1274,11 @@ func (m *MockCloudWatchLogsAPI) GetLogGroupFields(arg0 *cloudwatchlogs.GetLogGro
 
 // GetLogGroupFields indicates an expected call of GetLogGroupFields
 func (mr *MockCloudWatchLogsAPIMockRecorder) GetLogGroupFields(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLogGroupFields", reflect.TypeOf((*MockCloudWatchLogsAPI)(nil).GetLogGroupFields), arg0)
 }
 
 // GetLogGroupFieldsRequest mocks base method
 func (m *MockCloudWatchLogsAPI) GetLogGroupFieldsRequest(arg0 *cloudwatchlogs.GetLogGroupFieldsInput) (*request.Request, *cloudwatchlogs.GetLogGroupFieldsOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetLogGroupFieldsRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*cloudwatchlogs.GetLogGroupFieldsOutput)
@@ -1456,13 +1287,11 @@ func (m *MockCloudWatchLogsAPI) GetLogGroupFieldsRequest(arg0 *cloudwatchlogs.Ge
 
 // GetLogGroupFieldsRequest indicates an expected call of GetLogGroupFieldsRequest
 func (mr *MockCloudWatchLogsAPIMockRecorder) GetLogGroupFieldsRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLogGroupFieldsRequest", reflect.TypeOf((*MockCloudWatchLogsAPI)(nil).GetLogGroupFieldsRequest), arg0)
 }
 
 // GetLogGroupFieldsWithContext mocks base method
 func (m *MockCloudWatchLogsAPI) GetLogGroupFieldsWithContext(arg0 context.Context, arg1 *cloudwatchlogs.GetLogGroupFieldsInput, arg2 ...request.Option) (*cloudwatchlogs.GetLogGroupFieldsOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -1475,14 +1304,12 @@ func (m *MockCloudWatchLogsAPI) GetLogGroupFieldsWithContext(arg0 context.Contex
 
 // GetLogGroupFieldsWithContext indicates an expected call of GetLogGroupFieldsWithContext
 func (mr *MockCloudWatchLogsAPIMockRecorder) GetLogGroupFieldsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLogGroupFieldsWithContext", reflect.TypeOf((*MockCloudWatchLogsAPI)(nil).GetLogGroupFieldsWithContext), varargs...)
 }
 
 // GetLogRecord mocks base method
 func (m *MockCloudWatchLogsAPI) GetLogRecord(arg0 *cloudwatchlogs.GetLogRecordInput) (*cloudwatchlogs.GetLogRecordOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetLogRecord", arg0)
 	ret0, _ := ret[0].(*cloudwatchlogs.GetLogRecordOutput)
 	ret1, _ := ret[1].(error)
@@ -1491,13 +1318,11 @@ func (m *MockCloudWatchLogsAPI) GetLogRecord(arg0 *cloudwatchlogs.GetLogRecordIn
 
 // GetLogRecord indicates an expected call of GetLogRecord
 func (mr *MockCloudWatchLogsAPIMockRecorder) GetLogRecord(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLogRecord", reflect.TypeOf((*MockCloudWatchLogsAPI)(nil).GetLogRecord), arg0)
 }
 
 // GetLogRecordRequest mocks base method
 func (m *MockCloudWatchLogsAPI) GetLogRecordRequest(arg0 *cloudwatchlogs.GetLogRecordInput) (*request.Request, *cloudwatchlogs.GetLogRecordOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetLogRecordRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*cloudwatchlogs.GetLogRecordOutput)
@@ -1506,13 +1331,11 @@ func (m *MockCloudWatchLogsAPI) GetLogRecordRequest(arg0 *cloudwatchlogs.GetLogR
 
 // GetLogRecordRequest indicates an expected call of GetLogRecordRequest
 func (mr *MockCloudWatchLogsAPIMockRecorder) GetLogRecordRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLogRecordRequest", reflect.TypeOf((*MockCloudWatchLogsAPI)(nil).GetLogRecordRequest), arg0)
 }
 
 // GetLogRecordWithContext mocks base method
 func (m *MockCloudWatchLogsAPI) GetLogRecordWithContext(arg0 context.Context, arg1 *cloudwatchlogs.GetLogRecordInput, arg2 ...request.Option) (*cloudwatchlogs.GetLogRecordOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -1525,14 +1348,12 @@ func (m *MockCloudWatchLogsAPI) GetLogRecordWithContext(arg0 context.Context, ar
 
 // GetLogRecordWithContext indicates an expected call of GetLogRecordWithContext
 func (mr *MockCloudWatchLogsAPIMockRecorder) GetLogRecordWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLogRecordWithContext", reflect.TypeOf((*MockCloudWatchLogsAPI)(nil).GetLogRecordWithContext), varargs...)
 }
 
 // GetQueryResults mocks base method
 func (m *MockCloudWatchLogsAPI) GetQueryResults(arg0 *cloudwatchlogs.GetQueryResultsInput) (*cloudwatchlogs.GetQueryResultsOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetQueryResults", arg0)
 	ret0, _ := ret[0].(*cloudwatchlogs.GetQueryResultsOutput)
 	ret1, _ := ret[1].(error)
@@ -1541,13 +1362,11 @@ func (m *MockCloudWatchLogsAPI) GetQueryResults(arg0 *cloudwatchlogs.GetQueryRes
 
 // GetQueryResults indicates an expected call of GetQueryResults
 func (mr *MockCloudWatchLogsAPIMockRecorder) GetQueryResults(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetQueryResults", reflect.TypeOf((*MockCloudWatchLogsAPI)(nil).GetQueryResults), arg0)
 }
 
 // GetQueryResultsRequest mocks base method
 func (m *MockCloudWatchLogsAPI) GetQueryResultsRequest(arg0 *cloudwatchlogs.GetQueryResultsInput) (*request.Request, *cloudwatchlogs.GetQueryResultsOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetQueryResultsRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*cloudwatchlogs.GetQueryResultsOutput)
@@ -1556,13 +1375,11 @@ func (m *MockCloudWatchLogsAPI) GetQueryResultsRequest(arg0 *cloudwatchlogs.GetQ
 
 // GetQueryResultsRequest indicates an expected call of GetQueryResultsRequest
 func (mr *MockCloudWatchLogsAPIMockRecorder) GetQueryResultsRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetQueryResultsRequest", reflect.TypeOf((*MockCloudWatchLogsAPI)(nil).GetQueryResultsRequest), arg0)
 }
 
 // GetQueryResultsWithContext mocks base method
 func (m *MockCloudWatchLogsAPI) GetQueryResultsWithContext(arg0 context.Context, arg1 *cloudwatchlogs.GetQueryResultsInput, arg2 ...request.Option) (*cloudwatchlogs.GetQueryResultsOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -1575,14 +1392,12 @@ func (m *MockCloudWatchLogsAPI) GetQueryResultsWithContext(arg0 context.Context,
 
 // GetQueryResultsWithContext indicates an expected call of GetQueryResultsWithContext
 func (mr *MockCloudWatchLogsAPIMockRecorder) GetQueryResultsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetQueryResultsWithContext", reflect.TypeOf((*MockCloudWatchLogsAPI)(nil).GetQueryResultsWithContext), varargs...)
 }
 
 // ListTagsLogGroup mocks base method
 func (m *MockCloudWatchLogsAPI) ListTagsLogGroup(arg0 *cloudwatchlogs.ListTagsLogGroupInput) (*cloudwatchlogs.ListTagsLogGroupOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListTagsLogGroup", arg0)
 	ret0, _ := ret[0].(*cloudwatchlogs.ListTagsLogGroupOutput)
 	ret1, _ := ret[1].(error)
@@ -1591,13 +1406,11 @@ func (m *MockCloudWatchLogsAPI) ListTagsLogGroup(arg0 *cloudwatchlogs.ListTagsLo
 
 // ListTagsLogGroup indicates an expected call of ListTagsLogGroup
 func (mr *MockCloudWatchLogsAPIMockRecorder) ListTagsLogGroup(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListTagsLogGroup", reflect.TypeOf((*MockCloudWatchLogsAPI)(nil).ListTagsLogGroup), arg0)
 }
 
 // ListTagsLogGroupRequest mocks base method
 func (m *MockCloudWatchLogsAPI) ListTagsLogGroupRequest(arg0 *cloudwatchlogs.ListTagsLogGroupInput) (*request.Request, *cloudwatchlogs.ListTagsLogGroupOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListTagsLogGroupRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*cloudwatchlogs.ListTagsLogGroupOutput)
@@ -1606,13 +1419,11 @@ func (m *MockCloudWatchLogsAPI) ListTagsLogGroupRequest(arg0 *cloudwatchlogs.Lis
 
 // ListTagsLogGroupRequest indicates an expected call of ListTagsLogGroupRequest
 func (mr *MockCloudWatchLogsAPIMockRecorder) ListTagsLogGroupRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListTagsLogGroupRequest", reflect.TypeOf((*MockCloudWatchLogsAPI)(nil).ListTagsLogGroupRequest), arg0)
 }
 
 // ListTagsLogGroupWithContext mocks base method
 func (m *MockCloudWatchLogsAPI) ListTagsLogGroupWithContext(arg0 context.Context, arg1 *cloudwatchlogs.ListTagsLogGroupInput, arg2 ...request.Option) (*cloudwatchlogs.ListTagsLogGroupOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -1625,14 +1436,12 @@ func (m *MockCloudWatchLogsAPI) ListTagsLogGroupWithContext(arg0 context.Context
 
 // ListTagsLogGroupWithContext indicates an expected call of ListTagsLogGroupWithContext
 func (mr *MockCloudWatchLogsAPIMockRecorder) ListTagsLogGroupWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListTagsLogGroupWithContext", reflect.TypeOf((*MockCloudWatchLogsAPI)(nil).ListTagsLogGroupWithContext), varargs...)
 }
 
 // PutDestination mocks base method
 func (m *MockCloudWatchLogsAPI) PutDestination(arg0 *cloudwatchlogs.PutDestinationInput) (*cloudwatchlogs.PutDestinationOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PutDestination", arg0)
 	ret0, _ := ret[0].(*cloudwatchlogs.PutDestinationOutput)
 	ret1, _ := ret[1].(error)
@@ -1641,13 +1450,11 @@ func (m *MockCloudWatchLogsAPI) PutDestination(arg0 *cloudwatchlogs.PutDestinati
 
 // PutDestination indicates an expected call of PutDestination
 func (mr *MockCloudWatchLogsAPIMockRecorder) PutDestination(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutDestination", reflect.TypeOf((*MockCloudWatchLogsAPI)(nil).PutDestination), arg0)
 }
 
 // PutDestinationPolicy mocks base method
 func (m *MockCloudWatchLogsAPI) PutDestinationPolicy(arg0 *cloudwatchlogs.PutDestinationPolicyInput) (*cloudwatchlogs.PutDestinationPolicyOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PutDestinationPolicy", arg0)
 	ret0, _ := ret[0].(*cloudwatchlogs.PutDestinationPolicyOutput)
 	ret1, _ := ret[1].(error)
@@ -1656,13 +1463,11 @@ func (m *MockCloudWatchLogsAPI) PutDestinationPolicy(arg0 *cloudwatchlogs.PutDes
 
 // PutDestinationPolicy indicates an expected call of PutDestinationPolicy
 func (mr *MockCloudWatchLogsAPIMockRecorder) PutDestinationPolicy(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutDestinationPolicy", reflect.TypeOf((*MockCloudWatchLogsAPI)(nil).PutDestinationPolicy), arg0)
 }
 
 // PutDestinationPolicyRequest mocks base method
 func (m *MockCloudWatchLogsAPI) PutDestinationPolicyRequest(arg0 *cloudwatchlogs.PutDestinationPolicyInput) (*request.Request, *cloudwatchlogs.PutDestinationPolicyOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PutDestinationPolicyRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*cloudwatchlogs.PutDestinationPolicyOutput)
@@ -1671,13 +1476,11 @@ func (m *MockCloudWatchLogsAPI) PutDestinationPolicyRequest(arg0 *cloudwatchlogs
 
 // PutDestinationPolicyRequest indicates an expected call of PutDestinationPolicyRequest
 func (mr *MockCloudWatchLogsAPIMockRecorder) PutDestinationPolicyRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutDestinationPolicyRequest", reflect.TypeOf((*MockCloudWatchLogsAPI)(nil).PutDestinationPolicyRequest), arg0)
 }
 
 // PutDestinationPolicyWithContext mocks base method
 func (m *MockCloudWatchLogsAPI) PutDestinationPolicyWithContext(arg0 context.Context, arg1 *cloudwatchlogs.PutDestinationPolicyInput, arg2 ...request.Option) (*cloudwatchlogs.PutDestinationPolicyOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -1690,14 +1493,12 @@ func (m *MockCloudWatchLogsAPI) PutDestinationPolicyWithContext(arg0 context.Con
 
 // PutDestinationPolicyWithContext indicates an expected call of PutDestinationPolicyWithContext
 func (mr *MockCloudWatchLogsAPIMockRecorder) PutDestinationPolicyWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutDestinationPolicyWithContext", reflect.TypeOf((*MockCloudWatchLogsAPI)(nil).PutDestinationPolicyWithContext), varargs...)
 }
 
 // PutDestinationRequest mocks base method
 func (m *MockCloudWatchLogsAPI) PutDestinationRequest(arg0 *cloudwatchlogs.PutDestinationInput) (*request.Request, *cloudwatchlogs.PutDestinationOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PutDestinationRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*cloudwatchlogs.PutDestinationOutput)
@@ -1706,13 +1507,11 @@ func (m *MockCloudWatchLogsAPI) PutDestinationRequest(arg0 *cloudwatchlogs.PutDe
 
 // PutDestinationRequest indicates an expected call of PutDestinationRequest
 func (mr *MockCloudWatchLogsAPIMockRecorder) PutDestinationRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutDestinationRequest", reflect.TypeOf((*MockCloudWatchLogsAPI)(nil).PutDestinationRequest), arg0)
 }
 
 // PutDestinationWithContext mocks base method
 func (m *MockCloudWatchLogsAPI) PutDestinationWithContext(arg0 context.Context, arg1 *cloudwatchlogs.PutDestinationInput, arg2 ...request.Option) (*cloudwatchlogs.PutDestinationOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -1725,14 +1524,12 @@ func (m *MockCloudWatchLogsAPI) PutDestinationWithContext(arg0 context.Context, 
 
 // PutDestinationWithContext indicates an expected call of PutDestinationWithContext
 func (mr *MockCloudWatchLogsAPIMockRecorder) PutDestinationWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutDestinationWithContext", reflect.TypeOf((*MockCloudWatchLogsAPI)(nil).PutDestinationWithContext), varargs...)
 }
 
 // PutLogEvents mocks base method
 func (m *MockCloudWatchLogsAPI) PutLogEvents(arg0 *cloudwatchlogs.PutLogEventsInput) (*cloudwatchlogs.PutLogEventsOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PutLogEvents", arg0)
 	ret0, _ := ret[0].(*cloudwatchlogs.PutLogEventsOutput)
 	ret1, _ := ret[1].(error)
@@ -1741,13 +1538,11 @@ func (m *MockCloudWatchLogsAPI) PutLogEvents(arg0 *cloudwatchlogs.PutLogEventsIn
 
 // PutLogEvents indicates an expected call of PutLogEvents
 func (mr *MockCloudWatchLogsAPIMockRecorder) PutLogEvents(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutLogEvents", reflect.TypeOf((*MockCloudWatchLogsAPI)(nil).PutLogEvents), arg0)
 }
 
 // PutLogEventsRequest mocks base method
 func (m *MockCloudWatchLogsAPI) PutLogEventsRequest(arg0 *cloudwatchlogs.PutLogEventsInput) (*request.Request, *cloudwatchlogs.PutLogEventsOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PutLogEventsRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*cloudwatchlogs.PutLogEventsOutput)
@@ -1756,13 +1551,11 @@ func (m *MockCloudWatchLogsAPI) PutLogEventsRequest(arg0 *cloudwatchlogs.PutLogE
 
 // PutLogEventsRequest indicates an expected call of PutLogEventsRequest
 func (mr *MockCloudWatchLogsAPIMockRecorder) PutLogEventsRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutLogEventsRequest", reflect.TypeOf((*MockCloudWatchLogsAPI)(nil).PutLogEventsRequest), arg0)
 }
 
 // PutLogEventsWithContext mocks base method
 func (m *MockCloudWatchLogsAPI) PutLogEventsWithContext(arg0 context.Context, arg1 *cloudwatchlogs.PutLogEventsInput, arg2 ...request.Option) (*cloudwatchlogs.PutLogEventsOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -1775,14 +1568,12 @@ func (m *MockCloudWatchLogsAPI) PutLogEventsWithContext(arg0 context.Context, ar
 
 // PutLogEventsWithContext indicates an expected call of PutLogEventsWithContext
 func (mr *MockCloudWatchLogsAPIMockRecorder) PutLogEventsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutLogEventsWithContext", reflect.TypeOf((*MockCloudWatchLogsAPI)(nil).PutLogEventsWithContext), varargs...)
 }
 
 // PutMetricFilter mocks base method
 func (m *MockCloudWatchLogsAPI) PutMetricFilter(arg0 *cloudwatchlogs.PutMetricFilterInput) (*cloudwatchlogs.PutMetricFilterOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PutMetricFilter", arg0)
 	ret0, _ := ret[0].(*cloudwatchlogs.PutMetricFilterOutput)
 	ret1, _ := ret[1].(error)
@@ -1791,13 +1582,11 @@ func (m *MockCloudWatchLogsAPI) PutMetricFilter(arg0 *cloudwatchlogs.PutMetricFi
 
 // PutMetricFilter indicates an expected call of PutMetricFilter
 func (mr *MockCloudWatchLogsAPIMockRecorder) PutMetricFilter(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutMetricFilter", reflect.TypeOf((*MockCloudWatchLogsAPI)(nil).PutMetricFilter), arg0)
 }
 
 // PutMetricFilterRequest mocks base method
 func (m *MockCloudWatchLogsAPI) PutMetricFilterRequest(arg0 *cloudwatchlogs.PutMetricFilterInput) (*request.Request, *cloudwatchlogs.PutMetricFilterOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PutMetricFilterRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*cloudwatchlogs.PutMetricFilterOutput)
@@ -1806,13 +1595,11 @@ func (m *MockCloudWatchLogsAPI) PutMetricFilterRequest(arg0 *cloudwatchlogs.PutM
 
 // PutMetricFilterRequest indicates an expected call of PutMetricFilterRequest
 func (mr *MockCloudWatchLogsAPIMockRecorder) PutMetricFilterRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutMetricFilterRequest", reflect.TypeOf((*MockCloudWatchLogsAPI)(nil).PutMetricFilterRequest), arg0)
 }
 
 // PutMetricFilterWithContext mocks base method
 func (m *MockCloudWatchLogsAPI) PutMetricFilterWithContext(arg0 context.Context, arg1 *cloudwatchlogs.PutMetricFilterInput, arg2 ...request.Option) (*cloudwatchlogs.PutMetricFilterOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -1825,14 +1612,12 @@ func (m *MockCloudWatchLogsAPI) PutMetricFilterWithContext(arg0 context.Context,
 
 // PutMetricFilterWithContext indicates an expected call of PutMetricFilterWithContext
 func (mr *MockCloudWatchLogsAPIMockRecorder) PutMetricFilterWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutMetricFilterWithContext", reflect.TypeOf((*MockCloudWatchLogsAPI)(nil).PutMetricFilterWithContext), varargs...)
 }
 
 // PutResourcePolicy mocks base method
 func (m *MockCloudWatchLogsAPI) PutResourcePolicy(arg0 *cloudwatchlogs.PutResourcePolicyInput) (*cloudwatchlogs.PutResourcePolicyOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PutResourcePolicy", arg0)
 	ret0, _ := ret[0].(*cloudwatchlogs.PutResourcePolicyOutput)
 	ret1, _ := ret[1].(error)
@@ -1841,13 +1626,11 @@ func (m *MockCloudWatchLogsAPI) PutResourcePolicy(arg0 *cloudwatchlogs.PutResour
 
 // PutResourcePolicy indicates an expected call of PutResourcePolicy
 func (mr *MockCloudWatchLogsAPIMockRecorder) PutResourcePolicy(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutResourcePolicy", reflect.TypeOf((*MockCloudWatchLogsAPI)(nil).PutResourcePolicy), arg0)
 }
 
 // PutResourcePolicyRequest mocks base method
 func (m *MockCloudWatchLogsAPI) PutResourcePolicyRequest(arg0 *cloudwatchlogs.PutResourcePolicyInput) (*request.Request, *cloudwatchlogs.PutResourcePolicyOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PutResourcePolicyRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*cloudwatchlogs.PutResourcePolicyOutput)
@@ -1856,13 +1639,11 @@ func (m *MockCloudWatchLogsAPI) PutResourcePolicyRequest(arg0 *cloudwatchlogs.Pu
 
 // PutResourcePolicyRequest indicates an expected call of PutResourcePolicyRequest
 func (mr *MockCloudWatchLogsAPIMockRecorder) PutResourcePolicyRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutResourcePolicyRequest", reflect.TypeOf((*MockCloudWatchLogsAPI)(nil).PutResourcePolicyRequest), arg0)
 }
 
 // PutResourcePolicyWithContext mocks base method
 func (m *MockCloudWatchLogsAPI) PutResourcePolicyWithContext(arg0 context.Context, arg1 *cloudwatchlogs.PutResourcePolicyInput, arg2 ...request.Option) (*cloudwatchlogs.PutResourcePolicyOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -1875,14 +1656,12 @@ func (m *MockCloudWatchLogsAPI) PutResourcePolicyWithContext(arg0 context.Contex
 
 // PutResourcePolicyWithContext indicates an expected call of PutResourcePolicyWithContext
 func (mr *MockCloudWatchLogsAPIMockRecorder) PutResourcePolicyWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutResourcePolicyWithContext", reflect.TypeOf((*MockCloudWatchLogsAPI)(nil).PutResourcePolicyWithContext), varargs...)
 }
 
 // PutRetentionPolicy mocks base method
 func (m *MockCloudWatchLogsAPI) PutRetentionPolicy(arg0 *cloudwatchlogs.PutRetentionPolicyInput) (*cloudwatchlogs.PutRetentionPolicyOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PutRetentionPolicy", arg0)
 	ret0, _ := ret[0].(*cloudwatchlogs.PutRetentionPolicyOutput)
 	ret1, _ := ret[1].(error)
@@ -1891,13 +1670,11 @@ func (m *MockCloudWatchLogsAPI) PutRetentionPolicy(arg0 *cloudwatchlogs.PutReten
 
 // PutRetentionPolicy indicates an expected call of PutRetentionPolicy
 func (mr *MockCloudWatchLogsAPIMockRecorder) PutRetentionPolicy(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutRetentionPolicy", reflect.TypeOf((*MockCloudWatchLogsAPI)(nil).PutRetentionPolicy), arg0)
 }
 
 // PutRetentionPolicyRequest mocks base method
 func (m *MockCloudWatchLogsAPI) PutRetentionPolicyRequest(arg0 *cloudwatchlogs.PutRetentionPolicyInput) (*request.Request, *cloudwatchlogs.PutRetentionPolicyOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PutRetentionPolicyRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*cloudwatchlogs.PutRetentionPolicyOutput)
@@ -1906,13 +1683,11 @@ func (m *MockCloudWatchLogsAPI) PutRetentionPolicyRequest(arg0 *cloudwatchlogs.P
 
 // PutRetentionPolicyRequest indicates an expected call of PutRetentionPolicyRequest
 func (mr *MockCloudWatchLogsAPIMockRecorder) PutRetentionPolicyRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutRetentionPolicyRequest", reflect.TypeOf((*MockCloudWatchLogsAPI)(nil).PutRetentionPolicyRequest), arg0)
 }
 
 // PutRetentionPolicyWithContext mocks base method
 func (m *MockCloudWatchLogsAPI) PutRetentionPolicyWithContext(arg0 context.Context, arg1 *cloudwatchlogs.PutRetentionPolicyInput, arg2 ...request.Option) (*cloudwatchlogs.PutRetentionPolicyOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -1925,14 +1700,12 @@ func (m *MockCloudWatchLogsAPI) PutRetentionPolicyWithContext(arg0 context.Conte
 
 // PutRetentionPolicyWithContext indicates an expected call of PutRetentionPolicyWithContext
 func (mr *MockCloudWatchLogsAPIMockRecorder) PutRetentionPolicyWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutRetentionPolicyWithContext", reflect.TypeOf((*MockCloudWatchLogsAPI)(nil).PutRetentionPolicyWithContext), varargs...)
 }
 
 // PutSubscriptionFilter mocks base method
 func (m *MockCloudWatchLogsAPI) PutSubscriptionFilter(arg0 *cloudwatchlogs.PutSubscriptionFilterInput) (*cloudwatchlogs.PutSubscriptionFilterOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PutSubscriptionFilter", arg0)
 	ret0, _ := ret[0].(*cloudwatchlogs.PutSubscriptionFilterOutput)
 	ret1, _ := ret[1].(error)
@@ -1941,13 +1714,11 @@ func (m *MockCloudWatchLogsAPI) PutSubscriptionFilter(arg0 *cloudwatchlogs.PutSu
 
 // PutSubscriptionFilter indicates an expected call of PutSubscriptionFilter
 func (mr *MockCloudWatchLogsAPIMockRecorder) PutSubscriptionFilter(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutSubscriptionFilter", reflect.TypeOf((*MockCloudWatchLogsAPI)(nil).PutSubscriptionFilter), arg0)
 }
 
 // PutSubscriptionFilterRequest mocks base method
 func (m *MockCloudWatchLogsAPI) PutSubscriptionFilterRequest(arg0 *cloudwatchlogs.PutSubscriptionFilterInput) (*request.Request, *cloudwatchlogs.PutSubscriptionFilterOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PutSubscriptionFilterRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*cloudwatchlogs.PutSubscriptionFilterOutput)
@@ -1956,13 +1727,11 @@ func (m *MockCloudWatchLogsAPI) PutSubscriptionFilterRequest(arg0 *cloudwatchlog
 
 // PutSubscriptionFilterRequest indicates an expected call of PutSubscriptionFilterRequest
 func (mr *MockCloudWatchLogsAPIMockRecorder) PutSubscriptionFilterRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutSubscriptionFilterRequest", reflect.TypeOf((*MockCloudWatchLogsAPI)(nil).PutSubscriptionFilterRequest), arg0)
 }
 
 // PutSubscriptionFilterWithContext mocks base method
 func (m *MockCloudWatchLogsAPI) PutSubscriptionFilterWithContext(arg0 context.Context, arg1 *cloudwatchlogs.PutSubscriptionFilterInput, arg2 ...request.Option) (*cloudwatchlogs.PutSubscriptionFilterOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -1975,14 +1744,12 @@ func (m *MockCloudWatchLogsAPI) PutSubscriptionFilterWithContext(arg0 context.Co
 
 // PutSubscriptionFilterWithContext indicates an expected call of PutSubscriptionFilterWithContext
 func (mr *MockCloudWatchLogsAPIMockRecorder) PutSubscriptionFilterWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutSubscriptionFilterWithContext", reflect.TypeOf((*MockCloudWatchLogsAPI)(nil).PutSubscriptionFilterWithContext), varargs...)
 }
 
 // StartQuery mocks base method
 func (m *MockCloudWatchLogsAPI) StartQuery(arg0 *cloudwatchlogs.StartQueryInput) (*cloudwatchlogs.StartQueryOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StartQuery", arg0)
 	ret0, _ := ret[0].(*cloudwatchlogs.StartQueryOutput)
 	ret1, _ := ret[1].(error)
@@ -1991,13 +1758,11 @@ func (m *MockCloudWatchLogsAPI) StartQuery(arg0 *cloudwatchlogs.StartQueryInput)
 
 // StartQuery indicates an expected call of StartQuery
 func (mr *MockCloudWatchLogsAPIMockRecorder) StartQuery(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartQuery", reflect.TypeOf((*MockCloudWatchLogsAPI)(nil).StartQuery), arg0)
 }
 
 // StartQueryRequest mocks base method
 func (m *MockCloudWatchLogsAPI) StartQueryRequest(arg0 *cloudwatchlogs.StartQueryInput) (*request.Request, *cloudwatchlogs.StartQueryOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StartQueryRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*cloudwatchlogs.StartQueryOutput)
@@ -2006,13 +1771,11 @@ func (m *MockCloudWatchLogsAPI) StartQueryRequest(arg0 *cloudwatchlogs.StartQuer
 
 // StartQueryRequest indicates an expected call of StartQueryRequest
 func (mr *MockCloudWatchLogsAPIMockRecorder) StartQueryRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartQueryRequest", reflect.TypeOf((*MockCloudWatchLogsAPI)(nil).StartQueryRequest), arg0)
 }
 
 // StartQueryWithContext mocks base method
 func (m *MockCloudWatchLogsAPI) StartQueryWithContext(arg0 context.Context, arg1 *cloudwatchlogs.StartQueryInput, arg2 ...request.Option) (*cloudwatchlogs.StartQueryOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -2025,14 +1788,12 @@ func (m *MockCloudWatchLogsAPI) StartQueryWithContext(arg0 context.Context, arg1
 
 // StartQueryWithContext indicates an expected call of StartQueryWithContext
 func (mr *MockCloudWatchLogsAPIMockRecorder) StartQueryWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartQueryWithContext", reflect.TypeOf((*MockCloudWatchLogsAPI)(nil).StartQueryWithContext), varargs...)
 }
 
 // StopQuery mocks base method
 func (m *MockCloudWatchLogsAPI) StopQuery(arg0 *cloudwatchlogs.StopQueryInput) (*cloudwatchlogs.StopQueryOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StopQuery", arg0)
 	ret0, _ := ret[0].(*cloudwatchlogs.StopQueryOutput)
 	ret1, _ := ret[1].(error)
@@ -2041,13 +1802,11 @@ func (m *MockCloudWatchLogsAPI) StopQuery(arg0 *cloudwatchlogs.StopQueryInput) (
 
 // StopQuery indicates an expected call of StopQuery
 func (mr *MockCloudWatchLogsAPIMockRecorder) StopQuery(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StopQuery", reflect.TypeOf((*MockCloudWatchLogsAPI)(nil).StopQuery), arg0)
 }
 
 // StopQueryRequest mocks base method
 func (m *MockCloudWatchLogsAPI) StopQueryRequest(arg0 *cloudwatchlogs.StopQueryInput) (*request.Request, *cloudwatchlogs.StopQueryOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StopQueryRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*cloudwatchlogs.StopQueryOutput)
@@ -2056,13 +1815,11 @@ func (m *MockCloudWatchLogsAPI) StopQueryRequest(arg0 *cloudwatchlogs.StopQueryI
 
 // StopQueryRequest indicates an expected call of StopQueryRequest
 func (mr *MockCloudWatchLogsAPIMockRecorder) StopQueryRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StopQueryRequest", reflect.TypeOf((*MockCloudWatchLogsAPI)(nil).StopQueryRequest), arg0)
 }
 
 // StopQueryWithContext mocks base method
 func (m *MockCloudWatchLogsAPI) StopQueryWithContext(arg0 context.Context, arg1 *cloudwatchlogs.StopQueryInput, arg2 ...request.Option) (*cloudwatchlogs.StopQueryOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -2075,14 +1832,12 @@ func (m *MockCloudWatchLogsAPI) StopQueryWithContext(arg0 context.Context, arg1 
 
 // StopQueryWithContext indicates an expected call of StopQueryWithContext
 func (mr *MockCloudWatchLogsAPIMockRecorder) StopQueryWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StopQueryWithContext", reflect.TypeOf((*MockCloudWatchLogsAPI)(nil).StopQueryWithContext), varargs...)
 }
 
 // TagLogGroup mocks base method
 func (m *MockCloudWatchLogsAPI) TagLogGroup(arg0 *cloudwatchlogs.TagLogGroupInput) (*cloudwatchlogs.TagLogGroupOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "TagLogGroup", arg0)
 	ret0, _ := ret[0].(*cloudwatchlogs.TagLogGroupOutput)
 	ret1, _ := ret[1].(error)
@@ -2091,13 +1846,11 @@ func (m *MockCloudWatchLogsAPI) TagLogGroup(arg0 *cloudwatchlogs.TagLogGroupInpu
 
 // TagLogGroup indicates an expected call of TagLogGroup
 func (mr *MockCloudWatchLogsAPIMockRecorder) TagLogGroup(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TagLogGroup", reflect.TypeOf((*MockCloudWatchLogsAPI)(nil).TagLogGroup), arg0)
 }
 
 // TagLogGroupRequest mocks base method
 func (m *MockCloudWatchLogsAPI) TagLogGroupRequest(arg0 *cloudwatchlogs.TagLogGroupInput) (*request.Request, *cloudwatchlogs.TagLogGroupOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "TagLogGroupRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*cloudwatchlogs.TagLogGroupOutput)
@@ -2106,13 +1859,11 @@ func (m *MockCloudWatchLogsAPI) TagLogGroupRequest(arg0 *cloudwatchlogs.TagLogGr
 
 // TagLogGroupRequest indicates an expected call of TagLogGroupRequest
 func (mr *MockCloudWatchLogsAPIMockRecorder) TagLogGroupRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TagLogGroupRequest", reflect.TypeOf((*MockCloudWatchLogsAPI)(nil).TagLogGroupRequest), arg0)
 }
 
 // TagLogGroupWithContext mocks base method
 func (m *MockCloudWatchLogsAPI) TagLogGroupWithContext(arg0 context.Context, arg1 *cloudwatchlogs.TagLogGroupInput, arg2 ...request.Option) (*cloudwatchlogs.TagLogGroupOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -2125,14 +1876,12 @@ func (m *MockCloudWatchLogsAPI) TagLogGroupWithContext(arg0 context.Context, arg
 
 // TagLogGroupWithContext indicates an expected call of TagLogGroupWithContext
 func (mr *MockCloudWatchLogsAPIMockRecorder) TagLogGroupWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TagLogGroupWithContext", reflect.TypeOf((*MockCloudWatchLogsAPI)(nil).TagLogGroupWithContext), varargs...)
 }
 
 // TestMetricFilter mocks base method
 func (m *MockCloudWatchLogsAPI) TestMetricFilter(arg0 *cloudwatchlogs.TestMetricFilterInput) (*cloudwatchlogs.TestMetricFilterOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "TestMetricFilter", arg0)
 	ret0, _ := ret[0].(*cloudwatchlogs.TestMetricFilterOutput)
 	ret1, _ := ret[1].(error)
@@ -2141,13 +1890,11 @@ func (m *MockCloudWatchLogsAPI) TestMetricFilter(arg0 *cloudwatchlogs.TestMetric
 
 // TestMetricFilter indicates an expected call of TestMetricFilter
 func (mr *MockCloudWatchLogsAPIMockRecorder) TestMetricFilter(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TestMetricFilter", reflect.TypeOf((*MockCloudWatchLogsAPI)(nil).TestMetricFilter), arg0)
 }
 
 // TestMetricFilterRequest mocks base method
 func (m *MockCloudWatchLogsAPI) TestMetricFilterRequest(arg0 *cloudwatchlogs.TestMetricFilterInput) (*request.Request, *cloudwatchlogs.TestMetricFilterOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "TestMetricFilterRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*cloudwatchlogs.TestMetricFilterOutput)
@@ -2156,13 +1903,11 @@ func (m *MockCloudWatchLogsAPI) TestMetricFilterRequest(arg0 *cloudwatchlogs.Tes
 
 // TestMetricFilterRequest indicates an expected call of TestMetricFilterRequest
 func (mr *MockCloudWatchLogsAPIMockRecorder) TestMetricFilterRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TestMetricFilterRequest", reflect.TypeOf((*MockCloudWatchLogsAPI)(nil).TestMetricFilterRequest), arg0)
 }
 
 // TestMetricFilterWithContext mocks base method
 func (m *MockCloudWatchLogsAPI) TestMetricFilterWithContext(arg0 context.Context, arg1 *cloudwatchlogs.TestMetricFilterInput, arg2 ...request.Option) (*cloudwatchlogs.TestMetricFilterOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -2175,14 +1920,12 @@ func (m *MockCloudWatchLogsAPI) TestMetricFilterWithContext(arg0 context.Context
 
 // TestMetricFilterWithContext indicates an expected call of TestMetricFilterWithContext
 func (mr *MockCloudWatchLogsAPIMockRecorder) TestMetricFilterWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TestMetricFilterWithContext", reflect.TypeOf((*MockCloudWatchLogsAPI)(nil).TestMetricFilterWithContext), varargs...)
 }
 
 // UntagLogGroup mocks base method
 func (m *MockCloudWatchLogsAPI) UntagLogGroup(arg0 *cloudwatchlogs.UntagLogGroupInput) (*cloudwatchlogs.UntagLogGroupOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UntagLogGroup", arg0)
 	ret0, _ := ret[0].(*cloudwatchlogs.UntagLogGroupOutput)
 	ret1, _ := ret[1].(error)
@@ -2191,13 +1934,11 @@ func (m *MockCloudWatchLogsAPI) UntagLogGroup(arg0 *cloudwatchlogs.UntagLogGroup
 
 // UntagLogGroup indicates an expected call of UntagLogGroup
 func (mr *MockCloudWatchLogsAPIMockRecorder) UntagLogGroup(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UntagLogGroup", reflect.TypeOf((*MockCloudWatchLogsAPI)(nil).UntagLogGroup), arg0)
 }
 
 // UntagLogGroupRequest mocks base method
 func (m *MockCloudWatchLogsAPI) UntagLogGroupRequest(arg0 *cloudwatchlogs.UntagLogGroupInput) (*request.Request, *cloudwatchlogs.UntagLogGroupOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UntagLogGroupRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*cloudwatchlogs.UntagLogGroupOutput)
@@ -2206,13 +1947,11 @@ func (m *MockCloudWatchLogsAPI) UntagLogGroupRequest(arg0 *cloudwatchlogs.UntagL
 
 // UntagLogGroupRequest indicates an expected call of UntagLogGroupRequest
 func (mr *MockCloudWatchLogsAPIMockRecorder) UntagLogGroupRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UntagLogGroupRequest", reflect.TypeOf((*MockCloudWatchLogsAPI)(nil).UntagLogGroupRequest), arg0)
 }
 
 // UntagLogGroupWithContext mocks base method
 func (m *MockCloudWatchLogsAPI) UntagLogGroupWithContext(arg0 context.Context, arg1 *cloudwatchlogs.UntagLogGroupInput, arg2 ...request.Option) (*cloudwatchlogs.UntagLogGroupOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -2225,7 +1964,6 @@ func (m *MockCloudWatchLogsAPI) UntagLogGroupWithContext(arg0 context.Context, a
 
 // UntagLogGroupWithContext indicates an expected call of UntagLogGroupWithContext
 func (mr *MockCloudWatchLogsAPIMockRecorder) UntagLogGroupWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UntagLogGroupWithContext", reflect.TypeOf((*MockCloudWatchLogsAPI)(nil).UntagLogGroupWithContext), varargs...)
 }

--- a/ecs-cli/modules/clients/aws/ec2/mock/client.go
+++ b/ecs-cli/modules/clients/aws/ec2/mock/client.go
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2015-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the
@@ -49,7 +49,6 @@ func (m *MockEC2Client) EXPECT() *MockEC2ClientMockRecorder {
 
 // DescribeInstances mocks base method
 func (m *MockEC2Client) DescribeInstances(arg0 []*string) (map[string]*ec2.Instance, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeInstances", arg0)
 	ret0, _ := ret[0].(map[string]*ec2.Instance)
 	ret1, _ := ret[1].(error)
@@ -58,13 +57,11 @@ func (m *MockEC2Client) DescribeInstances(arg0 []*string) (map[string]*ec2.Insta
 
 // DescribeInstances indicates an expected call of DescribeInstances
 func (mr *MockEC2ClientMockRecorder) DescribeInstances(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeInstances", reflect.TypeOf((*MockEC2Client)(nil).DescribeInstances), arg0)
 }
 
 // DescribeNetworkInterfaces mocks base method
 func (m *MockEC2Client) DescribeNetworkInterfaces(arg0 []*string) ([]*ec2.NetworkInterface, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeNetworkInterfaces", arg0)
 	ret0, _ := ret[0].([]*ec2.NetworkInterface)
 	ret1, _ := ret[1].(error)
@@ -73,6 +70,5 @@ func (m *MockEC2Client) DescribeNetworkInterfaces(arg0 []*string) ([]*ec2.Networ
 
 // DescribeNetworkInterfaces indicates an expected call of DescribeNetworkInterfaces
 func (mr *MockEC2ClientMockRecorder) DescribeNetworkInterfaces(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeNetworkInterfaces", reflect.TypeOf((*MockEC2Client)(nil).DescribeNetworkInterfaces), arg0)
 }

--- a/ecs-cli/modules/clients/aws/ec2/mock/sdk/ec2iface_mock.go
+++ b/ecs-cli/modules/clients/aws/ec2/mock/sdk/ec2iface_mock.go
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2015-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the
@@ -51,7 +51,6 @@ func (m *MockEC2API) EXPECT() *MockEC2APIMockRecorder {
 
 // AcceptReservedInstancesExchangeQuote mocks base method
 func (m *MockEC2API) AcceptReservedInstancesExchangeQuote(arg0 *ec2.AcceptReservedInstancesExchangeQuoteInput) (*ec2.AcceptReservedInstancesExchangeQuoteOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AcceptReservedInstancesExchangeQuote", arg0)
 	ret0, _ := ret[0].(*ec2.AcceptReservedInstancesExchangeQuoteOutput)
 	ret1, _ := ret[1].(error)
@@ -60,13 +59,11 @@ func (m *MockEC2API) AcceptReservedInstancesExchangeQuote(arg0 *ec2.AcceptReserv
 
 // AcceptReservedInstancesExchangeQuote indicates an expected call of AcceptReservedInstancesExchangeQuote
 func (mr *MockEC2APIMockRecorder) AcceptReservedInstancesExchangeQuote(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AcceptReservedInstancesExchangeQuote", reflect.TypeOf((*MockEC2API)(nil).AcceptReservedInstancesExchangeQuote), arg0)
 }
 
 // AcceptReservedInstancesExchangeQuoteRequest mocks base method
 func (m *MockEC2API) AcceptReservedInstancesExchangeQuoteRequest(arg0 *ec2.AcceptReservedInstancesExchangeQuoteInput) (*request.Request, *ec2.AcceptReservedInstancesExchangeQuoteOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AcceptReservedInstancesExchangeQuoteRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.AcceptReservedInstancesExchangeQuoteOutput)
@@ -75,13 +72,11 @@ func (m *MockEC2API) AcceptReservedInstancesExchangeQuoteRequest(arg0 *ec2.Accep
 
 // AcceptReservedInstancesExchangeQuoteRequest indicates an expected call of AcceptReservedInstancesExchangeQuoteRequest
 func (mr *MockEC2APIMockRecorder) AcceptReservedInstancesExchangeQuoteRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AcceptReservedInstancesExchangeQuoteRequest", reflect.TypeOf((*MockEC2API)(nil).AcceptReservedInstancesExchangeQuoteRequest), arg0)
 }
 
 // AcceptReservedInstancesExchangeQuoteWithContext mocks base method
 func (m *MockEC2API) AcceptReservedInstancesExchangeQuoteWithContext(arg0 context.Context, arg1 *ec2.AcceptReservedInstancesExchangeQuoteInput, arg2 ...request.Option) (*ec2.AcceptReservedInstancesExchangeQuoteOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -94,14 +89,12 @@ func (m *MockEC2API) AcceptReservedInstancesExchangeQuoteWithContext(arg0 contex
 
 // AcceptReservedInstancesExchangeQuoteWithContext indicates an expected call of AcceptReservedInstancesExchangeQuoteWithContext
 func (mr *MockEC2APIMockRecorder) AcceptReservedInstancesExchangeQuoteWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AcceptReservedInstancesExchangeQuoteWithContext", reflect.TypeOf((*MockEC2API)(nil).AcceptReservedInstancesExchangeQuoteWithContext), varargs...)
 }
 
 // AcceptTransitGatewayVpcAttachment mocks base method
 func (m *MockEC2API) AcceptTransitGatewayVpcAttachment(arg0 *ec2.AcceptTransitGatewayVpcAttachmentInput) (*ec2.AcceptTransitGatewayVpcAttachmentOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AcceptTransitGatewayVpcAttachment", arg0)
 	ret0, _ := ret[0].(*ec2.AcceptTransitGatewayVpcAttachmentOutput)
 	ret1, _ := ret[1].(error)
@@ -110,13 +103,11 @@ func (m *MockEC2API) AcceptTransitGatewayVpcAttachment(arg0 *ec2.AcceptTransitGa
 
 // AcceptTransitGatewayVpcAttachment indicates an expected call of AcceptTransitGatewayVpcAttachment
 func (mr *MockEC2APIMockRecorder) AcceptTransitGatewayVpcAttachment(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AcceptTransitGatewayVpcAttachment", reflect.TypeOf((*MockEC2API)(nil).AcceptTransitGatewayVpcAttachment), arg0)
 }
 
 // AcceptTransitGatewayVpcAttachmentRequest mocks base method
 func (m *MockEC2API) AcceptTransitGatewayVpcAttachmentRequest(arg0 *ec2.AcceptTransitGatewayVpcAttachmentInput) (*request.Request, *ec2.AcceptTransitGatewayVpcAttachmentOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AcceptTransitGatewayVpcAttachmentRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.AcceptTransitGatewayVpcAttachmentOutput)
@@ -125,13 +116,11 @@ func (m *MockEC2API) AcceptTransitGatewayVpcAttachmentRequest(arg0 *ec2.AcceptTr
 
 // AcceptTransitGatewayVpcAttachmentRequest indicates an expected call of AcceptTransitGatewayVpcAttachmentRequest
 func (mr *MockEC2APIMockRecorder) AcceptTransitGatewayVpcAttachmentRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AcceptTransitGatewayVpcAttachmentRequest", reflect.TypeOf((*MockEC2API)(nil).AcceptTransitGatewayVpcAttachmentRequest), arg0)
 }
 
 // AcceptTransitGatewayVpcAttachmentWithContext mocks base method
 func (m *MockEC2API) AcceptTransitGatewayVpcAttachmentWithContext(arg0 context.Context, arg1 *ec2.AcceptTransitGatewayVpcAttachmentInput, arg2 ...request.Option) (*ec2.AcceptTransitGatewayVpcAttachmentOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -144,14 +133,12 @@ func (m *MockEC2API) AcceptTransitGatewayVpcAttachmentWithContext(arg0 context.C
 
 // AcceptTransitGatewayVpcAttachmentWithContext indicates an expected call of AcceptTransitGatewayVpcAttachmentWithContext
 func (mr *MockEC2APIMockRecorder) AcceptTransitGatewayVpcAttachmentWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AcceptTransitGatewayVpcAttachmentWithContext", reflect.TypeOf((*MockEC2API)(nil).AcceptTransitGatewayVpcAttachmentWithContext), varargs...)
 }
 
 // AcceptVpcEndpointConnections mocks base method
 func (m *MockEC2API) AcceptVpcEndpointConnections(arg0 *ec2.AcceptVpcEndpointConnectionsInput) (*ec2.AcceptVpcEndpointConnectionsOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AcceptVpcEndpointConnections", arg0)
 	ret0, _ := ret[0].(*ec2.AcceptVpcEndpointConnectionsOutput)
 	ret1, _ := ret[1].(error)
@@ -160,13 +147,11 @@ func (m *MockEC2API) AcceptVpcEndpointConnections(arg0 *ec2.AcceptVpcEndpointCon
 
 // AcceptVpcEndpointConnections indicates an expected call of AcceptVpcEndpointConnections
 func (mr *MockEC2APIMockRecorder) AcceptVpcEndpointConnections(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AcceptVpcEndpointConnections", reflect.TypeOf((*MockEC2API)(nil).AcceptVpcEndpointConnections), arg0)
 }
 
 // AcceptVpcEndpointConnectionsRequest mocks base method
 func (m *MockEC2API) AcceptVpcEndpointConnectionsRequest(arg0 *ec2.AcceptVpcEndpointConnectionsInput) (*request.Request, *ec2.AcceptVpcEndpointConnectionsOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AcceptVpcEndpointConnectionsRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.AcceptVpcEndpointConnectionsOutput)
@@ -175,13 +160,11 @@ func (m *MockEC2API) AcceptVpcEndpointConnectionsRequest(arg0 *ec2.AcceptVpcEndp
 
 // AcceptVpcEndpointConnectionsRequest indicates an expected call of AcceptVpcEndpointConnectionsRequest
 func (mr *MockEC2APIMockRecorder) AcceptVpcEndpointConnectionsRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AcceptVpcEndpointConnectionsRequest", reflect.TypeOf((*MockEC2API)(nil).AcceptVpcEndpointConnectionsRequest), arg0)
 }
 
 // AcceptVpcEndpointConnectionsWithContext mocks base method
 func (m *MockEC2API) AcceptVpcEndpointConnectionsWithContext(arg0 context.Context, arg1 *ec2.AcceptVpcEndpointConnectionsInput, arg2 ...request.Option) (*ec2.AcceptVpcEndpointConnectionsOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -194,14 +177,12 @@ func (m *MockEC2API) AcceptVpcEndpointConnectionsWithContext(arg0 context.Contex
 
 // AcceptVpcEndpointConnectionsWithContext indicates an expected call of AcceptVpcEndpointConnectionsWithContext
 func (mr *MockEC2APIMockRecorder) AcceptVpcEndpointConnectionsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AcceptVpcEndpointConnectionsWithContext", reflect.TypeOf((*MockEC2API)(nil).AcceptVpcEndpointConnectionsWithContext), varargs...)
 }
 
 // AcceptVpcPeeringConnection mocks base method
 func (m *MockEC2API) AcceptVpcPeeringConnection(arg0 *ec2.AcceptVpcPeeringConnectionInput) (*ec2.AcceptVpcPeeringConnectionOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AcceptVpcPeeringConnection", arg0)
 	ret0, _ := ret[0].(*ec2.AcceptVpcPeeringConnectionOutput)
 	ret1, _ := ret[1].(error)
@@ -210,13 +191,11 @@ func (m *MockEC2API) AcceptVpcPeeringConnection(arg0 *ec2.AcceptVpcPeeringConnec
 
 // AcceptVpcPeeringConnection indicates an expected call of AcceptVpcPeeringConnection
 func (mr *MockEC2APIMockRecorder) AcceptVpcPeeringConnection(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AcceptVpcPeeringConnection", reflect.TypeOf((*MockEC2API)(nil).AcceptVpcPeeringConnection), arg0)
 }
 
 // AcceptVpcPeeringConnectionRequest mocks base method
 func (m *MockEC2API) AcceptVpcPeeringConnectionRequest(arg0 *ec2.AcceptVpcPeeringConnectionInput) (*request.Request, *ec2.AcceptVpcPeeringConnectionOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AcceptVpcPeeringConnectionRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.AcceptVpcPeeringConnectionOutput)
@@ -225,13 +204,11 @@ func (m *MockEC2API) AcceptVpcPeeringConnectionRequest(arg0 *ec2.AcceptVpcPeerin
 
 // AcceptVpcPeeringConnectionRequest indicates an expected call of AcceptVpcPeeringConnectionRequest
 func (mr *MockEC2APIMockRecorder) AcceptVpcPeeringConnectionRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AcceptVpcPeeringConnectionRequest", reflect.TypeOf((*MockEC2API)(nil).AcceptVpcPeeringConnectionRequest), arg0)
 }
 
 // AcceptVpcPeeringConnectionWithContext mocks base method
 func (m *MockEC2API) AcceptVpcPeeringConnectionWithContext(arg0 context.Context, arg1 *ec2.AcceptVpcPeeringConnectionInput, arg2 ...request.Option) (*ec2.AcceptVpcPeeringConnectionOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -244,14 +221,12 @@ func (m *MockEC2API) AcceptVpcPeeringConnectionWithContext(arg0 context.Context,
 
 // AcceptVpcPeeringConnectionWithContext indicates an expected call of AcceptVpcPeeringConnectionWithContext
 func (mr *MockEC2APIMockRecorder) AcceptVpcPeeringConnectionWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AcceptVpcPeeringConnectionWithContext", reflect.TypeOf((*MockEC2API)(nil).AcceptVpcPeeringConnectionWithContext), varargs...)
 }
 
 // AdvertiseByoipCidr mocks base method
 func (m *MockEC2API) AdvertiseByoipCidr(arg0 *ec2.AdvertiseByoipCidrInput) (*ec2.AdvertiseByoipCidrOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AdvertiseByoipCidr", arg0)
 	ret0, _ := ret[0].(*ec2.AdvertiseByoipCidrOutput)
 	ret1, _ := ret[1].(error)
@@ -260,13 +235,11 @@ func (m *MockEC2API) AdvertiseByoipCidr(arg0 *ec2.AdvertiseByoipCidrInput) (*ec2
 
 // AdvertiseByoipCidr indicates an expected call of AdvertiseByoipCidr
 func (mr *MockEC2APIMockRecorder) AdvertiseByoipCidr(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AdvertiseByoipCidr", reflect.TypeOf((*MockEC2API)(nil).AdvertiseByoipCidr), arg0)
 }
 
 // AdvertiseByoipCidrRequest mocks base method
 func (m *MockEC2API) AdvertiseByoipCidrRequest(arg0 *ec2.AdvertiseByoipCidrInput) (*request.Request, *ec2.AdvertiseByoipCidrOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AdvertiseByoipCidrRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.AdvertiseByoipCidrOutput)
@@ -275,13 +248,11 @@ func (m *MockEC2API) AdvertiseByoipCidrRequest(arg0 *ec2.AdvertiseByoipCidrInput
 
 // AdvertiseByoipCidrRequest indicates an expected call of AdvertiseByoipCidrRequest
 func (mr *MockEC2APIMockRecorder) AdvertiseByoipCidrRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AdvertiseByoipCidrRequest", reflect.TypeOf((*MockEC2API)(nil).AdvertiseByoipCidrRequest), arg0)
 }
 
 // AdvertiseByoipCidrWithContext mocks base method
 func (m *MockEC2API) AdvertiseByoipCidrWithContext(arg0 context.Context, arg1 *ec2.AdvertiseByoipCidrInput, arg2 ...request.Option) (*ec2.AdvertiseByoipCidrOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -294,14 +265,12 @@ func (m *MockEC2API) AdvertiseByoipCidrWithContext(arg0 context.Context, arg1 *e
 
 // AdvertiseByoipCidrWithContext indicates an expected call of AdvertiseByoipCidrWithContext
 func (mr *MockEC2APIMockRecorder) AdvertiseByoipCidrWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AdvertiseByoipCidrWithContext", reflect.TypeOf((*MockEC2API)(nil).AdvertiseByoipCidrWithContext), varargs...)
 }
 
 // AllocateAddress mocks base method
 func (m *MockEC2API) AllocateAddress(arg0 *ec2.AllocateAddressInput) (*ec2.AllocateAddressOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AllocateAddress", arg0)
 	ret0, _ := ret[0].(*ec2.AllocateAddressOutput)
 	ret1, _ := ret[1].(error)
@@ -310,13 +279,11 @@ func (m *MockEC2API) AllocateAddress(arg0 *ec2.AllocateAddressInput) (*ec2.Alloc
 
 // AllocateAddress indicates an expected call of AllocateAddress
 func (mr *MockEC2APIMockRecorder) AllocateAddress(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllocateAddress", reflect.TypeOf((*MockEC2API)(nil).AllocateAddress), arg0)
 }
 
 // AllocateAddressRequest mocks base method
 func (m *MockEC2API) AllocateAddressRequest(arg0 *ec2.AllocateAddressInput) (*request.Request, *ec2.AllocateAddressOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AllocateAddressRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.AllocateAddressOutput)
@@ -325,13 +292,11 @@ func (m *MockEC2API) AllocateAddressRequest(arg0 *ec2.AllocateAddressInput) (*re
 
 // AllocateAddressRequest indicates an expected call of AllocateAddressRequest
 func (mr *MockEC2APIMockRecorder) AllocateAddressRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllocateAddressRequest", reflect.TypeOf((*MockEC2API)(nil).AllocateAddressRequest), arg0)
 }
 
 // AllocateAddressWithContext mocks base method
 func (m *MockEC2API) AllocateAddressWithContext(arg0 context.Context, arg1 *ec2.AllocateAddressInput, arg2 ...request.Option) (*ec2.AllocateAddressOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -344,14 +309,12 @@ func (m *MockEC2API) AllocateAddressWithContext(arg0 context.Context, arg1 *ec2.
 
 // AllocateAddressWithContext indicates an expected call of AllocateAddressWithContext
 func (mr *MockEC2APIMockRecorder) AllocateAddressWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllocateAddressWithContext", reflect.TypeOf((*MockEC2API)(nil).AllocateAddressWithContext), varargs...)
 }
 
 // AllocateHosts mocks base method
 func (m *MockEC2API) AllocateHosts(arg0 *ec2.AllocateHostsInput) (*ec2.AllocateHostsOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AllocateHosts", arg0)
 	ret0, _ := ret[0].(*ec2.AllocateHostsOutput)
 	ret1, _ := ret[1].(error)
@@ -360,13 +323,11 @@ func (m *MockEC2API) AllocateHosts(arg0 *ec2.AllocateHostsInput) (*ec2.AllocateH
 
 // AllocateHosts indicates an expected call of AllocateHosts
 func (mr *MockEC2APIMockRecorder) AllocateHosts(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllocateHosts", reflect.TypeOf((*MockEC2API)(nil).AllocateHosts), arg0)
 }
 
 // AllocateHostsRequest mocks base method
 func (m *MockEC2API) AllocateHostsRequest(arg0 *ec2.AllocateHostsInput) (*request.Request, *ec2.AllocateHostsOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AllocateHostsRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.AllocateHostsOutput)
@@ -375,13 +336,11 @@ func (m *MockEC2API) AllocateHostsRequest(arg0 *ec2.AllocateHostsInput) (*reques
 
 // AllocateHostsRequest indicates an expected call of AllocateHostsRequest
 func (mr *MockEC2APIMockRecorder) AllocateHostsRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllocateHostsRequest", reflect.TypeOf((*MockEC2API)(nil).AllocateHostsRequest), arg0)
 }
 
 // AllocateHostsWithContext mocks base method
 func (m *MockEC2API) AllocateHostsWithContext(arg0 context.Context, arg1 *ec2.AllocateHostsInput, arg2 ...request.Option) (*ec2.AllocateHostsOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -394,14 +353,12 @@ func (m *MockEC2API) AllocateHostsWithContext(arg0 context.Context, arg1 *ec2.Al
 
 // AllocateHostsWithContext indicates an expected call of AllocateHostsWithContext
 func (mr *MockEC2APIMockRecorder) AllocateHostsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllocateHostsWithContext", reflect.TypeOf((*MockEC2API)(nil).AllocateHostsWithContext), varargs...)
 }
 
 // ApplySecurityGroupsToClientVpnTargetNetwork mocks base method
 func (m *MockEC2API) ApplySecurityGroupsToClientVpnTargetNetwork(arg0 *ec2.ApplySecurityGroupsToClientVpnTargetNetworkInput) (*ec2.ApplySecurityGroupsToClientVpnTargetNetworkOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ApplySecurityGroupsToClientVpnTargetNetwork", arg0)
 	ret0, _ := ret[0].(*ec2.ApplySecurityGroupsToClientVpnTargetNetworkOutput)
 	ret1, _ := ret[1].(error)
@@ -410,13 +367,11 @@ func (m *MockEC2API) ApplySecurityGroupsToClientVpnTargetNetwork(arg0 *ec2.Apply
 
 // ApplySecurityGroupsToClientVpnTargetNetwork indicates an expected call of ApplySecurityGroupsToClientVpnTargetNetwork
 func (mr *MockEC2APIMockRecorder) ApplySecurityGroupsToClientVpnTargetNetwork(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplySecurityGroupsToClientVpnTargetNetwork", reflect.TypeOf((*MockEC2API)(nil).ApplySecurityGroupsToClientVpnTargetNetwork), arg0)
 }
 
 // ApplySecurityGroupsToClientVpnTargetNetworkRequest mocks base method
 func (m *MockEC2API) ApplySecurityGroupsToClientVpnTargetNetworkRequest(arg0 *ec2.ApplySecurityGroupsToClientVpnTargetNetworkInput) (*request.Request, *ec2.ApplySecurityGroupsToClientVpnTargetNetworkOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ApplySecurityGroupsToClientVpnTargetNetworkRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.ApplySecurityGroupsToClientVpnTargetNetworkOutput)
@@ -425,13 +380,11 @@ func (m *MockEC2API) ApplySecurityGroupsToClientVpnTargetNetworkRequest(arg0 *ec
 
 // ApplySecurityGroupsToClientVpnTargetNetworkRequest indicates an expected call of ApplySecurityGroupsToClientVpnTargetNetworkRequest
 func (mr *MockEC2APIMockRecorder) ApplySecurityGroupsToClientVpnTargetNetworkRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplySecurityGroupsToClientVpnTargetNetworkRequest", reflect.TypeOf((*MockEC2API)(nil).ApplySecurityGroupsToClientVpnTargetNetworkRequest), arg0)
 }
 
 // ApplySecurityGroupsToClientVpnTargetNetworkWithContext mocks base method
 func (m *MockEC2API) ApplySecurityGroupsToClientVpnTargetNetworkWithContext(arg0 context.Context, arg1 *ec2.ApplySecurityGroupsToClientVpnTargetNetworkInput, arg2 ...request.Option) (*ec2.ApplySecurityGroupsToClientVpnTargetNetworkOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -444,14 +397,12 @@ func (m *MockEC2API) ApplySecurityGroupsToClientVpnTargetNetworkWithContext(arg0
 
 // ApplySecurityGroupsToClientVpnTargetNetworkWithContext indicates an expected call of ApplySecurityGroupsToClientVpnTargetNetworkWithContext
 func (mr *MockEC2APIMockRecorder) ApplySecurityGroupsToClientVpnTargetNetworkWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplySecurityGroupsToClientVpnTargetNetworkWithContext", reflect.TypeOf((*MockEC2API)(nil).ApplySecurityGroupsToClientVpnTargetNetworkWithContext), varargs...)
 }
 
 // AssignIpv6Addresses mocks base method
 func (m *MockEC2API) AssignIpv6Addresses(arg0 *ec2.AssignIpv6AddressesInput) (*ec2.AssignIpv6AddressesOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AssignIpv6Addresses", arg0)
 	ret0, _ := ret[0].(*ec2.AssignIpv6AddressesOutput)
 	ret1, _ := ret[1].(error)
@@ -460,13 +411,11 @@ func (m *MockEC2API) AssignIpv6Addresses(arg0 *ec2.AssignIpv6AddressesInput) (*e
 
 // AssignIpv6Addresses indicates an expected call of AssignIpv6Addresses
 func (mr *MockEC2APIMockRecorder) AssignIpv6Addresses(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AssignIpv6Addresses", reflect.TypeOf((*MockEC2API)(nil).AssignIpv6Addresses), arg0)
 }
 
 // AssignIpv6AddressesRequest mocks base method
 func (m *MockEC2API) AssignIpv6AddressesRequest(arg0 *ec2.AssignIpv6AddressesInput) (*request.Request, *ec2.AssignIpv6AddressesOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AssignIpv6AddressesRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.AssignIpv6AddressesOutput)
@@ -475,13 +424,11 @@ func (m *MockEC2API) AssignIpv6AddressesRequest(arg0 *ec2.AssignIpv6AddressesInp
 
 // AssignIpv6AddressesRequest indicates an expected call of AssignIpv6AddressesRequest
 func (mr *MockEC2APIMockRecorder) AssignIpv6AddressesRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AssignIpv6AddressesRequest", reflect.TypeOf((*MockEC2API)(nil).AssignIpv6AddressesRequest), arg0)
 }
 
 // AssignIpv6AddressesWithContext mocks base method
 func (m *MockEC2API) AssignIpv6AddressesWithContext(arg0 context.Context, arg1 *ec2.AssignIpv6AddressesInput, arg2 ...request.Option) (*ec2.AssignIpv6AddressesOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -494,14 +441,12 @@ func (m *MockEC2API) AssignIpv6AddressesWithContext(arg0 context.Context, arg1 *
 
 // AssignIpv6AddressesWithContext indicates an expected call of AssignIpv6AddressesWithContext
 func (mr *MockEC2APIMockRecorder) AssignIpv6AddressesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AssignIpv6AddressesWithContext", reflect.TypeOf((*MockEC2API)(nil).AssignIpv6AddressesWithContext), varargs...)
 }
 
 // AssignPrivateIpAddresses mocks base method
 func (m *MockEC2API) AssignPrivateIpAddresses(arg0 *ec2.AssignPrivateIpAddressesInput) (*ec2.AssignPrivateIpAddressesOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AssignPrivateIpAddresses", arg0)
 	ret0, _ := ret[0].(*ec2.AssignPrivateIpAddressesOutput)
 	ret1, _ := ret[1].(error)
@@ -510,13 +455,11 @@ func (m *MockEC2API) AssignPrivateIpAddresses(arg0 *ec2.AssignPrivateIpAddresses
 
 // AssignPrivateIpAddresses indicates an expected call of AssignPrivateIpAddresses
 func (mr *MockEC2APIMockRecorder) AssignPrivateIpAddresses(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AssignPrivateIpAddresses", reflect.TypeOf((*MockEC2API)(nil).AssignPrivateIpAddresses), arg0)
 }
 
 // AssignPrivateIpAddressesRequest mocks base method
 func (m *MockEC2API) AssignPrivateIpAddressesRequest(arg0 *ec2.AssignPrivateIpAddressesInput) (*request.Request, *ec2.AssignPrivateIpAddressesOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AssignPrivateIpAddressesRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.AssignPrivateIpAddressesOutput)
@@ -525,13 +468,11 @@ func (m *MockEC2API) AssignPrivateIpAddressesRequest(arg0 *ec2.AssignPrivateIpAd
 
 // AssignPrivateIpAddressesRequest indicates an expected call of AssignPrivateIpAddressesRequest
 func (mr *MockEC2APIMockRecorder) AssignPrivateIpAddressesRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AssignPrivateIpAddressesRequest", reflect.TypeOf((*MockEC2API)(nil).AssignPrivateIpAddressesRequest), arg0)
 }
 
 // AssignPrivateIpAddressesWithContext mocks base method
 func (m *MockEC2API) AssignPrivateIpAddressesWithContext(arg0 context.Context, arg1 *ec2.AssignPrivateIpAddressesInput, arg2 ...request.Option) (*ec2.AssignPrivateIpAddressesOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -544,14 +485,12 @@ func (m *MockEC2API) AssignPrivateIpAddressesWithContext(arg0 context.Context, a
 
 // AssignPrivateIpAddressesWithContext indicates an expected call of AssignPrivateIpAddressesWithContext
 func (mr *MockEC2APIMockRecorder) AssignPrivateIpAddressesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AssignPrivateIpAddressesWithContext", reflect.TypeOf((*MockEC2API)(nil).AssignPrivateIpAddressesWithContext), varargs...)
 }
 
 // AssociateAddress mocks base method
 func (m *MockEC2API) AssociateAddress(arg0 *ec2.AssociateAddressInput) (*ec2.AssociateAddressOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AssociateAddress", arg0)
 	ret0, _ := ret[0].(*ec2.AssociateAddressOutput)
 	ret1, _ := ret[1].(error)
@@ -560,13 +499,11 @@ func (m *MockEC2API) AssociateAddress(arg0 *ec2.AssociateAddressInput) (*ec2.Ass
 
 // AssociateAddress indicates an expected call of AssociateAddress
 func (mr *MockEC2APIMockRecorder) AssociateAddress(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AssociateAddress", reflect.TypeOf((*MockEC2API)(nil).AssociateAddress), arg0)
 }
 
 // AssociateAddressRequest mocks base method
 func (m *MockEC2API) AssociateAddressRequest(arg0 *ec2.AssociateAddressInput) (*request.Request, *ec2.AssociateAddressOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AssociateAddressRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.AssociateAddressOutput)
@@ -575,13 +512,11 @@ func (m *MockEC2API) AssociateAddressRequest(arg0 *ec2.AssociateAddressInput) (*
 
 // AssociateAddressRequest indicates an expected call of AssociateAddressRequest
 func (mr *MockEC2APIMockRecorder) AssociateAddressRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AssociateAddressRequest", reflect.TypeOf((*MockEC2API)(nil).AssociateAddressRequest), arg0)
 }
 
 // AssociateAddressWithContext mocks base method
 func (m *MockEC2API) AssociateAddressWithContext(arg0 context.Context, arg1 *ec2.AssociateAddressInput, arg2 ...request.Option) (*ec2.AssociateAddressOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -594,14 +529,12 @@ func (m *MockEC2API) AssociateAddressWithContext(arg0 context.Context, arg1 *ec2
 
 // AssociateAddressWithContext indicates an expected call of AssociateAddressWithContext
 func (mr *MockEC2APIMockRecorder) AssociateAddressWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AssociateAddressWithContext", reflect.TypeOf((*MockEC2API)(nil).AssociateAddressWithContext), varargs...)
 }
 
 // AssociateClientVpnTargetNetwork mocks base method
 func (m *MockEC2API) AssociateClientVpnTargetNetwork(arg0 *ec2.AssociateClientVpnTargetNetworkInput) (*ec2.AssociateClientVpnTargetNetworkOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AssociateClientVpnTargetNetwork", arg0)
 	ret0, _ := ret[0].(*ec2.AssociateClientVpnTargetNetworkOutput)
 	ret1, _ := ret[1].(error)
@@ -610,13 +543,11 @@ func (m *MockEC2API) AssociateClientVpnTargetNetwork(arg0 *ec2.AssociateClientVp
 
 // AssociateClientVpnTargetNetwork indicates an expected call of AssociateClientVpnTargetNetwork
 func (mr *MockEC2APIMockRecorder) AssociateClientVpnTargetNetwork(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AssociateClientVpnTargetNetwork", reflect.TypeOf((*MockEC2API)(nil).AssociateClientVpnTargetNetwork), arg0)
 }
 
 // AssociateClientVpnTargetNetworkRequest mocks base method
 func (m *MockEC2API) AssociateClientVpnTargetNetworkRequest(arg0 *ec2.AssociateClientVpnTargetNetworkInput) (*request.Request, *ec2.AssociateClientVpnTargetNetworkOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AssociateClientVpnTargetNetworkRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.AssociateClientVpnTargetNetworkOutput)
@@ -625,13 +556,11 @@ func (m *MockEC2API) AssociateClientVpnTargetNetworkRequest(arg0 *ec2.AssociateC
 
 // AssociateClientVpnTargetNetworkRequest indicates an expected call of AssociateClientVpnTargetNetworkRequest
 func (mr *MockEC2APIMockRecorder) AssociateClientVpnTargetNetworkRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AssociateClientVpnTargetNetworkRequest", reflect.TypeOf((*MockEC2API)(nil).AssociateClientVpnTargetNetworkRequest), arg0)
 }
 
 // AssociateClientVpnTargetNetworkWithContext mocks base method
 func (m *MockEC2API) AssociateClientVpnTargetNetworkWithContext(arg0 context.Context, arg1 *ec2.AssociateClientVpnTargetNetworkInput, arg2 ...request.Option) (*ec2.AssociateClientVpnTargetNetworkOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -644,14 +573,12 @@ func (m *MockEC2API) AssociateClientVpnTargetNetworkWithContext(arg0 context.Con
 
 // AssociateClientVpnTargetNetworkWithContext indicates an expected call of AssociateClientVpnTargetNetworkWithContext
 func (mr *MockEC2APIMockRecorder) AssociateClientVpnTargetNetworkWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AssociateClientVpnTargetNetworkWithContext", reflect.TypeOf((*MockEC2API)(nil).AssociateClientVpnTargetNetworkWithContext), varargs...)
 }
 
 // AssociateDhcpOptions mocks base method
 func (m *MockEC2API) AssociateDhcpOptions(arg0 *ec2.AssociateDhcpOptionsInput) (*ec2.AssociateDhcpOptionsOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AssociateDhcpOptions", arg0)
 	ret0, _ := ret[0].(*ec2.AssociateDhcpOptionsOutput)
 	ret1, _ := ret[1].(error)
@@ -660,13 +587,11 @@ func (m *MockEC2API) AssociateDhcpOptions(arg0 *ec2.AssociateDhcpOptionsInput) (
 
 // AssociateDhcpOptions indicates an expected call of AssociateDhcpOptions
 func (mr *MockEC2APIMockRecorder) AssociateDhcpOptions(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AssociateDhcpOptions", reflect.TypeOf((*MockEC2API)(nil).AssociateDhcpOptions), arg0)
 }
 
 // AssociateDhcpOptionsRequest mocks base method
 func (m *MockEC2API) AssociateDhcpOptionsRequest(arg0 *ec2.AssociateDhcpOptionsInput) (*request.Request, *ec2.AssociateDhcpOptionsOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AssociateDhcpOptionsRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.AssociateDhcpOptionsOutput)
@@ -675,13 +600,11 @@ func (m *MockEC2API) AssociateDhcpOptionsRequest(arg0 *ec2.AssociateDhcpOptionsI
 
 // AssociateDhcpOptionsRequest indicates an expected call of AssociateDhcpOptionsRequest
 func (mr *MockEC2APIMockRecorder) AssociateDhcpOptionsRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AssociateDhcpOptionsRequest", reflect.TypeOf((*MockEC2API)(nil).AssociateDhcpOptionsRequest), arg0)
 }
 
 // AssociateDhcpOptionsWithContext mocks base method
 func (m *MockEC2API) AssociateDhcpOptionsWithContext(arg0 context.Context, arg1 *ec2.AssociateDhcpOptionsInput, arg2 ...request.Option) (*ec2.AssociateDhcpOptionsOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -694,14 +617,12 @@ func (m *MockEC2API) AssociateDhcpOptionsWithContext(arg0 context.Context, arg1 
 
 // AssociateDhcpOptionsWithContext indicates an expected call of AssociateDhcpOptionsWithContext
 func (mr *MockEC2APIMockRecorder) AssociateDhcpOptionsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AssociateDhcpOptionsWithContext", reflect.TypeOf((*MockEC2API)(nil).AssociateDhcpOptionsWithContext), varargs...)
 }
 
 // AssociateIamInstanceProfile mocks base method
 func (m *MockEC2API) AssociateIamInstanceProfile(arg0 *ec2.AssociateIamInstanceProfileInput) (*ec2.AssociateIamInstanceProfileOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AssociateIamInstanceProfile", arg0)
 	ret0, _ := ret[0].(*ec2.AssociateIamInstanceProfileOutput)
 	ret1, _ := ret[1].(error)
@@ -710,13 +631,11 @@ func (m *MockEC2API) AssociateIamInstanceProfile(arg0 *ec2.AssociateIamInstanceP
 
 // AssociateIamInstanceProfile indicates an expected call of AssociateIamInstanceProfile
 func (mr *MockEC2APIMockRecorder) AssociateIamInstanceProfile(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AssociateIamInstanceProfile", reflect.TypeOf((*MockEC2API)(nil).AssociateIamInstanceProfile), arg0)
 }
 
 // AssociateIamInstanceProfileRequest mocks base method
 func (m *MockEC2API) AssociateIamInstanceProfileRequest(arg0 *ec2.AssociateIamInstanceProfileInput) (*request.Request, *ec2.AssociateIamInstanceProfileOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AssociateIamInstanceProfileRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.AssociateIamInstanceProfileOutput)
@@ -725,13 +644,11 @@ func (m *MockEC2API) AssociateIamInstanceProfileRequest(arg0 *ec2.AssociateIamIn
 
 // AssociateIamInstanceProfileRequest indicates an expected call of AssociateIamInstanceProfileRequest
 func (mr *MockEC2APIMockRecorder) AssociateIamInstanceProfileRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AssociateIamInstanceProfileRequest", reflect.TypeOf((*MockEC2API)(nil).AssociateIamInstanceProfileRequest), arg0)
 }
 
 // AssociateIamInstanceProfileWithContext mocks base method
 func (m *MockEC2API) AssociateIamInstanceProfileWithContext(arg0 context.Context, arg1 *ec2.AssociateIamInstanceProfileInput, arg2 ...request.Option) (*ec2.AssociateIamInstanceProfileOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -744,14 +661,12 @@ func (m *MockEC2API) AssociateIamInstanceProfileWithContext(arg0 context.Context
 
 // AssociateIamInstanceProfileWithContext indicates an expected call of AssociateIamInstanceProfileWithContext
 func (mr *MockEC2APIMockRecorder) AssociateIamInstanceProfileWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AssociateIamInstanceProfileWithContext", reflect.TypeOf((*MockEC2API)(nil).AssociateIamInstanceProfileWithContext), varargs...)
 }
 
 // AssociateRouteTable mocks base method
 func (m *MockEC2API) AssociateRouteTable(arg0 *ec2.AssociateRouteTableInput) (*ec2.AssociateRouteTableOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AssociateRouteTable", arg0)
 	ret0, _ := ret[0].(*ec2.AssociateRouteTableOutput)
 	ret1, _ := ret[1].(error)
@@ -760,13 +675,11 @@ func (m *MockEC2API) AssociateRouteTable(arg0 *ec2.AssociateRouteTableInput) (*e
 
 // AssociateRouteTable indicates an expected call of AssociateRouteTable
 func (mr *MockEC2APIMockRecorder) AssociateRouteTable(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AssociateRouteTable", reflect.TypeOf((*MockEC2API)(nil).AssociateRouteTable), arg0)
 }
 
 // AssociateRouteTableRequest mocks base method
 func (m *MockEC2API) AssociateRouteTableRequest(arg0 *ec2.AssociateRouteTableInput) (*request.Request, *ec2.AssociateRouteTableOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AssociateRouteTableRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.AssociateRouteTableOutput)
@@ -775,13 +688,11 @@ func (m *MockEC2API) AssociateRouteTableRequest(arg0 *ec2.AssociateRouteTableInp
 
 // AssociateRouteTableRequest indicates an expected call of AssociateRouteTableRequest
 func (mr *MockEC2APIMockRecorder) AssociateRouteTableRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AssociateRouteTableRequest", reflect.TypeOf((*MockEC2API)(nil).AssociateRouteTableRequest), arg0)
 }
 
 // AssociateRouteTableWithContext mocks base method
 func (m *MockEC2API) AssociateRouteTableWithContext(arg0 context.Context, arg1 *ec2.AssociateRouteTableInput, arg2 ...request.Option) (*ec2.AssociateRouteTableOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -794,14 +705,12 @@ func (m *MockEC2API) AssociateRouteTableWithContext(arg0 context.Context, arg1 *
 
 // AssociateRouteTableWithContext indicates an expected call of AssociateRouteTableWithContext
 func (mr *MockEC2APIMockRecorder) AssociateRouteTableWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AssociateRouteTableWithContext", reflect.TypeOf((*MockEC2API)(nil).AssociateRouteTableWithContext), varargs...)
 }
 
 // AssociateSubnetCidrBlock mocks base method
 func (m *MockEC2API) AssociateSubnetCidrBlock(arg0 *ec2.AssociateSubnetCidrBlockInput) (*ec2.AssociateSubnetCidrBlockOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AssociateSubnetCidrBlock", arg0)
 	ret0, _ := ret[0].(*ec2.AssociateSubnetCidrBlockOutput)
 	ret1, _ := ret[1].(error)
@@ -810,13 +719,11 @@ func (m *MockEC2API) AssociateSubnetCidrBlock(arg0 *ec2.AssociateSubnetCidrBlock
 
 // AssociateSubnetCidrBlock indicates an expected call of AssociateSubnetCidrBlock
 func (mr *MockEC2APIMockRecorder) AssociateSubnetCidrBlock(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AssociateSubnetCidrBlock", reflect.TypeOf((*MockEC2API)(nil).AssociateSubnetCidrBlock), arg0)
 }
 
 // AssociateSubnetCidrBlockRequest mocks base method
 func (m *MockEC2API) AssociateSubnetCidrBlockRequest(arg0 *ec2.AssociateSubnetCidrBlockInput) (*request.Request, *ec2.AssociateSubnetCidrBlockOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AssociateSubnetCidrBlockRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.AssociateSubnetCidrBlockOutput)
@@ -825,13 +732,11 @@ func (m *MockEC2API) AssociateSubnetCidrBlockRequest(arg0 *ec2.AssociateSubnetCi
 
 // AssociateSubnetCidrBlockRequest indicates an expected call of AssociateSubnetCidrBlockRequest
 func (mr *MockEC2APIMockRecorder) AssociateSubnetCidrBlockRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AssociateSubnetCidrBlockRequest", reflect.TypeOf((*MockEC2API)(nil).AssociateSubnetCidrBlockRequest), arg0)
 }
 
 // AssociateSubnetCidrBlockWithContext mocks base method
 func (m *MockEC2API) AssociateSubnetCidrBlockWithContext(arg0 context.Context, arg1 *ec2.AssociateSubnetCidrBlockInput, arg2 ...request.Option) (*ec2.AssociateSubnetCidrBlockOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -844,14 +749,12 @@ func (m *MockEC2API) AssociateSubnetCidrBlockWithContext(arg0 context.Context, a
 
 // AssociateSubnetCidrBlockWithContext indicates an expected call of AssociateSubnetCidrBlockWithContext
 func (mr *MockEC2APIMockRecorder) AssociateSubnetCidrBlockWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AssociateSubnetCidrBlockWithContext", reflect.TypeOf((*MockEC2API)(nil).AssociateSubnetCidrBlockWithContext), varargs...)
 }
 
 // AssociateTransitGatewayRouteTable mocks base method
 func (m *MockEC2API) AssociateTransitGatewayRouteTable(arg0 *ec2.AssociateTransitGatewayRouteTableInput) (*ec2.AssociateTransitGatewayRouteTableOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AssociateTransitGatewayRouteTable", arg0)
 	ret0, _ := ret[0].(*ec2.AssociateTransitGatewayRouteTableOutput)
 	ret1, _ := ret[1].(error)
@@ -860,13 +763,11 @@ func (m *MockEC2API) AssociateTransitGatewayRouteTable(arg0 *ec2.AssociateTransi
 
 // AssociateTransitGatewayRouteTable indicates an expected call of AssociateTransitGatewayRouteTable
 func (mr *MockEC2APIMockRecorder) AssociateTransitGatewayRouteTable(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AssociateTransitGatewayRouteTable", reflect.TypeOf((*MockEC2API)(nil).AssociateTransitGatewayRouteTable), arg0)
 }
 
 // AssociateTransitGatewayRouteTableRequest mocks base method
 func (m *MockEC2API) AssociateTransitGatewayRouteTableRequest(arg0 *ec2.AssociateTransitGatewayRouteTableInput) (*request.Request, *ec2.AssociateTransitGatewayRouteTableOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AssociateTransitGatewayRouteTableRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.AssociateTransitGatewayRouteTableOutput)
@@ -875,13 +776,11 @@ func (m *MockEC2API) AssociateTransitGatewayRouteTableRequest(arg0 *ec2.Associat
 
 // AssociateTransitGatewayRouteTableRequest indicates an expected call of AssociateTransitGatewayRouteTableRequest
 func (mr *MockEC2APIMockRecorder) AssociateTransitGatewayRouteTableRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AssociateTransitGatewayRouteTableRequest", reflect.TypeOf((*MockEC2API)(nil).AssociateTransitGatewayRouteTableRequest), arg0)
 }
 
 // AssociateTransitGatewayRouteTableWithContext mocks base method
 func (m *MockEC2API) AssociateTransitGatewayRouteTableWithContext(arg0 context.Context, arg1 *ec2.AssociateTransitGatewayRouteTableInput, arg2 ...request.Option) (*ec2.AssociateTransitGatewayRouteTableOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -894,14 +793,12 @@ func (m *MockEC2API) AssociateTransitGatewayRouteTableWithContext(arg0 context.C
 
 // AssociateTransitGatewayRouteTableWithContext indicates an expected call of AssociateTransitGatewayRouteTableWithContext
 func (mr *MockEC2APIMockRecorder) AssociateTransitGatewayRouteTableWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AssociateTransitGatewayRouteTableWithContext", reflect.TypeOf((*MockEC2API)(nil).AssociateTransitGatewayRouteTableWithContext), varargs...)
 }
 
 // AssociateVpcCidrBlock mocks base method
 func (m *MockEC2API) AssociateVpcCidrBlock(arg0 *ec2.AssociateVpcCidrBlockInput) (*ec2.AssociateVpcCidrBlockOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AssociateVpcCidrBlock", arg0)
 	ret0, _ := ret[0].(*ec2.AssociateVpcCidrBlockOutput)
 	ret1, _ := ret[1].(error)
@@ -910,13 +807,11 @@ func (m *MockEC2API) AssociateVpcCidrBlock(arg0 *ec2.AssociateVpcCidrBlockInput)
 
 // AssociateVpcCidrBlock indicates an expected call of AssociateVpcCidrBlock
 func (mr *MockEC2APIMockRecorder) AssociateVpcCidrBlock(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AssociateVpcCidrBlock", reflect.TypeOf((*MockEC2API)(nil).AssociateVpcCidrBlock), arg0)
 }
 
 // AssociateVpcCidrBlockRequest mocks base method
 func (m *MockEC2API) AssociateVpcCidrBlockRequest(arg0 *ec2.AssociateVpcCidrBlockInput) (*request.Request, *ec2.AssociateVpcCidrBlockOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AssociateVpcCidrBlockRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.AssociateVpcCidrBlockOutput)
@@ -925,13 +820,11 @@ func (m *MockEC2API) AssociateVpcCidrBlockRequest(arg0 *ec2.AssociateVpcCidrBloc
 
 // AssociateVpcCidrBlockRequest indicates an expected call of AssociateVpcCidrBlockRequest
 func (mr *MockEC2APIMockRecorder) AssociateVpcCidrBlockRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AssociateVpcCidrBlockRequest", reflect.TypeOf((*MockEC2API)(nil).AssociateVpcCidrBlockRequest), arg0)
 }
 
 // AssociateVpcCidrBlockWithContext mocks base method
 func (m *MockEC2API) AssociateVpcCidrBlockWithContext(arg0 context.Context, arg1 *ec2.AssociateVpcCidrBlockInput, arg2 ...request.Option) (*ec2.AssociateVpcCidrBlockOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -944,14 +837,12 @@ func (m *MockEC2API) AssociateVpcCidrBlockWithContext(arg0 context.Context, arg1
 
 // AssociateVpcCidrBlockWithContext indicates an expected call of AssociateVpcCidrBlockWithContext
 func (mr *MockEC2APIMockRecorder) AssociateVpcCidrBlockWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AssociateVpcCidrBlockWithContext", reflect.TypeOf((*MockEC2API)(nil).AssociateVpcCidrBlockWithContext), varargs...)
 }
 
 // AttachClassicLinkVpc mocks base method
 func (m *MockEC2API) AttachClassicLinkVpc(arg0 *ec2.AttachClassicLinkVpcInput) (*ec2.AttachClassicLinkVpcOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AttachClassicLinkVpc", arg0)
 	ret0, _ := ret[0].(*ec2.AttachClassicLinkVpcOutput)
 	ret1, _ := ret[1].(error)
@@ -960,13 +851,11 @@ func (m *MockEC2API) AttachClassicLinkVpc(arg0 *ec2.AttachClassicLinkVpcInput) (
 
 // AttachClassicLinkVpc indicates an expected call of AttachClassicLinkVpc
 func (mr *MockEC2APIMockRecorder) AttachClassicLinkVpc(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AttachClassicLinkVpc", reflect.TypeOf((*MockEC2API)(nil).AttachClassicLinkVpc), arg0)
 }
 
 // AttachClassicLinkVpcRequest mocks base method
 func (m *MockEC2API) AttachClassicLinkVpcRequest(arg0 *ec2.AttachClassicLinkVpcInput) (*request.Request, *ec2.AttachClassicLinkVpcOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AttachClassicLinkVpcRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.AttachClassicLinkVpcOutput)
@@ -975,13 +864,11 @@ func (m *MockEC2API) AttachClassicLinkVpcRequest(arg0 *ec2.AttachClassicLinkVpcI
 
 // AttachClassicLinkVpcRequest indicates an expected call of AttachClassicLinkVpcRequest
 func (mr *MockEC2APIMockRecorder) AttachClassicLinkVpcRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AttachClassicLinkVpcRequest", reflect.TypeOf((*MockEC2API)(nil).AttachClassicLinkVpcRequest), arg0)
 }
 
 // AttachClassicLinkVpcWithContext mocks base method
 func (m *MockEC2API) AttachClassicLinkVpcWithContext(arg0 context.Context, arg1 *ec2.AttachClassicLinkVpcInput, arg2 ...request.Option) (*ec2.AttachClassicLinkVpcOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -994,14 +881,12 @@ func (m *MockEC2API) AttachClassicLinkVpcWithContext(arg0 context.Context, arg1 
 
 // AttachClassicLinkVpcWithContext indicates an expected call of AttachClassicLinkVpcWithContext
 func (mr *MockEC2APIMockRecorder) AttachClassicLinkVpcWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AttachClassicLinkVpcWithContext", reflect.TypeOf((*MockEC2API)(nil).AttachClassicLinkVpcWithContext), varargs...)
 }
 
 // AttachInternetGateway mocks base method
 func (m *MockEC2API) AttachInternetGateway(arg0 *ec2.AttachInternetGatewayInput) (*ec2.AttachInternetGatewayOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AttachInternetGateway", arg0)
 	ret0, _ := ret[0].(*ec2.AttachInternetGatewayOutput)
 	ret1, _ := ret[1].(error)
@@ -1010,13 +895,11 @@ func (m *MockEC2API) AttachInternetGateway(arg0 *ec2.AttachInternetGatewayInput)
 
 // AttachInternetGateway indicates an expected call of AttachInternetGateway
 func (mr *MockEC2APIMockRecorder) AttachInternetGateway(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AttachInternetGateway", reflect.TypeOf((*MockEC2API)(nil).AttachInternetGateway), arg0)
 }
 
 // AttachInternetGatewayRequest mocks base method
 func (m *MockEC2API) AttachInternetGatewayRequest(arg0 *ec2.AttachInternetGatewayInput) (*request.Request, *ec2.AttachInternetGatewayOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AttachInternetGatewayRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.AttachInternetGatewayOutput)
@@ -1025,13 +908,11 @@ func (m *MockEC2API) AttachInternetGatewayRequest(arg0 *ec2.AttachInternetGatewa
 
 // AttachInternetGatewayRequest indicates an expected call of AttachInternetGatewayRequest
 func (mr *MockEC2APIMockRecorder) AttachInternetGatewayRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AttachInternetGatewayRequest", reflect.TypeOf((*MockEC2API)(nil).AttachInternetGatewayRequest), arg0)
 }
 
 // AttachInternetGatewayWithContext mocks base method
 func (m *MockEC2API) AttachInternetGatewayWithContext(arg0 context.Context, arg1 *ec2.AttachInternetGatewayInput, arg2 ...request.Option) (*ec2.AttachInternetGatewayOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -1044,14 +925,12 @@ func (m *MockEC2API) AttachInternetGatewayWithContext(arg0 context.Context, arg1
 
 // AttachInternetGatewayWithContext indicates an expected call of AttachInternetGatewayWithContext
 func (mr *MockEC2APIMockRecorder) AttachInternetGatewayWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AttachInternetGatewayWithContext", reflect.TypeOf((*MockEC2API)(nil).AttachInternetGatewayWithContext), varargs...)
 }
 
 // AttachNetworkInterface mocks base method
 func (m *MockEC2API) AttachNetworkInterface(arg0 *ec2.AttachNetworkInterfaceInput) (*ec2.AttachNetworkInterfaceOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AttachNetworkInterface", arg0)
 	ret0, _ := ret[0].(*ec2.AttachNetworkInterfaceOutput)
 	ret1, _ := ret[1].(error)
@@ -1060,13 +939,11 @@ func (m *MockEC2API) AttachNetworkInterface(arg0 *ec2.AttachNetworkInterfaceInpu
 
 // AttachNetworkInterface indicates an expected call of AttachNetworkInterface
 func (mr *MockEC2APIMockRecorder) AttachNetworkInterface(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AttachNetworkInterface", reflect.TypeOf((*MockEC2API)(nil).AttachNetworkInterface), arg0)
 }
 
 // AttachNetworkInterfaceRequest mocks base method
 func (m *MockEC2API) AttachNetworkInterfaceRequest(arg0 *ec2.AttachNetworkInterfaceInput) (*request.Request, *ec2.AttachNetworkInterfaceOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AttachNetworkInterfaceRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.AttachNetworkInterfaceOutput)
@@ -1075,13 +952,11 @@ func (m *MockEC2API) AttachNetworkInterfaceRequest(arg0 *ec2.AttachNetworkInterf
 
 // AttachNetworkInterfaceRequest indicates an expected call of AttachNetworkInterfaceRequest
 func (mr *MockEC2APIMockRecorder) AttachNetworkInterfaceRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AttachNetworkInterfaceRequest", reflect.TypeOf((*MockEC2API)(nil).AttachNetworkInterfaceRequest), arg0)
 }
 
 // AttachNetworkInterfaceWithContext mocks base method
 func (m *MockEC2API) AttachNetworkInterfaceWithContext(arg0 context.Context, arg1 *ec2.AttachNetworkInterfaceInput, arg2 ...request.Option) (*ec2.AttachNetworkInterfaceOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -1094,14 +969,12 @@ func (m *MockEC2API) AttachNetworkInterfaceWithContext(arg0 context.Context, arg
 
 // AttachNetworkInterfaceWithContext indicates an expected call of AttachNetworkInterfaceWithContext
 func (mr *MockEC2APIMockRecorder) AttachNetworkInterfaceWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AttachNetworkInterfaceWithContext", reflect.TypeOf((*MockEC2API)(nil).AttachNetworkInterfaceWithContext), varargs...)
 }
 
 // AttachVolume mocks base method
 func (m *MockEC2API) AttachVolume(arg0 *ec2.AttachVolumeInput) (*ec2.VolumeAttachment, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AttachVolume", arg0)
 	ret0, _ := ret[0].(*ec2.VolumeAttachment)
 	ret1, _ := ret[1].(error)
@@ -1110,13 +983,11 @@ func (m *MockEC2API) AttachVolume(arg0 *ec2.AttachVolumeInput) (*ec2.VolumeAttac
 
 // AttachVolume indicates an expected call of AttachVolume
 func (mr *MockEC2APIMockRecorder) AttachVolume(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AttachVolume", reflect.TypeOf((*MockEC2API)(nil).AttachVolume), arg0)
 }
 
 // AttachVolumeRequest mocks base method
 func (m *MockEC2API) AttachVolumeRequest(arg0 *ec2.AttachVolumeInput) (*request.Request, *ec2.VolumeAttachment) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AttachVolumeRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.VolumeAttachment)
@@ -1125,13 +996,11 @@ func (m *MockEC2API) AttachVolumeRequest(arg0 *ec2.AttachVolumeInput) (*request.
 
 // AttachVolumeRequest indicates an expected call of AttachVolumeRequest
 func (mr *MockEC2APIMockRecorder) AttachVolumeRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AttachVolumeRequest", reflect.TypeOf((*MockEC2API)(nil).AttachVolumeRequest), arg0)
 }
 
 // AttachVolumeWithContext mocks base method
 func (m *MockEC2API) AttachVolumeWithContext(arg0 context.Context, arg1 *ec2.AttachVolumeInput, arg2 ...request.Option) (*ec2.VolumeAttachment, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -1144,14 +1013,12 @@ func (m *MockEC2API) AttachVolumeWithContext(arg0 context.Context, arg1 *ec2.Att
 
 // AttachVolumeWithContext indicates an expected call of AttachVolumeWithContext
 func (mr *MockEC2APIMockRecorder) AttachVolumeWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AttachVolumeWithContext", reflect.TypeOf((*MockEC2API)(nil).AttachVolumeWithContext), varargs...)
 }
 
 // AttachVpnGateway mocks base method
 func (m *MockEC2API) AttachVpnGateway(arg0 *ec2.AttachVpnGatewayInput) (*ec2.AttachVpnGatewayOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AttachVpnGateway", arg0)
 	ret0, _ := ret[0].(*ec2.AttachVpnGatewayOutput)
 	ret1, _ := ret[1].(error)
@@ -1160,13 +1027,11 @@ func (m *MockEC2API) AttachVpnGateway(arg0 *ec2.AttachVpnGatewayInput) (*ec2.Att
 
 // AttachVpnGateway indicates an expected call of AttachVpnGateway
 func (mr *MockEC2APIMockRecorder) AttachVpnGateway(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AttachVpnGateway", reflect.TypeOf((*MockEC2API)(nil).AttachVpnGateway), arg0)
 }
 
 // AttachVpnGatewayRequest mocks base method
 func (m *MockEC2API) AttachVpnGatewayRequest(arg0 *ec2.AttachVpnGatewayInput) (*request.Request, *ec2.AttachVpnGatewayOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AttachVpnGatewayRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.AttachVpnGatewayOutput)
@@ -1175,13 +1040,11 @@ func (m *MockEC2API) AttachVpnGatewayRequest(arg0 *ec2.AttachVpnGatewayInput) (*
 
 // AttachVpnGatewayRequest indicates an expected call of AttachVpnGatewayRequest
 func (mr *MockEC2APIMockRecorder) AttachVpnGatewayRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AttachVpnGatewayRequest", reflect.TypeOf((*MockEC2API)(nil).AttachVpnGatewayRequest), arg0)
 }
 
 // AttachVpnGatewayWithContext mocks base method
 func (m *MockEC2API) AttachVpnGatewayWithContext(arg0 context.Context, arg1 *ec2.AttachVpnGatewayInput, arg2 ...request.Option) (*ec2.AttachVpnGatewayOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -1194,14 +1057,12 @@ func (m *MockEC2API) AttachVpnGatewayWithContext(arg0 context.Context, arg1 *ec2
 
 // AttachVpnGatewayWithContext indicates an expected call of AttachVpnGatewayWithContext
 func (mr *MockEC2APIMockRecorder) AttachVpnGatewayWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AttachVpnGatewayWithContext", reflect.TypeOf((*MockEC2API)(nil).AttachVpnGatewayWithContext), varargs...)
 }
 
 // AuthorizeClientVpnIngress mocks base method
 func (m *MockEC2API) AuthorizeClientVpnIngress(arg0 *ec2.AuthorizeClientVpnIngressInput) (*ec2.AuthorizeClientVpnIngressOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AuthorizeClientVpnIngress", arg0)
 	ret0, _ := ret[0].(*ec2.AuthorizeClientVpnIngressOutput)
 	ret1, _ := ret[1].(error)
@@ -1210,13 +1071,11 @@ func (m *MockEC2API) AuthorizeClientVpnIngress(arg0 *ec2.AuthorizeClientVpnIngre
 
 // AuthorizeClientVpnIngress indicates an expected call of AuthorizeClientVpnIngress
 func (mr *MockEC2APIMockRecorder) AuthorizeClientVpnIngress(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AuthorizeClientVpnIngress", reflect.TypeOf((*MockEC2API)(nil).AuthorizeClientVpnIngress), arg0)
 }
 
 // AuthorizeClientVpnIngressRequest mocks base method
 func (m *MockEC2API) AuthorizeClientVpnIngressRequest(arg0 *ec2.AuthorizeClientVpnIngressInput) (*request.Request, *ec2.AuthorizeClientVpnIngressOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AuthorizeClientVpnIngressRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.AuthorizeClientVpnIngressOutput)
@@ -1225,13 +1084,11 @@ func (m *MockEC2API) AuthorizeClientVpnIngressRequest(arg0 *ec2.AuthorizeClientV
 
 // AuthorizeClientVpnIngressRequest indicates an expected call of AuthorizeClientVpnIngressRequest
 func (mr *MockEC2APIMockRecorder) AuthorizeClientVpnIngressRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AuthorizeClientVpnIngressRequest", reflect.TypeOf((*MockEC2API)(nil).AuthorizeClientVpnIngressRequest), arg0)
 }
 
 // AuthorizeClientVpnIngressWithContext mocks base method
 func (m *MockEC2API) AuthorizeClientVpnIngressWithContext(arg0 context.Context, arg1 *ec2.AuthorizeClientVpnIngressInput, arg2 ...request.Option) (*ec2.AuthorizeClientVpnIngressOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -1244,14 +1101,12 @@ func (m *MockEC2API) AuthorizeClientVpnIngressWithContext(arg0 context.Context, 
 
 // AuthorizeClientVpnIngressWithContext indicates an expected call of AuthorizeClientVpnIngressWithContext
 func (mr *MockEC2APIMockRecorder) AuthorizeClientVpnIngressWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AuthorizeClientVpnIngressWithContext", reflect.TypeOf((*MockEC2API)(nil).AuthorizeClientVpnIngressWithContext), varargs...)
 }
 
 // AuthorizeSecurityGroupEgress mocks base method
 func (m *MockEC2API) AuthorizeSecurityGroupEgress(arg0 *ec2.AuthorizeSecurityGroupEgressInput) (*ec2.AuthorizeSecurityGroupEgressOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AuthorizeSecurityGroupEgress", arg0)
 	ret0, _ := ret[0].(*ec2.AuthorizeSecurityGroupEgressOutput)
 	ret1, _ := ret[1].(error)
@@ -1260,13 +1115,11 @@ func (m *MockEC2API) AuthorizeSecurityGroupEgress(arg0 *ec2.AuthorizeSecurityGro
 
 // AuthorizeSecurityGroupEgress indicates an expected call of AuthorizeSecurityGroupEgress
 func (mr *MockEC2APIMockRecorder) AuthorizeSecurityGroupEgress(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AuthorizeSecurityGroupEgress", reflect.TypeOf((*MockEC2API)(nil).AuthorizeSecurityGroupEgress), arg0)
 }
 
 // AuthorizeSecurityGroupEgressRequest mocks base method
 func (m *MockEC2API) AuthorizeSecurityGroupEgressRequest(arg0 *ec2.AuthorizeSecurityGroupEgressInput) (*request.Request, *ec2.AuthorizeSecurityGroupEgressOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AuthorizeSecurityGroupEgressRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.AuthorizeSecurityGroupEgressOutput)
@@ -1275,13 +1128,11 @@ func (m *MockEC2API) AuthorizeSecurityGroupEgressRequest(arg0 *ec2.AuthorizeSecu
 
 // AuthorizeSecurityGroupEgressRequest indicates an expected call of AuthorizeSecurityGroupEgressRequest
 func (mr *MockEC2APIMockRecorder) AuthorizeSecurityGroupEgressRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AuthorizeSecurityGroupEgressRequest", reflect.TypeOf((*MockEC2API)(nil).AuthorizeSecurityGroupEgressRequest), arg0)
 }
 
 // AuthorizeSecurityGroupEgressWithContext mocks base method
 func (m *MockEC2API) AuthorizeSecurityGroupEgressWithContext(arg0 context.Context, arg1 *ec2.AuthorizeSecurityGroupEgressInput, arg2 ...request.Option) (*ec2.AuthorizeSecurityGroupEgressOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -1294,14 +1145,12 @@ func (m *MockEC2API) AuthorizeSecurityGroupEgressWithContext(arg0 context.Contex
 
 // AuthorizeSecurityGroupEgressWithContext indicates an expected call of AuthorizeSecurityGroupEgressWithContext
 func (mr *MockEC2APIMockRecorder) AuthorizeSecurityGroupEgressWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AuthorizeSecurityGroupEgressWithContext", reflect.TypeOf((*MockEC2API)(nil).AuthorizeSecurityGroupEgressWithContext), varargs...)
 }
 
 // AuthorizeSecurityGroupIngress mocks base method
 func (m *MockEC2API) AuthorizeSecurityGroupIngress(arg0 *ec2.AuthorizeSecurityGroupIngressInput) (*ec2.AuthorizeSecurityGroupIngressOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AuthorizeSecurityGroupIngress", arg0)
 	ret0, _ := ret[0].(*ec2.AuthorizeSecurityGroupIngressOutput)
 	ret1, _ := ret[1].(error)
@@ -1310,13 +1159,11 @@ func (m *MockEC2API) AuthorizeSecurityGroupIngress(arg0 *ec2.AuthorizeSecurityGr
 
 // AuthorizeSecurityGroupIngress indicates an expected call of AuthorizeSecurityGroupIngress
 func (mr *MockEC2APIMockRecorder) AuthorizeSecurityGroupIngress(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AuthorizeSecurityGroupIngress", reflect.TypeOf((*MockEC2API)(nil).AuthorizeSecurityGroupIngress), arg0)
 }
 
 // AuthorizeSecurityGroupIngressRequest mocks base method
 func (m *MockEC2API) AuthorizeSecurityGroupIngressRequest(arg0 *ec2.AuthorizeSecurityGroupIngressInput) (*request.Request, *ec2.AuthorizeSecurityGroupIngressOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AuthorizeSecurityGroupIngressRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.AuthorizeSecurityGroupIngressOutput)
@@ -1325,13 +1172,11 @@ func (m *MockEC2API) AuthorizeSecurityGroupIngressRequest(arg0 *ec2.AuthorizeSec
 
 // AuthorizeSecurityGroupIngressRequest indicates an expected call of AuthorizeSecurityGroupIngressRequest
 func (mr *MockEC2APIMockRecorder) AuthorizeSecurityGroupIngressRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AuthorizeSecurityGroupIngressRequest", reflect.TypeOf((*MockEC2API)(nil).AuthorizeSecurityGroupIngressRequest), arg0)
 }
 
 // AuthorizeSecurityGroupIngressWithContext mocks base method
 func (m *MockEC2API) AuthorizeSecurityGroupIngressWithContext(arg0 context.Context, arg1 *ec2.AuthorizeSecurityGroupIngressInput, arg2 ...request.Option) (*ec2.AuthorizeSecurityGroupIngressOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -1344,14 +1189,12 @@ func (m *MockEC2API) AuthorizeSecurityGroupIngressWithContext(arg0 context.Conte
 
 // AuthorizeSecurityGroupIngressWithContext indicates an expected call of AuthorizeSecurityGroupIngressWithContext
 func (mr *MockEC2APIMockRecorder) AuthorizeSecurityGroupIngressWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AuthorizeSecurityGroupIngressWithContext", reflect.TypeOf((*MockEC2API)(nil).AuthorizeSecurityGroupIngressWithContext), varargs...)
 }
 
 // BundleInstance mocks base method
 func (m *MockEC2API) BundleInstance(arg0 *ec2.BundleInstanceInput) (*ec2.BundleInstanceOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "BundleInstance", arg0)
 	ret0, _ := ret[0].(*ec2.BundleInstanceOutput)
 	ret1, _ := ret[1].(error)
@@ -1360,13 +1203,11 @@ func (m *MockEC2API) BundleInstance(arg0 *ec2.BundleInstanceInput) (*ec2.BundleI
 
 // BundleInstance indicates an expected call of BundleInstance
 func (mr *MockEC2APIMockRecorder) BundleInstance(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BundleInstance", reflect.TypeOf((*MockEC2API)(nil).BundleInstance), arg0)
 }
 
 // BundleInstanceRequest mocks base method
 func (m *MockEC2API) BundleInstanceRequest(arg0 *ec2.BundleInstanceInput) (*request.Request, *ec2.BundleInstanceOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "BundleInstanceRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.BundleInstanceOutput)
@@ -1375,13 +1216,11 @@ func (m *MockEC2API) BundleInstanceRequest(arg0 *ec2.BundleInstanceInput) (*requ
 
 // BundleInstanceRequest indicates an expected call of BundleInstanceRequest
 func (mr *MockEC2APIMockRecorder) BundleInstanceRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BundleInstanceRequest", reflect.TypeOf((*MockEC2API)(nil).BundleInstanceRequest), arg0)
 }
 
 // BundleInstanceWithContext mocks base method
 func (m *MockEC2API) BundleInstanceWithContext(arg0 context.Context, arg1 *ec2.BundleInstanceInput, arg2 ...request.Option) (*ec2.BundleInstanceOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -1394,14 +1233,12 @@ func (m *MockEC2API) BundleInstanceWithContext(arg0 context.Context, arg1 *ec2.B
 
 // BundleInstanceWithContext indicates an expected call of BundleInstanceWithContext
 func (mr *MockEC2APIMockRecorder) BundleInstanceWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BundleInstanceWithContext", reflect.TypeOf((*MockEC2API)(nil).BundleInstanceWithContext), varargs...)
 }
 
 // CancelBundleTask mocks base method
 func (m *MockEC2API) CancelBundleTask(arg0 *ec2.CancelBundleTaskInput) (*ec2.CancelBundleTaskOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CancelBundleTask", arg0)
 	ret0, _ := ret[0].(*ec2.CancelBundleTaskOutput)
 	ret1, _ := ret[1].(error)
@@ -1410,13 +1247,11 @@ func (m *MockEC2API) CancelBundleTask(arg0 *ec2.CancelBundleTaskInput) (*ec2.Can
 
 // CancelBundleTask indicates an expected call of CancelBundleTask
 func (mr *MockEC2APIMockRecorder) CancelBundleTask(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CancelBundleTask", reflect.TypeOf((*MockEC2API)(nil).CancelBundleTask), arg0)
 }
 
 // CancelBundleTaskRequest mocks base method
 func (m *MockEC2API) CancelBundleTaskRequest(arg0 *ec2.CancelBundleTaskInput) (*request.Request, *ec2.CancelBundleTaskOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CancelBundleTaskRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.CancelBundleTaskOutput)
@@ -1425,13 +1260,11 @@ func (m *MockEC2API) CancelBundleTaskRequest(arg0 *ec2.CancelBundleTaskInput) (*
 
 // CancelBundleTaskRequest indicates an expected call of CancelBundleTaskRequest
 func (mr *MockEC2APIMockRecorder) CancelBundleTaskRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CancelBundleTaskRequest", reflect.TypeOf((*MockEC2API)(nil).CancelBundleTaskRequest), arg0)
 }
 
 // CancelBundleTaskWithContext mocks base method
 func (m *MockEC2API) CancelBundleTaskWithContext(arg0 context.Context, arg1 *ec2.CancelBundleTaskInput, arg2 ...request.Option) (*ec2.CancelBundleTaskOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -1444,14 +1277,12 @@ func (m *MockEC2API) CancelBundleTaskWithContext(arg0 context.Context, arg1 *ec2
 
 // CancelBundleTaskWithContext indicates an expected call of CancelBundleTaskWithContext
 func (mr *MockEC2APIMockRecorder) CancelBundleTaskWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CancelBundleTaskWithContext", reflect.TypeOf((*MockEC2API)(nil).CancelBundleTaskWithContext), varargs...)
 }
 
 // CancelCapacityReservation mocks base method
 func (m *MockEC2API) CancelCapacityReservation(arg0 *ec2.CancelCapacityReservationInput) (*ec2.CancelCapacityReservationOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CancelCapacityReservation", arg0)
 	ret0, _ := ret[0].(*ec2.CancelCapacityReservationOutput)
 	ret1, _ := ret[1].(error)
@@ -1460,13 +1291,11 @@ func (m *MockEC2API) CancelCapacityReservation(arg0 *ec2.CancelCapacityReservati
 
 // CancelCapacityReservation indicates an expected call of CancelCapacityReservation
 func (mr *MockEC2APIMockRecorder) CancelCapacityReservation(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CancelCapacityReservation", reflect.TypeOf((*MockEC2API)(nil).CancelCapacityReservation), arg0)
 }
 
 // CancelCapacityReservationRequest mocks base method
 func (m *MockEC2API) CancelCapacityReservationRequest(arg0 *ec2.CancelCapacityReservationInput) (*request.Request, *ec2.CancelCapacityReservationOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CancelCapacityReservationRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.CancelCapacityReservationOutput)
@@ -1475,13 +1304,11 @@ func (m *MockEC2API) CancelCapacityReservationRequest(arg0 *ec2.CancelCapacityRe
 
 // CancelCapacityReservationRequest indicates an expected call of CancelCapacityReservationRequest
 func (mr *MockEC2APIMockRecorder) CancelCapacityReservationRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CancelCapacityReservationRequest", reflect.TypeOf((*MockEC2API)(nil).CancelCapacityReservationRequest), arg0)
 }
 
 // CancelCapacityReservationWithContext mocks base method
 func (m *MockEC2API) CancelCapacityReservationWithContext(arg0 context.Context, arg1 *ec2.CancelCapacityReservationInput, arg2 ...request.Option) (*ec2.CancelCapacityReservationOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -1494,14 +1321,12 @@ func (m *MockEC2API) CancelCapacityReservationWithContext(arg0 context.Context, 
 
 // CancelCapacityReservationWithContext indicates an expected call of CancelCapacityReservationWithContext
 func (mr *MockEC2APIMockRecorder) CancelCapacityReservationWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CancelCapacityReservationWithContext", reflect.TypeOf((*MockEC2API)(nil).CancelCapacityReservationWithContext), varargs...)
 }
 
 // CancelConversionTask mocks base method
 func (m *MockEC2API) CancelConversionTask(arg0 *ec2.CancelConversionTaskInput) (*ec2.CancelConversionTaskOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CancelConversionTask", arg0)
 	ret0, _ := ret[0].(*ec2.CancelConversionTaskOutput)
 	ret1, _ := ret[1].(error)
@@ -1510,13 +1335,11 @@ func (m *MockEC2API) CancelConversionTask(arg0 *ec2.CancelConversionTaskInput) (
 
 // CancelConversionTask indicates an expected call of CancelConversionTask
 func (mr *MockEC2APIMockRecorder) CancelConversionTask(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CancelConversionTask", reflect.TypeOf((*MockEC2API)(nil).CancelConversionTask), arg0)
 }
 
 // CancelConversionTaskRequest mocks base method
 func (m *MockEC2API) CancelConversionTaskRequest(arg0 *ec2.CancelConversionTaskInput) (*request.Request, *ec2.CancelConversionTaskOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CancelConversionTaskRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.CancelConversionTaskOutput)
@@ -1525,13 +1348,11 @@ func (m *MockEC2API) CancelConversionTaskRequest(arg0 *ec2.CancelConversionTaskI
 
 // CancelConversionTaskRequest indicates an expected call of CancelConversionTaskRequest
 func (mr *MockEC2APIMockRecorder) CancelConversionTaskRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CancelConversionTaskRequest", reflect.TypeOf((*MockEC2API)(nil).CancelConversionTaskRequest), arg0)
 }
 
 // CancelConversionTaskWithContext mocks base method
 func (m *MockEC2API) CancelConversionTaskWithContext(arg0 context.Context, arg1 *ec2.CancelConversionTaskInput, arg2 ...request.Option) (*ec2.CancelConversionTaskOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -1544,14 +1365,12 @@ func (m *MockEC2API) CancelConversionTaskWithContext(arg0 context.Context, arg1 
 
 // CancelConversionTaskWithContext indicates an expected call of CancelConversionTaskWithContext
 func (mr *MockEC2APIMockRecorder) CancelConversionTaskWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CancelConversionTaskWithContext", reflect.TypeOf((*MockEC2API)(nil).CancelConversionTaskWithContext), varargs...)
 }
 
 // CancelExportTask mocks base method
 func (m *MockEC2API) CancelExportTask(arg0 *ec2.CancelExportTaskInput) (*ec2.CancelExportTaskOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CancelExportTask", arg0)
 	ret0, _ := ret[0].(*ec2.CancelExportTaskOutput)
 	ret1, _ := ret[1].(error)
@@ -1560,13 +1379,11 @@ func (m *MockEC2API) CancelExportTask(arg0 *ec2.CancelExportTaskInput) (*ec2.Can
 
 // CancelExportTask indicates an expected call of CancelExportTask
 func (mr *MockEC2APIMockRecorder) CancelExportTask(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CancelExportTask", reflect.TypeOf((*MockEC2API)(nil).CancelExportTask), arg0)
 }
 
 // CancelExportTaskRequest mocks base method
 func (m *MockEC2API) CancelExportTaskRequest(arg0 *ec2.CancelExportTaskInput) (*request.Request, *ec2.CancelExportTaskOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CancelExportTaskRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.CancelExportTaskOutput)
@@ -1575,13 +1392,11 @@ func (m *MockEC2API) CancelExportTaskRequest(arg0 *ec2.CancelExportTaskInput) (*
 
 // CancelExportTaskRequest indicates an expected call of CancelExportTaskRequest
 func (mr *MockEC2APIMockRecorder) CancelExportTaskRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CancelExportTaskRequest", reflect.TypeOf((*MockEC2API)(nil).CancelExportTaskRequest), arg0)
 }
 
 // CancelExportTaskWithContext mocks base method
 func (m *MockEC2API) CancelExportTaskWithContext(arg0 context.Context, arg1 *ec2.CancelExportTaskInput, arg2 ...request.Option) (*ec2.CancelExportTaskOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -1594,14 +1409,12 @@ func (m *MockEC2API) CancelExportTaskWithContext(arg0 context.Context, arg1 *ec2
 
 // CancelExportTaskWithContext indicates an expected call of CancelExportTaskWithContext
 func (mr *MockEC2APIMockRecorder) CancelExportTaskWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CancelExportTaskWithContext", reflect.TypeOf((*MockEC2API)(nil).CancelExportTaskWithContext), varargs...)
 }
 
 // CancelImportTask mocks base method
 func (m *MockEC2API) CancelImportTask(arg0 *ec2.CancelImportTaskInput) (*ec2.CancelImportTaskOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CancelImportTask", arg0)
 	ret0, _ := ret[0].(*ec2.CancelImportTaskOutput)
 	ret1, _ := ret[1].(error)
@@ -1610,13 +1423,11 @@ func (m *MockEC2API) CancelImportTask(arg0 *ec2.CancelImportTaskInput) (*ec2.Can
 
 // CancelImportTask indicates an expected call of CancelImportTask
 func (mr *MockEC2APIMockRecorder) CancelImportTask(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CancelImportTask", reflect.TypeOf((*MockEC2API)(nil).CancelImportTask), arg0)
 }
 
 // CancelImportTaskRequest mocks base method
 func (m *MockEC2API) CancelImportTaskRequest(arg0 *ec2.CancelImportTaskInput) (*request.Request, *ec2.CancelImportTaskOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CancelImportTaskRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.CancelImportTaskOutput)
@@ -1625,13 +1436,11 @@ func (m *MockEC2API) CancelImportTaskRequest(arg0 *ec2.CancelImportTaskInput) (*
 
 // CancelImportTaskRequest indicates an expected call of CancelImportTaskRequest
 func (mr *MockEC2APIMockRecorder) CancelImportTaskRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CancelImportTaskRequest", reflect.TypeOf((*MockEC2API)(nil).CancelImportTaskRequest), arg0)
 }
 
 // CancelImportTaskWithContext mocks base method
 func (m *MockEC2API) CancelImportTaskWithContext(arg0 context.Context, arg1 *ec2.CancelImportTaskInput, arg2 ...request.Option) (*ec2.CancelImportTaskOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -1644,14 +1453,12 @@ func (m *MockEC2API) CancelImportTaskWithContext(arg0 context.Context, arg1 *ec2
 
 // CancelImportTaskWithContext indicates an expected call of CancelImportTaskWithContext
 func (mr *MockEC2APIMockRecorder) CancelImportTaskWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CancelImportTaskWithContext", reflect.TypeOf((*MockEC2API)(nil).CancelImportTaskWithContext), varargs...)
 }
 
 // CancelReservedInstancesListing mocks base method
 func (m *MockEC2API) CancelReservedInstancesListing(arg0 *ec2.CancelReservedInstancesListingInput) (*ec2.CancelReservedInstancesListingOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CancelReservedInstancesListing", arg0)
 	ret0, _ := ret[0].(*ec2.CancelReservedInstancesListingOutput)
 	ret1, _ := ret[1].(error)
@@ -1660,13 +1467,11 @@ func (m *MockEC2API) CancelReservedInstancesListing(arg0 *ec2.CancelReservedInst
 
 // CancelReservedInstancesListing indicates an expected call of CancelReservedInstancesListing
 func (mr *MockEC2APIMockRecorder) CancelReservedInstancesListing(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CancelReservedInstancesListing", reflect.TypeOf((*MockEC2API)(nil).CancelReservedInstancesListing), arg0)
 }
 
 // CancelReservedInstancesListingRequest mocks base method
 func (m *MockEC2API) CancelReservedInstancesListingRequest(arg0 *ec2.CancelReservedInstancesListingInput) (*request.Request, *ec2.CancelReservedInstancesListingOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CancelReservedInstancesListingRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.CancelReservedInstancesListingOutput)
@@ -1675,13 +1480,11 @@ func (m *MockEC2API) CancelReservedInstancesListingRequest(arg0 *ec2.CancelReser
 
 // CancelReservedInstancesListingRequest indicates an expected call of CancelReservedInstancesListingRequest
 func (mr *MockEC2APIMockRecorder) CancelReservedInstancesListingRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CancelReservedInstancesListingRequest", reflect.TypeOf((*MockEC2API)(nil).CancelReservedInstancesListingRequest), arg0)
 }
 
 // CancelReservedInstancesListingWithContext mocks base method
 func (m *MockEC2API) CancelReservedInstancesListingWithContext(arg0 context.Context, arg1 *ec2.CancelReservedInstancesListingInput, arg2 ...request.Option) (*ec2.CancelReservedInstancesListingOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -1694,14 +1497,12 @@ func (m *MockEC2API) CancelReservedInstancesListingWithContext(arg0 context.Cont
 
 // CancelReservedInstancesListingWithContext indicates an expected call of CancelReservedInstancesListingWithContext
 func (mr *MockEC2APIMockRecorder) CancelReservedInstancesListingWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CancelReservedInstancesListingWithContext", reflect.TypeOf((*MockEC2API)(nil).CancelReservedInstancesListingWithContext), varargs...)
 }
 
 // CancelSpotFleetRequests mocks base method
 func (m *MockEC2API) CancelSpotFleetRequests(arg0 *ec2.CancelSpotFleetRequestsInput) (*ec2.CancelSpotFleetRequestsOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CancelSpotFleetRequests", arg0)
 	ret0, _ := ret[0].(*ec2.CancelSpotFleetRequestsOutput)
 	ret1, _ := ret[1].(error)
@@ -1710,13 +1511,11 @@ func (m *MockEC2API) CancelSpotFleetRequests(arg0 *ec2.CancelSpotFleetRequestsIn
 
 // CancelSpotFleetRequests indicates an expected call of CancelSpotFleetRequests
 func (mr *MockEC2APIMockRecorder) CancelSpotFleetRequests(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CancelSpotFleetRequests", reflect.TypeOf((*MockEC2API)(nil).CancelSpotFleetRequests), arg0)
 }
 
 // CancelSpotFleetRequestsRequest mocks base method
 func (m *MockEC2API) CancelSpotFleetRequestsRequest(arg0 *ec2.CancelSpotFleetRequestsInput) (*request.Request, *ec2.CancelSpotFleetRequestsOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CancelSpotFleetRequestsRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.CancelSpotFleetRequestsOutput)
@@ -1725,13 +1524,11 @@ func (m *MockEC2API) CancelSpotFleetRequestsRequest(arg0 *ec2.CancelSpotFleetReq
 
 // CancelSpotFleetRequestsRequest indicates an expected call of CancelSpotFleetRequestsRequest
 func (mr *MockEC2APIMockRecorder) CancelSpotFleetRequestsRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CancelSpotFleetRequestsRequest", reflect.TypeOf((*MockEC2API)(nil).CancelSpotFleetRequestsRequest), arg0)
 }
 
 // CancelSpotFleetRequestsWithContext mocks base method
 func (m *MockEC2API) CancelSpotFleetRequestsWithContext(arg0 context.Context, arg1 *ec2.CancelSpotFleetRequestsInput, arg2 ...request.Option) (*ec2.CancelSpotFleetRequestsOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -1744,14 +1541,12 @@ func (m *MockEC2API) CancelSpotFleetRequestsWithContext(arg0 context.Context, ar
 
 // CancelSpotFleetRequestsWithContext indicates an expected call of CancelSpotFleetRequestsWithContext
 func (mr *MockEC2APIMockRecorder) CancelSpotFleetRequestsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CancelSpotFleetRequestsWithContext", reflect.TypeOf((*MockEC2API)(nil).CancelSpotFleetRequestsWithContext), varargs...)
 }
 
 // CancelSpotInstanceRequests mocks base method
 func (m *MockEC2API) CancelSpotInstanceRequests(arg0 *ec2.CancelSpotInstanceRequestsInput) (*ec2.CancelSpotInstanceRequestsOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CancelSpotInstanceRequests", arg0)
 	ret0, _ := ret[0].(*ec2.CancelSpotInstanceRequestsOutput)
 	ret1, _ := ret[1].(error)
@@ -1760,13 +1555,11 @@ func (m *MockEC2API) CancelSpotInstanceRequests(arg0 *ec2.CancelSpotInstanceRequ
 
 // CancelSpotInstanceRequests indicates an expected call of CancelSpotInstanceRequests
 func (mr *MockEC2APIMockRecorder) CancelSpotInstanceRequests(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CancelSpotInstanceRequests", reflect.TypeOf((*MockEC2API)(nil).CancelSpotInstanceRequests), arg0)
 }
 
 // CancelSpotInstanceRequestsRequest mocks base method
 func (m *MockEC2API) CancelSpotInstanceRequestsRequest(arg0 *ec2.CancelSpotInstanceRequestsInput) (*request.Request, *ec2.CancelSpotInstanceRequestsOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CancelSpotInstanceRequestsRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.CancelSpotInstanceRequestsOutput)
@@ -1775,13 +1568,11 @@ func (m *MockEC2API) CancelSpotInstanceRequestsRequest(arg0 *ec2.CancelSpotInsta
 
 // CancelSpotInstanceRequestsRequest indicates an expected call of CancelSpotInstanceRequestsRequest
 func (mr *MockEC2APIMockRecorder) CancelSpotInstanceRequestsRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CancelSpotInstanceRequestsRequest", reflect.TypeOf((*MockEC2API)(nil).CancelSpotInstanceRequestsRequest), arg0)
 }
 
 // CancelSpotInstanceRequestsWithContext mocks base method
 func (m *MockEC2API) CancelSpotInstanceRequestsWithContext(arg0 context.Context, arg1 *ec2.CancelSpotInstanceRequestsInput, arg2 ...request.Option) (*ec2.CancelSpotInstanceRequestsOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -1794,14 +1585,12 @@ func (m *MockEC2API) CancelSpotInstanceRequestsWithContext(arg0 context.Context,
 
 // CancelSpotInstanceRequestsWithContext indicates an expected call of CancelSpotInstanceRequestsWithContext
 func (mr *MockEC2APIMockRecorder) CancelSpotInstanceRequestsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CancelSpotInstanceRequestsWithContext", reflect.TypeOf((*MockEC2API)(nil).CancelSpotInstanceRequestsWithContext), varargs...)
 }
 
 // ConfirmProductInstance mocks base method
 func (m *MockEC2API) ConfirmProductInstance(arg0 *ec2.ConfirmProductInstanceInput) (*ec2.ConfirmProductInstanceOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ConfirmProductInstance", arg0)
 	ret0, _ := ret[0].(*ec2.ConfirmProductInstanceOutput)
 	ret1, _ := ret[1].(error)
@@ -1810,13 +1599,11 @@ func (m *MockEC2API) ConfirmProductInstance(arg0 *ec2.ConfirmProductInstanceInpu
 
 // ConfirmProductInstance indicates an expected call of ConfirmProductInstance
 func (mr *MockEC2APIMockRecorder) ConfirmProductInstance(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConfirmProductInstance", reflect.TypeOf((*MockEC2API)(nil).ConfirmProductInstance), arg0)
 }
 
 // ConfirmProductInstanceRequest mocks base method
 func (m *MockEC2API) ConfirmProductInstanceRequest(arg0 *ec2.ConfirmProductInstanceInput) (*request.Request, *ec2.ConfirmProductInstanceOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ConfirmProductInstanceRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.ConfirmProductInstanceOutput)
@@ -1825,13 +1612,11 @@ func (m *MockEC2API) ConfirmProductInstanceRequest(arg0 *ec2.ConfirmProductInsta
 
 // ConfirmProductInstanceRequest indicates an expected call of ConfirmProductInstanceRequest
 func (mr *MockEC2APIMockRecorder) ConfirmProductInstanceRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConfirmProductInstanceRequest", reflect.TypeOf((*MockEC2API)(nil).ConfirmProductInstanceRequest), arg0)
 }
 
 // ConfirmProductInstanceWithContext mocks base method
 func (m *MockEC2API) ConfirmProductInstanceWithContext(arg0 context.Context, arg1 *ec2.ConfirmProductInstanceInput, arg2 ...request.Option) (*ec2.ConfirmProductInstanceOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -1844,14 +1629,12 @@ func (m *MockEC2API) ConfirmProductInstanceWithContext(arg0 context.Context, arg
 
 // ConfirmProductInstanceWithContext indicates an expected call of ConfirmProductInstanceWithContext
 func (mr *MockEC2APIMockRecorder) ConfirmProductInstanceWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConfirmProductInstanceWithContext", reflect.TypeOf((*MockEC2API)(nil).ConfirmProductInstanceWithContext), varargs...)
 }
 
 // CopyFpgaImage mocks base method
 func (m *MockEC2API) CopyFpgaImage(arg0 *ec2.CopyFpgaImageInput) (*ec2.CopyFpgaImageOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CopyFpgaImage", arg0)
 	ret0, _ := ret[0].(*ec2.CopyFpgaImageOutput)
 	ret1, _ := ret[1].(error)
@@ -1860,13 +1643,11 @@ func (m *MockEC2API) CopyFpgaImage(arg0 *ec2.CopyFpgaImageInput) (*ec2.CopyFpgaI
 
 // CopyFpgaImage indicates an expected call of CopyFpgaImage
 func (mr *MockEC2APIMockRecorder) CopyFpgaImage(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CopyFpgaImage", reflect.TypeOf((*MockEC2API)(nil).CopyFpgaImage), arg0)
 }
 
 // CopyFpgaImageRequest mocks base method
 func (m *MockEC2API) CopyFpgaImageRequest(arg0 *ec2.CopyFpgaImageInput) (*request.Request, *ec2.CopyFpgaImageOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CopyFpgaImageRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.CopyFpgaImageOutput)
@@ -1875,13 +1656,11 @@ func (m *MockEC2API) CopyFpgaImageRequest(arg0 *ec2.CopyFpgaImageInput) (*reques
 
 // CopyFpgaImageRequest indicates an expected call of CopyFpgaImageRequest
 func (mr *MockEC2APIMockRecorder) CopyFpgaImageRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CopyFpgaImageRequest", reflect.TypeOf((*MockEC2API)(nil).CopyFpgaImageRequest), arg0)
 }
 
 // CopyFpgaImageWithContext mocks base method
 func (m *MockEC2API) CopyFpgaImageWithContext(arg0 context.Context, arg1 *ec2.CopyFpgaImageInput, arg2 ...request.Option) (*ec2.CopyFpgaImageOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -1894,14 +1673,12 @@ func (m *MockEC2API) CopyFpgaImageWithContext(arg0 context.Context, arg1 *ec2.Co
 
 // CopyFpgaImageWithContext indicates an expected call of CopyFpgaImageWithContext
 func (mr *MockEC2APIMockRecorder) CopyFpgaImageWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CopyFpgaImageWithContext", reflect.TypeOf((*MockEC2API)(nil).CopyFpgaImageWithContext), varargs...)
 }
 
 // CopyImage mocks base method
 func (m *MockEC2API) CopyImage(arg0 *ec2.CopyImageInput) (*ec2.CopyImageOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CopyImage", arg0)
 	ret0, _ := ret[0].(*ec2.CopyImageOutput)
 	ret1, _ := ret[1].(error)
@@ -1910,13 +1687,11 @@ func (m *MockEC2API) CopyImage(arg0 *ec2.CopyImageInput) (*ec2.CopyImageOutput, 
 
 // CopyImage indicates an expected call of CopyImage
 func (mr *MockEC2APIMockRecorder) CopyImage(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CopyImage", reflect.TypeOf((*MockEC2API)(nil).CopyImage), arg0)
 }
 
 // CopyImageRequest mocks base method
 func (m *MockEC2API) CopyImageRequest(arg0 *ec2.CopyImageInput) (*request.Request, *ec2.CopyImageOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CopyImageRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.CopyImageOutput)
@@ -1925,13 +1700,11 @@ func (m *MockEC2API) CopyImageRequest(arg0 *ec2.CopyImageInput) (*request.Reques
 
 // CopyImageRequest indicates an expected call of CopyImageRequest
 func (mr *MockEC2APIMockRecorder) CopyImageRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CopyImageRequest", reflect.TypeOf((*MockEC2API)(nil).CopyImageRequest), arg0)
 }
 
 // CopyImageWithContext mocks base method
 func (m *MockEC2API) CopyImageWithContext(arg0 context.Context, arg1 *ec2.CopyImageInput, arg2 ...request.Option) (*ec2.CopyImageOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -1944,14 +1717,12 @@ func (m *MockEC2API) CopyImageWithContext(arg0 context.Context, arg1 *ec2.CopyIm
 
 // CopyImageWithContext indicates an expected call of CopyImageWithContext
 func (mr *MockEC2APIMockRecorder) CopyImageWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CopyImageWithContext", reflect.TypeOf((*MockEC2API)(nil).CopyImageWithContext), varargs...)
 }
 
 // CopySnapshot mocks base method
 func (m *MockEC2API) CopySnapshot(arg0 *ec2.CopySnapshotInput) (*ec2.CopySnapshotOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CopySnapshot", arg0)
 	ret0, _ := ret[0].(*ec2.CopySnapshotOutput)
 	ret1, _ := ret[1].(error)
@@ -1960,13 +1731,11 @@ func (m *MockEC2API) CopySnapshot(arg0 *ec2.CopySnapshotInput) (*ec2.CopySnapsho
 
 // CopySnapshot indicates an expected call of CopySnapshot
 func (mr *MockEC2APIMockRecorder) CopySnapshot(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CopySnapshot", reflect.TypeOf((*MockEC2API)(nil).CopySnapshot), arg0)
 }
 
 // CopySnapshotRequest mocks base method
 func (m *MockEC2API) CopySnapshotRequest(arg0 *ec2.CopySnapshotInput) (*request.Request, *ec2.CopySnapshotOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CopySnapshotRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.CopySnapshotOutput)
@@ -1975,13 +1744,11 @@ func (m *MockEC2API) CopySnapshotRequest(arg0 *ec2.CopySnapshotInput) (*request.
 
 // CopySnapshotRequest indicates an expected call of CopySnapshotRequest
 func (mr *MockEC2APIMockRecorder) CopySnapshotRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CopySnapshotRequest", reflect.TypeOf((*MockEC2API)(nil).CopySnapshotRequest), arg0)
 }
 
 // CopySnapshotWithContext mocks base method
 func (m *MockEC2API) CopySnapshotWithContext(arg0 context.Context, arg1 *ec2.CopySnapshotInput, arg2 ...request.Option) (*ec2.CopySnapshotOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -1994,14 +1761,12 @@ func (m *MockEC2API) CopySnapshotWithContext(arg0 context.Context, arg1 *ec2.Cop
 
 // CopySnapshotWithContext indicates an expected call of CopySnapshotWithContext
 func (mr *MockEC2APIMockRecorder) CopySnapshotWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CopySnapshotWithContext", reflect.TypeOf((*MockEC2API)(nil).CopySnapshotWithContext), varargs...)
 }
 
 // CreateCapacityReservation mocks base method
 func (m *MockEC2API) CreateCapacityReservation(arg0 *ec2.CreateCapacityReservationInput) (*ec2.CreateCapacityReservationOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateCapacityReservation", arg0)
 	ret0, _ := ret[0].(*ec2.CreateCapacityReservationOutput)
 	ret1, _ := ret[1].(error)
@@ -2010,13 +1775,11 @@ func (m *MockEC2API) CreateCapacityReservation(arg0 *ec2.CreateCapacityReservati
 
 // CreateCapacityReservation indicates an expected call of CreateCapacityReservation
 func (mr *MockEC2APIMockRecorder) CreateCapacityReservation(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateCapacityReservation", reflect.TypeOf((*MockEC2API)(nil).CreateCapacityReservation), arg0)
 }
 
 // CreateCapacityReservationRequest mocks base method
 func (m *MockEC2API) CreateCapacityReservationRequest(arg0 *ec2.CreateCapacityReservationInput) (*request.Request, *ec2.CreateCapacityReservationOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateCapacityReservationRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.CreateCapacityReservationOutput)
@@ -2025,13 +1788,11 @@ func (m *MockEC2API) CreateCapacityReservationRequest(arg0 *ec2.CreateCapacityRe
 
 // CreateCapacityReservationRequest indicates an expected call of CreateCapacityReservationRequest
 func (mr *MockEC2APIMockRecorder) CreateCapacityReservationRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateCapacityReservationRequest", reflect.TypeOf((*MockEC2API)(nil).CreateCapacityReservationRequest), arg0)
 }
 
 // CreateCapacityReservationWithContext mocks base method
 func (m *MockEC2API) CreateCapacityReservationWithContext(arg0 context.Context, arg1 *ec2.CreateCapacityReservationInput, arg2 ...request.Option) (*ec2.CreateCapacityReservationOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -2044,14 +1805,12 @@ func (m *MockEC2API) CreateCapacityReservationWithContext(arg0 context.Context, 
 
 // CreateCapacityReservationWithContext indicates an expected call of CreateCapacityReservationWithContext
 func (mr *MockEC2APIMockRecorder) CreateCapacityReservationWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateCapacityReservationWithContext", reflect.TypeOf((*MockEC2API)(nil).CreateCapacityReservationWithContext), varargs...)
 }
 
 // CreateClientVpnEndpoint mocks base method
 func (m *MockEC2API) CreateClientVpnEndpoint(arg0 *ec2.CreateClientVpnEndpointInput) (*ec2.CreateClientVpnEndpointOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateClientVpnEndpoint", arg0)
 	ret0, _ := ret[0].(*ec2.CreateClientVpnEndpointOutput)
 	ret1, _ := ret[1].(error)
@@ -2060,13 +1819,11 @@ func (m *MockEC2API) CreateClientVpnEndpoint(arg0 *ec2.CreateClientVpnEndpointIn
 
 // CreateClientVpnEndpoint indicates an expected call of CreateClientVpnEndpoint
 func (mr *MockEC2APIMockRecorder) CreateClientVpnEndpoint(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateClientVpnEndpoint", reflect.TypeOf((*MockEC2API)(nil).CreateClientVpnEndpoint), arg0)
 }
 
 // CreateClientVpnEndpointRequest mocks base method
 func (m *MockEC2API) CreateClientVpnEndpointRequest(arg0 *ec2.CreateClientVpnEndpointInput) (*request.Request, *ec2.CreateClientVpnEndpointOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateClientVpnEndpointRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.CreateClientVpnEndpointOutput)
@@ -2075,13 +1832,11 @@ func (m *MockEC2API) CreateClientVpnEndpointRequest(arg0 *ec2.CreateClientVpnEnd
 
 // CreateClientVpnEndpointRequest indicates an expected call of CreateClientVpnEndpointRequest
 func (mr *MockEC2APIMockRecorder) CreateClientVpnEndpointRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateClientVpnEndpointRequest", reflect.TypeOf((*MockEC2API)(nil).CreateClientVpnEndpointRequest), arg0)
 }
 
 // CreateClientVpnEndpointWithContext mocks base method
 func (m *MockEC2API) CreateClientVpnEndpointWithContext(arg0 context.Context, arg1 *ec2.CreateClientVpnEndpointInput, arg2 ...request.Option) (*ec2.CreateClientVpnEndpointOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -2094,14 +1849,12 @@ func (m *MockEC2API) CreateClientVpnEndpointWithContext(arg0 context.Context, ar
 
 // CreateClientVpnEndpointWithContext indicates an expected call of CreateClientVpnEndpointWithContext
 func (mr *MockEC2APIMockRecorder) CreateClientVpnEndpointWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateClientVpnEndpointWithContext", reflect.TypeOf((*MockEC2API)(nil).CreateClientVpnEndpointWithContext), varargs...)
 }
 
 // CreateClientVpnRoute mocks base method
 func (m *MockEC2API) CreateClientVpnRoute(arg0 *ec2.CreateClientVpnRouteInput) (*ec2.CreateClientVpnRouteOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateClientVpnRoute", arg0)
 	ret0, _ := ret[0].(*ec2.CreateClientVpnRouteOutput)
 	ret1, _ := ret[1].(error)
@@ -2110,13 +1863,11 @@ func (m *MockEC2API) CreateClientVpnRoute(arg0 *ec2.CreateClientVpnRouteInput) (
 
 // CreateClientVpnRoute indicates an expected call of CreateClientVpnRoute
 func (mr *MockEC2APIMockRecorder) CreateClientVpnRoute(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateClientVpnRoute", reflect.TypeOf((*MockEC2API)(nil).CreateClientVpnRoute), arg0)
 }
 
 // CreateClientVpnRouteRequest mocks base method
 func (m *MockEC2API) CreateClientVpnRouteRequest(arg0 *ec2.CreateClientVpnRouteInput) (*request.Request, *ec2.CreateClientVpnRouteOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateClientVpnRouteRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.CreateClientVpnRouteOutput)
@@ -2125,13 +1876,11 @@ func (m *MockEC2API) CreateClientVpnRouteRequest(arg0 *ec2.CreateClientVpnRouteI
 
 // CreateClientVpnRouteRequest indicates an expected call of CreateClientVpnRouteRequest
 func (mr *MockEC2APIMockRecorder) CreateClientVpnRouteRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateClientVpnRouteRequest", reflect.TypeOf((*MockEC2API)(nil).CreateClientVpnRouteRequest), arg0)
 }
 
 // CreateClientVpnRouteWithContext mocks base method
 func (m *MockEC2API) CreateClientVpnRouteWithContext(arg0 context.Context, arg1 *ec2.CreateClientVpnRouteInput, arg2 ...request.Option) (*ec2.CreateClientVpnRouteOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -2144,14 +1893,12 @@ func (m *MockEC2API) CreateClientVpnRouteWithContext(arg0 context.Context, arg1 
 
 // CreateClientVpnRouteWithContext indicates an expected call of CreateClientVpnRouteWithContext
 func (mr *MockEC2APIMockRecorder) CreateClientVpnRouteWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateClientVpnRouteWithContext", reflect.TypeOf((*MockEC2API)(nil).CreateClientVpnRouteWithContext), varargs...)
 }
 
 // CreateCustomerGateway mocks base method
 func (m *MockEC2API) CreateCustomerGateway(arg0 *ec2.CreateCustomerGatewayInput) (*ec2.CreateCustomerGatewayOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateCustomerGateway", arg0)
 	ret0, _ := ret[0].(*ec2.CreateCustomerGatewayOutput)
 	ret1, _ := ret[1].(error)
@@ -2160,13 +1907,11 @@ func (m *MockEC2API) CreateCustomerGateway(arg0 *ec2.CreateCustomerGatewayInput)
 
 // CreateCustomerGateway indicates an expected call of CreateCustomerGateway
 func (mr *MockEC2APIMockRecorder) CreateCustomerGateway(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateCustomerGateway", reflect.TypeOf((*MockEC2API)(nil).CreateCustomerGateway), arg0)
 }
 
 // CreateCustomerGatewayRequest mocks base method
 func (m *MockEC2API) CreateCustomerGatewayRequest(arg0 *ec2.CreateCustomerGatewayInput) (*request.Request, *ec2.CreateCustomerGatewayOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateCustomerGatewayRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.CreateCustomerGatewayOutput)
@@ -2175,13 +1920,11 @@ func (m *MockEC2API) CreateCustomerGatewayRequest(arg0 *ec2.CreateCustomerGatewa
 
 // CreateCustomerGatewayRequest indicates an expected call of CreateCustomerGatewayRequest
 func (mr *MockEC2APIMockRecorder) CreateCustomerGatewayRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateCustomerGatewayRequest", reflect.TypeOf((*MockEC2API)(nil).CreateCustomerGatewayRequest), arg0)
 }
 
 // CreateCustomerGatewayWithContext mocks base method
 func (m *MockEC2API) CreateCustomerGatewayWithContext(arg0 context.Context, arg1 *ec2.CreateCustomerGatewayInput, arg2 ...request.Option) (*ec2.CreateCustomerGatewayOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -2194,14 +1937,12 @@ func (m *MockEC2API) CreateCustomerGatewayWithContext(arg0 context.Context, arg1
 
 // CreateCustomerGatewayWithContext indicates an expected call of CreateCustomerGatewayWithContext
 func (mr *MockEC2APIMockRecorder) CreateCustomerGatewayWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateCustomerGatewayWithContext", reflect.TypeOf((*MockEC2API)(nil).CreateCustomerGatewayWithContext), varargs...)
 }
 
 // CreateDefaultSubnet mocks base method
 func (m *MockEC2API) CreateDefaultSubnet(arg0 *ec2.CreateDefaultSubnetInput) (*ec2.CreateDefaultSubnetOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateDefaultSubnet", arg0)
 	ret0, _ := ret[0].(*ec2.CreateDefaultSubnetOutput)
 	ret1, _ := ret[1].(error)
@@ -2210,13 +1951,11 @@ func (m *MockEC2API) CreateDefaultSubnet(arg0 *ec2.CreateDefaultSubnetInput) (*e
 
 // CreateDefaultSubnet indicates an expected call of CreateDefaultSubnet
 func (mr *MockEC2APIMockRecorder) CreateDefaultSubnet(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateDefaultSubnet", reflect.TypeOf((*MockEC2API)(nil).CreateDefaultSubnet), arg0)
 }
 
 // CreateDefaultSubnetRequest mocks base method
 func (m *MockEC2API) CreateDefaultSubnetRequest(arg0 *ec2.CreateDefaultSubnetInput) (*request.Request, *ec2.CreateDefaultSubnetOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateDefaultSubnetRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.CreateDefaultSubnetOutput)
@@ -2225,13 +1964,11 @@ func (m *MockEC2API) CreateDefaultSubnetRequest(arg0 *ec2.CreateDefaultSubnetInp
 
 // CreateDefaultSubnetRequest indicates an expected call of CreateDefaultSubnetRequest
 func (mr *MockEC2APIMockRecorder) CreateDefaultSubnetRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateDefaultSubnetRequest", reflect.TypeOf((*MockEC2API)(nil).CreateDefaultSubnetRequest), arg0)
 }
 
 // CreateDefaultSubnetWithContext mocks base method
 func (m *MockEC2API) CreateDefaultSubnetWithContext(arg0 context.Context, arg1 *ec2.CreateDefaultSubnetInput, arg2 ...request.Option) (*ec2.CreateDefaultSubnetOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -2244,14 +1981,12 @@ func (m *MockEC2API) CreateDefaultSubnetWithContext(arg0 context.Context, arg1 *
 
 // CreateDefaultSubnetWithContext indicates an expected call of CreateDefaultSubnetWithContext
 func (mr *MockEC2APIMockRecorder) CreateDefaultSubnetWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateDefaultSubnetWithContext", reflect.TypeOf((*MockEC2API)(nil).CreateDefaultSubnetWithContext), varargs...)
 }
 
 // CreateDefaultVpc mocks base method
 func (m *MockEC2API) CreateDefaultVpc(arg0 *ec2.CreateDefaultVpcInput) (*ec2.CreateDefaultVpcOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateDefaultVpc", arg0)
 	ret0, _ := ret[0].(*ec2.CreateDefaultVpcOutput)
 	ret1, _ := ret[1].(error)
@@ -2260,13 +1995,11 @@ func (m *MockEC2API) CreateDefaultVpc(arg0 *ec2.CreateDefaultVpcInput) (*ec2.Cre
 
 // CreateDefaultVpc indicates an expected call of CreateDefaultVpc
 func (mr *MockEC2APIMockRecorder) CreateDefaultVpc(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateDefaultVpc", reflect.TypeOf((*MockEC2API)(nil).CreateDefaultVpc), arg0)
 }
 
 // CreateDefaultVpcRequest mocks base method
 func (m *MockEC2API) CreateDefaultVpcRequest(arg0 *ec2.CreateDefaultVpcInput) (*request.Request, *ec2.CreateDefaultVpcOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateDefaultVpcRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.CreateDefaultVpcOutput)
@@ -2275,13 +2008,11 @@ func (m *MockEC2API) CreateDefaultVpcRequest(arg0 *ec2.CreateDefaultVpcInput) (*
 
 // CreateDefaultVpcRequest indicates an expected call of CreateDefaultVpcRequest
 func (mr *MockEC2APIMockRecorder) CreateDefaultVpcRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateDefaultVpcRequest", reflect.TypeOf((*MockEC2API)(nil).CreateDefaultVpcRequest), arg0)
 }
 
 // CreateDefaultVpcWithContext mocks base method
 func (m *MockEC2API) CreateDefaultVpcWithContext(arg0 context.Context, arg1 *ec2.CreateDefaultVpcInput, arg2 ...request.Option) (*ec2.CreateDefaultVpcOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -2294,14 +2025,12 @@ func (m *MockEC2API) CreateDefaultVpcWithContext(arg0 context.Context, arg1 *ec2
 
 // CreateDefaultVpcWithContext indicates an expected call of CreateDefaultVpcWithContext
 func (mr *MockEC2APIMockRecorder) CreateDefaultVpcWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateDefaultVpcWithContext", reflect.TypeOf((*MockEC2API)(nil).CreateDefaultVpcWithContext), varargs...)
 }
 
 // CreateDhcpOptions mocks base method
 func (m *MockEC2API) CreateDhcpOptions(arg0 *ec2.CreateDhcpOptionsInput) (*ec2.CreateDhcpOptionsOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateDhcpOptions", arg0)
 	ret0, _ := ret[0].(*ec2.CreateDhcpOptionsOutput)
 	ret1, _ := ret[1].(error)
@@ -2310,13 +2039,11 @@ func (m *MockEC2API) CreateDhcpOptions(arg0 *ec2.CreateDhcpOptionsInput) (*ec2.C
 
 // CreateDhcpOptions indicates an expected call of CreateDhcpOptions
 func (mr *MockEC2APIMockRecorder) CreateDhcpOptions(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateDhcpOptions", reflect.TypeOf((*MockEC2API)(nil).CreateDhcpOptions), arg0)
 }
 
 // CreateDhcpOptionsRequest mocks base method
 func (m *MockEC2API) CreateDhcpOptionsRequest(arg0 *ec2.CreateDhcpOptionsInput) (*request.Request, *ec2.CreateDhcpOptionsOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateDhcpOptionsRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.CreateDhcpOptionsOutput)
@@ -2325,13 +2052,11 @@ func (m *MockEC2API) CreateDhcpOptionsRequest(arg0 *ec2.CreateDhcpOptionsInput) 
 
 // CreateDhcpOptionsRequest indicates an expected call of CreateDhcpOptionsRequest
 func (mr *MockEC2APIMockRecorder) CreateDhcpOptionsRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateDhcpOptionsRequest", reflect.TypeOf((*MockEC2API)(nil).CreateDhcpOptionsRequest), arg0)
 }
 
 // CreateDhcpOptionsWithContext mocks base method
 func (m *MockEC2API) CreateDhcpOptionsWithContext(arg0 context.Context, arg1 *ec2.CreateDhcpOptionsInput, arg2 ...request.Option) (*ec2.CreateDhcpOptionsOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -2344,14 +2069,12 @@ func (m *MockEC2API) CreateDhcpOptionsWithContext(arg0 context.Context, arg1 *ec
 
 // CreateDhcpOptionsWithContext indicates an expected call of CreateDhcpOptionsWithContext
 func (mr *MockEC2APIMockRecorder) CreateDhcpOptionsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateDhcpOptionsWithContext", reflect.TypeOf((*MockEC2API)(nil).CreateDhcpOptionsWithContext), varargs...)
 }
 
 // CreateEgressOnlyInternetGateway mocks base method
 func (m *MockEC2API) CreateEgressOnlyInternetGateway(arg0 *ec2.CreateEgressOnlyInternetGatewayInput) (*ec2.CreateEgressOnlyInternetGatewayOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateEgressOnlyInternetGateway", arg0)
 	ret0, _ := ret[0].(*ec2.CreateEgressOnlyInternetGatewayOutput)
 	ret1, _ := ret[1].(error)
@@ -2360,13 +2083,11 @@ func (m *MockEC2API) CreateEgressOnlyInternetGateway(arg0 *ec2.CreateEgressOnlyI
 
 // CreateEgressOnlyInternetGateway indicates an expected call of CreateEgressOnlyInternetGateway
 func (mr *MockEC2APIMockRecorder) CreateEgressOnlyInternetGateway(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateEgressOnlyInternetGateway", reflect.TypeOf((*MockEC2API)(nil).CreateEgressOnlyInternetGateway), arg0)
 }
 
 // CreateEgressOnlyInternetGatewayRequest mocks base method
 func (m *MockEC2API) CreateEgressOnlyInternetGatewayRequest(arg0 *ec2.CreateEgressOnlyInternetGatewayInput) (*request.Request, *ec2.CreateEgressOnlyInternetGatewayOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateEgressOnlyInternetGatewayRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.CreateEgressOnlyInternetGatewayOutput)
@@ -2375,13 +2096,11 @@ func (m *MockEC2API) CreateEgressOnlyInternetGatewayRequest(arg0 *ec2.CreateEgre
 
 // CreateEgressOnlyInternetGatewayRequest indicates an expected call of CreateEgressOnlyInternetGatewayRequest
 func (mr *MockEC2APIMockRecorder) CreateEgressOnlyInternetGatewayRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateEgressOnlyInternetGatewayRequest", reflect.TypeOf((*MockEC2API)(nil).CreateEgressOnlyInternetGatewayRequest), arg0)
 }
 
 // CreateEgressOnlyInternetGatewayWithContext mocks base method
 func (m *MockEC2API) CreateEgressOnlyInternetGatewayWithContext(arg0 context.Context, arg1 *ec2.CreateEgressOnlyInternetGatewayInput, arg2 ...request.Option) (*ec2.CreateEgressOnlyInternetGatewayOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -2394,14 +2113,12 @@ func (m *MockEC2API) CreateEgressOnlyInternetGatewayWithContext(arg0 context.Con
 
 // CreateEgressOnlyInternetGatewayWithContext indicates an expected call of CreateEgressOnlyInternetGatewayWithContext
 func (mr *MockEC2APIMockRecorder) CreateEgressOnlyInternetGatewayWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateEgressOnlyInternetGatewayWithContext", reflect.TypeOf((*MockEC2API)(nil).CreateEgressOnlyInternetGatewayWithContext), varargs...)
 }
 
 // CreateFleet mocks base method
 func (m *MockEC2API) CreateFleet(arg0 *ec2.CreateFleetInput) (*ec2.CreateFleetOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateFleet", arg0)
 	ret0, _ := ret[0].(*ec2.CreateFleetOutput)
 	ret1, _ := ret[1].(error)
@@ -2410,13 +2127,11 @@ func (m *MockEC2API) CreateFleet(arg0 *ec2.CreateFleetInput) (*ec2.CreateFleetOu
 
 // CreateFleet indicates an expected call of CreateFleet
 func (mr *MockEC2APIMockRecorder) CreateFleet(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateFleet", reflect.TypeOf((*MockEC2API)(nil).CreateFleet), arg0)
 }
 
 // CreateFleetRequest mocks base method
 func (m *MockEC2API) CreateFleetRequest(arg0 *ec2.CreateFleetInput) (*request.Request, *ec2.CreateFleetOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateFleetRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.CreateFleetOutput)
@@ -2425,13 +2140,11 @@ func (m *MockEC2API) CreateFleetRequest(arg0 *ec2.CreateFleetInput) (*request.Re
 
 // CreateFleetRequest indicates an expected call of CreateFleetRequest
 func (mr *MockEC2APIMockRecorder) CreateFleetRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateFleetRequest", reflect.TypeOf((*MockEC2API)(nil).CreateFleetRequest), arg0)
 }
 
 // CreateFleetWithContext mocks base method
 func (m *MockEC2API) CreateFleetWithContext(arg0 context.Context, arg1 *ec2.CreateFleetInput, arg2 ...request.Option) (*ec2.CreateFleetOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -2444,14 +2157,12 @@ func (m *MockEC2API) CreateFleetWithContext(arg0 context.Context, arg1 *ec2.Crea
 
 // CreateFleetWithContext indicates an expected call of CreateFleetWithContext
 func (mr *MockEC2APIMockRecorder) CreateFleetWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateFleetWithContext", reflect.TypeOf((*MockEC2API)(nil).CreateFleetWithContext), varargs...)
 }
 
 // CreateFlowLogs mocks base method
 func (m *MockEC2API) CreateFlowLogs(arg0 *ec2.CreateFlowLogsInput) (*ec2.CreateFlowLogsOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateFlowLogs", arg0)
 	ret0, _ := ret[0].(*ec2.CreateFlowLogsOutput)
 	ret1, _ := ret[1].(error)
@@ -2460,13 +2171,11 @@ func (m *MockEC2API) CreateFlowLogs(arg0 *ec2.CreateFlowLogsInput) (*ec2.CreateF
 
 // CreateFlowLogs indicates an expected call of CreateFlowLogs
 func (mr *MockEC2APIMockRecorder) CreateFlowLogs(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateFlowLogs", reflect.TypeOf((*MockEC2API)(nil).CreateFlowLogs), arg0)
 }
 
 // CreateFlowLogsRequest mocks base method
 func (m *MockEC2API) CreateFlowLogsRequest(arg0 *ec2.CreateFlowLogsInput) (*request.Request, *ec2.CreateFlowLogsOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateFlowLogsRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.CreateFlowLogsOutput)
@@ -2475,13 +2184,11 @@ func (m *MockEC2API) CreateFlowLogsRequest(arg0 *ec2.CreateFlowLogsInput) (*requ
 
 // CreateFlowLogsRequest indicates an expected call of CreateFlowLogsRequest
 func (mr *MockEC2APIMockRecorder) CreateFlowLogsRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateFlowLogsRequest", reflect.TypeOf((*MockEC2API)(nil).CreateFlowLogsRequest), arg0)
 }
 
 // CreateFlowLogsWithContext mocks base method
 func (m *MockEC2API) CreateFlowLogsWithContext(arg0 context.Context, arg1 *ec2.CreateFlowLogsInput, arg2 ...request.Option) (*ec2.CreateFlowLogsOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -2494,14 +2201,12 @@ func (m *MockEC2API) CreateFlowLogsWithContext(arg0 context.Context, arg1 *ec2.C
 
 // CreateFlowLogsWithContext indicates an expected call of CreateFlowLogsWithContext
 func (mr *MockEC2APIMockRecorder) CreateFlowLogsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateFlowLogsWithContext", reflect.TypeOf((*MockEC2API)(nil).CreateFlowLogsWithContext), varargs...)
 }
 
 // CreateFpgaImage mocks base method
 func (m *MockEC2API) CreateFpgaImage(arg0 *ec2.CreateFpgaImageInput) (*ec2.CreateFpgaImageOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateFpgaImage", arg0)
 	ret0, _ := ret[0].(*ec2.CreateFpgaImageOutput)
 	ret1, _ := ret[1].(error)
@@ -2510,13 +2215,11 @@ func (m *MockEC2API) CreateFpgaImage(arg0 *ec2.CreateFpgaImageInput) (*ec2.Creat
 
 // CreateFpgaImage indicates an expected call of CreateFpgaImage
 func (mr *MockEC2APIMockRecorder) CreateFpgaImage(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateFpgaImage", reflect.TypeOf((*MockEC2API)(nil).CreateFpgaImage), arg0)
 }
 
 // CreateFpgaImageRequest mocks base method
 func (m *MockEC2API) CreateFpgaImageRequest(arg0 *ec2.CreateFpgaImageInput) (*request.Request, *ec2.CreateFpgaImageOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateFpgaImageRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.CreateFpgaImageOutput)
@@ -2525,13 +2228,11 @@ func (m *MockEC2API) CreateFpgaImageRequest(arg0 *ec2.CreateFpgaImageInput) (*re
 
 // CreateFpgaImageRequest indicates an expected call of CreateFpgaImageRequest
 func (mr *MockEC2APIMockRecorder) CreateFpgaImageRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateFpgaImageRequest", reflect.TypeOf((*MockEC2API)(nil).CreateFpgaImageRequest), arg0)
 }
 
 // CreateFpgaImageWithContext mocks base method
 func (m *MockEC2API) CreateFpgaImageWithContext(arg0 context.Context, arg1 *ec2.CreateFpgaImageInput, arg2 ...request.Option) (*ec2.CreateFpgaImageOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -2544,14 +2245,12 @@ func (m *MockEC2API) CreateFpgaImageWithContext(arg0 context.Context, arg1 *ec2.
 
 // CreateFpgaImageWithContext indicates an expected call of CreateFpgaImageWithContext
 func (mr *MockEC2APIMockRecorder) CreateFpgaImageWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateFpgaImageWithContext", reflect.TypeOf((*MockEC2API)(nil).CreateFpgaImageWithContext), varargs...)
 }
 
 // CreateImage mocks base method
 func (m *MockEC2API) CreateImage(arg0 *ec2.CreateImageInput) (*ec2.CreateImageOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateImage", arg0)
 	ret0, _ := ret[0].(*ec2.CreateImageOutput)
 	ret1, _ := ret[1].(error)
@@ -2560,13 +2259,11 @@ func (m *MockEC2API) CreateImage(arg0 *ec2.CreateImageInput) (*ec2.CreateImageOu
 
 // CreateImage indicates an expected call of CreateImage
 func (mr *MockEC2APIMockRecorder) CreateImage(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateImage", reflect.TypeOf((*MockEC2API)(nil).CreateImage), arg0)
 }
 
 // CreateImageRequest mocks base method
 func (m *MockEC2API) CreateImageRequest(arg0 *ec2.CreateImageInput) (*request.Request, *ec2.CreateImageOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateImageRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.CreateImageOutput)
@@ -2575,13 +2272,11 @@ func (m *MockEC2API) CreateImageRequest(arg0 *ec2.CreateImageInput) (*request.Re
 
 // CreateImageRequest indicates an expected call of CreateImageRequest
 func (mr *MockEC2APIMockRecorder) CreateImageRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateImageRequest", reflect.TypeOf((*MockEC2API)(nil).CreateImageRequest), arg0)
 }
 
 // CreateImageWithContext mocks base method
 func (m *MockEC2API) CreateImageWithContext(arg0 context.Context, arg1 *ec2.CreateImageInput, arg2 ...request.Option) (*ec2.CreateImageOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -2594,14 +2289,12 @@ func (m *MockEC2API) CreateImageWithContext(arg0 context.Context, arg1 *ec2.Crea
 
 // CreateImageWithContext indicates an expected call of CreateImageWithContext
 func (mr *MockEC2APIMockRecorder) CreateImageWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateImageWithContext", reflect.TypeOf((*MockEC2API)(nil).CreateImageWithContext), varargs...)
 }
 
 // CreateInstanceExportTask mocks base method
 func (m *MockEC2API) CreateInstanceExportTask(arg0 *ec2.CreateInstanceExportTaskInput) (*ec2.CreateInstanceExportTaskOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateInstanceExportTask", arg0)
 	ret0, _ := ret[0].(*ec2.CreateInstanceExportTaskOutput)
 	ret1, _ := ret[1].(error)
@@ -2610,13 +2303,11 @@ func (m *MockEC2API) CreateInstanceExportTask(arg0 *ec2.CreateInstanceExportTask
 
 // CreateInstanceExportTask indicates an expected call of CreateInstanceExportTask
 func (mr *MockEC2APIMockRecorder) CreateInstanceExportTask(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateInstanceExportTask", reflect.TypeOf((*MockEC2API)(nil).CreateInstanceExportTask), arg0)
 }
 
 // CreateInstanceExportTaskRequest mocks base method
 func (m *MockEC2API) CreateInstanceExportTaskRequest(arg0 *ec2.CreateInstanceExportTaskInput) (*request.Request, *ec2.CreateInstanceExportTaskOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateInstanceExportTaskRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.CreateInstanceExportTaskOutput)
@@ -2625,13 +2316,11 @@ func (m *MockEC2API) CreateInstanceExportTaskRequest(arg0 *ec2.CreateInstanceExp
 
 // CreateInstanceExportTaskRequest indicates an expected call of CreateInstanceExportTaskRequest
 func (mr *MockEC2APIMockRecorder) CreateInstanceExportTaskRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateInstanceExportTaskRequest", reflect.TypeOf((*MockEC2API)(nil).CreateInstanceExportTaskRequest), arg0)
 }
 
 // CreateInstanceExportTaskWithContext mocks base method
 func (m *MockEC2API) CreateInstanceExportTaskWithContext(arg0 context.Context, arg1 *ec2.CreateInstanceExportTaskInput, arg2 ...request.Option) (*ec2.CreateInstanceExportTaskOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -2644,14 +2333,12 @@ func (m *MockEC2API) CreateInstanceExportTaskWithContext(arg0 context.Context, a
 
 // CreateInstanceExportTaskWithContext indicates an expected call of CreateInstanceExportTaskWithContext
 func (mr *MockEC2APIMockRecorder) CreateInstanceExportTaskWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateInstanceExportTaskWithContext", reflect.TypeOf((*MockEC2API)(nil).CreateInstanceExportTaskWithContext), varargs...)
 }
 
 // CreateInternetGateway mocks base method
 func (m *MockEC2API) CreateInternetGateway(arg0 *ec2.CreateInternetGatewayInput) (*ec2.CreateInternetGatewayOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateInternetGateway", arg0)
 	ret0, _ := ret[0].(*ec2.CreateInternetGatewayOutput)
 	ret1, _ := ret[1].(error)
@@ -2660,13 +2347,11 @@ func (m *MockEC2API) CreateInternetGateway(arg0 *ec2.CreateInternetGatewayInput)
 
 // CreateInternetGateway indicates an expected call of CreateInternetGateway
 func (mr *MockEC2APIMockRecorder) CreateInternetGateway(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateInternetGateway", reflect.TypeOf((*MockEC2API)(nil).CreateInternetGateway), arg0)
 }
 
 // CreateInternetGatewayRequest mocks base method
 func (m *MockEC2API) CreateInternetGatewayRequest(arg0 *ec2.CreateInternetGatewayInput) (*request.Request, *ec2.CreateInternetGatewayOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateInternetGatewayRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.CreateInternetGatewayOutput)
@@ -2675,13 +2360,11 @@ func (m *MockEC2API) CreateInternetGatewayRequest(arg0 *ec2.CreateInternetGatewa
 
 // CreateInternetGatewayRequest indicates an expected call of CreateInternetGatewayRequest
 func (mr *MockEC2APIMockRecorder) CreateInternetGatewayRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateInternetGatewayRequest", reflect.TypeOf((*MockEC2API)(nil).CreateInternetGatewayRequest), arg0)
 }
 
 // CreateInternetGatewayWithContext mocks base method
 func (m *MockEC2API) CreateInternetGatewayWithContext(arg0 context.Context, arg1 *ec2.CreateInternetGatewayInput, arg2 ...request.Option) (*ec2.CreateInternetGatewayOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -2694,14 +2377,12 @@ func (m *MockEC2API) CreateInternetGatewayWithContext(arg0 context.Context, arg1
 
 // CreateInternetGatewayWithContext indicates an expected call of CreateInternetGatewayWithContext
 func (mr *MockEC2APIMockRecorder) CreateInternetGatewayWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateInternetGatewayWithContext", reflect.TypeOf((*MockEC2API)(nil).CreateInternetGatewayWithContext), varargs...)
 }
 
 // CreateKeyPair mocks base method
 func (m *MockEC2API) CreateKeyPair(arg0 *ec2.CreateKeyPairInput) (*ec2.CreateKeyPairOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateKeyPair", arg0)
 	ret0, _ := ret[0].(*ec2.CreateKeyPairOutput)
 	ret1, _ := ret[1].(error)
@@ -2710,13 +2391,11 @@ func (m *MockEC2API) CreateKeyPair(arg0 *ec2.CreateKeyPairInput) (*ec2.CreateKey
 
 // CreateKeyPair indicates an expected call of CreateKeyPair
 func (mr *MockEC2APIMockRecorder) CreateKeyPair(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateKeyPair", reflect.TypeOf((*MockEC2API)(nil).CreateKeyPair), arg0)
 }
 
 // CreateKeyPairRequest mocks base method
 func (m *MockEC2API) CreateKeyPairRequest(arg0 *ec2.CreateKeyPairInput) (*request.Request, *ec2.CreateKeyPairOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateKeyPairRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.CreateKeyPairOutput)
@@ -2725,13 +2404,11 @@ func (m *MockEC2API) CreateKeyPairRequest(arg0 *ec2.CreateKeyPairInput) (*reques
 
 // CreateKeyPairRequest indicates an expected call of CreateKeyPairRequest
 func (mr *MockEC2APIMockRecorder) CreateKeyPairRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateKeyPairRequest", reflect.TypeOf((*MockEC2API)(nil).CreateKeyPairRequest), arg0)
 }
 
 // CreateKeyPairWithContext mocks base method
 func (m *MockEC2API) CreateKeyPairWithContext(arg0 context.Context, arg1 *ec2.CreateKeyPairInput, arg2 ...request.Option) (*ec2.CreateKeyPairOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -2744,14 +2421,12 @@ func (m *MockEC2API) CreateKeyPairWithContext(arg0 context.Context, arg1 *ec2.Cr
 
 // CreateKeyPairWithContext indicates an expected call of CreateKeyPairWithContext
 func (mr *MockEC2APIMockRecorder) CreateKeyPairWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateKeyPairWithContext", reflect.TypeOf((*MockEC2API)(nil).CreateKeyPairWithContext), varargs...)
 }
 
 // CreateLaunchTemplate mocks base method
 func (m *MockEC2API) CreateLaunchTemplate(arg0 *ec2.CreateLaunchTemplateInput) (*ec2.CreateLaunchTemplateOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateLaunchTemplate", arg0)
 	ret0, _ := ret[0].(*ec2.CreateLaunchTemplateOutput)
 	ret1, _ := ret[1].(error)
@@ -2760,13 +2435,11 @@ func (m *MockEC2API) CreateLaunchTemplate(arg0 *ec2.CreateLaunchTemplateInput) (
 
 // CreateLaunchTemplate indicates an expected call of CreateLaunchTemplate
 func (mr *MockEC2APIMockRecorder) CreateLaunchTemplate(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateLaunchTemplate", reflect.TypeOf((*MockEC2API)(nil).CreateLaunchTemplate), arg0)
 }
 
 // CreateLaunchTemplateRequest mocks base method
 func (m *MockEC2API) CreateLaunchTemplateRequest(arg0 *ec2.CreateLaunchTemplateInput) (*request.Request, *ec2.CreateLaunchTemplateOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateLaunchTemplateRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.CreateLaunchTemplateOutput)
@@ -2775,13 +2448,11 @@ func (m *MockEC2API) CreateLaunchTemplateRequest(arg0 *ec2.CreateLaunchTemplateI
 
 // CreateLaunchTemplateRequest indicates an expected call of CreateLaunchTemplateRequest
 func (mr *MockEC2APIMockRecorder) CreateLaunchTemplateRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateLaunchTemplateRequest", reflect.TypeOf((*MockEC2API)(nil).CreateLaunchTemplateRequest), arg0)
 }
 
 // CreateLaunchTemplateVersion mocks base method
 func (m *MockEC2API) CreateLaunchTemplateVersion(arg0 *ec2.CreateLaunchTemplateVersionInput) (*ec2.CreateLaunchTemplateVersionOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateLaunchTemplateVersion", arg0)
 	ret0, _ := ret[0].(*ec2.CreateLaunchTemplateVersionOutput)
 	ret1, _ := ret[1].(error)
@@ -2790,13 +2461,11 @@ func (m *MockEC2API) CreateLaunchTemplateVersion(arg0 *ec2.CreateLaunchTemplateV
 
 // CreateLaunchTemplateVersion indicates an expected call of CreateLaunchTemplateVersion
 func (mr *MockEC2APIMockRecorder) CreateLaunchTemplateVersion(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateLaunchTemplateVersion", reflect.TypeOf((*MockEC2API)(nil).CreateLaunchTemplateVersion), arg0)
 }
 
 // CreateLaunchTemplateVersionRequest mocks base method
 func (m *MockEC2API) CreateLaunchTemplateVersionRequest(arg0 *ec2.CreateLaunchTemplateVersionInput) (*request.Request, *ec2.CreateLaunchTemplateVersionOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateLaunchTemplateVersionRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.CreateLaunchTemplateVersionOutput)
@@ -2805,13 +2474,11 @@ func (m *MockEC2API) CreateLaunchTemplateVersionRequest(arg0 *ec2.CreateLaunchTe
 
 // CreateLaunchTemplateVersionRequest indicates an expected call of CreateLaunchTemplateVersionRequest
 func (mr *MockEC2APIMockRecorder) CreateLaunchTemplateVersionRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateLaunchTemplateVersionRequest", reflect.TypeOf((*MockEC2API)(nil).CreateLaunchTemplateVersionRequest), arg0)
 }
 
 // CreateLaunchTemplateVersionWithContext mocks base method
 func (m *MockEC2API) CreateLaunchTemplateVersionWithContext(arg0 context.Context, arg1 *ec2.CreateLaunchTemplateVersionInput, arg2 ...request.Option) (*ec2.CreateLaunchTemplateVersionOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -2824,14 +2491,12 @@ func (m *MockEC2API) CreateLaunchTemplateVersionWithContext(arg0 context.Context
 
 // CreateLaunchTemplateVersionWithContext indicates an expected call of CreateLaunchTemplateVersionWithContext
 func (mr *MockEC2APIMockRecorder) CreateLaunchTemplateVersionWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateLaunchTemplateVersionWithContext", reflect.TypeOf((*MockEC2API)(nil).CreateLaunchTemplateVersionWithContext), varargs...)
 }
 
 // CreateLaunchTemplateWithContext mocks base method
 func (m *MockEC2API) CreateLaunchTemplateWithContext(arg0 context.Context, arg1 *ec2.CreateLaunchTemplateInput, arg2 ...request.Option) (*ec2.CreateLaunchTemplateOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -2844,14 +2509,12 @@ func (m *MockEC2API) CreateLaunchTemplateWithContext(arg0 context.Context, arg1 
 
 // CreateLaunchTemplateWithContext indicates an expected call of CreateLaunchTemplateWithContext
 func (mr *MockEC2APIMockRecorder) CreateLaunchTemplateWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateLaunchTemplateWithContext", reflect.TypeOf((*MockEC2API)(nil).CreateLaunchTemplateWithContext), varargs...)
 }
 
 // CreateNatGateway mocks base method
 func (m *MockEC2API) CreateNatGateway(arg0 *ec2.CreateNatGatewayInput) (*ec2.CreateNatGatewayOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateNatGateway", arg0)
 	ret0, _ := ret[0].(*ec2.CreateNatGatewayOutput)
 	ret1, _ := ret[1].(error)
@@ -2860,13 +2523,11 @@ func (m *MockEC2API) CreateNatGateway(arg0 *ec2.CreateNatGatewayInput) (*ec2.Cre
 
 // CreateNatGateway indicates an expected call of CreateNatGateway
 func (mr *MockEC2APIMockRecorder) CreateNatGateway(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateNatGateway", reflect.TypeOf((*MockEC2API)(nil).CreateNatGateway), arg0)
 }
 
 // CreateNatGatewayRequest mocks base method
 func (m *MockEC2API) CreateNatGatewayRequest(arg0 *ec2.CreateNatGatewayInput) (*request.Request, *ec2.CreateNatGatewayOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateNatGatewayRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.CreateNatGatewayOutput)
@@ -2875,13 +2536,11 @@ func (m *MockEC2API) CreateNatGatewayRequest(arg0 *ec2.CreateNatGatewayInput) (*
 
 // CreateNatGatewayRequest indicates an expected call of CreateNatGatewayRequest
 func (mr *MockEC2APIMockRecorder) CreateNatGatewayRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateNatGatewayRequest", reflect.TypeOf((*MockEC2API)(nil).CreateNatGatewayRequest), arg0)
 }
 
 // CreateNatGatewayWithContext mocks base method
 func (m *MockEC2API) CreateNatGatewayWithContext(arg0 context.Context, arg1 *ec2.CreateNatGatewayInput, arg2 ...request.Option) (*ec2.CreateNatGatewayOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -2894,14 +2553,12 @@ func (m *MockEC2API) CreateNatGatewayWithContext(arg0 context.Context, arg1 *ec2
 
 // CreateNatGatewayWithContext indicates an expected call of CreateNatGatewayWithContext
 func (mr *MockEC2APIMockRecorder) CreateNatGatewayWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateNatGatewayWithContext", reflect.TypeOf((*MockEC2API)(nil).CreateNatGatewayWithContext), varargs...)
 }
 
 // CreateNetworkAcl mocks base method
 func (m *MockEC2API) CreateNetworkAcl(arg0 *ec2.CreateNetworkAclInput) (*ec2.CreateNetworkAclOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateNetworkAcl", arg0)
 	ret0, _ := ret[0].(*ec2.CreateNetworkAclOutput)
 	ret1, _ := ret[1].(error)
@@ -2910,13 +2567,11 @@ func (m *MockEC2API) CreateNetworkAcl(arg0 *ec2.CreateNetworkAclInput) (*ec2.Cre
 
 // CreateNetworkAcl indicates an expected call of CreateNetworkAcl
 func (mr *MockEC2APIMockRecorder) CreateNetworkAcl(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateNetworkAcl", reflect.TypeOf((*MockEC2API)(nil).CreateNetworkAcl), arg0)
 }
 
 // CreateNetworkAclEntry mocks base method
 func (m *MockEC2API) CreateNetworkAclEntry(arg0 *ec2.CreateNetworkAclEntryInput) (*ec2.CreateNetworkAclEntryOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateNetworkAclEntry", arg0)
 	ret0, _ := ret[0].(*ec2.CreateNetworkAclEntryOutput)
 	ret1, _ := ret[1].(error)
@@ -2925,13 +2580,11 @@ func (m *MockEC2API) CreateNetworkAclEntry(arg0 *ec2.CreateNetworkAclEntryInput)
 
 // CreateNetworkAclEntry indicates an expected call of CreateNetworkAclEntry
 func (mr *MockEC2APIMockRecorder) CreateNetworkAclEntry(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateNetworkAclEntry", reflect.TypeOf((*MockEC2API)(nil).CreateNetworkAclEntry), arg0)
 }
 
 // CreateNetworkAclEntryRequest mocks base method
 func (m *MockEC2API) CreateNetworkAclEntryRequest(arg0 *ec2.CreateNetworkAclEntryInput) (*request.Request, *ec2.CreateNetworkAclEntryOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateNetworkAclEntryRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.CreateNetworkAclEntryOutput)
@@ -2940,13 +2593,11 @@ func (m *MockEC2API) CreateNetworkAclEntryRequest(arg0 *ec2.CreateNetworkAclEntr
 
 // CreateNetworkAclEntryRequest indicates an expected call of CreateNetworkAclEntryRequest
 func (mr *MockEC2APIMockRecorder) CreateNetworkAclEntryRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateNetworkAclEntryRequest", reflect.TypeOf((*MockEC2API)(nil).CreateNetworkAclEntryRequest), arg0)
 }
 
 // CreateNetworkAclEntryWithContext mocks base method
 func (m *MockEC2API) CreateNetworkAclEntryWithContext(arg0 context.Context, arg1 *ec2.CreateNetworkAclEntryInput, arg2 ...request.Option) (*ec2.CreateNetworkAclEntryOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -2959,14 +2610,12 @@ func (m *MockEC2API) CreateNetworkAclEntryWithContext(arg0 context.Context, arg1
 
 // CreateNetworkAclEntryWithContext indicates an expected call of CreateNetworkAclEntryWithContext
 func (mr *MockEC2APIMockRecorder) CreateNetworkAclEntryWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateNetworkAclEntryWithContext", reflect.TypeOf((*MockEC2API)(nil).CreateNetworkAclEntryWithContext), varargs...)
 }
 
 // CreateNetworkAclRequest mocks base method
 func (m *MockEC2API) CreateNetworkAclRequest(arg0 *ec2.CreateNetworkAclInput) (*request.Request, *ec2.CreateNetworkAclOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateNetworkAclRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.CreateNetworkAclOutput)
@@ -2975,13 +2624,11 @@ func (m *MockEC2API) CreateNetworkAclRequest(arg0 *ec2.CreateNetworkAclInput) (*
 
 // CreateNetworkAclRequest indicates an expected call of CreateNetworkAclRequest
 func (mr *MockEC2APIMockRecorder) CreateNetworkAclRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateNetworkAclRequest", reflect.TypeOf((*MockEC2API)(nil).CreateNetworkAclRequest), arg0)
 }
 
 // CreateNetworkAclWithContext mocks base method
 func (m *MockEC2API) CreateNetworkAclWithContext(arg0 context.Context, arg1 *ec2.CreateNetworkAclInput, arg2 ...request.Option) (*ec2.CreateNetworkAclOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -2994,14 +2641,12 @@ func (m *MockEC2API) CreateNetworkAclWithContext(arg0 context.Context, arg1 *ec2
 
 // CreateNetworkAclWithContext indicates an expected call of CreateNetworkAclWithContext
 func (mr *MockEC2APIMockRecorder) CreateNetworkAclWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateNetworkAclWithContext", reflect.TypeOf((*MockEC2API)(nil).CreateNetworkAclWithContext), varargs...)
 }
 
 // CreateNetworkInterface mocks base method
 func (m *MockEC2API) CreateNetworkInterface(arg0 *ec2.CreateNetworkInterfaceInput) (*ec2.CreateNetworkInterfaceOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateNetworkInterface", arg0)
 	ret0, _ := ret[0].(*ec2.CreateNetworkInterfaceOutput)
 	ret1, _ := ret[1].(error)
@@ -3010,13 +2655,11 @@ func (m *MockEC2API) CreateNetworkInterface(arg0 *ec2.CreateNetworkInterfaceInpu
 
 // CreateNetworkInterface indicates an expected call of CreateNetworkInterface
 func (mr *MockEC2APIMockRecorder) CreateNetworkInterface(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateNetworkInterface", reflect.TypeOf((*MockEC2API)(nil).CreateNetworkInterface), arg0)
 }
 
 // CreateNetworkInterfacePermission mocks base method
 func (m *MockEC2API) CreateNetworkInterfacePermission(arg0 *ec2.CreateNetworkInterfacePermissionInput) (*ec2.CreateNetworkInterfacePermissionOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateNetworkInterfacePermission", arg0)
 	ret0, _ := ret[0].(*ec2.CreateNetworkInterfacePermissionOutput)
 	ret1, _ := ret[1].(error)
@@ -3025,13 +2668,11 @@ func (m *MockEC2API) CreateNetworkInterfacePermission(arg0 *ec2.CreateNetworkInt
 
 // CreateNetworkInterfacePermission indicates an expected call of CreateNetworkInterfacePermission
 func (mr *MockEC2APIMockRecorder) CreateNetworkInterfacePermission(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateNetworkInterfacePermission", reflect.TypeOf((*MockEC2API)(nil).CreateNetworkInterfacePermission), arg0)
 }
 
 // CreateNetworkInterfacePermissionRequest mocks base method
 func (m *MockEC2API) CreateNetworkInterfacePermissionRequest(arg0 *ec2.CreateNetworkInterfacePermissionInput) (*request.Request, *ec2.CreateNetworkInterfacePermissionOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateNetworkInterfacePermissionRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.CreateNetworkInterfacePermissionOutput)
@@ -3040,13 +2681,11 @@ func (m *MockEC2API) CreateNetworkInterfacePermissionRequest(arg0 *ec2.CreateNet
 
 // CreateNetworkInterfacePermissionRequest indicates an expected call of CreateNetworkInterfacePermissionRequest
 func (mr *MockEC2APIMockRecorder) CreateNetworkInterfacePermissionRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateNetworkInterfacePermissionRequest", reflect.TypeOf((*MockEC2API)(nil).CreateNetworkInterfacePermissionRequest), arg0)
 }
 
 // CreateNetworkInterfacePermissionWithContext mocks base method
 func (m *MockEC2API) CreateNetworkInterfacePermissionWithContext(arg0 context.Context, arg1 *ec2.CreateNetworkInterfacePermissionInput, arg2 ...request.Option) (*ec2.CreateNetworkInterfacePermissionOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -3059,14 +2698,12 @@ func (m *MockEC2API) CreateNetworkInterfacePermissionWithContext(arg0 context.Co
 
 // CreateNetworkInterfacePermissionWithContext indicates an expected call of CreateNetworkInterfacePermissionWithContext
 func (mr *MockEC2APIMockRecorder) CreateNetworkInterfacePermissionWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateNetworkInterfacePermissionWithContext", reflect.TypeOf((*MockEC2API)(nil).CreateNetworkInterfacePermissionWithContext), varargs...)
 }
 
 // CreateNetworkInterfaceRequest mocks base method
 func (m *MockEC2API) CreateNetworkInterfaceRequest(arg0 *ec2.CreateNetworkInterfaceInput) (*request.Request, *ec2.CreateNetworkInterfaceOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateNetworkInterfaceRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.CreateNetworkInterfaceOutput)
@@ -3075,13 +2712,11 @@ func (m *MockEC2API) CreateNetworkInterfaceRequest(arg0 *ec2.CreateNetworkInterf
 
 // CreateNetworkInterfaceRequest indicates an expected call of CreateNetworkInterfaceRequest
 func (mr *MockEC2APIMockRecorder) CreateNetworkInterfaceRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateNetworkInterfaceRequest", reflect.TypeOf((*MockEC2API)(nil).CreateNetworkInterfaceRequest), arg0)
 }
 
 // CreateNetworkInterfaceWithContext mocks base method
 func (m *MockEC2API) CreateNetworkInterfaceWithContext(arg0 context.Context, arg1 *ec2.CreateNetworkInterfaceInput, arg2 ...request.Option) (*ec2.CreateNetworkInterfaceOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -3094,14 +2729,12 @@ func (m *MockEC2API) CreateNetworkInterfaceWithContext(arg0 context.Context, arg
 
 // CreateNetworkInterfaceWithContext indicates an expected call of CreateNetworkInterfaceWithContext
 func (mr *MockEC2APIMockRecorder) CreateNetworkInterfaceWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateNetworkInterfaceWithContext", reflect.TypeOf((*MockEC2API)(nil).CreateNetworkInterfaceWithContext), varargs...)
 }
 
 // CreatePlacementGroup mocks base method
 func (m *MockEC2API) CreatePlacementGroup(arg0 *ec2.CreatePlacementGroupInput) (*ec2.CreatePlacementGroupOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreatePlacementGroup", arg0)
 	ret0, _ := ret[0].(*ec2.CreatePlacementGroupOutput)
 	ret1, _ := ret[1].(error)
@@ -3110,13 +2743,11 @@ func (m *MockEC2API) CreatePlacementGroup(arg0 *ec2.CreatePlacementGroupInput) (
 
 // CreatePlacementGroup indicates an expected call of CreatePlacementGroup
 func (mr *MockEC2APIMockRecorder) CreatePlacementGroup(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreatePlacementGroup", reflect.TypeOf((*MockEC2API)(nil).CreatePlacementGroup), arg0)
 }
 
 // CreatePlacementGroupRequest mocks base method
 func (m *MockEC2API) CreatePlacementGroupRequest(arg0 *ec2.CreatePlacementGroupInput) (*request.Request, *ec2.CreatePlacementGroupOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreatePlacementGroupRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.CreatePlacementGroupOutput)
@@ -3125,13 +2756,11 @@ func (m *MockEC2API) CreatePlacementGroupRequest(arg0 *ec2.CreatePlacementGroupI
 
 // CreatePlacementGroupRequest indicates an expected call of CreatePlacementGroupRequest
 func (mr *MockEC2APIMockRecorder) CreatePlacementGroupRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreatePlacementGroupRequest", reflect.TypeOf((*MockEC2API)(nil).CreatePlacementGroupRequest), arg0)
 }
 
 // CreatePlacementGroupWithContext mocks base method
 func (m *MockEC2API) CreatePlacementGroupWithContext(arg0 context.Context, arg1 *ec2.CreatePlacementGroupInput, arg2 ...request.Option) (*ec2.CreatePlacementGroupOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -3144,14 +2773,12 @@ func (m *MockEC2API) CreatePlacementGroupWithContext(arg0 context.Context, arg1 
 
 // CreatePlacementGroupWithContext indicates an expected call of CreatePlacementGroupWithContext
 func (mr *MockEC2APIMockRecorder) CreatePlacementGroupWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreatePlacementGroupWithContext", reflect.TypeOf((*MockEC2API)(nil).CreatePlacementGroupWithContext), varargs...)
 }
 
 // CreateReservedInstancesListing mocks base method
 func (m *MockEC2API) CreateReservedInstancesListing(arg0 *ec2.CreateReservedInstancesListingInput) (*ec2.CreateReservedInstancesListingOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateReservedInstancesListing", arg0)
 	ret0, _ := ret[0].(*ec2.CreateReservedInstancesListingOutput)
 	ret1, _ := ret[1].(error)
@@ -3160,13 +2787,11 @@ func (m *MockEC2API) CreateReservedInstancesListing(arg0 *ec2.CreateReservedInst
 
 // CreateReservedInstancesListing indicates an expected call of CreateReservedInstancesListing
 func (mr *MockEC2APIMockRecorder) CreateReservedInstancesListing(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateReservedInstancesListing", reflect.TypeOf((*MockEC2API)(nil).CreateReservedInstancesListing), arg0)
 }
 
 // CreateReservedInstancesListingRequest mocks base method
 func (m *MockEC2API) CreateReservedInstancesListingRequest(arg0 *ec2.CreateReservedInstancesListingInput) (*request.Request, *ec2.CreateReservedInstancesListingOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateReservedInstancesListingRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.CreateReservedInstancesListingOutput)
@@ -3175,13 +2800,11 @@ func (m *MockEC2API) CreateReservedInstancesListingRequest(arg0 *ec2.CreateReser
 
 // CreateReservedInstancesListingRequest indicates an expected call of CreateReservedInstancesListingRequest
 func (mr *MockEC2APIMockRecorder) CreateReservedInstancesListingRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateReservedInstancesListingRequest", reflect.TypeOf((*MockEC2API)(nil).CreateReservedInstancesListingRequest), arg0)
 }
 
 // CreateReservedInstancesListingWithContext mocks base method
 func (m *MockEC2API) CreateReservedInstancesListingWithContext(arg0 context.Context, arg1 *ec2.CreateReservedInstancesListingInput, arg2 ...request.Option) (*ec2.CreateReservedInstancesListingOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -3194,14 +2817,12 @@ func (m *MockEC2API) CreateReservedInstancesListingWithContext(arg0 context.Cont
 
 // CreateReservedInstancesListingWithContext indicates an expected call of CreateReservedInstancesListingWithContext
 func (mr *MockEC2APIMockRecorder) CreateReservedInstancesListingWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateReservedInstancesListingWithContext", reflect.TypeOf((*MockEC2API)(nil).CreateReservedInstancesListingWithContext), varargs...)
 }
 
 // CreateRoute mocks base method
 func (m *MockEC2API) CreateRoute(arg0 *ec2.CreateRouteInput) (*ec2.CreateRouteOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateRoute", arg0)
 	ret0, _ := ret[0].(*ec2.CreateRouteOutput)
 	ret1, _ := ret[1].(error)
@@ -3210,13 +2831,11 @@ func (m *MockEC2API) CreateRoute(arg0 *ec2.CreateRouteInput) (*ec2.CreateRouteOu
 
 // CreateRoute indicates an expected call of CreateRoute
 func (mr *MockEC2APIMockRecorder) CreateRoute(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateRoute", reflect.TypeOf((*MockEC2API)(nil).CreateRoute), arg0)
 }
 
 // CreateRouteRequest mocks base method
 func (m *MockEC2API) CreateRouteRequest(arg0 *ec2.CreateRouteInput) (*request.Request, *ec2.CreateRouteOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateRouteRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.CreateRouteOutput)
@@ -3225,13 +2844,11 @@ func (m *MockEC2API) CreateRouteRequest(arg0 *ec2.CreateRouteInput) (*request.Re
 
 // CreateRouteRequest indicates an expected call of CreateRouteRequest
 func (mr *MockEC2APIMockRecorder) CreateRouteRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateRouteRequest", reflect.TypeOf((*MockEC2API)(nil).CreateRouteRequest), arg0)
 }
 
 // CreateRouteTable mocks base method
 func (m *MockEC2API) CreateRouteTable(arg0 *ec2.CreateRouteTableInput) (*ec2.CreateRouteTableOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateRouteTable", arg0)
 	ret0, _ := ret[0].(*ec2.CreateRouteTableOutput)
 	ret1, _ := ret[1].(error)
@@ -3240,13 +2857,11 @@ func (m *MockEC2API) CreateRouteTable(arg0 *ec2.CreateRouteTableInput) (*ec2.Cre
 
 // CreateRouteTable indicates an expected call of CreateRouteTable
 func (mr *MockEC2APIMockRecorder) CreateRouteTable(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateRouteTable", reflect.TypeOf((*MockEC2API)(nil).CreateRouteTable), arg0)
 }
 
 // CreateRouteTableRequest mocks base method
 func (m *MockEC2API) CreateRouteTableRequest(arg0 *ec2.CreateRouteTableInput) (*request.Request, *ec2.CreateRouteTableOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateRouteTableRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.CreateRouteTableOutput)
@@ -3255,13 +2870,11 @@ func (m *MockEC2API) CreateRouteTableRequest(arg0 *ec2.CreateRouteTableInput) (*
 
 // CreateRouteTableRequest indicates an expected call of CreateRouteTableRequest
 func (mr *MockEC2APIMockRecorder) CreateRouteTableRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateRouteTableRequest", reflect.TypeOf((*MockEC2API)(nil).CreateRouteTableRequest), arg0)
 }
 
 // CreateRouteTableWithContext mocks base method
 func (m *MockEC2API) CreateRouteTableWithContext(arg0 context.Context, arg1 *ec2.CreateRouteTableInput, arg2 ...request.Option) (*ec2.CreateRouteTableOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -3274,14 +2887,12 @@ func (m *MockEC2API) CreateRouteTableWithContext(arg0 context.Context, arg1 *ec2
 
 // CreateRouteTableWithContext indicates an expected call of CreateRouteTableWithContext
 func (mr *MockEC2APIMockRecorder) CreateRouteTableWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateRouteTableWithContext", reflect.TypeOf((*MockEC2API)(nil).CreateRouteTableWithContext), varargs...)
 }
 
 // CreateRouteWithContext mocks base method
 func (m *MockEC2API) CreateRouteWithContext(arg0 context.Context, arg1 *ec2.CreateRouteInput, arg2 ...request.Option) (*ec2.CreateRouteOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -3294,14 +2905,12 @@ func (m *MockEC2API) CreateRouteWithContext(arg0 context.Context, arg1 *ec2.Crea
 
 // CreateRouteWithContext indicates an expected call of CreateRouteWithContext
 func (mr *MockEC2APIMockRecorder) CreateRouteWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateRouteWithContext", reflect.TypeOf((*MockEC2API)(nil).CreateRouteWithContext), varargs...)
 }
 
 // CreateSecurityGroup mocks base method
 func (m *MockEC2API) CreateSecurityGroup(arg0 *ec2.CreateSecurityGroupInput) (*ec2.CreateSecurityGroupOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateSecurityGroup", arg0)
 	ret0, _ := ret[0].(*ec2.CreateSecurityGroupOutput)
 	ret1, _ := ret[1].(error)
@@ -3310,13 +2919,11 @@ func (m *MockEC2API) CreateSecurityGroup(arg0 *ec2.CreateSecurityGroupInput) (*e
 
 // CreateSecurityGroup indicates an expected call of CreateSecurityGroup
 func (mr *MockEC2APIMockRecorder) CreateSecurityGroup(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateSecurityGroup", reflect.TypeOf((*MockEC2API)(nil).CreateSecurityGroup), arg0)
 }
 
 // CreateSecurityGroupRequest mocks base method
 func (m *MockEC2API) CreateSecurityGroupRequest(arg0 *ec2.CreateSecurityGroupInput) (*request.Request, *ec2.CreateSecurityGroupOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateSecurityGroupRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.CreateSecurityGroupOutput)
@@ -3325,13 +2932,11 @@ func (m *MockEC2API) CreateSecurityGroupRequest(arg0 *ec2.CreateSecurityGroupInp
 
 // CreateSecurityGroupRequest indicates an expected call of CreateSecurityGroupRequest
 func (mr *MockEC2APIMockRecorder) CreateSecurityGroupRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateSecurityGroupRequest", reflect.TypeOf((*MockEC2API)(nil).CreateSecurityGroupRequest), arg0)
 }
 
 // CreateSecurityGroupWithContext mocks base method
 func (m *MockEC2API) CreateSecurityGroupWithContext(arg0 context.Context, arg1 *ec2.CreateSecurityGroupInput, arg2 ...request.Option) (*ec2.CreateSecurityGroupOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -3344,14 +2949,12 @@ func (m *MockEC2API) CreateSecurityGroupWithContext(arg0 context.Context, arg1 *
 
 // CreateSecurityGroupWithContext indicates an expected call of CreateSecurityGroupWithContext
 func (mr *MockEC2APIMockRecorder) CreateSecurityGroupWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateSecurityGroupWithContext", reflect.TypeOf((*MockEC2API)(nil).CreateSecurityGroupWithContext), varargs...)
 }
 
 // CreateSnapshot mocks base method
 func (m *MockEC2API) CreateSnapshot(arg0 *ec2.CreateSnapshotInput) (*ec2.Snapshot, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateSnapshot", arg0)
 	ret0, _ := ret[0].(*ec2.Snapshot)
 	ret1, _ := ret[1].(error)
@@ -3360,13 +2963,11 @@ func (m *MockEC2API) CreateSnapshot(arg0 *ec2.CreateSnapshotInput) (*ec2.Snapsho
 
 // CreateSnapshot indicates an expected call of CreateSnapshot
 func (mr *MockEC2APIMockRecorder) CreateSnapshot(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateSnapshot", reflect.TypeOf((*MockEC2API)(nil).CreateSnapshot), arg0)
 }
 
 // CreateSnapshotRequest mocks base method
 func (m *MockEC2API) CreateSnapshotRequest(arg0 *ec2.CreateSnapshotInput) (*request.Request, *ec2.Snapshot) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateSnapshotRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.Snapshot)
@@ -3375,13 +2976,11 @@ func (m *MockEC2API) CreateSnapshotRequest(arg0 *ec2.CreateSnapshotInput) (*requ
 
 // CreateSnapshotRequest indicates an expected call of CreateSnapshotRequest
 func (mr *MockEC2APIMockRecorder) CreateSnapshotRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateSnapshotRequest", reflect.TypeOf((*MockEC2API)(nil).CreateSnapshotRequest), arg0)
 }
 
 // CreateSnapshotWithContext mocks base method
 func (m *MockEC2API) CreateSnapshotWithContext(arg0 context.Context, arg1 *ec2.CreateSnapshotInput, arg2 ...request.Option) (*ec2.Snapshot, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -3394,14 +2993,12 @@ func (m *MockEC2API) CreateSnapshotWithContext(arg0 context.Context, arg1 *ec2.C
 
 // CreateSnapshotWithContext indicates an expected call of CreateSnapshotWithContext
 func (mr *MockEC2APIMockRecorder) CreateSnapshotWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateSnapshotWithContext", reflect.TypeOf((*MockEC2API)(nil).CreateSnapshotWithContext), varargs...)
 }
 
 // CreateSpotDatafeedSubscription mocks base method
 func (m *MockEC2API) CreateSpotDatafeedSubscription(arg0 *ec2.CreateSpotDatafeedSubscriptionInput) (*ec2.CreateSpotDatafeedSubscriptionOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateSpotDatafeedSubscription", arg0)
 	ret0, _ := ret[0].(*ec2.CreateSpotDatafeedSubscriptionOutput)
 	ret1, _ := ret[1].(error)
@@ -3410,13 +3007,11 @@ func (m *MockEC2API) CreateSpotDatafeedSubscription(arg0 *ec2.CreateSpotDatafeed
 
 // CreateSpotDatafeedSubscription indicates an expected call of CreateSpotDatafeedSubscription
 func (mr *MockEC2APIMockRecorder) CreateSpotDatafeedSubscription(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateSpotDatafeedSubscription", reflect.TypeOf((*MockEC2API)(nil).CreateSpotDatafeedSubscription), arg0)
 }
 
 // CreateSpotDatafeedSubscriptionRequest mocks base method
 func (m *MockEC2API) CreateSpotDatafeedSubscriptionRequest(arg0 *ec2.CreateSpotDatafeedSubscriptionInput) (*request.Request, *ec2.CreateSpotDatafeedSubscriptionOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateSpotDatafeedSubscriptionRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.CreateSpotDatafeedSubscriptionOutput)
@@ -3425,13 +3020,11 @@ func (m *MockEC2API) CreateSpotDatafeedSubscriptionRequest(arg0 *ec2.CreateSpotD
 
 // CreateSpotDatafeedSubscriptionRequest indicates an expected call of CreateSpotDatafeedSubscriptionRequest
 func (mr *MockEC2APIMockRecorder) CreateSpotDatafeedSubscriptionRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateSpotDatafeedSubscriptionRequest", reflect.TypeOf((*MockEC2API)(nil).CreateSpotDatafeedSubscriptionRequest), arg0)
 }
 
 // CreateSpotDatafeedSubscriptionWithContext mocks base method
 func (m *MockEC2API) CreateSpotDatafeedSubscriptionWithContext(arg0 context.Context, arg1 *ec2.CreateSpotDatafeedSubscriptionInput, arg2 ...request.Option) (*ec2.CreateSpotDatafeedSubscriptionOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -3444,14 +3037,12 @@ func (m *MockEC2API) CreateSpotDatafeedSubscriptionWithContext(arg0 context.Cont
 
 // CreateSpotDatafeedSubscriptionWithContext indicates an expected call of CreateSpotDatafeedSubscriptionWithContext
 func (mr *MockEC2APIMockRecorder) CreateSpotDatafeedSubscriptionWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateSpotDatafeedSubscriptionWithContext", reflect.TypeOf((*MockEC2API)(nil).CreateSpotDatafeedSubscriptionWithContext), varargs...)
 }
 
 // CreateSubnet mocks base method
 func (m *MockEC2API) CreateSubnet(arg0 *ec2.CreateSubnetInput) (*ec2.CreateSubnetOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateSubnet", arg0)
 	ret0, _ := ret[0].(*ec2.CreateSubnetOutput)
 	ret1, _ := ret[1].(error)
@@ -3460,13 +3051,11 @@ func (m *MockEC2API) CreateSubnet(arg0 *ec2.CreateSubnetInput) (*ec2.CreateSubne
 
 // CreateSubnet indicates an expected call of CreateSubnet
 func (mr *MockEC2APIMockRecorder) CreateSubnet(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateSubnet", reflect.TypeOf((*MockEC2API)(nil).CreateSubnet), arg0)
 }
 
 // CreateSubnetRequest mocks base method
 func (m *MockEC2API) CreateSubnetRequest(arg0 *ec2.CreateSubnetInput) (*request.Request, *ec2.CreateSubnetOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateSubnetRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.CreateSubnetOutput)
@@ -3475,13 +3064,11 @@ func (m *MockEC2API) CreateSubnetRequest(arg0 *ec2.CreateSubnetInput) (*request.
 
 // CreateSubnetRequest indicates an expected call of CreateSubnetRequest
 func (mr *MockEC2APIMockRecorder) CreateSubnetRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateSubnetRequest", reflect.TypeOf((*MockEC2API)(nil).CreateSubnetRequest), arg0)
 }
 
 // CreateSubnetWithContext mocks base method
 func (m *MockEC2API) CreateSubnetWithContext(arg0 context.Context, arg1 *ec2.CreateSubnetInput, arg2 ...request.Option) (*ec2.CreateSubnetOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -3494,14 +3081,12 @@ func (m *MockEC2API) CreateSubnetWithContext(arg0 context.Context, arg1 *ec2.Cre
 
 // CreateSubnetWithContext indicates an expected call of CreateSubnetWithContext
 func (mr *MockEC2APIMockRecorder) CreateSubnetWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateSubnetWithContext", reflect.TypeOf((*MockEC2API)(nil).CreateSubnetWithContext), varargs...)
 }
 
 // CreateTags mocks base method
 func (m *MockEC2API) CreateTags(arg0 *ec2.CreateTagsInput) (*ec2.CreateTagsOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateTags", arg0)
 	ret0, _ := ret[0].(*ec2.CreateTagsOutput)
 	ret1, _ := ret[1].(error)
@@ -3510,13 +3095,11 @@ func (m *MockEC2API) CreateTags(arg0 *ec2.CreateTagsInput) (*ec2.CreateTagsOutpu
 
 // CreateTags indicates an expected call of CreateTags
 func (mr *MockEC2APIMockRecorder) CreateTags(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateTags", reflect.TypeOf((*MockEC2API)(nil).CreateTags), arg0)
 }
 
 // CreateTagsRequest mocks base method
 func (m *MockEC2API) CreateTagsRequest(arg0 *ec2.CreateTagsInput) (*request.Request, *ec2.CreateTagsOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateTagsRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.CreateTagsOutput)
@@ -3525,13 +3108,11 @@ func (m *MockEC2API) CreateTagsRequest(arg0 *ec2.CreateTagsInput) (*request.Requ
 
 // CreateTagsRequest indicates an expected call of CreateTagsRequest
 func (mr *MockEC2APIMockRecorder) CreateTagsRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateTagsRequest", reflect.TypeOf((*MockEC2API)(nil).CreateTagsRequest), arg0)
 }
 
 // CreateTagsWithContext mocks base method
 func (m *MockEC2API) CreateTagsWithContext(arg0 context.Context, arg1 *ec2.CreateTagsInput, arg2 ...request.Option) (*ec2.CreateTagsOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -3544,14 +3125,12 @@ func (m *MockEC2API) CreateTagsWithContext(arg0 context.Context, arg1 *ec2.Creat
 
 // CreateTagsWithContext indicates an expected call of CreateTagsWithContext
 func (mr *MockEC2APIMockRecorder) CreateTagsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateTagsWithContext", reflect.TypeOf((*MockEC2API)(nil).CreateTagsWithContext), varargs...)
 }
 
 // CreateTransitGateway mocks base method
 func (m *MockEC2API) CreateTransitGateway(arg0 *ec2.CreateTransitGatewayInput) (*ec2.CreateTransitGatewayOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateTransitGateway", arg0)
 	ret0, _ := ret[0].(*ec2.CreateTransitGatewayOutput)
 	ret1, _ := ret[1].(error)
@@ -3560,13 +3139,11 @@ func (m *MockEC2API) CreateTransitGateway(arg0 *ec2.CreateTransitGatewayInput) (
 
 // CreateTransitGateway indicates an expected call of CreateTransitGateway
 func (mr *MockEC2APIMockRecorder) CreateTransitGateway(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateTransitGateway", reflect.TypeOf((*MockEC2API)(nil).CreateTransitGateway), arg0)
 }
 
 // CreateTransitGatewayRequest mocks base method
 func (m *MockEC2API) CreateTransitGatewayRequest(arg0 *ec2.CreateTransitGatewayInput) (*request.Request, *ec2.CreateTransitGatewayOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateTransitGatewayRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.CreateTransitGatewayOutput)
@@ -3575,13 +3152,11 @@ func (m *MockEC2API) CreateTransitGatewayRequest(arg0 *ec2.CreateTransitGatewayI
 
 // CreateTransitGatewayRequest indicates an expected call of CreateTransitGatewayRequest
 func (mr *MockEC2APIMockRecorder) CreateTransitGatewayRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateTransitGatewayRequest", reflect.TypeOf((*MockEC2API)(nil).CreateTransitGatewayRequest), arg0)
 }
 
 // CreateTransitGatewayRoute mocks base method
 func (m *MockEC2API) CreateTransitGatewayRoute(arg0 *ec2.CreateTransitGatewayRouteInput) (*ec2.CreateTransitGatewayRouteOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateTransitGatewayRoute", arg0)
 	ret0, _ := ret[0].(*ec2.CreateTransitGatewayRouteOutput)
 	ret1, _ := ret[1].(error)
@@ -3590,13 +3165,11 @@ func (m *MockEC2API) CreateTransitGatewayRoute(arg0 *ec2.CreateTransitGatewayRou
 
 // CreateTransitGatewayRoute indicates an expected call of CreateTransitGatewayRoute
 func (mr *MockEC2APIMockRecorder) CreateTransitGatewayRoute(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateTransitGatewayRoute", reflect.TypeOf((*MockEC2API)(nil).CreateTransitGatewayRoute), arg0)
 }
 
 // CreateTransitGatewayRouteRequest mocks base method
 func (m *MockEC2API) CreateTransitGatewayRouteRequest(arg0 *ec2.CreateTransitGatewayRouteInput) (*request.Request, *ec2.CreateTransitGatewayRouteOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateTransitGatewayRouteRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.CreateTransitGatewayRouteOutput)
@@ -3605,13 +3178,11 @@ func (m *MockEC2API) CreateTransitGatewayRouteRequest(arg0 *ec2.CreateTransitGat
 
 // CreateTransitGatewayRouteRequest indicates an expected call of CreateTransitGatewayRouteRequest
 func (mr *MockEC2APIMockRecorder) CreateTransitGatewayRouteRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateTransitGatewayRouteRequest", reflect.TypeOf((*MockEC2API)(nil).CreateTransitGatewayRouteRequest), arg0)
 }
 
 // CreateTransitGatewayRouteTable mocks base method
 func (m *MockEC2API) CreateTransitGatewayRouteTable(arg0 *ec2.CreateTransitGatewayRouteTableInput) (*ec2.CreateTransitGatewayRouteTableOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateTransitGatewayRouteTable", arg0)
 	ret0, _ := ret[0].(*ec2.CreateTransitGatewayRouteTableOutput)
 	ret1, _ := ret[1].(error)
@@ -3620,13 +3191,11 @@ func (m *MockEC2API) CreateTransitGatewayRouteTable(arg0 *ec2.CreateTransitGatew
 
 // CreateTransitGatewayRouteTable indicates an expected call of CreateTransitGatewayRouteTable
 func (mr *MockEC2APIMockRecorder) CreateTransitGatewayRouteTable(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateTransitGatewayRouteTable", reflect.TypeOf((*MockEC2API)(nil).CreateTransitGatewayRouteTable), arg0)
 }
 
 // CreateTransitGatewayRouteTableRequest mocks base method
 func (m *MockEC2API) CreateTransitGatewayRouteTableRequest(arg0 *ec2.CreateTransitGatewayRouteTableInput) (*request.Request, *ec2.CreateTransitGatewayRouteTableOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateTransitGatewayRouteTableRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.CreateTransitGatewayRouteTableOutput)
@@ -3635,13 +3204,11 @@ func (m *MockEC2API) CreateTransitGatewayRouteTableRequest(arg0 *ec2.CreateTrans
 
 // CreateTransitGatewayRouteTableRequest indicates an expected call of CreateTransitGatewayRouteTableRequest
 func (mr *MockEC2APIMockRecorder) CreateTransitGatewayRouteTableRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateTransitGatewayRouteTableRequest", reflect.TypeOf((*MockEC2API)(nil).CreateTransitGatewayRouteTableRequest), arg0)
 }
 
 // CreateTransitGatewayRouteTableWithContext mocks base method
 func (m *MockEC2API) CreateTransitGatewayRouteTableWithContext(arg0 context.Context, arg1 *ec2.CreateTransitGatewayRouteTableInput, arg2 ...request.Option) (*ec2.CreateTransitGatewayRouteTableOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -3654,14 +3221,12 @@ func (m *MockEC2API) CreateTransitGatewayRouteTableWithContext(arg0 context.Cont
 
 // CreateTransitGatewayRouteTableWithContext indicates an expected call of CreateTransitGatewayRouteTableWithContext
 func (mr *MockEC2APIMockRecorder) CreateTransitGatewayRouteTableWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateTransitGatewayRouteTableWithContext", reflect.TypeOf((*MockEC2API)(nil).CreateTransitGatewayRouteTableWithContext), varargs...)
 }
 
 // CreateTransitGatewayRouteWithContext mocks base method
 func (m *MockEC2API) CreateTransitGatewayRouteWithContext(arg0 context.Context, arg1 *ec2.CreateTransitGatewayRouteInput, arg2 ...request.Option) (*ec2.CreateTransitGatewayRouteOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -3674,14 +3239,12 @@ func (m *MockEC2API) CreateTransitGatewayRouteWithContext(arg0 context.Context, 
 
 // CreateTransitGatewayRouteWithContext indicates an expected call of CreateTransitGatewayRouteWithContext
 func (mr *MockEC2APIMockRecorder) CreateTransitGatewayRouteWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateTransitGatewayRouteWithContext", reflect.TypeOf((*MockEC2API)(nil).CreateTransitGatewayRouteWithContext), varargs...)
 }
 
 // CreateTransitGatewayVpcAttachment mocks base method
 func (m *MockEC2API) CreateTransitGatewayVpcAttachment(arg0 *ec2.CreateTransitGatewayVpcAttachmentInput) (*ec2.CreateTransitGatewayVpcAttachmentOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateTransitGatewayVpcAttachment", arg0)
 	ret0, _ := ret[0].(*ec2.CreateTransitGatewayVpcAttachmentOutput)
 	ret1, _ := ret[1].(error)
@@ -3690,13 +3253,11 @@ func (m *MockEC2API) CreateTransitGatewayVpcAttachment(arg0 *ec2.CreateTransitGa
 
 // CreateTransitGatewayVpcAttachment indicates an expected call of CreateTransitGatewayVpcAttachment
 func (mr *MockEC2APIMockRecorder) CreateTransitGatewayVpcAttachment(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateTransitGatewayVpcAttachment", reflect.TypeOf((*MockEC2API)(nil).CreateTransitGatewayVpcAttachment), arg0)
 }
 
 // CreateTransitGatewayVpcAttachmentRequest mocks base method
 func (m *MockEC2API) CreateTransitGatewayVpcAttachmentRequest(arg0 *ec2.CreateTransitGatewayVpcAttachmentInput) (*request.Request, *ec2.CreateTransitGatewayVpcAttachmentOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateTransitGatewayVpcAttachmentRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.CreateTransitGatewayVpcAttachmentOutput)
@@ -3705,13 +3266,11 @@ func (m *MockEC2API) CreateTransitGatewayVpcAttachmentRequest(arg0 *ec2.CreateTr
 
 // CreateTransitGatewayVpcAttachmentRequest indicates an expected call of CreateTransitGatewayVpcAttachmentRequest
 func (mr *MockEC2APIMockRecorder) CreateTransitGatewayVpcAttachmentRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateTransitGatewayVpcAttachmentRequest", reflect.TypeOf((*MockEC2API)(nil).CreateTransitGatewayVpcAttachmentRequest), arg0)
 }
 
 // CreateTransitGatewayVpcAttachmentWithContext mocks base method
 func (m *MockEC2API) CreateTransitGatewayVpcAttachmentWithContext(arg0 context.Context, arg1 *ec2.CreateTransitGatewayVpcAttachmentInput, arg2 ...request.Option) (*ec2.CreateTransitGatewayVpcAttachmentOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -3724,14 +3283,12 @@ func (m *MockEC2API) CreateTransitGatewayVpcAttachmentWithContext(arg0 context.C
 
 // CreateTransitGatewayVpcAttachmentWithContext indicates an expected call of CreateTransitGatewayVpcAttachmentWithContext
 func (mr *MockEC2APIMockRecorder) CreateTransitGatewayVpcAttachmentWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateTransitGatewayVpcAttachmentWithContext", reflect.TypeOf((*MockEC2API)(nil).CreateTransitGatewayVpcAttachmentWithContext), varargs...)
 }
 
 // CreateTransitGatewayWithContext mocks base method
 func (m *MockEC2API) CreateTransitGatewayWithContext(arg0 context.Context, arg1 *ec2.CreateTransitGatewayInput, arg2 ...request.Option) (*ec2.CreateTransitGatewayOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -3744,14 +3301,12 @@ func (m *MockEC2API) CreateTransitGatewayWithContext(arg0 context.Context, arg1 
 
 // CreateTransitGatewayWithContext indicates an expected call of CreateTransitGatewayWithContext
 func (mr *MockEC2APIMockRecorder) CreateTransitGatewayWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateTransitGatewayWithContext", reflect.TypeOf((*MockEC2API)(nil).CreateTransitGatewayWithContext), varargs...)
 }
 
 // CreateVolume mocks base method
 func (m *MockEC2API) CreateVolume(arg0 *ec2.CreateVolumeInput) (*ec2.Volume, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateVolume", arg0)
 	ret0, _ := ret[0].(*ec2.Volume)
 	ret1, _ := ret[1].(error)
@@ -3760,13 +3315,11 @@ func (m *MockEC2API) CreateVolume(arg0 *ec2.CreateVolumeInput) (*ec2.Volume, err
 
 // CreateVolume indicates an expected call of CreateVolume
 func (mr *MockEC2APIMockRecorder) CreateVolume(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateVolume", reflect.TypeOf((*MockEC2API)(nil).CreateVolume), arg0)
 }
 
 // CreateVolumeRequest mocks base method
 func (m *MockEC2API) CreateVolumeRequest(arg0 *ec2.CreateVolumeInput) (*request.Request, *ec2.Volume) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateVolumeRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.Volume)
@@ -3775,13 +3328,11 @@ func (m *MockEC2API) CreateVolumeRequest(arg0 *ec2.CreateVolumeInput) (*request.
 
 // CreateVolumeRequest indicates an expected call of CreateVolumeRequest
 func (mr *MockEC2APIMockRecorder) CreateVolumeRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateVolumeRequest", reflect.TypeOf((*MockEC2API)(nil).CreateVolumeRequest), arg0)
 }
 
 // CreateVolumeWithContext mocks base method
 func (m *MockEC2API) CreateVolumeWithContext(arg0 context.Context, arg1 *ec2.CreateVolumeInput, arg2 ...request.Option) (*ec2.Volume, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -3794,14 +3345,12 @@ func (m *MockEC2API) CreateVolumeWithContext(arg0 context.Context, arg1 *ec2.Cre
 
 // CreateVolumeWithContext indicates an expected call of CreateVolumeWithContext
 func (mr *MockEC2APIMockRecorder) CreateVolumeWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateVolumeWithContext", reflect.TypeOf((*MockEC2API)(nil).CreateVolumeWithContext), varargs...)
 }
 
 // CreateVpc mocks base method
 func (m *MockEC2API) CreateVpc(arg0 *ec2.CreateVpcInput) (*ec2.CreateVpcOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateVpc", arg0)
 	ret0, _ := ret[0].(*ec2.CreateVpcOutput)
 	ret1, _ := ret[1].(error)
@@ -3810,13 +3359,11 @@ func (m *MockEC2API) CreateVpc(arg0 *ec2.CreateVpcInput) (*ec2.CreateVpcOutput, 
 
 // CreateVpc indicates an expected call of CreateVpc
 func (mr *MockEC2APIMockRecorder) CreateVpc(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateVpc", reflect.TypeOf((*MockEC2API)(nil).CreateVpc), arg0)
 }
 
 // CreateVpcEndpoint mocks base method
 func (m *MockEC2API) CreateVpcEndpoint(arg0 *ec2.CreateVpcEndpointInput) (*ec2.CreateVpcEndpointOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateVpcEndpoint", arg0)
 	ret0, _ := ret[0].(*ec2.CreateVpcEndpointOutput)
 	ret1, _ := ret[1].(error)
@@ -3825,13 +3372,11 @@ func (m *MockEC2API) CreateVpcEndpoint(arg0 *ec2.CreateVpcEndpointInput) (*ec2.C
 
 // CreateVpcEndpoint indicates an expected call of CreateVpcEndpoint
 func (mr *MockEC2APIMockRecorder) CreateVpcEndpoint(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateVpcEndpoint", reflect.TypeOf((*MockEC2API)(nil).CreateVpcEndpoint), arg0)
 }
 
 // CreateVpcEndpointConnectionNotification mocks base method
 func (m *MockEC2API) CreateVpcEndpointConnectionNotification(arg0 *ec2.CreateVpcEndpointConnectionNotificationInput) (*ec2.CreateVpcEndpointConnectionNotificationOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateVpcEndpointConnectionNotification", arg0)
 	ret0, _ := ret[0].(*ec2.CreateVpcEndpointConnectionNotificationOutput)
 	ret1, _ := ret[1].(error)
@@ -3840,13 +3385,11 @@ func (m *MockEC2API) CreateVpcEndpointConnectionNotification(arg0 *ec2.CreateVpc
 
 // CreateVpcEndpointConnectionNotification indicates an expected call of CreateVpcEndpointConnectionNotification
 func (mr *MockEC2APIMockRecorder) CreateVpcEndpointConnectionNotification(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateVpcEndpointConnectionNotification", reflect.TypeOf((*MockEC2API)(nil).CreateVpcEndpointConnectionNotification), arg0)
 }
 
 // CreateVpcEndpointConnectionNotificationRequest mocks base method
 func (m *MockEC2API) CreateVpcEndpointConnectionNotificationRequest(arg0 *ec2.CreateVpcEndpointConnectionNotificationInput) (*request.Request, *ec2.CreateVpcEndpointConnectionNotificationOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateVpcEndpointConnectionNotificationRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.CreateVpcEndpointConnectionNotificationOutput)
@@ -3855,13 +3398,11 @@ func (m *MockEC2API) CreateVpcEndpointConnectionNotificationRequest(arg0 *ec2.Cr
 
 // CreateVpcEndpointConnectionNotificationRequest indicates an expected call of CreateVpcEndpointConnectionNotificationRequest
 func (mr *MockEC2APIMockRecorder) CreateVpcEndpointConnectionNotificationRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateVpcEndpointConnectionNotificationRequest", reflect.TypeOf((*MockEC2API)(nil).CreateVpcEndpointConnectionNotificationRequest), arg0)
 }
 
 // CreateVpcEndpointConnectionNotificationWithContext mocks base method
 func (m *MockEC2API) CreateVpcEndpointConnectionNotificationWithContext(arg0 context.Context, arg1 *ec2.CreateVpcEndpointConnectionNotificationInput, arg2 ...request.Option) (*ec2.CreateVpcEndpointConnectionNotificationOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -3874,14 +3415,12 @@ func (m *MockEC2API) CreateVpcEndpointConnectionNotificationWithContext(arg0 con
 
 // CreateVpcEndpointConnectionNotificationWithContext indicates an expected call of CreateVpcEndpointConnectionNotificationWithContext
 func (mr *MockEC2APIMockRecorder) CreateVpcEndpointConnectionNotificationWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateVpcEndpointConnectionNotificationWithContext", reflect.TypeOf((*MockEC2API)(nil).CreateVpcEndpointConnectionNotificationWithContext), varargs...)
 }
 
 // CreateVpcEndpointRequest mocks base method
 func (m *MockEC2API) CreateVpcEndpointRequest(arg0 *ec2.CreateVpcEndpointInput) (*request.Request, *ec2.CreateVpcEndpointOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateVpcEndpointRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.CreateVpcEndpointOutput)
@@ -3890,13 +3429,11 @@ func (m *MockEC2API) CreateVpcEndpointRequest(arg0 *ec2.CreateVpcEndpointInput) 
 
 // CreateVpcEndpointRequest indicates an expected call of CreateVpcEndpointRequest
 func (mr *MockEC2APIMockRecorder) CreateVpcEndpointRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateVpcEndpointRequest", reflect.TypeOf((*MockEC2API)(nil).CreateVpcEndpointRequest), arg0)
 }
 
 // CreateVpcEndpointServiceConfiguration mocks base method
 func (m *MockEC2API) CreateVpcEndpointServiceConfiguration(arg0 *ec2.CreateVpcEndpointServiceConfigurationInput) (*ec2.CreateVpcEndpointServiceConfigurationOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateVpcEndpointServiceConfiguration", arg0)
 	ret0, _ := ret[0].(*ec2.CreateVpcEndpointServiceConfigurationOutput)
 	ret1, _ := ret[1].(error)
@@ -3905,13 +3442,11 @@ func (m *MockEC2API) CreateVpcEndpointServiceConfiguration(arg0 *ec2.CreateVpcEn
 
 // CreateVpcEndpointServiceConfiguration indicates an expected call of CreateVpcEndpointServiceConfiguration
 func (mr *MockEC2APIMockRecorder) CreateVpcEndpointServiceConfiguration(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateVpcEndpointServiceConfiguration", reflect.TypeOf((*MockEC2API)(nil).CreateVpcEndpointServiceConfiguration), arg0)
 }
 
 // CreateVpcEndpointServiceConfigurationRequest mocks base method
 func (m *MockEC2API) CreateVpcEndpointServiceConfigurationRequest(arg0 *ec2.CreateVpcEndpointServiceConfigurationInput) (*request.Request, *ec2.CreateVpcEndpointServiceConfigurationOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateVpcEndpointServiceConfigurationRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.CreateVpcEndpointServiceConfigurationOutput)
@@ -3920,13 +3455,11 @@ func (m *MockEC2API) CreateVpcEndpointServiceConfigurationRequest(arg0 *ec2.Crea
 
 // CreateVpcEndpointServiceConfigurationRequest indicates an expected call of CreateVpcEndpointServiceConfigurationRequest
 func (mr *MockEC2APIMockRecorder) CreateVpcEndpointServiceConfigurationRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateVpcEndpointServiceConfigurationRequest", reflect.TypeOf((*MockEC2API)(nil).CreateVpcEndpointServiceConfigurationRequest), arg0)
 }
 
 // CreateVpcEndpointServiceConfigurationWithContext mocks base method
 func (m *MockEC2API) CreateVpcEndpointServiceConfigurationWithContext(arg0 context.Context, arg1 *ec2.CreateVpcEndpointServiceConfigurationInput, arg2 ...request.Option) (*ec2.CreateVpcEndpointServiceConfigurationOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -3939,14 +3472,12 @@ func (m *MockEC2API) CreateVpcEndpointServiceConfigurationWithContext(arg0 conte
 
 // CreateVpcEndpointServiceConfigurationWithContext indicates an expected call of CreateVpcEndpointServiceConfigurationWithContext
 func (mr *MockEC2APIMockRecorder) CreateVpcEndpointServiceConfigurationWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateVpcEndpointServiceConfigurationWithContext", reflect.TypeOf((*MockEC2API)(nil).CreateVpcEndpointServiceConfigurationWithContext), varargs...)
 }
 
 // CreateVpcEndpointWithContext mocks base method
 func (m *MockEC2API) CreateVpcEndpointWithContext(arg0 context.Context, arg1 *ec2.CreateVpcEndpointInput, arg2 ...request.Option) (*ec2.CreateVpcEndpointOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -3959,14 +3490,12 @@ func (m *MockEC2API) CreateVpcEndpointWithContext(arg0 context.Context, arg1 *ec
 
 // CreateVpcEndpointWithContext indicates an expected call of CreateVpcEndpointWithContext
 func (mr *MockEC2APIMockRecorder) CreateVpcEndpointWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateVpcEndpointWithContext", reflect.TypeOf((*MockEC2API)(nil).CreateVpcEndpointWithContext), varargs...)
 }
 
 // CreateVpcPeeringConnection mocks base method
 func (m *MockEC2API) CreateVpcPeeringConnection(arg0 *ec2.CreateVpcPeeringConnectionInput) (*ec2.CreateVpcPeeringConnectionOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateVpcPeeringConnection", arg0)
 	ret0, _ := ret[0].(*ec2.CreateVpcPeeringConnectionOutput)
 	ret1, _ := ret[1].(error)
@@ -3975,13 +3504,11 @@ func (m *MockEC2API) CreateVpcPeeringConnection(arg0 *ec2.CreateVpcPeeringConnec
 
 // CreateVpcPeeringConnection indicates an expected call of CreateVpcPeeringConnection
 func (mr *MockEC2APIMockRecorder) CreateVpcPeeringConnection(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateVpcPeeringConnection", reflect.TypeOf((*MockEC2API)(nil).CreateVpcPeeringConnection), arg0)
 }
 
 // CreateVpcPeeringConnectionRequest mocks base method
 func (m *MockEC2API) CreateVpcPeeringConnectionRequest(arg0 *ec2.CreateVpcPeeringConnectionInput) (*request.Request, *ec2.CreateVpcPeeringConnectionOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateVpcPeeringConnectionRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.CreateVpcPeeringConnectionOutput)
@@ -3990,13 +3517,11 @@ func (m *MockEC2API) CreateVpcPeeringConnectionRequest(arg0 *ec2.CreateVpcPeerin
 
 // CreateVpcPeeringConnectionRequest indicates an expected call of CreateVpcPeeringConnectionRequest
 func (mr *MockEC2APIMockRecorder) CreateVpcPeeringConnectionRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateVpcPeeringConnectionRequest", reflect.TypeOf((*MockEC2API)(nil).CreateVpcPeeringConnectionRequest), arg0)
 }
 
 // CreateVpcPeeringConnectionWithContext mocks base method
 func (m *MockEC2API) CreateVpcPeeringConnectionWithContext(arg0 context.Context, arg1 *ec2.CreateVpcPeeringConnectionInput, arg2 ...request.Option) (*ec2.CreateVpcPeeringConnectionOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -4009,14 +3534,12 @@ func (m *MockEC2API) CreateVpcPeeringConnectionWithContext(arg0 context.Context,
 
 // CreateVpcPeeringConnectionWithContext indicates an expected call of CreateVpcPeeringConnectionWithContext
 func (mr *MockEC2APIMockRecorder) CreateVpcPeeringConnectionWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateVpcPeeringConnectionWithContext", reflect.TypeOf((*MockEC2API)(nil).CreateVpcPeeringConnectionWithContext), varargs...)
 }
 
 // CreateVpcRequest mocks base method
 func (m *MockEC2API) CreateVpcRequest(arg0 *ec2.CreateVpcInput) (*request.Request, *ec2.CreateVpcOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateVpcRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.CreateVpcOutput)
@@ -4025,13 +3548,11 @@ func (m *MockEC2API) CreateVpcRequest(arg0 *ec2.CreateVpcInput) (*request.Reques
 
 // CreateVpcRequest indicates an expected call of CreateVpcRequest
 func (mr *MockEC2APIMockRecorder) CreateVpcRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateVpcRequest", reflect.TypeOf((*MockEC2API)(nil).CreateVpcRequest), arg0)
 }
 
 // CreateVpcWithContext mocks base method
 func (m *MockEC2API) CreateVpcWithContext(arg0 context.Context, arg1 *ec2.CreateVpcInput, arg2 ...request.Option) (*ec2.CreateVpcOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -4044,14 +3565,12 @@ func (m *MockEC2API) CreateVpcWithContext(arg0 context.Context, arg1 *ec2.Create
 
 // CreateVpcWithContext indicates an expected call of CreateVpcWithContext
 func (mr *MockEC2APIMockRecorder) CreateVpcWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateVpcWithContext", reflect.TypeOf((*MockEC2API)(nil).CreateVpcWithContext), varargs...)
 }
 
 // CreateVpnConnection mocks base method
 func (m *MockEC2API) CreateVpnConnection(arg0 *ec2.CreateVpnConnectionInput) (*ec2.CreateVpnConnectionOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateVpnConnection", arg0)
 	ret0, _ := ret[0].(*ec2.CreateVpnConnectionOutput)
 	ret1, _ := ret[1].(error)
@@ -4060,13 +3579,11 @@ func (m *MockEC2API) CreateVpnConnection(arg0 *ec2.CreateVpnConnectionInput) (*e
 
 // CreateVpnConnection indicates an expected call of CreateVpnConnection
 func (mr *MockEC2APIMockRecorder) CreateVpnConnection(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateVpnConnection", reflect.TypeOf((*MockEC2API)(nil).CreateVpnConnection), arg0)
 }
 
 // CreateVpnConnectionRequest mocks base method
 func (m *MockEC2API) CreateVpnConnectionRequest(arg0 *ec2.CreateVpnConnectionInput) (*request.Request, *ec2.CreateVpnConnectionOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateVpnConnectionRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.CreateVpnConnectionOutput)
@@ -4075,13 +3592,11 @@ func (m *MockEC2API) CreateVpnConnectionRequest(arg0 *ec2.CreateVpnConnectionInp
 
 // CreateVpnConnectionRequest indicates an expected call of CreateVpnConnectionRequest
 func (mr *MockEC2APIMockRecorder) CreateVpnConnectionRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateVpnConnectionRequest", reflect.TypeOf((*MockEC2API)(nil).CreateVpnConnectionRequest), arg0)
 }
 
 // CreateVpnConnectionRoute mocks base method
 func (m *MockEC2API) CreateVpnConnectionRoute(arg0 *ec2.CreateVpnConnectionRouteInput) (*ec2.CreateVpnConnectionRouteOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateVpnConnectionRoute", arg0)
 	ret0, _ := ret[0].(*ec2.CreateVpnConnectionRouteOutput)
 	ret1, _ := ret[1].(error)
@@ -4090,13 +3605,11 @@ func (m *MockEC2API) CreateVpnConnectionRoute(arg0 *ec2.CreateVpnConnectionRoute
 
 // CreateVpnConnectionRoute indicates an expected call of CreateVpnConnectionRoute
 func (mr *MockEC2APIMockRecorder) CreateVpnConnectionRoute(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateVpnConnectionRoute", reflect.TypeOf((*MockEC2API)(nil).CreateVpnConnectionRoute), arg0)
 }
 
 // CreateVpnConnectionRouteRequest mocks base method
 func (m *MockEC2API) CreateVpnConnectionRouteRequest(arg0 *ec2.CreateVpnConnectionRouteInput) (*request.Request, *ec2.CreateVpnConnectionRouteOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateVpnConnectionRouteRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.CreateVpnConnectionRouteOutput)
@@ -4105,13 +3618,11 @@ func (m *MockEC2API) CreateVpnConnectionRouteRequest(arg0 *ec2.CreateVpnConnecti
 
 // CreateVpnConnectionRouteRequest indicates an expected call of CreateVpnConnectionRouteRequest
 func (mr *MockEC2APIMockRecorder) CreateVpnConnectionRouteRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateVpnConnectionRouteRequest", reflect.TypeOf((*MockEC2API)(nil).CreateVpnConnectionRouteRequest), arg0)
 }
 
 // CreateVpnConnectionRouteWithContext mocks base method
 func (m *MockEC2API) CreateVpnConnectionRouteWithContext(arg0 context.Context, arg1 *ec2.CreateVpnConnectionRouteInput, arg2 ...request.Option) (*ec2.CreateVpnConnectionRouteOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -4124,14 +3635,12 @@ func (m *MockEC2API) CreateVpnConnectionRouteWithContext(arg0 context.Context, a
 
 // CreateVpnConnectionRouteWithContext indicates an expected call of CreateVpnConnectionRouteWithContext
 func (mr *MockEC2APIMockRecorder) CreateVpnConnectionRouteWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateVpnConnectionRouteWithContext", reflect.TypeOf((*MockEC2API)(nil).CreateVpnConnectionRouteWithContext), varargs...)
 }
 
 // CreateVpnConnectionWithContext mocks base method
 func (m *MockEC2API) CreateVpnConnectionWithContext(arg0 context.Context, arg1 *ec2.CreateVpnConnectionInput, arg2 ...request.Option) (*ec2.CreateVpnConnectionOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -4144,14 +3653,12 @@ func (m *MockEC2API) CreateVpnConnectionWithContext(arg0 context.Context, arg1 *
 
 // CreateVpnConnectionWithContext indicates an expected call of CreateVpnConnectionWithContext
 func (mr *MockEC2APIMockRecorder) CreateVpnConnectionWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateVpnConnectionWithContext", reflect.TypeOf((*MockEC2API)(nil).CreateVpnConnectionWithContext), varargs...)
 }
 
 // CreateVpnGateway mocks base method
 func (m *MockEC2API) CreateVpnGateway(arg0 *ec2.CreateVpnGatewayInput) (*ec2.CreateVpnGatewayOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateVpnGateway", arg0)
 	ret0, _ := ret[0].(*ec2.CreateVpnGatewayOutput)
 	ret1, _ := ret[1].(error)
@@ -4160,13 +3667,11 @@ func (m *MockEC2API) CreateVpnGateway(arg0 *ec2.CreateVpnGatewayInput) (*ec2.Cre
 
 // CreateVpnGateway indicates an expected call of CreateVpnGateway
 func (mr *MockEC2APIMockRecorder) CreateVpnGateway(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateVpnGateway", reflect.TypeOf((*MockEC2API)(nil).CreateVpnGateway), arg0)
 }
 
 // CreateVpnGatewayRequest mocks base method
 func (m *MockEC2API) CreateVpnGatewayRequest(arg0 *ec2.CreateVpnGatewayInput) (*request.Request, *ec2.CreateVpnGatewayOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateVpnGatewayRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.CreateVpnGatewayOutput)
@@ -4175,13 +3680,11 @@ func (m *MockEC2API) CreateVpnGatewayRequest(arg0 *ec2.CreateVpnGatewayInput) (*
 
 // CreateVpnGatewayRequest indicates an expected call of CreateVpnGatewayRequest
 func (mr *MockEC2APIMockRecorder) CreateVpnGatewayRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateVpnGatewayRequest", reflect.TypeOf((*MockEC2API)(nil).CreateVpnGatewayRequest), arg0)
 }
 
 // CreateVpnGatewayWithContext mocks base method
 func (m *MockEC2API) CreateVpnGatewayWithContext(arg0 context.Context, arg1 *ec2.CreateVpnGatewayInput, arg2 ...request.Option) (*ec2.CreateVpnGatewayOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -4194,14 +3697,12 @@ func (m *MockEC2API) CreateVpnGatewayWithContext(arg0 context.Context, arg1 *ec2
 
 // CreateVpnGatewayWithContext indicates an expected call of CreateVpnGatewayWithContext
 func (mr *MockEC2APIMockRecorder) CreateVpnGatewayWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateVpnGatewayWithContext", reflect.TypeOf((*MockEC2API)(nil).CreateVpnGatewayWithContext), varargs...)
 }
 
 // DeleteClientVpnEndpoint mocks base method
 func (m *MockEC2API) DeleteClientVpnEndpoint(arg0 *ec2.DeleteClientVpnEndpointInput) (*ec2.DeleteClientVpnEndpointOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteClientVpnEndpoint", arg0)
 	ret0, _ := ret[0].(*ec2.DeleteClientVpnEndpointOutput)
 	ret1, _ := ret[1].(error)
@@ -4210,13 +3711,11 @@ func (m *MockEC2API) DeleteClientVpnEndpoint(arg0 *ec2.DeleteClientVpnEndpointIn
 
 // DeleteClientVpnEndpoint indicates an expected call of DeleteClientVpnEndpoint
 func (mr *MockEC2APIMockRecorder) DeleteClientVpnEndpoint(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteClientVpnEndpoint", reflect.TypeOf((*MockEC2API)(nil).DeleteClientVpnEndpoint), arg0)
 }
 
 // DeleteClientVpnEndpointRequest mocks base method
 func (m *MockEC2API) DeleteClientVpnEndpointRequest(arg0 *ec2.DeleteClientVpnEndpointInput) (*request.Request, *ec2.DeleteClientVpnEndpointOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteClientVpnEndpointRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DeleteClientVpnEndpointOutput)
@@ -4225,13 +3724,11 @@ func (m *MockEC2API) DeleteClientVpnEndpointRequest(arg0 *ec2.DeleteClientVpnEnd
 
 // DeleteClientVpnEndpointRequest indicates an expected call of DeleteClientVpnEndpointRequest
 func (mr *MockEC2APIMockRecorder) DeleteClientVpnEndpointRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteClientVpnEndpointRequest", reflect.TypeOf((*MockEC2API)(nil).DeleteClientVpnEndpointRequest), arg0)
 }
 
 // DeleteClientVpnEndpointWithContext mocks base method
 func (m *MockEC2API) DeleteClientVpnEndpointWithContext(arg0 context.Context, arg1 *ec2.DeleteClientVpnEndpointInput, arg2 ...request.Option) (*ec2.DeleteClientVpnEndpointOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -4244,14 +3741,12 @@ func (m *MockEC2API) DeleteClientVpnEndpointWithContext(arg0 context.Context, ar
 
 // DeleteClientVpnEndpointWithContext indicates an expected call of DeleteClientVpnEndpointWithContext
 func (mr *MockEC2APIMockRecorder) DeleteClientVpnEndpointWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteClientVpnEndpointWithContext", reflect.TypeOf((*MockEC2API)(nil).DeleteClientVpnEndpointWithContext), varargs...)
 }
 
 // DeleteClientVpnRoute mocks base method
 func (m *MockEC2API) DeleteClientVpnRoute(arg0 *ec2.DeleteClientVpnRouteInput) (*ec2.DeleteClientVpnRouteOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteClientVpnRoute", arg0)
 	ret0, _ := ret[0].(*ec2.DeleteClientVpnRouteOutput)
 	ret1, _ := ret[1].(error)
@@ -4260,13 +3755,11 @@ func (m *MockEC2API) DeleteClientVpnRoute(arg0 *ec2.DeleteClientVpnRouteInput) (
 
 // DeleteClientVpnRoute indicates an expected call of DeleteClientVpnRoute
 func (mr *MockEC2APIMockRecorder) DeleteClientVpnRoute(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteClientVpnRoute", reflect.TypeOf((*MockEC2API)(nil).DeleteClientVpnRoute), arg0)
 }
 
 // DeleteClientVpnRouteRequest mocks base method
 func (m *MockEC2API) DeleteClientVpnRouteRequest(arg0 *ec2.DeleteClientVpnRouteInput) (*request.Request, *ec2.DeleteClientVpnRouteOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteClientVpnRouteRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DeleteClientVpnRouteOutput)
@@ -4275,13 +3768,11 @@ func (m *MockEC2API) DeleteClientVpnRouteRequest(arg0 *ec2.DeleteClientVpnRouteI
 
 // DeleteClientVpnRouteRequest indicates an expected call of DeleteClientVpnRouteRequest
 func (mr *MockEC2APIMockRecorder) DeleteClientVpnRouteRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteClientVpnRouteRequest", reflect.TypeOf((*MockEC2API)(nil).DeleteClientVpnRouteRequest), arg0)
 }
 
 // DeleteClientVpnRouteWithContext mocks base method
 func (m *MockEC2API) DeleteClientVpnRouteWithContext(arg0 context.Context, arg1 *ec2.DeleteClientVpnRouteInput, arg2 ...request.Option) (*ec2.DeleteClientVpnRouteOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -4294,14 +3785,12 @@ func (m *MockEC2API) DeleteClientVpnRouteWithContext(arg0 context.Context, arg1 
 
 // DeleteClientVpnRouteWithContext indicates an expected call of DeleteClientVpnRouteWithContext
 func (mr *MockEC2APIMockRecorder) DeleteClientVpnRouteWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteClientVpnRouteWithContext", reflect.TypeOf((*MockEC2API)(nil).DeleteClientVpnRouteWithContext), varargs...)
 }
 
 // DeleteCustomerGateway mocks base method
 func (m *MockEC2API) DeleteCustomerGateway(arg0 *ec2.DeleteCustomerGatewayInput) (*ec2.DeleteCustomerGatewayOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteCustomerGateway", arg0)
 	ret0, _ := ret[0].(*ec2.DeleteCustomerGatewayOutput)
 	ret1, _ := ret[1].(error)
@@ -4310,13 +3799,11 @@ func (m *MockEC2API) DeleteCustomerGateway(arg0 *ec2.DeleteCustomerGatewayInput)
 
 // DeleteCustomerGateway indicates an expected call of DeleteCustomerGateway
 func (mr *MockEC2APIMockRecorder) DeleteCustomerGateway(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteCustomerGateway", reflect.TypeOf((*MockEC2API)(nil).DeleteCustomerGateway), arg0)
 }
 
 // DeleteCustomerGatewayRequest mocks base method
 func (m *MockEC2API) DeleteCustomerGatewayRequest(arg0 *ec2.DeleteCustomerGatewayInput) (*request.Request, *ec2.DeleteCustomerGatewayOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteCustomerGatewayRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DeleteCustomerGatewayOutput)
@@ -4325,13 +3812,11 @@ func (m *MockEC2API) DeleteCustomerGatewayRequest(arg0 *ec2.DeleteCustomerGatewa
 
 // DeleteCustomerGatewayRequest indicates an expected call of DeleteCustomerGatewayRequest
 func (mr *MockEC2APIMockRecorder) DeleteCustomerGatewayRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteCustomerGatewayRequest", reflect.TypeOf((*MockEC2API)(nil).DeleteCustomerGatewayRequest), arg0)
 }
 
 // DeleteCustomerGatewayWithContext mocks base method
 func (m *MockEC2API) DeleteCustomerGatewayWithContext(arg0 context.Context, arg1 *ec2.DeleteCustomerGatewayInput, arg2 ...request.Option) (*ec2.DeleteCustomerGatewayOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -4344,14 +3829,12 @@ func (m *MockEC2API) DeleteCustomerGatewayWithContext(arg0 context.Context, arg1
 
 // DeleteCustomerGatewayWithContext indicates an expected call of DeleteCustomerGatewayWithContext
 func (mr *MockEC2APIMockRecorder) DeleteCustomerGatewayWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteCustomerGatewayWithContext", reflect.TypeOf((*MockEC2API)(nil).DeleteCustomerGatewayWithContext), varargs...)
 }
 
 // DeleteDhcpOptions mocks base method
 func (m *MockEC2API) DeleteDhcpOptions(arg0 *ec2.DeleteDhcpOptionsInput) (*ec2.DeleteDhcpOptionsOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteDhcpOptions", arg0)
 	ret0, _ := ret[0].(*ec2.DeleteDhcpOptionsOutput)
 	ret1, _ := ret[1].(error)
@@ -4360,13 +3843,11 @@ func (m *MockEC2API) DeleteDhcpOptions(arg0 *ec2.DeleteDhcpOptionsInput) (*ec2.D
 
 // DeleteDhcpOptions indicates an expected call of DeleteDhcpOptions
 func (mr *MockEC2APIMockRecorder) DeleteDhcpOptions(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteDhcpOptions", reflect.TypeOf((*MockEC2API)(nil).DeleteDhcpOptions), arg0)
 }
 
 // DeleteDhcpOptionsRequest mocks base method
 func (m *MockEC2API) DeleteDhcpOptionsRequest(arg0 *ec2.DeleteDhcpOptionsInput) (*request.Request, *ec2.DeleteDhcpOptionsOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteDhcpOptionsRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DeleteDhcpOptionsOutput)
@@ -4375,13 +3856,11 @@ func (m *MockEC2API) DeleteDhcpOptionsRequest(arg0 *ec2.DeleteDhcpOptionsInput) 
 
 // DeleteDhcpOptionsRequest indicates an expected call of DeleteDhcpOptionsRequest
 func (mr *MockEC2APIMockRecorder) DeleteDhcpOptionsRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteDhcpOptionsRequest", reflect.TypeOf((*MockEC2API)(nil).DeleteDhcpOptionsRequest), arg0)
 }
 
 // DeleteDhcpOptionsWithContext mocks base method
 func (m *MockEC2API) DeleteDhcpOptionsWithContext(arg0 context.Context, arg1 *ec2.DeleteDhcpOptionsInput, arg2 ...request.Option) (*ec2.DeleteDhcpOptionsOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -4394,14 +3873,12 @@ func (m *MockEC2API) DeleteDhcpOptionsWithContext(arg0 context.Context, arg1 *ec
 
 // DeleteDhcpOptionsWithContext indicates an expected call of DeleteDhcpOptionsWithContext
 func (mr *MockEC2APIMockRecorder) DeleteDhcpOptionsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteDhcpOptionsWithContext", reflect.TypeOf((*MockEC2API)(nil).DeleteDhcpOptionsWithContext), varargs...)
 }
 
 // DeleteEgressOnlyInternetGateway mocks base method
 func (m *MockEC2API) DeleteEgressOnlyInternetGateway(arg0 *ec2.DeleteEgressOnlyInternetGatewayInput) (*ec2.DeleteEgressOnlyInternetGatewayOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteEgressOnlyInternetGateway", arg0)
 	ret0, _ := ret[0].(*ec2.DeleteEgressOnlyInternetGatewayOutput)
 	ret1, _ := ret[1].(error)
@@ -4410,13 +3887,11 @@ func (m *MockEC2API) DeleteEgressOnlyInternetGateway(arg0 *ec2.DeleteEgressOnlyI
 
 // DeleteEgressOnlyInternetGateway indicates an expected call of DeleteEgressOnlyInternetGateway
 func (mr *MockEC2APIMockRecorder) DeleteEgressOnlyInternetGateway(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteEgressOnlyInternetGateway", reflect.TypeOf((*MockEC2API)(nil).DeleteEgressOnlyInternetGateway), arg0)
 }
 
 // DeleteEgressOnlyInternetGatewayRequest mocks base method
 func (m *MockEC2API) DeleteEgressOnlyInternetGatewayRequest(arg0 *ec2.DeleteEgressOnlyInternetGatewayInput) (*request.Request, *ec2.DeleteEgressOnlyInternetGatewayOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteEgressOnlyInternetGatewayRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DeleteEgressOnlyInternetGatewayOutput)
@@ -4425,13 +3900,11 @@ func (m *MockEC2API) DeleteEgressOnlyInternetGatewayRequest(arg0 *ec2.DeleteEgre
 
 // DeleteEgressOnlyInternetGatewayRequest indicates an expected call of DeleteEgressOnlyInternetGatewayRequest
 func (mr *MockEC2APIMockRecorder) DeleteEgressOnlyInternetGatewayRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteEgressOnlyInternetGatewayRequest", reflect.TypeOf((*MockEC2API)(nil).DeleteEgressOnlyInternetGatewayRequest), arg0)
 }
 
 // DeleteEgressOnlyInternetGatewayWithContext mocks base method
 func (m *MockEC2API) DeleteEgressOnlyInternetGatewayWithContext(arg0 context.Context, arg1 *ec2.DeleteEgressOnlyInternetGatewayInput, arg2 ...request.Option) (*ec2.DeleteEgressOnlyInternetGatewayOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -4444,14 +3917,12 @@ func (m *MockEC2API) DeleteEgressOnlyInternetGatewayWithContext(arg0 context.Con
 
 // DeleteEgressOnlyInternetGatewayWithContext indicates an expected call of DeleteEgressOnlyInternetGatewayWithContext
 func (mr *MockEC2APIMockRecorder) DeleteEgressOnlyInternetGatewayWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteEgressOnlyInternetGatewayWithContext", reflect.TypeOf((*MockEC2API)(nil).DeleteEgressOnlyInternetGatewayWithContext), varargs...)
 }
 
 // DeleteFleets mocks base method
 func (m *MockEC2API) DeleteFleets(arg0 *ec2.DeleteFleetsInput) (*ec2.DeleteFleetsOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteFleets", arg0)
 	ret0, _ := ret[0].(*ec2.DeleteFleetsOutput)
 	ret1, _ := ret[1].(error)
@@ -4460,13 +3931,11 @@ func (m *MockEC2API) DeleteFleets(arg0 *ec2.DeleteFleetsInput) (*ec2.DeleteFleet
 
 // DeleteFleets indicates an expected call of DeleteFleets
 func (mr *MockEC2APIMockRecorder) DeleteFleets(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteFleets", reflect.TypeOf((*MockEC2API)(nil).DeleteFleets), arg0)
 }
 
 // DeleteFleetsRequest mocks base method
 func (m *MockEC2API) DeleteFleetsRequest(arg0 *ec2.DeleteFleetsInput) (*request.Request, *ec2.DeleteFleetsOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteFleetsRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DeleteFleetsOutput)
@@ -4475,13 +3944,11 @@ func (m *MockEC2API) DeleteFleetsRequest(arg0 *ec2.DeleteFleetsInput) (*request.
 
 // DeleteFleetsRequest indicates an expected call of DeleteFleetsRequest
 func (mr *MockEC2APIMockRecorder) DeleteFleetsRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteFleetsRequest", reflect.TypeOf((*MockEC2API)(nil).DeleteFleetsRequest), arg0)
 }
 
 // DeleteFleetsWithContext mocks base method
 func (m *MockEC2API) DeleteFleetsWithContext(arg0 context.Context, arg1 *ec2.DeleteFleetsInput, arg2 ...request.Option) (*ec2.DeleteFleetsOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -4494,14 +3961,12 @@ func (m *MockEC2API) DeleteFleetsWithContext(arg0 context.Context, arg1 *ec2.Del
 
 // DeleteFleetsWithContext indicates an expected call of DeleteFleetsWithContext
 func (mr *MockEC2APIMockRecorder) DeleteFleetsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteFleetsWithContext", reflect.TypeOf((*MockEC2API)(nil).DeleteFleetsWithContext), varargs...)
 }
 
 // DeleteFlowLogs mocks base method
 func (m *MockEC2API) DeleteFlowLogs(arg0 *ec2.DeleteFlowLogsInput) (*ec2.DeleteFlowLogsOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteFlowLogs", arg0)
 	ret0, _ := ret[0].(*ec2.DeleteFlowLogsOutput)
 	ret1, _ := ret[1].(error)
@@ -4510,13 +3975,11 @@ func (m *MockEC2API) DeleteFlowLogs(arg0 *ec2.DeleteFlowLogsInput) (*ec2.DeleteF
 
 // DeleteFlowLogs indicates an expected call of DeleteFlowLogs
 func (mr *MockEC2APIMockRecorder) DeleteFlowLogs(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteFlowLogs", reflect.TypeOf((*MockEC2API)(nil).DeleteFlowLogs), arg0)
 }
 
 // DeleteFlowLogsRequest mocks base method
 func (m *MockEC2API) DeleteFlowLogsRequest(arg0 *ec2.DeleteFlowLogsInput) (*request.Request, *ec2.DeleteFlowLogsOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteFlowLogsRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DeleteFlowLogsOutput)
@@ -4525,13 +3988,11 @@ func (m *MockEC2API) DeleteFlowLogsRequest(arg0 *ec2.DeleteFlowLogsInput) (*requ
 
 // DeleteFlowLogsRequest indicates an expected call of DeleteFlowLogsRequest
 func (mr *MockEC2APIMockRecorder) DeleteFlowLogsRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteFlowLogsRequest", reflect.TypeOf((*MockEC2API)(nil).DeleteFlowLogsRequest), arg0)
 }
 
 // DeleteFlowLogsWithContext mocks base method
 func (m *MockEC2API) DeleteFlowLogsWithContext(arg0 context.Context, arg1 *ec2.DeleteFlowLogsInput, arg2 ...request.Option) (*ec2.DeleteFlowLogsOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -4544,14 +4005,12 @@ func (m *MockEC2API) DeleteFlowLogsWithContext(arg0 context.Context, arg1 *ec2.D
 
 // DeleteFlowLogsWithContext indicates an expected call of DeleteFlowLogsWithContext
 func (mr *MockEC2APIMockRecorder) DeleteFlowLogsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteFlowLogsWithContext", reflect.TypeOf((*MockEC2API)(nil).DeleteFlowLogsWithContext), varargs...)
 }
 
 // DeleteFpgaImage mocks base method
 func (m *MockEC2API) DeleteFpgaImage(arg0 *ec2.DeleteFpgaImageInput) (*ec2.DeleteFpgaImageOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteFpgaImage", arg0)
 	ret0, _ := ret[0].(*ec2.DeleteFpgaImageOutput)
 	ret1, _ := ret[1].(error)
@@ -4560,13 +4019,11 @@ func (m *MockEC2API) DeleteFpgaImage(arg0 *ec2.DeleteFpgaImageInput) (*ec2.Delet
 
 // DeleteFpgaImage indicates an expected call of DeleteFpgaImage
 func (mr *MockEC2APIMockRecorder) DeleteFpgaImage(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteFpgaImage", reflect.TypeOf((*MockEC2API)(nil).DeleteFpgaImage), arg0)
 }
 
 // DeleteFpgaImageRequest mocks base method
 func (m *MockEC2API) DeleteFpgaImageRequest(arg0 *ec2.DeleteFpgaImageInput) (*request.Request, *ec2.DeleteFpgaImageOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteFpgaImageRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DeleteFpgaImageOutput)
@@ -4575,13 +4032,11 @@ func (m *MockEC2API) DeleteFpgaImageRequest(arg0 *ec2.DeleteFpgaImageInput) (*re
 
 // DeleteFpgaImageRequest indicates an expected call of DeleteFpgaImageRequest
 func (mr *MockEC2APIMockRecorder) DeleteFpgaImageRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteFpgaImageRequest", reflect.TypeOf((*MockEC2API)(nil).DeleteFpgaImageRequest), arg0)
 }
 
 // DeleteFpgaImageWithContext mocks base method
 func (m *MockEC2API) DeleteFpgaImageWithContext(arg0 context.Context, arg1 *ec2.DeleteFpgaImageInput, arg2 ...request.Option) (*ec2.DeleteFpgaImageOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -4594,14 +4049,12 @@ func (m *MockEC2API) DeleteFpgaImageWithContext(arg0 context.Context, arg1 *ec2.
 
 // DeleteFpgaImageWithContext indicates an expected call of DeleteFpgaImageWithContext
 func (mr *MockEC2APIMockRecorder) DeleteFpgaImageWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteFpgaImageWithContext", reflect.TypeOf((*MockEC2API)(nil).DeleteFpgaImageWithContext), varargs...)
 }
 
 // DeleteInternetGateway mocks base method
 func (m *MockEC2API) DeleteInternetGateway(arg0 *ec2.DeleteInternetGatewayInput) (*ec2.DeleteInternetGatewayOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteInternetGateway", arg0)
 	ret0, _ := ret[0].(*ec2.DeleteInternetGatewayOutput)
 	ret1, _ := ret[1].(error)
@@ -4610,13 +4063,11 @@ func (m *MockEC2API) DeleteInternetGateway(arg0 *ec2.DeleteInternetGatewayInput)
 
 // DeleteInternetGateway indicates an expected call of DeleteInternetGateway
 func (mr *MockEC2APIMockRecorder) DeleteInternetGateway(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteInternetGateway", reflect.TypeOf((*MockEC2API)(nil).DeleteInternetGateway), arg0)
 }
 
 // DeleteInternetGatewayRequest mocks base method
 func (m *MockEC2API) DeleteInternetGatewayRequest(arg0 *ec2.DeleteInternetGatewayInput) (*request.Request, *ec2.DeleteInternetGatewayOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteInternetGatewayRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DeleteInternetGatewayOutput)
@@ -4625,13 +4076,11 @@ func (m *MockEC2API) DeleteInternetGatewayRequest(arg0 *ec2.DeleteInternetGatewa
 
 // DeleteInternetGatewayRequest indicates an expected call of DeleteInternetGatewayRequest
 func (mr *MockEC2APIMockRecorder) DeleteInternetGatewayRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteInternetGatewayRequest", reflect.TypeOf((*MockEC2API)(nil).DeleteInternetGatewayRequest), arg0)
 }
 
 // DeleteInternetGatewayWithContext mocks base method
 func (m *MockEC2API) DeleteInternetGatewayWithContext(arg0 context.Context, arg1 *ec2.DeleteInternetGatewayInput, arg2 ...request.Option) (*ec2.DeleteInternetGatewayOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -4644,14 +4093,12 @@ func (m *MockEC2API) DeleteInternetGatewayWithContext(arg0 context.Context, arg1
 
 // DeleteInternetGatewayWithContext indicates an expected call of DeleteInternetGatewayWithContext
 func (mr *MockEC2APIMockRecorder) DeleteInternetGatewayWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteInternetGatewayWithContext", reflect.TypeOf((*MockEC2API)(nil).DeleteInternetGatewayWithContext), varargs...)
 }
 
 // DeleteKeyPair mocks base method
 func (m *MockEC2API) DeleteKeyPair(arg0 *ec2.DeleteKeyPairInput) (*ec2.DeleteKeyPairOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteKeyPair", arg0)
 	ret0, _ := ret[0].(*ec2.DeleteKeyPairOutput)
 	ret1, _ := ret[1].(error)
@@ -4660,13 +4107,11 @@ func (m *MockEC2API) DeleteKeyPair(arg0 *ec2.DeleteKeyPairInput) (*ec2.DeleteKey
 
 // DeleteKeyPair indicates an expected call of DeleteKeyPair
 func (mr *MockEC2APIMockRecorder) DeleteKeyPair(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteKeyPair", reflect.TypeOf((*MockEC2API)(nil).DeleteKeyPair), arg0)
 }
 
 // DeleteKeyPairRequest mocks base method
 func (m *MockEC2API) DeleteKeyPairRequest(arg0 *ec2.DeleteKeyPairInput) (*request.Request, *ec2.DeleteKeyPairOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteKeyPairRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DeleteKeyPairOutput)
@@ -4675,13 +4120,11 @@ func (m *MockEC2API) DeleteKeyPairRequest(arg0 *ec2.DeleteKeyPairInput) (*reques
 
 // DeleteKeyPairRequest indicates an expected call of DeleteKeyPairRequest
 func (mr *MockEC2APIMockRecorder) DeleteKeyPairRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteKeyPairRequest", reflect.TypeOf((*MockEC2API)(nil).DeleteKeyPairRequest), arg0)
 }
 
 // DeleteKeyPairWithContext mocks base method
 func (m *MockEC2API) DeleteKeyPairWithContext(arg0 context.Context, arg1 *ec2.DeleteKeyPairInput, arg2 ...request.Option) (*ec2.DeleteKeyPairOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -4694,14 +4137,12 @@ func (m *MockEC2API) DeleteKeyPairWithContext(arg0 context.Context, arg1 *ec2.De
 
 // DeleteKeyPairWithContext indicates an expected call of DeleteKeyPairWithContext
 func (mr *MockEC2APIMockRecorder) DeleteKeyPairWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteKeyPairWithContext", reflect.TypeOf((*MockEC2API)(nil).DeleteKeyPairWithContext), varargs...)
 }
 
 // DeleteLaunchTemplate mocks base method
 func (m *MockEC2API) DeleteLaunchTemplate(arg0 *ec2.DeleteLaunchTemplateInput) (*ec2.DeleteLaunchTemplateOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteLaunchTemplate", arg0)
 	ret0, _ := ret[0].(*ec2.DeleteLaunchTemplateOutput)
 	ret1, _ := ret[1].(error)
@@ -4710,13 +4151,11 @@ func (m *MockEC2API) DeleteLaunchTemplate(arg0 *ec2.DeleteLaunchTemplateInput) (
 
 // DeleteLaunchTemplate indicates an expected call of DeleteLaunchTemplate
 func (mr *MockEC2APIMockRecorder) DeleteLaunchTemplate(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteLaunchTemplate", reflect.TypeOf((*MockEC2API)(nil).DeleteLaunchTemplate), arg0)
 }
 
 // DeleteLaunchTemplateRequest mocks base method
 func (m *MockEC2API) DeleteLaunchTemplateRequest(arg0 *ec2.DeleteLaunchTemplateInput) (*request.Request, *ec2.DeleteLaunchTemplateOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteLaunchTemplateRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DeleteLaunchTemplateOutput)
@@ -4725,13 +4164,11 @@ func (m *MockEC2API) DeleteLaunchTemplateRequest(arg0 *ec2.DeleteLaunchTemplateI
 
 // DeleteLaunchTemplateRequest indicates an expected call of DeleteLaunchTemplateRequest
 func (mr *MockEC2APIMockRecorder) DeleteLaunchTemplateRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteLaunchTemplateRequest", reflect.TypeOf((*MockEC2API)(nil).DeleteLaunchTemplateRequest), arg0)
 }
 
 // DeleteLaunchTemplateVersions mocks base method
 func (m *MockEC2API) DeleteLaunchTemplateVersions(arg0 *ec2.DeleteLaunchTemplateVersionsInput) (*ec2.DeleteLaunchTemplateVersionsOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteLaunchTemplateVersions", arg0)
 	ret0, _ := ret[0].(*ec2.DeleteLaunchTemplateVersionsOutput)
 	ret1, _ := ret[1].(error)
@@ -4740,13 +4177,11 @@ func (m *MockEC2API) DeleteLaunchTemplateVersions(arg0 *ec2.DeleteLaunchTemplate
 
 // DeleteLaunchTemplateVersions indicates an expected call of DeleteLaunchTemplateVersions
 func (mr *MockEC2APIMockRecorder) DeleteLaunchTemplateVersions(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteLaunchTemplateVersions", reflect.TypeOf((*MockEC2API)(nil).DeleteLaunchTemplateVersions), arg0)
 }
 
 // DeleteLaunchTemplateVersionsRequest mocks base method
 func (m *MockEC2API) DeleteLaunchTemplateVersionsRequest(arg0 *ec2.DeleteLaunchTemplateVersionsInput) (*request.Request, *ec2.DeleteLaunchTemplateVersionsOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteLaunchTemplateVersionsRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DeleteLaunchTemplateVersionsOutput)
@@ -4755,13 +4190,11 @@ func (m *MockEC2API) DeleteLaunchTemplateVersionsRequest(arg0 *ec2.DeleteLaunchT
 
 // DeleteLaunchTemplateVersionsRequest indicates an expected call of DeleteLaunchTemplateVersionsRequest
 func (mr *MockEC2APIMockRecorder) DeleteLaunchTemplateVersionsRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteLaunchTemplateVersionsRequest", reflect.TypeOf((*MockEC2API)(nil).DeleteLaunchTemplateVersionsRequest), arg0)
 }
 
 // DeleteLaunchTemplateVersionsWithContext mocks base method
 func (m *MockEC2API) DeleteLaunchTemplateVersionsWithContext(arg0 context.Context, arg1 *ec2.DeleteLaunchTemplateVersionsInput, arg2 ...request.Option) (*ec2.DeleteLaunchTemplateVersionsOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -4774,14 +4207,12 @@ func (m *MockEC2API) DeleteLaunchTemplateVersionsWithContext(arg0 context.Contex
 
 // DeleteLaunchTemplateVersionsWithContext indicates an expected call of DeleteLaunchTemplateVersionsWithContext
 func (mr *MockEC2APIMockRecorder) DeleteLaunchTemplateVersionsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteLaunchTemplateVersionsWithContext", reflect.TypeOf((*MockEC2API)(nil).DeleteLaunchTemplateVersionsWithContext), varargs...)
 }
 
 // DeleteLaunchTemplateWithContext mocks base method
 func (m *MockEC2API) DeleteLaunchTemplateWithContext(arg0 context.Context, arg1 *ec2.DeleteLaunchTemplateInput, arg2 ...request.Option) (*ec2.DeleteLaunchTemplateOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -4794,14 +4225,12 @@ func (m *MockEC2API) DeleteLaunchTemplateWithContext(arg0 context.Context, arg1 
 
 // DeleteLaunchTemplateWithContext indicates an expected call of DeleteLaunchTemplateWithContext
 func (mr *MockEC2APIMockRecorder) DeleteLaunchTemplateWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteLaunchTemplateWithContext", reflect.TypeOf((*MockEC2API)(nil).DeleteLaunchTemplateWithContext), varargs...)
 }
 
 // DeleteNatGateway mocks base method
 func (m *MockEC2API) DeleteNatGateway(arg0 *ec2.DeleteNatGatewayInput) (*ec2.DeleteNatGatewayOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteNatGateway", arg0)
 	ret0, _ := ret[0].(*ec2.DeleteNatGatewayOutput)
 	ret1, _ := ret[1].(error)
@@ -4810,13 +4239,11 @@ func (m *MockEC2API) DeleteNatGateway(arg0 *ec2.DeleteNatGatewayInput) (*ec2.Del
 
 // DeleteNatGateway indicates an expected call of DeleteNatGateway
 func (mr *MockEC2APIMockRecorder) DeleteNatGateway(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteNatGateway", reflect.TypeOf((*MockEC2API)(nil).DeleteNatGateway), arg0)
 }
 
 // DeleteNatGatewayRequest mocks base method
 func (m *MockEC2API) DeleteNatGatewayRequest(arg0 *ec2.DeleteNatGatewayInput) (*request.Request, *ec2.DeleteNatGatewayOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteNatGatewayRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DeleteNatGatewayOutput)
@@ -4825,13 +4252,11 @@ func (m *MockEC2API) DeleteNatGatewayRequest(arg0 *ec2.DeleteNatGatewayInput) (*
 
 // DeleteNatGatewayRequest indicates an expected call of DeleteNatGatewayRequest
 func (mr *MockEC2APIMockRecorder) DeleteNatGatewayRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteNatGatewayRequest", reflect.TypeOf((*MockEC2API)(nil).DeleteNatGatewayRequest), arg0)
 }
 
 // DeleteNatGatewayWithContext mocks base method
 func (m *MockEC2API) DeleteNatGatewayWithContext(arg0 context.Context, arg1 *ec2.DeleteNatGatewayInput, arg2 ...request.Option) (*ec2.DeleteNatGatewayOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -4844,14 +4269,12 @@ func (m *MockEC2API) DeleteNatGatewayWithContext(arg0 context.Context, arg1 *ec2
 
 // DeleteNatGatewayWithContext indicates an expected call of DeleteNatGatewayWithContext
 func (mr *MockEC2APIMockRecorder) DeleteNatGatewayWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteNatGatewayWithContext", reflect.TypeOf((*MockEC2API)(nil).DeleteNatGatewayWithContext), varargs...)
 }
 
 // DeleteNetworkAcl mocks base method
 func (m *MockEC2API) DeleteNetworkAcl(arg0 *ec2.DeleteNetworkAclInput) (*ec2.DeleteNetworkAclOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteNetworkAcl", arg0)
 	ret0, _ := ret[0].(*ec2.DeleteNetworkAclOutput)
 	ret1, _ := ret[1].(error)
@@ -4860,13 +4283,11 @@ func (m *MockEC2API) DeleteNetworkAcl(arg0 *ec2.DeleteNetworkAclInput) (*ec2.Del
 
 // DeleteNetworkAcl indicates an expected call of DeleteNetworkAcl
 func (mr *MockEC2APIMockRecorder) DeleteNetworkAcl(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteNetworkAcl", reflect.TypeOf((*MockEC2API)(nil).DeleteNetworkAcl), arg0)
 }
 
 // DeleteNetworkAclEntry mocks base method
 func (m *MockEC2API) DeleteNetworkAclEntry(arg0 *ec2.DeleteNetworkAclEntryInput) (*ec2.DeleteNetworkAclEntryOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteNetworkAclEntry", arg0)
 	ret0, _ := ret[0].(*ec2.DeleteNetworkAclEntryOutput)
 	ret1, _ := ret[1].(error)
@@ -4875,13 +4296,11 @@ func (m *MockEC2API) DeleteNetworkAclEntry(arg0 *ec2.DeleteNetworkAclEntryInput)
 
 // DeleteNetworkAclEntry indicates an expected call of DeleteNetworkAclEntry
 func (mr *MockEC2APIMockRecorder) DeleteNetworkAclEntry(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteNetworkAclEntry", reflect.TypeOf((*MockEC2API)(nil).DeleteNetworkAclEntry), arg0)
 }
 
 // DeleteNetworkAclEntryRequest mocks base method
 func (m *MockEC2API) DeleteNetworkAclEntryRequest(arg0 *ec2.DeleteNetworkAclEntryInput) (*request.Request, *ec2.DeleteNetworkAclEntryOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteNetworkAclEntryRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DeleteNetworkAclEntryOutput)
@@ -4890,13 +4309,11 @@ func (m *MockEC2API) DeleteNetworkAclEntryRequest(arg0 *ec2.DeleteNetworkAclEntr
 
 // DeleteNetworkAclEntryRequest indicates an expected call of DeleteNetworkAclEntryRequest
 func (mr *MockEC2APIMockRecorder) DeleteNetworkAclEntryRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteNetworkAclEntryRequest", reflect.TypeOf((*MockEC2API)(nil).DeleteNetworkAclEntryRequest), arg0)
 }
 
 // DeleteNetworkAclEntryWithContext mocks base method
 func (m *MockEC2API) DeleteNetworkAclEntryWithContext(arg0 context.Context, arg1 *ec2.DeleteNetworkAclEntryInput, arg2 ...request.Option) (*ec2.DeleteNetworkAclEntryOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -4909,14 +4326,12 @@ func (m *MockEC2API) DeleteNetworkAclEntryWithContext(arg0 context.Context, arg1
 
 // DeleteNetworkAclEntryWithContext indicates an expected call of DeleteNetworkAclEntryWithContext
 func (mr *MockEC2APIMockRecorder) DeleteNetworkAclEntryWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteNetworkAclEntryWithContext", reflect.TypeOf((*MockEC2API)(nil).DeleteNetworkAclEntryWithContext), varargs...)
 }
 
 // DeleteNetworkAclRequest mocks base method
 func (m *MockEC2API) DeleteNetworkAclRequest(arg0 *ec2.DeleteNetworkAclInput) (*request.Request, *ec2.DeleteNetworkAclOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteNetworkAclRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DeleteNetworkAclOutput)
@@ -4925,13 +4340,11 @@ func (m *MockEC2API) DeleteNetworkAclRequest(arg0 *ec2.DeleteNetworkAclInput) (*
 
 // DeleteNetworkAclRequest indicates an expected call of DeleteNetworkAclRequest
 func (mr *MockEC2APIMockRecorder) DeleteNetworkAclRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteNetworkAclRequest", reflect.TypeOf((*MockEC2API)(nil).DeleteNetworkAclRequest), arg0)
 }
 
 // DeleteNetworkAclWithContext mocks base method
 func (m *MockEC2API) DeleteNetworkAclWithContext(arg0 context.Context, arg1 *ec2.DeleteNetworkAclInput, arg2 ...request.Option) (*ec2.DeleteNetworkAclOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -4944,14 +4357,12 @@ func (m *MockEC2API) DeleteNetworkAclWithContext(arg0 context.Context, arg1 *ec2
 
 // DeleteNetworkAclWithContext indicates an expected call of DeleteNetworkAclWithContext
 func (mr *MockEC2APIMockRecorder) DeleteNetworkAclWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteNetworkAclWithContext", reflect.TypeOf((*MockEC2API)(nil).DeleteNetworkAclWithContext), varargs...)
 }
 
 // DeleteNetworkInterface mocks base method
 func (m *MockEC2API) DeleteNetworkInterface(arg0 *ec2.DeleteNetworkInterfaceInput) (*ec2.DeleteNetworkInterfaceOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteNetworkInterface", arg0)
 	ret0, _ := ret[0].(*ec2.DeleteNetworkInterfaceOutput)
 	ret1, _ := ret[1].(error)
@@ -4960,13 +4371,11 @@ func (m *MockEC2API) DeleteNetworkInterface(arg0 *ec2.DeleteNetworkInterfaceInpu
 
 // DeleteNetworkInterface indicates an expected call of DeleteNetworkInterface
 func (mr *MockEC2APIMockRecorder) DeleteNetworkInterface(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteNetworkInterface", reflect.TypeOf((*MockEC2API)(nil).DeleteNetworkInterface), arg0)
 }
 
 // DeleteNetworkInterfacePermission mocks base method
 func (m *MockEC2API) DeleteNetworkInterfacePermission(arg0 *ec2.DeleteNetworkInterfacePermissionInput) (*ec2.DeleteNetworkInterfacePermissionOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteNetworkInterfacePermission", arg0)
 	ret0, _ := ret[0].(*ec2.DeleteNetworkInterfacePermissionOutput)
 	ret1, _ := ret[1].(error)
@@ -4975,13 +4384,11 @@ func (m *MockEC2API) DeleteNetworkInterfacePermission(arg0 *ec2.DeleteNetworkInt
 
 // DeleteNetworkInterfacePermission indicates an expected call of DeleteNetworkInterfacePermission
 func (mr *MockEC2APIMockRecorder) DeleteNetworkInterfacePermission(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteNetworkInterfacePermission", reflect.TypeOf((*MockEC2API)(nil).DeleteNetworkInterfacePermission), arg0)
 }
 
 // DeleteNetworkInterfacePermissionRequest mocks base method
 func (m *MockEC2API) DeleteNetworkInterfacePermissionRequest(arg0 *ec2.DeleteNetworkInterfacePermissionInput) (*request.Request, *ec2.DeleteNetworkInterfacePermissionOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteNetworkInterfacePermissionRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DeleteNetworkInterfacePermissionOutput)
@@ -4990,13 +4397,11 @@ func (m *MockEC2API) DeleteNetworkInterfacePermissionRequest(arg0 *ec2.DeleteNet
 
 // DeleteNetworkInterfacePermissionRequest indicates an expected call of DeleteNetworkInterfacePermissionRequest
 func (mr *MockEC2APIMockRecorder) DeleteNetworkInterfacePermissionRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteNetworkInterfacePermissionRequest", reflect.TypeOf((*MockEC2API)(nil).DeleteNetworkInterfacePermissionRequest), arg0)
 }
 
 // DeleteNetworkInterfacePermissionWithContext mocks base method
 func (m *MockEC2API) DeleteNetworkInterfacePermissionWithContext(arg0 context.Context, arg1 *ec2.DeleteNetworkInterfacePermissionInput, arg2 ...request.Option) (*ec2.DeleteNetworkInterfacePermissionOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -5009,14 +4414,12 @@ func (m *MockEC2API) DeleteNetworkInterfacePermissionWithContext(arg0 context.Co
 
 // DeleteNetworkInterfacePermissionWithContext indicates an expected call of DeleteNetworkInterfacePermissionWithContext
 func (mr *MockEC2APIMockRecorder) DeleteNetworkInterfacePermissionWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteNetworkInterfacePermissionWithContext", reflect.TypeOf((*MockEC2API)(nil).DeleteNetworkInterfacePermissionWithContext), varargs...)
 }
 
 // DeleteNetworkInterfaceRequest mocks base method
 func (m *MockEC2API) DeleteNetworkInterfaceRequest(arg0 *ec2.DeleteNetworkInterfaceInput) (*request.Request, *ec2.DeleteNetworkInterfaceOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteNetworkInterfaceRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DeleteNetworkInterfaceOutput)
@@ -5025,13 +4428,11 @@ func (m *MockEC2API) DeleteNetworkInterfaceRequest(arg0 *ec2.DeleteNetworkInterf
 
 // DeleteNetworkInterfaceRequest indicates an expected call of DeleteNetworkInterfaceRequest
 func (mr *MockEC2APIMockRecorder) DeleteNetworkInterfaceRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteNetworkInterfaceRequest", reflect.TypeOf((*MockEC2API)(nil).DeleteNetworkInterfaceRequest), arg0)
 }
 
 // DeleteNetworkInterfaceWithContext mocks base method
 func (m *MockEC2API) DeleteNetworkInterfaceWithContext(arg0 context.Context, arg1 *ec2.DeleteNetworkInterfaceInput, arg2 ...request.Option) (*ec2.DeleteNetworkInterfaceOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -5044,14 +4445,12 @@ func (m *MockEC2API) DeleteNetworkInterfaceWithContext(arg0 context.Context, arg
 
 // DeleteNetworkInterfaceWithContext indicates an expected call of DeleteNetworkInterfaceWithContext
 func (mr *MockEC2APIMockRecorder) DeleteNetworkInterfaceWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteNetworkInterfaceWithContext", reflect.TypeOf((*MockEC2API)(nil).DeleteNetworkInterfaceWithContext), varargs...)
 }
 
 // DeletePlacementGroup mocks base method
 func (m *MockEC2API) DeletePlacementGroup(arg0 *ec2.DeletePlacementGroupInput) (*ec2.DeletePlacementGroupOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeletePlacementGroup", arg0)
 	ret0, _ := ret[0].(*ec2.DeletePlacementGroupOutput)
 	ret1, _ := ret[1].(error)
@@ -5060,13 +4459,11 @@ func (m *MockEC2API) DeletePlacementGroup(arg0 *ec2.DeletePlacementGroupInput) (
 
 // DeletePlacementGroup indicates an expected call of DeletePlacementGroup
 func (mr *MockEC2APIMockRecorder) DeletePlacementGroup(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeletePlacementGroup", reflect.TypeOf((*MockEC2API)(nil).DeletePlacementGroup), arg0)
 }
 
 // DeletePlacementGroupRequest mocks base method
 func (m *MockEC2API) DeletePlacementGroupRequest(arg0 *ec2.DeletePlacementGroupInput) (*request.Request, *ec2.DeletePlacementGroupOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeletePlacementGroupRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DeletePlacementGroupOutput)
@@ -5075,13 +4472,11 @@ func (m *MockEC2API) DeletePlacementGroupRequest(arg0 *ec2.DeletePlacementGroupI
 
 // DeletePlacementGroupRequest indicates an expected call of DeletePlacementGroupRequest
 func (mr *MockEC2APIMockRecorder) DeletePlacementGroupRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeletePlacementGroupRequest", reflect.TypeOf((*MockEC2API)(nil).DeletePlacementGroupRequest), arg0)
 }
 
 // DeletePlacementGroupWithContext mocks base method
 func (m *MockEC2API) DeletePlacementGroupWithContext(arg0 context.Context, arg1 *ec2.DeletePlacementGroupInput, arg2 ...request.Option) (*ec2.DeletePlacementGroupOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -5094,14 +4489,12 @@ func (m *MockEC2API) DeletePlacementGroupWithContext(arg0 context.Context, arg1 
 
 // DeletePlacementGroupWithContext indicates an expected call of DeletePlacementGroupWithContext
 func (mr *MockEC2APIMockRecorder) DeletePlacementGroupWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeletePlacementGroupWithContext", reflect.TypeOf((*MockEC2API)(nil).DeletePlacementGroupWithContext), varargs...)
 }
 
 // DeleteRoute mocks base method
 func (m *MockEC2API) DeleteRoute(arg0 *ec2.DeleteRouteInput) (*ec2.DeleteRouteOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteRoute", arg0)
 	ret0, _ := ret[0].(*ec2.DeleteRouteOutput)
 	ret1, _ := ret[1].(error)
@@ -5110,13 +4503,11 @@ func (m *MockEC2API) DeleteRoute(arg0 *ec2.DeleteRouteInput) (*ec2.DeleteRouteOu
 
 // DeleteRoute indicates an expected call of DeleteRoute
 func (mr *MockEC2APIMockRecorder) DeleteRoute(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteRoute", reflect.TypeOf((*MockEC2API)(nil).DeleteRoute), arg0)
 }
 
 // DeleteRouteRequest mocks base method
 func (m *MockEC2API) DeleteRouteRequest(arg0 *ec2.DeleteRouteInput) (*request.Request, *ec2.DeleteRouteOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteRouteRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DeleteRouteOutput)
@@ -5125,13 +4516,11 @@ func (m *MockEC2API) DeleteRouteRequest(arg0 *ec2.DeleteRouteInput) (*request.Re
 
 // DeleteRouteRequest indicates an expected call of DeleteRouteRequest
 func (mr *MockEC2APIMockRecorder) DeleteRouteRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteRouteRequest", reflect.TypeOf((*MockEC2API)(nil).DeleteRouteRequest), arg0)
 }
 
 // DeleteRouteTable mocks base method
 func (m *MockEC2API) DeleteRouteTable(arg0 *ec2.DeleteRouteTableInput) (*ec2.DeleteRouteTableOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteRouteTable", arg0)
 	ret0, _ := ret[0].(*ec2.DeleteRouteTableOutput)
 	ret1, _ := ret[1].(error)
@@ -5140,13 +4529,11 @@ func (m *MockEC2API) DeleteRouteTable(arg0 *ec2.DeleteRouteTableInput) (*ec2.Del
 
 // DeleteRouteTable indicates an expected call of DeleteRouteTable
 func (mr *MockEC2APIMockRecorder) DeleteRouteTable(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteRouteTable", reflect.TypeOf((*MockEC2API)(nil).DeleteRouteTable), arg0)
 }
 
 // DeleteRouteTableRequest mocks base method
 func (m *MockEC2API) DeleteRouteTableRequest(arg0 *ec2.DeleteRouteTableInput) (*request.Request, *ec2.DeleteRouteTableOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteRouteTableRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DeleteRouteTableOutput)
@@ -5155,13 +4542,11 @@ func (m *MockEC2API) DeleteRouteTableRequest(arg0 *ec2.DeleteRouteTableInput) (*
 
 // DeleteRouteTableRequest indicates an expected call of DeleteRouteTableRequest
 func (mr *MockEC2APIMockRecorder) DeleteRouteTableRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteRouteTableRequest", reflect.TypeOf((*MockEC2API)(nil).DeleteRouteTableRequest), arg0)
 }
 
 // DeleteRouteTableWithContext mocks base method
 func (m *MockEC2API) DeleteRouteTableWithContext(arg0 context.Context, arg1 *ec2.DeleteRouteTableInput, arg2 ...request.Option) (*ec2.DeleteRouteTableOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -5174,14 +4559,12 @@ func (m *MockEC2API) DeleteRouteTableWithContext(arg0 context.Context, arg1 *ec2
 
 // DeleteRouteTableWithContext indicates an expected call of DeleteRouteTableWithContext
 func (mr *MockEC2APIMockRecorder) DeleteRouteTableWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteRouteTableWithContext", reflect.TypeOf((*MockEC2API)(nil).DeleteRouteTableWithContext), varargs...)
 }
 
 // DeleteRouteWithContext mocks base method
 func (m *MockEC2API) DeleteRouteWithContext(arg0 context.Context, arg1 *ec2.DeleteRouteInput, arg2 ...request.Option) (*ec2.DeleteRouteOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -5194,14 +4577,12 @@ func (m *MockEC2API) DeleteRouteWithContext(arg0 context.Context, arg1 *ec2.Dele
 
 // DeleteRouteWithContext indicates an expected call of DeleteRouteWithContext
 func (mr *MockEC2APIMockRecorder) DeleteRouteWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteRouteWithContext", reflect.TypeOf((*MockEC2API)(nil).DeleteRouteWithContext), varargs...)
 }
 
 // DeleteSecurityGroup mocks base method
 func (m *MockEC2API) DeleteSecurityGroup(arg0 *ec2.DeleteSecurityGroupInput) (*ec2.DeleteSecurityGroupOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteSecurityGroup", arg0)
 	ret0, _ := ret[0].(*ec2.DeleteSecurityGroupOutput)
 	ret1, _ := ret[1].(error)
@@ -5210,13 +4591,11 @@ func (m *MockEC2API) DeleteSecurityGroup(arg0 *ec2.DeleteSecurityGroupInput) (*e
 
 // DeleteSecurityGroup indicates an expected call of DeleteSecurityGroup
 func (mr *MockEC2APIMockRecorder) DeleteSecurityGroup(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteSecurityGroup", reflect.TypeOf((*MockEC2API)(nil).DeleteSecurityGroup), arg0)
 }
 
 // DeleteSecurityGroupRequest mocks base method
 func (m *MockEC2API) DeleteSecurityGroupRequest(arg0 *ec2.DeleteSecurityGroupInput) (*request.Request, *ec2.DeleteSecurityGroupOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteSecurityGroupRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DeleteSecurityGroupOutput)
@@ -5225,13 +4604,11 @@ func (m *MockEC2API) DeleteSecurityGroupRequest(arg0 *ec2.DeleteSecurityGroupInp
 
 // DeleteSecurityGroupRequest indicates an expected call of DeleteSecurityGroupRequest
 func (mr *MockEC2APIMockRecorder) DeleteSecurityGroupRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteSecurityGroupRequest", reflect.TypeOf((*MockEC2API)(nil).DeleteSecurityGroupRequest), arg0)
 }
 
 // DeleteSecurityGroupWithContext mocks base method
 func (m *MockEC2API) DeleteSecurityGroupWithContext(arg0 context.Context, arg1 *ec2.DeleteSecurityGroupInput, arg2 ...request.Option) (*ec2.DeleteSecurityGroupOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -5244,14 +4621,12 @@ func (m *MockEC2API) DeleteSecurityGroupWithContext(arg0 context.Context, arg1 *
 
 // DeleteSecurityGroupWithContext indicates an expected call of DeleteSecurityGroupWithContext
 func (mr *MockEC2APIMockRecorder) DeleteSecurityGroupWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteSecurityGroupWithContext", reflect.TypeOf((*MockEC2API)(nil).DeleteSecurityGroupWithContext), varargs...)
 }
 
 // DeleteSnapshot mocks base method
 func (m *MockEC2API) DeleteSnapshot(arg0 *ec2.DeleteSnapshotInput) (*ec2.DeleteSnapshotOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteSnapshot", arg0)
 	ret0, _ := ret[0].(*ec2.DeleteSnapshotOutput)
 	ret1, _ := ret[1].(error)
@@ -5260,13 +4635,11 @@ func (m *MockEC2API) DeleteSnapshot(arg0 *ec2.DeleteSnapshotInput) (*ec2.DeleteS
 
 // DeleteSnapshot indicates an expected call of DeleteSnapshot
 func (mr *MockEC2APIMockRecorder) DeleteSnapshot(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteSnapshot", reflect.TypeOf((*MockEC2API)(nil).DeleteSnapshot), arg0)
 }
 
 // DeleteSnapshotRequest mocks base method
 func (m *MockEC2API) DeleteSnapshotRequest(arg0 *ec2.DeleteSnapshotInput) (*request.Request, *ec2.DeleteSnapshotOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteSnapshotRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DeleteSnapshotOutput)
@@ -5275,13 +4648,11 @@ func (m *MockEC2API) DeleteSnapshotRequest(arg0 *ec2.DeleteSnapshotInput) (*requ
 
 // DeleteSnapshotRequest indicates an expected call of DeleteSnapshotRequest
 func (mr *MockEC2APIMockRecorder) DeleteSnapshotRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteSnapshotRequest", reflect.TypeOf((*MockEC2API)(nil).DeleteSnapshotRequest), arg0)
 }
 
 // DeleteSnapshotWithContext mocks base method
 func (m *MockEC2API) DeleteSnapshotWithContext(arg0 context.Context, arg1 *ec2.DeleteSnapshotInput, arg2 ...request.Option) (*ec2.DeleteSnapshotOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -5294,14 +4665,12 @@ func (m *MockEC2API) DeleteSnapshotWithContext(arg0 context.Context, arg1 *ec2.D
 
 // DeleteSnapshotWithContext indicates an expected call of DeleteSnapshotWithContext
 func (mr *MockEC2APIMockRecorder) DeleteSnapshotWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteSnapshotWithContext", reflect.TypeOf((*MockEC2API)(nil).DeleteSnapshotWithContext), varargs...)
 }
 
 // DeleteSpotDatafeedSubscription mocks base method
 func (m *MockEC2API) DeleteSpotDatafeedSubscription(arg0 *ec2.DeleteSpotDatafeedSubscriptionInput) (*ec2.DeleteSpotDatafeedSubscriptionOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteSpotDatafeedSubscription", arg0)
 	ret0, _ := ret[0].(*ec2.DeleteSpotDatafeedSubscriptionOutput)
 	ret1, _ := ret[1].(error)
@@ -5310,13 +4679,11 @@ func (m *MockEC2API) DeleteSpotDatafeedSubscription(arg0 *ec2.DeleteSpotDatafeed
 
 // DeleteSpotDatafeedSubscription indicates an expected call of DeleteSpotDatafeedSubscription
 func (mr *MockEC2APIMockRecorder) DeleteSpotDatafeedSubscription(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteSpotDatafeedSubscription", reflect.TypeOf((*MockEC2API)(nil).DeleteSpotDatafeedSubscription), arg0)
 }
 
 // DeleteSpotDatafeedSubscriptionRequest mocks base method
 func (m *MockEC2API) DeleteSpotDatafeedSubscriptionRequest(arg0 *ec2.DeleteSpotDatafeedSubscriptionInput) (*request.Request, *ec2.DeleteSpotDatafeedSubscriptionOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteSpotDatafeedSubscriptionRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DeleteSpotDatafeedSubscriptionOutput)
@@ -5325,13 +4692,11 @@ func (m *MockEC2API) DeleteSpotDatafeedSubscriptionRequest(arg0 *ec2.DeleteSpotD
 
 // DeleteSpotDatafeedSubscriptionRequest indicates an expected call of DeleteSpotDatafeedSubscriptionRequest
 func (mr *MockEC2APIMockRecorder) DeleteSpotDatafeedSubscriptionRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteSpotDatafeedSubscriptionRequest", reflect.TypeOf((*MockEC2API)(nil).DeleteSpotDatafeedSubscriptionRequest), arg0)
 }
 
 // DeleteSpotDatafeedSubscriptionWithContext mocks base method
 func (m *MockEC2API) DeleteSpotDatafeedSubscriptionWithContext(arg0 context.Context, arg1 *ec2.DeleteSpotDatafeedSubscriptionInput, arg2 ...request.Option) (*ec2.DeleteSpotDatafeedSubscriptionOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -5344,14 +4709,12 @@ func (m *MockEC2API) DeleteSpotDatafeedSubscriptionWithContext(arg0 context.Cont
 
 // DeleteSpotDatafeedSubscriptionWithContext indicates an expected call of DeleteSpotDatafeedSubscriptionWithContext
 func (mr *MockEC2APIMockRecorder) DeleteSpotDatafeedSubscriptionWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteSpotDatafeedSubscriptionWithContext", reflect.TypeOf((*MockEC2API)(nil).DeleteSpotDatafeedSubscriptionWithContext), varargs...)
 }
 
 // DeleteSubnet mocks base method
 func (m *MockEC2API) DeleteSubnet(arg0 *ec2.DeleteSubnetInput) (*ec2.DeleteSubnetOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteSubnet", arg0)
 	ret0, _ := ret[0].(*ec2.DeleteSubnetOutput)
 	ret1, _ := ret[1].(error)
@@ -5360,13 +4723,11 @@ func (m *MockEC2API) DeleteSubnet(arg0 *ec2.DeleteSubnetInput) (*ec2.DeleteSubne
 
 // DeleteSubnet indicates an expected call of DeleteSubnet
 func (mr *MockEC2APIMockRecorder) DeleteSubnet(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteSubnet", reflect.TypeOf((*MockEC2API)(nil).DeleteSubnet), arg0)
 }
 
 // DeleteSubnetRequest mocks base method
 func (m *MockEC2API) DeleteSubnetRequest(arg0 *ec2.DeleteSubnetInput) (*request.Request, *ec2.DeleteSubnetOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteSubnetRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DeleteSubnetOutput)
@@ -5375,13 +4736,11 @@ func (m *MockEC2API) DeleteSubnetRequest(arg0 *ec2.DeleteSubnetInput) (*request.
 
 // DeleteSubnetRequest indicates an expected call of DeleteSubnetRequest
 func (mr *MockEC2APIMockRecorder) DeleteSubnetRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteSubnetRequest", reflect.TypeOf((*MockEC2API)(nil).DeleteSubnetRequest), arg0)
 }
 
 // DeleteSubnetWithContext mocks base method
 func (m *MockEC2API) DeleteSubnetWithContext(arg0 context.Context, arg1 *ec2.DeleteSubnetInput, arg2 ...request.Option) (*ec2.DeleteSubnetOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -5394,14 +4753,12 @@ func (m *MockEC2API) DeleteSubnetWithContext(arg0 context.Context, arg1 *ec2.Del
 
 // DeleteSubnetWithContext indicates an expected call of DeleteSubnetWithContext
 func (mr *MockEC2APIMockRecorder) DeleteSubnetWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteSubnetWithContext", reflect.TypeOf((*MockEC2API)(nil).DeleteSubnetWithContext), varargs...)
 }
 
 // DeleteTags mocks base method
 func (m *MockEC2API) DeleteTags(arg0 *ec2.DeleteTagsInput) (*ec2.DeleteTagsOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteTags", arg0)
 	ret0, _ := ret[0].(*ec2.DeleteTagsOutput)
 	ret1, _ := ret[1].(error)
@@ -5410,13 +4767,11 @@ func (m *MockEC2API) DeleteTags(arg0 *ec2.DeleteTagsInput) (*ec2.DeleteTagsOutpu
 
 // DeleteTags indicates an expected call of DeleteTags
 func (mr *MockEC2APIMockRecorder) DeleteTags(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteTags", reflect.TypeOf((*MockEC2API)(nil).DeleteTags), arg0)
 }
 
 // DeleteTagsRequest mocks base method
 func (m *MockEC2API) DeleteTagsRequest(arg0 *ec2.DeleteTagsInput) (*request.Request, *ec2.DeleteTagsOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteTagsRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DeleteTagsOutput)
@@ -5425,13 +4780,11 @@ func (m *MockEC2API) DeleteTagsRequest(arg0 *ec2.DeleteTagsInput) (*request.Requ
 
 // DeleteTagsRequest indicates an expected call of DeleteTagsRequest
 func (mr *MockEC2APIMockRecorder) DeleteTagsRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteTagsRequest", reflect.TypeOf((*MockEC2API)(nil).DeleteTagsRequest), arg0)
 }
 
 // DeleteTagsWithContext mocks base method
 func (m *MockEC2API) DeleteTagsWithContext(arg0 context.Context, arg1 *ec2.DeleteTagsInput, arg2 ...request.Option) (*ec2.DeleteTagsOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -5444,14 +4797,12 @@ func (m *MockEC2API) DeleteTagsWithContext(arg0 context.Context, arg1 *ec2.Delet
 
 // DeleteTagsWithContext indicates an expected call of DeleteTagsWithContext
 func (mr *MockEC2APIMockRecorder) DeleteTagsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteTagsWithContext", reflect.TypeOf((*MockEC2API)(nil).DeleteTagsWithContext), varargs...)
 }
 
 // DeleteTransitGateway mocks base method
 func (m *MockEC2API) DeleteTransitGateway(arg0 *ec2.DeleteTransitGatewayInput) (*ec2.DeleteTransitGatewayOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteTransitGateway", arg0)
 	ret0, _ := ret[0].(*ec2.DeleteTransitGatewayOutput)
 	ret1, _ := ret[1].(error)
@@ -5460,13 +4811,11 @@ func (m *MockEC2API) DeleteTransitGateway(arg0 *ec2.DeleteTransitGatewayInput) (
 
 // DeleteTransitGateway indicates an expected call of DeleteTransitGateway
 func (mr *MockEC2APIMockRecorder) DeleteTransitGateway(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteTransitGateway", reflect.TypeOf((*MockEC2API)(nil).DeleteTransitGateway), arg0)
 }
 
 // DeleteTransitGatewayRequest mocks base method
 func (m *MockEC2API) DeleteTransitGatewayRequest(arg0 *ec2.DeleteTransitGatewayInput) (*request.Request, *ec2.DeleteTransitGatewayOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteTransitGatewayRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DeleteTransitGatewayOutput)
@@ -5475,13 +4824,11 @@ func (m *MockEC2API) DeleteTransitGatewayRequest(arg0 *ec2.DeleteTransitGatewayI
 
 // DeleteTransitGatewayRequest indicates an expected call of DeleteTransitGatewayRequest
 func (mr *MockEC2APIMockRecorder) DeleteTransitGatewayRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteTransitGatewayRequest", reflect.TypeOf((*MockEC2API)(nil).DeleteTransitGatewayRequest), arg0)
 }
 
 // DeleteTransitGatewayRoute mocks base method
 func (m *MockEC2API) DeleteTransitGatewayRoute(arg0 *ec2.DeleteTransitGatewayRouteInput) (*ec2.DeleteTransitGatewayRouteOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteTransitGatewayRoute", arg0)
 	ret0, _ := ret[0].(*ec2.DeleteTransitGatewayRouteOutput)
 	ret1, _ := ret[1].(error)
@@ -5490,13 +4837,11 @@ func (m *MockEC2API) DeleteTransitGatewayRoute(arg0 *ec2.DeleteTransitGatewayRou
 
 // DeleteTransitGatewayRoute indicates an expected call of DeleteTransitGatewayRoute
 func (mr *MockEC2APIMockRecorder) DeleteTransitGatewayRoute(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteTransitGatewayRoute", reflect.TypeOf((*MockEC2API)(nil).DeleteTransitGatewayRoute), arg0)
 }
 
 // DeleteTransitGatewayRouteRequest mocks base method
 func (m *MockEC2API) DeleteTransitGatewayRouteRequest(arg0 *ec2.DeleteTransitGatewayRouteInput) (*request.Request, *ec2.DeleteTransitGatewayRouteOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteTransitGatewayRouteRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DeleteTransitGatewayRouteOutput)
@@ -5505,13 +4850,11 @@ func (m *MockEC2API) DeleteTransitGatewayRouteRequest(arg0 *ec2.DeleteTransitGat
 
 // DeleteTransitGatewayRouteRequest indicates an expected call of DeleteTransitGatewayRouteRequest
 func (mr *MockEC2APIMockRecorder) DeleteTransitGatewayRouteRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteTransitGatewayRouteRequest", reflect.TypeOf((*MockEC2API)(nil).DeleteTransitGatewayRouteRequest), arg0)
 }
 
 // DeleteTransitGatewayRouteTable mocks base method
 func (m *MockEC2API) DeleteTransitGatewayRouteTable(arg0 *ec2.DeleteTransitGatewayRouteTableInput) (*ec2.DeleteTransitGatewayRouteTableOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteTransitGatewayRouteTable", arg0)
 	ret0, _ := ret[0].(*ec2.DeleteTransitGatewayRouteTableOutput)
 	ret1, _ := ret[1].(error)
@@ -5520,13 +4863,11 @@ func (m *MockEC2API) DeleteTransitGatewayRouteTable(arg0 *ec2.DeleteTransitGatew
 
 // DeleteTransitGatewayRouteTable indicates an expected call of DeleteTransitGatewayRouteTable
 func (mr *MockEC2APIMockRecorder) DeleteTransitGatewayRouteTable(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteTransitGatewayRouteTable", reflect.TypeOf((*MockEC2API)(nil).DeleteTransitGatewayRouteTable), arg0)
 }
 
 // DeleteTransitGatewayRouteTableRequest mocks base method
 func (m *MockEC2API) DeleteTransitGatewayRouteTableRequest(arg0 *ec2.DeleteTransitGatewayRouteTableInput) (*request.Request, *ec2.DeleteTransitGatewayRouteTableOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteTransitGatewayRouteTableRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DeleteTransitGatewayRouteTableOutput)
@@ -5535,13 +4876,11 @@ func (m *MockEC2API) DeleteTransitGatewayRouteTableRequest(arg0 *ec2.DeleteTrans
 
 // DeleteTransitGatewayRouteTableRequest indicates an expected call of DeleteTransitGatewayRouteTableRequest
 func (mr *MockEC2APIMockRecorder) DeleteTransitGatewayRouteTableRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteTransitGatewayRouteTableRequest", reflect.TypeOf((*MockEC2API)(nil).DeleteTransitGatewayRouteTableRequest), arg0)
 }
 
 // DeleteTransitGatewayRouteTableWithContext mocks base method
 func (m *MockEC2API) DeleteTransitGatewayRouteTableWithContext(arg0 context.Context, arg1 *ec2.DeleteTransitGatewayRouteTableInput, arg2 ...request.Option) (*ec2.DeleteTransitGatewayRouteTableOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -5554,14 +4893,12 @@ func (m *MockEC2API) DeleteTransitGatewayRouteTableWithContext(arg0 context.Cont
 
 // DeleteTransitGatewayRouteTableWithContext indicates an expected call of DeleteTransitGatewayRouteTableWithContext
 func (mr *MockEC2APIMockRecorder) DeleteTransitGatewayRouteTableWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteTransitGatewayRouteTableWithContext", reflect.TypeOf((*MockEC2API)(nil).DeleteTransitGatewayRouteTableWithContext), varargs...)
 }
 
 // DeleteTransitGatewayRouteWithContext mocks base method
 func (m *MockEC2API) DeleteTransitGatewayRouteWithContext(arg0 context.Context, arg1 *ec2.DeleteTransitGatewayRouteInput, arg2 ...request.Option) (*ec2.DeleteTransitGatewayRouteOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -5574,14 +4911,12 @@ func (m *MockEC2API) DeleteTransitGatewayRouteWithContext(arg0 context.Context, 
 
 // DeleteTransitGatewayRouteWithContext indicates an expected call of DeleteTransitGatewayRouteWithContext
 func (mr *MockEC2APIMockRecorder) DeleteTransitGatewayRouteWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteTransitGatewayRouteWithContext", reflect.TypeOf((*MockEC2API)(nil).DeleteTransitGatewayRouteWithContext), varargs...)
 }
 
 // DeleteTransitGatewayVpcAttachment mocks base method
 func (m *MockEC2API) DeleteTransitGatewayVpcAttachment(arg0 *ec2.DeleteTransitGatewayVpcAttachmentInput) (*ec2.DeleteTransitGatewayVpcAttachmentOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteTransitGatewayVpcAttachment", arg0)
 	ret0, _ := ret[0].(*ec2.DeleteTransitGatewayVpcAttachmentOutput)
 	ret1, _ := ret[1].(error)
@@ -5590,13 +4925,11 @@ func (m *MockEC2API) DeleteTransitGatewayVpcAttachment(arg0 *ec2.DeleteTransitGa
 
 // DeleteTransitGatewayVpcAttachment indicates an expected call of DeleteTransitGatewayVpcAttachment
 func (mr *MockEC2APIMockRecorder) DeleteTransitGatewayVpcAttachment(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteTransitGatewayVpcAttachment", reflect.TypeOf((*MockEC2API)(nil).DeleteTransitGatewayVpcAttachment), arg0)
 }
 
 // DeleteTransitGatewayVpcAttachmentRequest mocks base method
 func (m *MockEC2API) DeleteTransitGatewayVpcAttachmentRequest(arg0 *ec2.DeleteTransitGatewayVpcAttachmentInput) (*request.Request, *ec2.DeleteTransitGatewayVpcAttachmentOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteTransitGatewayVpcAttachmentRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DeleteTransitGatewayVpcAttachmentOutput)
@@ -5605,13 +4938,11 @@ func (m *MockEC2API) DeleteTransitGatewayVpcAttachmentRequest(arg0 *ec2.DeleteTr
 
 // DeleteTransitGatewayVpcAttachmentRequest indicates an expected call of DeleteTransitGatewayVpcAttachmentRequest
 func (mr *MockEC2APIMockRecorder) DeleteTransitGatewayVpcAttachmentRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteTransitGatewayVpcAttachmentRequest", reflect.TypeOf((*MockEC2API)(nil).DeleteTransitGatewayVpcAttachmentRequest), arg0)
 }
 
 // DeleteTransitGatewayVpcAttachmentWithContext mocks base method
 func (m *MockEC2API) DeleteTransitGatewayVpcAttachmentWithContext(arg0 context.Context, arg1 *ec2.DeleteTransitGatewayVpcAttachmentInput, arg2 ...request.Option) (*ec2.DeleteTransitGatewayVpcAttachmentOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -5624,14 +4955,12 @@ func (m *MockEC2API) DeleteTransitGatewayVpcAttachmentWithContext(arg0 context.C
 
 // DeleteTransitGatewayVpcAttachmentWithContext indicates an expected call of DeleteTransitGatewayVpcAttachmentWithContext
 func (mr *MockEC2APIMockRecorder) DeleteTransitGatewayVpcAttachmentWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteTransitGatewayVpcAttachmentWithContext", reflect.TypeOf((*MockEC2API)(nil).DeleteTransitGatewayVpcAttachmentWithContext), varargs...)
 }
 
 // DeleteTransitGatewayWithContext mocks base method
 func (m *MockEC2API) DeleteTransitGatewayWithContext(arg0 context.Context, arg1 *ec2.DeleteTransitGatewayInput, arg2 ...request.Option) (*ec2.DeleteTransitGatewayOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -5644,14 +4973,12 @@ func (m *MockEC2API) DeleteTransitGatewayWithContext(arg0 context.Context, arg1 
 
 // DeleteTransitGatewayWithContext indicates an expected call of DeleteTransitGatewayWithContext
 func (mr *MockEC2APIMockRecorder) DeleteTransitGatewayWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteTransitGatewayWithContext", reflect.TypeOf((*MockEC2API)(nil).DeleteTransitGatewayWithContext), varargs...)
 }
 
 // DeleteVolume mocks base method
 func (m *MockEC2API) DeleteVolume(arg0 *ec2.DeleteVolumeInput) (*ec2.DeleteVolumeOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteVolume", arg0)
 	ret0, _ := ret[0].(*ec2.DeleteVolumeOutput)
 	ret1, _ := ret[1].(error)
@@ -5660,13 +4987,11 @@ func (m *MockEC2API) DeleteVolume(arg0 *ec2.DeleteVolumeInput) (*ec2.DeleteVolum
 
 // DeleteVolume indicates an expected call of DeleteVolume
 func (mr *MockEC2APIMockRecorder) DeleteVolume(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteVolume", reflect.TypeOf((*MockEC2API)(nil).DeleteVolume), arg0)
 }
 
 // DeleteVolumeRequest mocks base method
 func (m *MockEC2API) DeleteVolumeRequest(arg0 *ec2.DeleteVolumeInput) (*request.Request, *ec2.DeleteVolumeOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteVolumeRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DeleteVolumeOutput)
@@ -5675,13 +5000,11 @@ func (m *MockEC2API) DeleteVolumeRequest(arg0 *ec2.DeleteVolumeInput) (*request.
 
 // DeleteVolumeRequest indicates an expected call of DeleteVolumeRequest
 func (mr *MockEC2APIMockRecorder) DeleteVolumeRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteVolumeRequest", reflect.TypeOf((*MockEC2API)(nil).DeleteVolumeRequest), arg0)
 }
 
 // DeleteVolumeWithContext mocks base method
 func (m *MockEC2API) DeleteVolumeWithContext(arg0 context.Context, arg1 *ec2.DeleteVolumeInput, arg2 ...request.Option) (*ec2.DeleteVolumeOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -5694,14 +5017,12 @@ func (m *MockEC2API) DeleteVolumeWithContext(arg0 context.Context, arg1 *ec2.Del
 
 // DeleteVolumeWithContext indicates an expected call of DeleteVolumeWithContext
 func (mr *MockEC2APIMockRecorder) DeleteVolumeWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteVolumeWithContext", reflect.TypeOf((*MockEC2API)(nil).DeleteVolumeWithContext), varargs...)
 }
 
 // DeleteVpc mocks base method
 func (m *MockEC2API) DeleteVpc(arg0 *ec2.DeleteVpcInput) (*ec2.DeleteVpcOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteVpc", arg0)
 	ret0, _ := ret[0].(*ec2.DeleteVpcOutput)
 	ret1, _ := ret[1].(error)
@@ -5710,13 +5031,11 @@ func (m *MockEC2API) DeleteVpc(arg0 *ec2.DeleteVpcInput) (*ec2.DeleteVpcOutput, 
 
 // DeleteVpc indicates an expected call of DeleteVpc
 func (mr *MockEC2APIMockRecorder) DeleteVpc(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteVpc", reflect.TypeOf((*MockEC2API)(nil).DeleteVpc), arg0)
 }
 
 // DeleteVpcEndpointConnectionNotifications mocks base method
 func (m *MockEC2API) DeleteVpcEndpointConnectionNotifications(arg0 *ec2.DeleteVpcEndpointConnectionNotificationsInput) (*ec2.DeleteVpcEndpointConnectionNotificationsOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteVpcEndpointConnectionNotifications", arg0)
 	ret0, _ := ret[0].(*ec2.DeleteVpcEndpointConnectionNotificationsOutput)
 	ret1, _ := ret[1].(error)
@@ -5725,13 +5044,11 @@ func (m *MockEC2API) DeleteVpcEndpointConnectionNotifications(arg0 *ec2.DeleteVp
 
 // DeleteVpcEndpointConnectionNotifications indicates an expected call of DeleteVpcEndpointConnectionNotifications
 func (mr *MockEC2APIMockRecorder) DeleteVpcEndpointConnectionNotifications(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteVpcEndpointConnectionNotifications", reflect.TypeOf((*MockEC2API)(nil).DeleteVpcEndpointConnectionNotifications), arg0)
 }
 
 // DeleteVpcEndpointConnectionNotificationsRequest mocks base method
 func (m *MockEC2API) DeleteVpcEndpointConnectionNotificationsRequest(arg0 *ec2.DeleteVpcEndpointConnectionNotificationsInput) (*request.Request, *ec2.DeleteVpcEndpointConnectionNotificationsOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteVpcEndpointConnectionNotificationsRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DeleteVpcEndpointConnectionNotificationsOutput)
@@ -5740,13 +5057,11 @@ func (m *MockEC2API) DeleteVpcEndpointConnectionNotificationsRequest(arg0 *ec2.D
 
 // DeleteVpcEndpointConnectionNotificationsRequest indicates an expected call of DeleteVpcEndpointConnectionNotificationsRequest
 func (mr *MockEC2APIMockRecorder) DeleteVpcEndpointConnectionNotificationsRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteVpcEndpointConnectionNotificationsRequest", reflect.TypeOf((*MockEC2API)(nil).DeleteVpcEndpointConnectionNotificationsRequest), arg0)
 }
 
 // DeleteVpcEndpointConnectionNotificationsWithContext mocks base method
 func (m *MockEC2API) DeleteVpcEndpointConnectionNotificationsWithContext(arg0 context.Context, arg1 *ec2.DeleteVpcEndpointConnectionNotificationsInput, arg2 ...request.Option) (*ec2.DeleteVpcEndpointConnectionNotificationsOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -5759,14 +5074,12 @@ func (m *MockEC2API) DeleteVpcEndpointConnectionNotificationsWithContext(arg0 co
 
 // DeleteVpcEndpointConnectionNotificationsWithContext indicates an expected call of DeleteVpcEndpointConnectionNotificationsWithContext
 func (mr *MockEC2APIMockRecorder) DeleteVpcEndpointConnectionNotificationsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteVpcEndpointConnectionNotificationsWithContext", reflect.TypeOf((*MockEC2API)(nil).DeleteVpcEndpointConnectionNotificationsWithContext), varargs...)
 }
 
 // DeleteVpcEndpointServiceConfigurations mocks base method
 func (m *MockEC2API) DeleteVpcEndpointServiceConfigurations(arg0 *ec2.DeleteVpcEndpointServiceConfigurationsInput) (*ec2.DeleteVpcEndpointServiceConfigurationsOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteVpcEndpointServiceConfigurations", arg0)
 	ret0, _ := ret[0].(*ec2.DeleteVpcEndpointServiceConfigurationsOutput)
 	ret1, _ := ret[1].(error)
@@ -5775,13 +5088,11 @@ func (m *MockEC2API) DeleteVpcEndpointServiceConfigurations(arg0 *ec2.DeleteVpcE
 
 // DeleteVpcEndpointServiceConfigurations indicates an expected call of DeleteVpcEndpointServiceConfigurations
 func (mr *MockEC2APIMockRecorder) DeleteVpcEndpointServiceConfigurations(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteVpcEndpointServiceConfigurations", reflect.TypeOf((*MockEC2API)(nil).DeleteVpcEndpointServiceConfigurations), arg0)
 }
 
 // DeleteVpcEndpointServiceConfigurationsRequest mocks base method
 func (m *MockEC2API) DeleteVpcEndpointServiceConfigurationsRequest(arg0 *ec2.DeleteVpcEndpointServiceConfigurationsInput) (*request.Request, *ec2.DeleteVpcEndpointServiceConfigurationsOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteVpcEndpointServiceConfigurationsRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DeleteVpcEndpointServiceConfigurationsOutput)
@@ -5790,13 +5101,11 @@ func (m *MockEC2API) DeleteVpcEndpointServiceConfigurationsRequest(arg0 *ec2.Del
 
 // DeleteVpcEndpointServiceConfigurationsRequest indicates an expected call of DeleteVpcEndpointServiceConfigurationsRequest
 func (mr *MockEC2APIMockRecorder) DeleteVpcEndpointServiceConfigurationsRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteVpcEndpointServiceConfigurationsRequest", reflect.TypeOf((*MockEC2API)(nil).DeleteVpcEndpointServiceConfigurationsRequest), arg0)
 }
 
 // DeleteVpcEndpointServiceConfigurationsWithContext mocks base method
 func (m *MockEC2API) DeleteVpcEndpointServiceConfigurationsWithContext(arg0 context.Context, arg1 *ec2.DeleteVpcEndpointServiceConfigurationsInput, arg2 ...request.Option) (*ec2.DeleteVpcEndpointServiceConfigurationsOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -5809,14 +5118,12 @@ func (m *MockEC2API) DeleteVpcEndpointServiceConfigurationsWithContext(arg0 cont
 
 // DeleteVpcEndpointServiceConfigurationsWithContext indicates an expected call of DeleteVpcEndpointServiceConfigurationsWithContext
 func (mr *MockEC2APIMockRecorder) DeleteVpcEndpointServiceConfigurationsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteVpcEndpointServiceConfigurationsWithContext", reflect.TypeOf((*MockEC2API)(nil).DeleteVpcEndpointServiceConfigurationsWithContext), varargs...)
 }
 
 // DeleteVpcEndpoints mocks base method
 func (m *MockEC2API) DeleteVpcEndpoints(arg0 *ec2.DeleteVpcEndpointsInput) (*ec2.DeleteVpcEndpointsOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteVpcEndpoints", arg0)
 	ret0, _ := ret[0].(*ec2.DeleteVpcEndpointsOutput)
 	ret1, _ := ret[1].(error)
@@ -5825,13 +5132,11 @@ func (m *MockEC2API) DeleteVpcEndpoints(arg0 *ec2.DeleteVpcEndpointsInput) (*ec2
 
 // DeleteVpcEndpoints indicates an expected call of DeleteVpcEndpoints
 func (mr *MockEC2APIMockRecorder) DeleteVpcEndpoints(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteVpcEndpoints", reflect.TypeOf((*MockEC2API)(nil).DeleteVpcEndpoints), arg0)
 }
 
 // DeleteVpcEndpointsRequest mocks base method
 func (m *MockEC2API) DeleteVpcEndpointsRequest(arg0 *ec2.DeleteVpcEndpointsInput) (*request.Request, *ec2.DeleteVpcEndpointsOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteVpcEndpointsRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DeleteVpcEndpointsOutput)
@@ -5840,13 +5145,11 @@ func (m *MockEC2API) DeleteVpcEndpointsRequest(arg0 *ec2.DeleteVpcEndpointsInput
 
 // DeleteVpcEndpointsRequest indicates an expected call of DeleteVpcEndpointsRequest
 func (mr *MockEC2APIMockRecorder) DeleteVpcEndpointsRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteVpcEndpointsRequest", reflect.TypeOf((*MockEC2API)(nil).DeleteVpcEndpointsRequest), arg0)
 }
 
 // DeleteVpcEndpointsWithContext mocks base method
 func (m *MockEC2API) DeleteVpcEndpointsWithContext(arg0 context.Context, arg1 *ec2.DeleteVpcEndpointsInput, arg2 ...request.Option) (*ec2.DeleteVpcEndpointsOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -5859,14 +5162,12 @@ func (m *MockEC2API) DeleteVpcEndpointsWithContext(arg0 context.Context, arg1 *e
 
 // DeleteVpcEndpointsWithContext indicates an expected call of DeleteVpcEndpointsWithContext
 func (mr *MockEC2APIMockRecorder) DeleteVpcEndpointsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteVpcEndpointsWithContext", reflect.TypeOf((*MockEC2API)(nil).DeleteVpcEndpointsWithContext), varargs...)
 }
 
 // DeleteVpcPeeringConnection mocks base method
 func (m *MockEC2API) DeleteVpcPeeringConnection(arg0 *ec2.DeleteVpcPeeringConnectionInput) (*ec2.DeleteVpcPeeringConnectionOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteVpcPeeringConnection", arg0)
 	ret0, _ := ret[0].(*ec2.DeleteVpcPeeringConnectionOutput)
 	ret1, _ := ret[1].(error)
@@ -5875,13 +5176,11 @@ func (m *MockEC2API) DeleteVpcPeeringConnection(arg0 *ec2.DeleteVpcPeeringConnec
 
 // DeleteVpcPeeringConnection indicates an expected call of DeleteVpcPeeringConnection
 func (mr *MockEC2APIMockRecorder) DeleteVpcPeeringConnection(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteVpcPeeringConnection", reflect.TypeOf((*MockEC2API)(nil).DeleteVpcPeeringConnection), arg0)
 }
 
 // DeleteVpcPeeringConnectionRequest mocks base method
 func (m *MockEC2API) DeleteVpcPeeringConnectionRequest(arg0 *ec2.DeleteVpcPeeringConnectionInput) (*request.Request, *ec2.DeleteVpcPeeringConnectionOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteVpcPeeringConnectionRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DeleteVpcPeeringConnectionOutput)
@@ -5890,13 +5189,11 @@ func (m *MockEC2API) DeleteVpcPeeringConnectionRequest(arg0 *ec2.DeleteVpcPeerin
 
 // DeleteVpcPeeringConnectionRequest indicates an expected call of DeleteVpcPeeringConnectionRequest
 func (mr *MockEC2APIMockRecorder) DeleteVpcPeeringConnectionRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteVpcPeeringConnectionRequest", reflect.TypeOf((*MockEC2API)(nil).DeleteVpcPeeringConnectionRequest), arg0)
 }
 
 // DeleteVpcPeeringConnectionWithContext mocks base method
 func (m *MockEC2API) DeleteVpcPeeringConnectionWithContext(arg0 context.Context, arg1 *ec2.DeleteVpcPeeringConnectionInput, arg2 ...request.Option) (*ec2.DeleteVpcPeeringConnectionOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -5909,14 +5206,12 @@ func (m *MockEC2API) DeleteVpcPeeringConnectionWithContext(arg0 context.Context,
 
 // DeleteVpcPeeringConnectionWithContext indicates an expected call of DeleteVpcPeeringConnectionWithContext
 func (mr *MockEC2APIMockRecorder) DeleteVpcPeeringConnectionWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteVpcPeeringConnectionWithContext", reflect.TypeOf((*MockEC2API)(nil).DeleteVpcPeeringConnectionWithContext), varargs...)
 }
 
 // DeleteVpcRequest mocks base method
 func (m *MockEC2API) DeleteVpcRequest(arg0 *ec2.DeleteVpcInput) (*request.Request, *ec2.DeleteVpcOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteVpcRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DeleteVpcOutput)
@@ -5925,13 +5220,11 @@ func (m *MockEC2API) DeleteVpcRequest(arg0 *ec2.DeleteVpcInput) (*request.Reques
 
 // DeleteVpcRequest indicates an expected call of DeleteVpcRequest
 func (mr *MockEC2APIMockRecorder) DeleteVpcRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteVpcRequest", reflect.TypeOf((*MockEC2API)(nil).DeleteVpcRequest), arg0)
 }
 
 // DeleteVpcWithContext mocks base method
 func (m *MockEC2API) DeleteVpcWithContext(arg0 context.Context, arg1 *ec2.DeleteVpcInput, arg2 ...request.Option) (*ec2.DeleteVpcOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -5944,14 +5237,12 @@ func (m *MockEC2API) DeleteVpcWithContext(arg0 context.Context, arg1 *ec2.Delete
 
 // DeleteVpcWithContext indicates an expected call of DeleteVpcWithContext
 func (mr *MockEC2APIMockRecorder) DeleteVpcWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteVpcWithContext", reflect.TypeOf((*MockEC2API)(nil).DeleteVpcWithContext), varargs...)
 }
 
 // DeleteVpnConnection mocks base method
 func (m *MockEC2API) DeleteVpnConnection(arg0 *ec2.DeleteVpnConnectionInput) (*ec2.DeleteVpnConnectionOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteVpnConnection", arg0)
 	ret0, _ := ret[0].(*ec2.DeleteVpnConnectionOutput)
 	ret1, _ := ret[1].(error)
@@ -5960,13 +5251,11 @@ func (m *MockEC2API) DeleteVpnConnection(arg0 *ec2.DeleteVpnConnectionInput) (*e
 
 // DeleteVpnConnection indicates an expected call of DeleteVpnConnection
 func (mr *MockEC2APIMockRecorder) DeleteVpnConnection(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteVpnConnection", reflect.TypeOf((*MockEC2API)(nil).DeleteVpnConnection), arg0)
 }
 
 // DeleteVpnConnectionRequest mocks base method
 func (m *MockEC2API) DeleteVpnConnectionRequest(arg0 *ec2.DeleteVpnConnectionInput) (*request.Request, *ec2.DeleteVpnConnectionOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteVpnConnectionRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DeleteVpnConnectionOutput)
@@ -5975,13 +5264,11 @@ func (m *MockEC2API) DeleteVpnConnectionRequest(arg0 *ec2.DeleteVpnConnectionInp
 
 // DeleteVpnConnectionRequest indicates an expected call of DeleteVpnConnectionRequest
 func (mr *MockEC2APIMockRecorder) DeleteVpnConnectionRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteVpnConnectionRequest", reflect.TypeOf((*MockEC2API)(nil).DeleteVpnConnectionRequest), arg0)
 }
 
 // DeleteVpnConnectionRoute mocks base method
 func (m *MockEC2API) DeleteVpnConnectionRoute(arg0 *ec2.DeleteVpnConnectionRouteInput) (*ec2.DeleteVpnConnectionRouteOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteVpnConnectionRoute", arg0)
 	ret0, _ := ret[0].(*ec2.DeleteVpnConnectionRouteOutput)
 	ret1, _ := ret[1].(error)
@@ -5990,13 +5277,11 @@ func (m *MockEC2API) DeleteVpnConnectionRoute(arg0 *ec2.DeleteVpnConnectionRoute
 
 // DeleteVpnConnectionRoute indicates an expected call of DeleteVpnConnectionRoute
 func (mr *MockEC2APIMockRecorder) DeleteVpnConnectionRoute(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteVpnConnectionRoute", reflect.TypeOf((*MockEC2API)(nil).DeleteVpnConnectionRoute), arg0)
 }
 
 // DeleteVpnConnectionRouteRequest mocks base method
 func (m *MockEC2API) DeleteVpnConnectionRouteRequest(arg0 *ec2.DeleteVpnConnectionRouteInput) (*request.Request, *ec2.DeleteVpnConnectionRouteOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteVpnConnectionRouteRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DeleteVpnConnectionRouteOutput)
@@ -6005,13 +5290,11 @@ func (m *MockEC2API) DeleteVpnConnectionRouteRequest(arg0 *ec2.DeleteVpnConnecti
 
 // DeleteVpnConnectionRouteRequest indicates an expected call of DeleteVpnConnectionRouteRequest
 func (mr *MockEC2APIMockRecorder) DeleteVpnConnectionRouteRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteVpnConnectionRouteRequest", reflect.TypeOf((*MockEC2API)(nil).DeleteVpnConnectionRouteRequest), arg0)
 }
 
 // DeleteVpnConnectionRouteWithContext mocks base method
 func (m *MockEC2API) DeleteVpnConnectionRouteWithContext(arg0 context.Context, arg1 *ec2.DeleteVpnConnectionRouteInput, arg2 ...request.Option) (*ec2.DeleteVpnConnectionRouteOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -6024,14 +5307,12 @@ func (m *MockEC2API) DeleteVpnConnectionRouteWithContext(arg0 context.Context, a
 
 // DeleteVpnConnectionRouteWithContext indicates an expected call of DeleteVpnConnectionRouteWithContext
 func (mr *MockEC2APIMockRecorder) DeleteVpnConnectionRouteWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteVpnConnectionRouteWithContext", reflect.TypeOf((*MockEC2API)(nil).DeleteVpnConnectionRouteWithContext), varargs...)
 }
 
 // DeleteVpnConnectionWithContext mocks base method
 func (m *MockEC2API) DeleteVpnConnectionWithContext(arg0 context.Context, arg1 *ec2.DeleteVpnConnectionInput, arg2 ...request.Option) (*ec2.DeleteVpnConnectionOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -6044,14 +5325,12 @@ func (m *MockEC2API) DeleteVpnConnectionWithContext(arg0 context.Context, arg1 *
 
 // DeleteVpnConnectionWithContext indicates an expected call of DeleteVpnConnectionWithContext
 func (mr *MockEC2APIMockRecorder) DeleteVpnConnectionWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteVpnConnectionWithContext", reflect.TypeOf((*MockEC2API)(nil).DeleteVpnConnectionWithContext), varargs...)
 }
 
 // DeleteVpnGateway mocks base method
 func (m *MockEC2API) DeleteVpnGateway(arg0 *ec2.DeleteVpnGatewayInput) (*ec2.DeleteVpnGatewayOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteVpnGateway", arg0)
 	ret0, _ := ret[0].(*ec2.DeleteVpnGatewayOutput)
 	ret1, _ := ret[1].(error)
@@ -6060,13 +5339,11 @@ func (m *MockEC2API) DeleteVpnGateway(arg0 *ec2.DeleteVpnGatewayInput) (*ec2.Del
 
 // DeleteVpnGateway indicates an expected call of DeleteVpnGateway
 func (mr *MockEC2APIMockRecorder) DeleteVpnGateway(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteVpnGateway", reflect.TypeOf((*MockEC2API)(nil).DeleteVpnGateway), arg0)
 }
 
 // DeleteVpnGatewayRequest mocks base method
 func (m *MockEC2API) DeleteVpnGatewayRequest(arg0 *ec2.DeleteVpnGatewayInput) (*request.Request, *ec2.DeleteVpnGatewayOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteVpnGatewayRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DeleteVpnGatewayOutput)
@@ -6075,13 +5352,11 @@ func (m *MockEC2API) DeleteVpnGatewayRequest(arg0 *ec2.DeleteVpnGatewayInput) (*
 
 // DeleteVpnGatewayRequest indicates an expected call of DeleteVpnGatewayRequest
 func (mr *MockEC2APIMockRecorder) DeleteVpnGatewayRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteVpnGatewayRequest", reflect.TypeOf((*MockEC2API)(nil).DeleteVpnGatewayRequest), arg0)
 }
 
 // DeleteVpnGatewayWithContext mocks base method
 func (m *MockEC2API) DeleteVpnGatewayWithContext(arg0 context.Context, arg1 *ec2.DeleteVpnGatewayInput, arg2 ...request.Option) (*ec2.DeleteVpnGatewayOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -6094,14 +5369,12 @@ func (m *MockEC2API) DeleteVpnGatewayWithContext(arg0 context.Context, arg1 *ec2
 
 // DeleteVpnGatewayWithContext indicates an expected call of DeleteVpnGatewayWithContext
 func (mr *MockEC2APIMockRecorder) DeleteVpnGatewayWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteVpnGatewayWithContext", reflect.TypeOf((*MockEC2API)(nil).DeleteVpnGatewayWithContext), varargs...)
 }
 
 // DeprovisionByoipCidr mocks base method
 func (m *MockEC2API) DeprovisionByoipCidr(arg0 *ec2.DeprovisionByoipCidrInput) (*ec2.DeprovisionByoipCidrOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeprovisionByoipCidr", arg0)
 	ret0, _ := ret[0].(*ec2.DeprovisionByoipCidrOutput)
 	ret1, _ := ret[1].(error)
@@ -6110,13 +5383,11 @@ func (m *MockEC2API) DeprovisionByoipCidr(arg0 *ec2.DeprovisionByoipCidrInput) (
 
 // DeprovisionByoipCidr indicates an expected call of DeprovisionByoipCidr
 func (mr *MockEC2APIMockRecorder) DeprovisionByoipCidr(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeprovisionByoipCidr", reflect.TypeOf((*MockEC2API)(nil).DeprovisionByoipCidr), arg0)
 }
 
 // DeprovisionByoipCidrRequest mocks base method
 func (m *MockEC2API) DeprovisionByoipCidrRequest(arg0 *ec2.DeprovisionByoipCidrInput) (*request.Request, *ec2.DeprovisionByoipCidrOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeprovisionByoipCidrRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DeprovisionByoipCidrOutput)
@@ -6125,13 +5396,11 @@ func (m *MockEC2API) DeprovisionByoipCidrRequest(arg0 *ec2.DeprovisionByoipCidrI
 
 // DeprovisionByoipCidrRequest indicates an expected call of DeprovisionByoipCidrRequest
 func (mr *MockEC2APIMockRecorder) DeprovisionByoipCidrRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeprovisionByoipCidrRequest", reflect.TypeOf((*MockEC2API)(nil).DeprovisionByoipCidrRequest), arg0)
 }
 
 // DeprovisionByoipCidrWithContext mocks base method
 func (m *MockEC2API) DeprovisionByoipCidrWithContext(arg0 context.Context, arg1 *ec2.DeprovisionByoipCidrInput, arg2 ...request.Option) (*ec2.DeprovisionByoipCidrOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -6144,14 +5413,12 @@ func (m *MockEC2API) DeprovisionByoipCidrWithContext(arg0 context.Context, arg1 
 
 // DeprovisionByoipCidrWithContext indicates an expected call of DeprovisionByoipCidrWithContext
 func (mr *MockEC2APIMockRecorder) DeprovisionByoipCidrWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeprovisionByoipCidrWithContext", reflect.TypeOf((*MockEC2API)(nil).DeprovisionByoipCidrWithContext), varargs...)
 }
 
 // DeregisterImage mocks base method
 func (m *MockEC2API) DeregisterImage(arg0 *ec2.DeregisterImageInput) (*ec2.DeregisterImageOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeregisterImage", arg0)
 	ret0, _ := ret[0].(*ec2.DeregisterImageOutput)
 	ret1, _ := ret[1].(error)
@@ -6160,13 +5427,11 @@ func (m *MockEC2API) DeregisterImage(arg0 *ec2.DeregisterImageInput) (*ec2.Dereg
 
 // DeregisterImage indicates an expected call of DeregisterImage
 func (mr *MockEC2APIMockRecorder) DeregisterImage(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeregisterImage", reflect.TypeOf((*MockEC2API)(nil).DeregisterImage), arg0)
 }
 
 // DeregisterImageRequest mocks base method
 func (m *MockEC2API) DeregisterImageRequest(arg0 *ec2.DeregisterImageInput) (*request.Request, *ec2.DeregisterImageOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeregisterImageRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DeregisterImageOutput)
@@ -6175,13 +5440,11 @@ func (m *MockEC2API) DeregisterImageRequest(arg0 *ec2.DeregisterImageInput) (*re
 
 // DeregisterImageRequest indicates an expected call of DeregisterImageRequest
 func (mr *MockEC2APIMockRecorder) DeregisterImageRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeregisterImageRequest", reflect.TypeOf((*MockEC2API)(nil).DeregisterImageRequest), arg0)
 }
 
 // DeregisterImageWithContext mocks base method
 func (m *MockEC2API) DeregisterImageWithContext(arg0 context.Context, arg1 *ec2.DeregisterImageInput, arg2 ...request.Option) (*ec2.DeregisterImageOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -6194,14 +5457,12 @@ func (m *MockEC2API) DeregisterImageWithContext(arg0 context.Context, arg1 *ec2.
 
 // DeregisterImageWithContext indicates an expected call of DeregisterImageWithContext
 func (mr *MockEC2APIMockRecorder) DeregisterImageWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeregisterImageWithContext", reflect.TypeOf((*MockEC2API)(nil).DeregisterImageWithContext), varargs...)
 }
 
 // DescribeAccountAttributes mocks base method
 func (m *MockEC2API) DescribeAccountAttributes(arg0 *ec2.DescribeAccountAttributesInput) (*ec2.DescribeAccountAttributesOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeAccountAttributes", arg0)
 	ret0, _ := ret[0].(*ec2.DescribeAccountAttributesOutput)
 	ret1, _ := ret[1].(error)
@@ -6210,13 +5471,11 @@ func (m *MockEC2API) DescribeAccountAttributes(arg0 *ec2.DescribeAccountAttribut
 
 // DescribeAccountAttributes indicates an expected call of DescribeAccountAttributes
 func (mr *MockEC2APIMockRecorder) DescribeAccountAttributes(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeAccountAttributes", reflect.TypeOf((*MockEC2API)(nil).DescribeAccountAttributes), arg0)
 }
 
 // DescribeAccountAttributesRequest mocks base method
 func (m *MockEC2API) DescribeAccountAttributesRequest(arg0 *ec2.DescribeAccountAttributesInput) (*request.Request, *ec2.DescribeAccountAttributesOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeAccountAttributesRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DescribeAccountAttributesOutput)
@@ -6225,13 +5484,11 @@ func (m *MockEC2API) DescribeAccountAttributesRequest(arg0 *ec2.DescribeAccountA
 
 // DescribeAccountAttributesRequest indicates an expected call of DescribeAccountAttributesRequest
 func (mr *MockEC2APIMockRecorder) DescribeAccountAttributesRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeAccountAttributesRequest", reflect.TypeOf((*MockEC2API)(nil).DescribeAccountAttributesRequest), arg0)
 }
 
 // DescribeAccountAttributesWithContext mocks base method
 func (m *MockEC2API) DescribeAccountAttributesWithContext(arg0 context.Context, arg1 *ec2.DescribeAccountAttributesInput, arg2 ...request.Option) (*ec2.DescribeAccountAttributesOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -6244,14 +5501,12 @@ func (m *MockEC2API) DescribeAccountAttributesWithContext(arg0 context.Context, 
 
 // DescribeAccountAttributesWithContext indicates an expected call of DescribeAccountAttributesWithContext
 func (mr *MockEC2APIMockRecorder) DescribeAccountAttributesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeAccountAttributesWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeAccountAttributesWithContext), varargs...)
 }
 
 // DescribeAddresses mocks base method
 func (m *MockEC2API) DescribeAddresses(arg0 *ec2.DescribeAddressesInput) (*ec2.DescribeAddressesOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeAddresses", arg0)
 	ret0, _ := ret[0].(*ec2.DescribeAddressesOutput)
 	ret1, _ := ret[1].(error)
@@ -6260,13 +5515,11 @@ func (m *MockEC2API) DescribeAddresses(arg0 *ec2.DescribeAddressesInput) (*ec2.D
 
 // DescribeAddresses indicates an expected call of DescribeAddresses
 func (mr *MockEC2APIMockRecorder) DescribeAddresses(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeAddresses", reflect.TypeOf((*MockEC2API)(nil).DescribeAddresses), arg0)
 }
 
 // DescribeAddressesRequest mocks base method
 func (m *MockEC2API) DescribeAddressesRequest(arg0 *ec2.DescribeAddressesInput) (*request.Request, *ec2.DescribeAddressesOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeAddressesRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DescribeAddressesOutput)
@@ -6275,13 +5528,11 @@ func (m *MockEC2API) DescribeAddressesRequest(arg0 *ec2.DescribeAddressesInput) 
 
 // DescribeAddressesRequest indicates an expected call of DescribeAddressesRequest
 func (mr *MockEC2APIMockRecorder) DescribeAddressesRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeAddressesRequest", reflect.TypeOf((*MockEC2API)(nil).DescribeAddressesRequest), arg0)
 }
 
 // DescribeAddressesWithContext mocks base method
 func (m *MockEC2API) DescribeAddressesWithContext(arg0 context.Context, arg1 *ec2.DescribeAddressesInput, arg2 ...request.Option) (*ec2.DescribeAddressesOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -6294,14 +5545,12 @@ func (m *MockEC2API) DescribeAddressesWithContext(arg0 context.Context, arg1 *ec
 
 // DescribeAddressesWithContext indicates an expected call of DescribeAddressesWithContext
 func (mr *MockEC2APIMockRecorder) DescribeAddressesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeAddressesWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeAddressesWithContext), varargs...)
 }
 
 // DescribeAggregateIdFormat mocks base method
 func (m *MockEC2API) DescribeAggregateIdFormat(arg0 *ec2.DescribeAggregateIdFormatInput) (*ec2.DescribeAggregateIdFormatOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeAggregateIdFormat", arg0)
 	ret0, _ := ret[0].(*ec2.DescribeAggregateIdFormatOutput)
 	ret1, _ := ret[1].(error)
@@ -6310,13 +5559,11 @@ func (m *MockEC2API) DescribeAggregateIdFormat(arg0 *ec2.DescribeAggregateIdForm
 
 // DescribeAggregateIdFormat indicates an expected call of DescribeAggregateIdFormat
 func (mr *MockEC2APIMockRecorder) DescribeAggregateIdFormat(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeAggregateIdFormat", reflect.TypeOf((*MockEC2API)(nil).DescribeAggregateIdFormat), arg0)
 }
 
 // DescribeAggregateIdFormatRequest mocks base method
 func (m *MockEC2API) DescribeAggregateIdFormatRequest(arg0 *ec2.DescribeAggregateIdFormatInput) (*request.Request, *ec2.DescribeAggregateIdFormatOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeAggregateIdFormatRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DescribeAggregateIdFormatOutput)
@@ -6325,13 +5572,11 @@ func (m *MockEC2API) DescribeAggregateIdFormatRequest(arg0 *ec2.DescribeAggregat
 
 // DescribeAggregateIdFormatRequest indicates an expected call of DescribeAggregateIdFormatRequest
 func (mr *MockEC2APIMockRecorder) DescribeAggregateIdFormatRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeAggregateIdFormatRequest", reflect.TypeOf((*MockEC2API)(nil).DescribeAggregateIdFormatRequest), arg0)
 }
 
 // DescribeAggregateIdFormatWithContext mocks base method
 func (m *MockEC2API) DescribeAggregateIdFormatWithContext(arg0 context.Context, arg1 *ec2.DescribeAggregateIdFormatInput, arg2 ...request.Option) (*ec2.DescribeAggregateIdFormatOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -6344,14 +5589,12 @@ func (m *MockEC2API) DescribeAggregateIdFormatWithContext(arg0 context.Context, 
 
 // DescribeAggregateIdFormatWithContext indicates an expected call of DescribeAggregateIdFormatWithContext
 func (mr *MockEC2APIMockRecorder) DescribeAggregateIdFormatWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeAggregateIdFormatWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeAggregateIdFormatWithContext), varargs...)
 }
 
 // DescribeAvailabilityZones mocks base method
 func (m *MockEC2API) DescribeAvailabilityZones(arg0 *ec2.DescribeAvailabilityZonesInput) (*ec2.DescribeAvailabilityZonesOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeAvailabilityZones", arg0)
 	ret0, _ := ret[0].(*ec2.DescribeAvailabilityZonesOutput)
 	ret1, _ := ret[1].(error)
@@ -6360,13 +5603,11 @@ func (m *MockEC2API) DescribeAvailabilityZones(arg0 *ec2.DescribeAvailabilityZon
 
 // DescribeAvailabilityZones indicates an expected call of DescribeAvailabilityZones
 func (mr *MockEC2APIMockRecorder) DescribeAvailabilityZones(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeAvailabilityZones", reflect.TypeOf((*MockEC2API)(nil).DescribeAvailabilityZones), arg0)
 }
 
 // DescribeAvailabilityZonesRequest mocks base method
 func (m *MockEC2API) DescribeAvailabilityZonesRequest(arg0 *ec2.DescribeAvailabilityZonesInput) (*request.Request, *ec2.DescribeAvailabilityZonesOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeAvailabilityZonesRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DescribeAvailabilityZonesOutput)
@@ -6375,13 +5616,11 @@ func (m *MockEC2API) DescribeAvailabilityZonesRequest(arg0 *ec2.DescribeAvailabi
 
 // DescribeAvailabilityZonesRequest indicates an expected call of DescribeAvailabilityZonesRequest
 func (mr *MockEC2APIMockRecorder) DescribeAvailabilityZonesRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeAvailabilityZonesRequest", reflect.TypeOf((*MockEC2API)(nil).DescribeAvailabilityZonesRequest), arg0)
 }
 
 // DescribeAvailabilityZonesWithContext mocks base method
 func (m *MockEC2API) DescribeAvailabilityZonesWithContext(arg0 context.Context, arg1 *ec2.DescribeAvailabilityZonesInput, arg2 ...request.Option) (*ec2.DescribeAvailabilityZonesOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -6394,14 +5633,12 @@ func (m *MockEC2API) DescribeAvailabilityZonesWithContext(arg0 context.Context, 
 
 // DescribeAvailabilityZonesWithContext indicates an expected call of DescribeAvailabilityZonesWithContext
 func (mr *MockEC2APIMockRecorder) DescribeAvailabilityZonesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeAvailabilityZonesWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeAvailabilityZonesWithContext), varargs...)
 }
 
 // DescribeBundleTasks mocks base method
 func (m *MockEC2API) DescribeBundleTasks(arg0 *ec2.DescribeBundleTasksInput) (*ec2.DescribeBundleTasksOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeBundleTasks", arg0)
 	ret0, _ := ret[0].(*ec2.DescribeBundleTasksOutput)
 	ret1, _ := ret[1].(error)
@@ -6410,13 +5647,11 @@ func (m *MockEC2API) DescribeBundleTasks(arg0 *ec2.DescribeBundleTasksInput) (*e
 
 // DescribeBundleTasks indicates an expected call of DescribeBundleTasks
 func (mr *MockEC2APIMockRecorder) DescribeBundleTasks(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeBundleTasks", reflect.TypeOf((*MockEC2API)(nil).DescribeBundleTasks), arg0)
 }
 
 // DescribeBundleTasksRequest mocks base method
 func (m *MockEC2API) DescribeBundleTasksRequest(arg0 *ec2.DescribeBundleTasksInput) (*request.Request, *ec2.DescribeBundleTasksOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeBundleTasksRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DescribeBundleTasksOutput)
@@ -6425,13 +5660,11 @@ func (m *MockEC2API) DescribeBundleTasksRequest(arg0 *ec2.DescribeBundleTasksInp
 
 // DescribeBundleTasksRequest indicates an expected call of DescribeBundleTasksRequest
 func (mr *MockEC2APIMockRecorder) DescribeBundleTasksRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeBundleTasksRequest", reflect.TypeOf((*MockEC2API)(nil).DescribeBundleTasksRequest), arg0)
 }
 
 // DescribeBundleTasksWithContext mocks base method
 func (m *MockEC2API) DescribeBundleTasksWithContext(arg0 context.Context, arg1 *ec2.DescribeBundleTasksInput, arg2 ...request.Option) (*ec2.DescribeBundleTasksOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -6444,14 +5677,12 @@ func (m *MockEC2API) DescribeBundleTasksWithContext(arg0 context.Context, arg1 *
 
 // DescribeBundleTasksWithContext indicates an expected call of DescribeBundleTasksWithContext
 func (mr *MockEC2APIMockRecorder) DescribeBundleTasksWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeBundleTasksWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeBundleTasksWithContext), varargs...)
 }
 
 // DescribeByoipCidrs mocks base method
 func (m *MockEC2API) DescribeByoipCidrs(arg0 *ec2.DescribeByoipCidrsInput) (*ec2.DescribeByoipCidrsOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeByoipCidrs", arg0)
 	ret0, _ := ret[0].(*ec2.DescribeByoipCidrsOutput)
 	ret1, _ := ret[1].(error)
@@ -6460,13 +5691,11 @@ func (m *MockEC2API) DescribeByoipCidrs(arg0 *ec2.DescribeByoipCidrsInput) (*ec2
 
 // DescribeByoipCidrs indicates an expected call of DescribeByoipCidrs
 func (mr *MockEC2APIMockRecorder) DescribeByoipCidrs(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeByoipCidrs", reflect.TypeOf((*MockEC2API)(nil).DescribeByoipCidrs), arg0)
 }
 
 // DescribeByoipCidrsRequest mocks base method
 func (m *MockEC2API) DescribeByoipCidrsRequest(arg0 *ec2.DescribeByoipCidrsInput) (*request.Request, *ec2.DescribeByoipCidrsOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeByoipCidrsRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DescribeByoipCidrsOutput)
@@ -6475,13 +5704,11 @@ func (m *MockEC2API) DescribeByoipCidrsRequest(arg0 *ec2.DescribeByoipCidrsInput
 
 // DescribeByoipCidrsRequest indicates an expected call of DescribeByoipCidrsRequest
 func (mr *MockEC2APIMockRecorder) DescribeByoipCidrsRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeByoipCidrsRequest", reflect.TypeOf((*MockEC2API)(nil).DescribeByoipCidrsRequest), arg0)
 }
 
 // DescribeByoipCidrsWithContext mocks base method
 func (m *MockEC2API) DescribeByoipCidrsWithContext(arg0 context.Context, arg1 *ec2.DescribeByoipCidrsInput, arg2 ...request.Option) (*ec2.DescribeByoipCidrsOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -6494,14 +5721,12 @@ func (m *MockEC2API) DescribeByoipCidrsWithContext(arg0 context.Context, arg1 *e
 
 // DescribeByoipCidrsWithContext indicates an expected call of DescribeByoipCidrsWithContext
 func (mr *MockEC2APIMockRecorder) DescribeByoipCidrsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeByoipCidrsWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeByoipCidrsWithContext), varargs...)
 }
 
 // DescribeCapacityReservations mocks base method
 func (m *MockEC2API) DescribeCapacityReservations(arg0 *ec2.DescribeCapacityReservationsInput) (*ec2.DescribeCapacityReservationsOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeCapacityReservations", arg0)
 	ret0, _ := ret[0].(*ec2.DescribeCapacityReservationsOutput)
 	ret1, _ := ret[1].(error)
@@ -6510,13 +5735,11 @@ func (m *MockEC2API) DescribeCapacityReservations(arg0 *ec2.DescribeCapacityRese
 
 // DescribeCapacityReservations indicates an expected call of DescribeCapacityReservations
 func (mr *MockEC2APIMockRecorder) DescribeCapacityReservations(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeCapacityReservations", reflect.TypeOf((*MockEC2API)(nil).DescribeCapacityReservations), arg0)
 }
 
 // DescribeCapacityReservationsRequest mocks base method
 func (m *MockEC2API) DescribeCapacityReservationsRequest(arg0 *ec2.DescribeCapacityReservationsInput) (*request.Request, *ec2.DescribeCapacityReservationsOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeCapacityReservationsRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DescribeCapacityReservationsOutput)
@@ -6525,13 +5748,11 @@ func (m *MockEC2API) DescribeCapacityReservationsRequest(arg0 *ec2.DescribeCapac
 
 // DescribeCapacityReservationsRequest indicates an expected call of DescribeCapacityReservationsRequest
 func (mr *MockEC2APIMockRecorder) DescribeCapacityReservationsRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeCapacityReservationsRequest", reflect.TypeOf((*MockEC2API)(nil).DescribeCapacityReservationsRequest), arg0)
 }
 
 // DescribeCapacityReservationsWithContext mocks base method
 func (m *MockEC2API) DescribeCapacityReservationsWithContext(arg0 context.Context, arg1 *ec2.DescribeCapacityReservationsInput, arg2 ...request.Option) (*ec2.DescribeCapacityReservationsOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -6544,14 +5765,12 @@ func (m *MockEC2API) DescribeCapacityReservationsWithContext(arg0 context.Contex
 
 // DescribeCapacityReservationsWithContext indicates an expected call of DescribeCapacityReservationsWithContext
 func (mr *MockEC2APIMockRecorder) DescribeCapacityReservationsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeCapacityReservationsWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeCapacityReservationsWithContext), varargs...)
 }
 
 // DescribeClassicLinkInstances mocks base method
 func (m *MockEC2API) DescribeClassicLinkInstances(arg0 *ec2.DescribeClassicLinkInstancesInput) (*ec2.DescribeClassicLinkInstancesOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeClassicLinkInstances", arg0)
 	ret0, _ := ret[0].(*ec2.DescribeClassicLinkInstancesOutput)
 	ret1, _ := ret[1].(error)
@@ -6560,13 +5779,11 @@ func (m *MockEC2API) DescribeClassicLinkInstances(arg0 *ec2.DescribeClassicLinkI
 
 // DescribeClassicLinkInstances indicates an expected call of DescribeClassicLinkInstances
 func (mr *MockEC2APIMockRecorder) DescribeClassicLinkInstances(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeClassicLinkInstances", reflect.TypeOf((*MockEC2API)(nil).DescribeClassicLinkInstances), arg0)
 }
 
 // DescribeClassicLinkInstancesRequest mocks base method
 func (m *MockEC2API) DescribeClassicLinkInstancesRequest(arg0 *ec2.DescribeClassicLinkInstancesInput) (*request.Request, *ec2.DescribeClassicLinkInstancesOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeClassicLinkInstancesRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DescribeClassicLinkInstancesOutput)
@@ -6575,13 +5792,11 @@ func (m *MockEC2API) DescribeClassicLinkInstancesRequest(arg0 *ec2.DescribeClass
 
 // DescribeClassicLinkInstancesRequest indicates an expected call of DescribeClassicLinkInstancesRequest
 func (mr *MockEC2APIMockRecorder) DescribeClassicLinkInstancesRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeClassicLinkInstancesRequest", reflect.TypeOf((*MockEC2API)(nil).DescribeClassicLinkInstancesRequest), arg0)
 }
 
 // DescribeClassicLinkInstancesWithContext mocks base method
 func (m *MockEC2API) DescribeClassicLinkInstancesWithContext(arg0 context.Context, arg1 *ec2.DescribeClassicLinkInstancesInput, arg2 ...request.Option) (*ec2.DescribeClassicLinkInstancesOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -6594,14 +5809,12 @@ func (m *MockEC2API) DescribeClassicLinkInstancesWithContext(arg0 context.Contex
 
 // DescribeClassicLinkInstancesWithContext indicates an expected call of DescribeClassicLinkInstancesWithContext
 func (mr *MockEC2APIMockRecorder) DescribeClassicLinkInstancesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeClassicLinkInstancesWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeClassicLinkInstancesWithContext), varargs...)
 }
 
 // DescribeClientVpnAuthorizationRules mocks base method
 func (m *MockEC2API) DescribeClientVpnAuthorizationRules(arg0 *ec2.DescribeClientVpnAuthorizationRulesInput) (*ec2.DescribeClientVpnAuthorizationRulesOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeClientVpnAuthorizationRules", arg0)
 	ret0, _ := ret[0].(*ec2.DescribeClientVpnAuthorizationRulesOutput)
 	ret1, _ := ret[1].(error)
@@ -6610,13 +5823,11 @@ func (m *MockEC2API) DescribeClientVpnAuthorizationRules(arg0 *ec2.DescribeClien
 
 // DescribeClientVpnAuthorizationRules indicates an expected call of DescribeClientVpnAuthorizationRules
 func (mr *MockEC2APIMockRecorder) DescribeClientVpnAuthorizationRules(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeClientVpnAuthorizationRules", reflect.TypeOf((*MockEC2API)(nil).DescribeClientVpnAuthorizationRules), arg0)
 }
 
 // DescribeClientVpnAuthorizationRulesRequest mocks base method
 func (m *MockEC2API) DescribeClientVpnAuthorizationRulesRequest(arg0 *ec2.DescribeClientVpnAuthorizationRulesInput) (*request.Request, *ec2.DescribeClientVpnAuthorizationRulesOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeClientVpnAuthorizationRulesRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DescribeClientVpnAuthorizationRulesOutput)
@@ -6625,13 +5836,11 @@ func (m *MockEC2API) DescribeClientVpnAuthorizationRulesRequest(arg0 *ec2.Descri
 
 // DescribeClientVpnAuthorizationRulesRequest indicates an expected call of DescribeClientVpnAuthorizationRulesRequest
 func (mr *MockEC2APIMockRecorder) DescribeClientVpnAuthorizationRulesRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeClientVpnAuthorizationRulesRequest", reflect.TypeOf((*MockEC2API)(nil).DescribeClientVpnAuthorizationRulesRequest), arg0)
 }
 
 // DescribeClientVpnAuthorizationRulesWithContext mocks base method
 func (m *MockEC2API) DescribeClientVpnAuthorizationRulesWithContext(arg0 context.Context, arg1 *ec2.DescribeClientVpnAuthorizationRulesInput, arg2 ...request.Option) (*ec2.DescribeClientVpnAuthorizationRulesOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -6644,14 +5853,12 @@ func (m *MockEC2API) DescribeClientVpnAuthorizationRulesWithContext(arg0 context
 
 // DescribeClientVpnAuthorizationRulesWithContext indicates an expected call of DescribeClientVpnAuthorizationRulesWithContext
 func (mr *MockEC2APIMockRecorder) DescribeClientVpnAuthorizationRulesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeClientVpnAuthorizationRulesWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeClientVpnAuthorizationRulesWithContext), varargs...)
 }
 
 // DescribeClientVpnConnections mocks base method
 func (m *MockEC2API) DescribeClientVpnConnections(arg0 *ec2.DescribeClientVpnConnectionsInput) (*ec2.DescribeClientVpnConnectionsOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeClientVpnConnections", arg0)
 	ret0, _ := ret[0].(*ec2.DescribeClientVpnConnectionsOutput)
 	ret1, _ := ret[1].(error)
@@ -6660,13 +5867,11 @@ func (m *MockEC2API) DescribeClientVpnConnections(arg0 *ec2.DescribeClientVpnCon
 
 // DescribeClientVpnConnections indicates an expected call of DescribeClientVpnConnections
 func (mr *MockEC2APIMockRecorder) DescribeClientVpnConnections(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeClientVpnConnections", reflect.TypeOf((*MockEC2API)(nil).DescribeClientVpnConnections), arg0)
 }
 
 // DescribeClientVpnConnectionsRequest mocks base method
 func (m *MockEC2API) DescribeClientVpnConnectionsRequest(arg0 *ec2.DescribeClientVpnConnectionsInput) (*request.Request, *ec2.DescribeClientVpnConnectionsOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeClientVpnConnectionsRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DescribeClientVpnConnectionsOutput)
@@ -6675,13 +5880,11 @@ func (m *MockEC2API) DescribeClientVpnConnectionsRequest(arg0 *ec2.DescribeClien
 
 // DescribeClientVpnConnectionsRequest indicates an expected call of DescribeClientVpnConnectionsRequest
 func (mr *MockEC2APIMockRecorder) DescribeClientVpnConnectionsRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeClientVpnConnectionsRequest", reflect.TypeOf((*MockEC2API)(nil).DescribeClientVpnConnectionsRequest), arg0)
 }
 
 // DescribeClientVpnConnectionsWithContext mocks base method
 func (m *MockEC2API) DescribeClientVpnConnectionsWithContext(arg0 context.Context, arg1 *ec2.DescribeClientVpnConnectionsInput, arg2 ...request.Option) (*ec2.DescribeClientVpnConnectionsOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -6694,14 +5897,12 @@ func (m *MockEC2API) DescribeClientVpnConnectionsWithContext(arg0 context.Contex
 
 // DescribeClientVpnConnectionsWithContext indicates an expected call of DescribeClientVpnConnectionsWithContext
 func (mr *MockEC2APIMockRecorder) DescribeClientVpnConnectionsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeClientVpnConnectionsWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeClientVpnConnectionsWithContext), varargs...)
 }
 
 // DescribeClientVpnEndpoints mocks base method
 func (m *MockEC2API) DescribeClientVpnEndpoints(arg0 *ec2.DescribeClientVpnEndpointsInput) (*ec2.DescribeClientVpnEndpointsOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeClientVpnEndpoints", arg0)
 	ret0, _ := ret[0].(*ec2.DescribeClientVpnEndpointsOutput)
 	ret1, _ := ret[1].(error)
@@ -6710,13 +5911,11 @@ func (m *MockEC2API) DescribeClientVpnEndpoints(arg0 *ec2.DescribeClientVpnEndpo
 
 // DescribeClientVpnEndpoints indicates an expected call of DescribeClientVpnEndpoints
 func (mr *MockEC2APIMockRecorder) DescribeClientVpnEndpoints(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeClientVpnEndpoints", reflect.TypeOf((*MockEC2API)(nil).DescribeClientVpnEndpoints), arg0)
 }
 
 // DescribeClientVpnEndpointsRequest mocks base method
 func (m *MockEC2API) DescribeClientVpnEndpointsRequest(arg0 *ec2.DescribeClientVpnEndpointsInput) (*request.Request, *ec2.DescribeClientVpnEndpointsOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeClientVpnEndpointsRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DescribeClientVpnEndpointsOutput)
@@ -6725,13 +5924,11 @@ func (m *MockEC2API) DescribeClientVpnEndpointsRequest(arg0 *ec2.DescribeClientV
 
 // DescribeClientVpnEndpointsRequest indicates an expected call of DescribeClientVpnEndpointsRequest
 func (mr *MockEC2APIMockRecorder) DescribeClientVpnEndpointsRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeClientVpnEndpointsRequest", reflect.TypeOf((*MockEC2API)(nil).DescribeClientVpnEndpointsRequest), arg0)
 }
 
 // DescribeClientVpnEndpointsWithContext mocks base method
 func (m *MockEC2API) DescribeClientVpnEndpointsWithContext(arg0 context.Context, arg1 *ec2.DescribeClientVpnEndpointsInput, arg2 ...request.Option) (*ec2.DescribeClientVpnEndpointsOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -6744,14 +5941,12 @@ func (m *MockEC2API) DescribeClientVpnEndpointsWithContext(arg0 context.Context,
 
 // DescribeClientVpnEndpointsWithContext indicates an expected call of DescribeClientVpnEndpointsWithContext
 func (mr *MockEC2APIMockRecorder) DescribeClientVpnEndpointsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeClientVpnEndpointsWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeClientVpnEndpointsWithContext), varargs...)
 }
 
 // DescribeClientVpnRoutes mocks base method
 func (m *MockEC2API) DescribeClientVpnRoutes(arg0 *ec2.DescribeClientVpnRoutesInput) (*ec2.DescribeClientVpnRoutesOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeClientVpnRoutes", arg0)
 	ret0, _ := ret[0].(*ec2.DescribeClientVpnRoutesOutput)
 	ret1, _ := ret[1].(error)
@@ -6760,13 +5955,11 @@ func (m *MockEC2API) DescribeClientVpnRoutes(arg0 *ec2.DescribeClientVpnRoutesIn
 
 // DescribeClientVpnRoutes indicates an expected call of DescribeClientVpnRoutes
 func (mr *MockEC2APIMockRecorder) DescribeClientVpnRoutes(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeClientVpnRoutes", reflect.TypeOf((*MockEC2API)(nil).DescribeClientVpnRoutes), arg0)
 }
 
 // DescribeClientVpnRoutesRequest mocks base method
 func (m *MockEC2API) DescribeClientVpnRoutesRequest(arg0 *ec2.DescribeClientVpnRoutesInput) (*request.Request, *ec2.DescribeClientVpnRoutesOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeClientVpnRoutesRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DescribeClientVpnRoutesOutput)
@@ -6775,13 +5968,11 @@ func (m *MockEC2API) DescribeClientVpnRoutesRequest(arg0 *ec2.DescribeClientVpnR
 
 // DescribeClientVpnRoutesRequest indicates an expected call of DescribeClientVpnRoutesRequest
 func (mr *MockEC2APIMockRecorder) DescribeClientVpnRoutesRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeClientVpnRoutesRequest", reflect.TypeOf((*MockEC2API)(nil).DescribeClientVpnRoutesRequest), arg0)
 }
 
 // DescribeClientVpnRoutesWithContext mocks base method
 func (m *MockEC2API) DescribeClientVpnRoutesWithContext(arg0 context.Context, arg1 *ec2.DescribeClientVpnRoutesInput, arg2 ...request.Option) (*ec2.DescribeClientVpnRoutesOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -6794,14 +5985,12 @@ func (m *MockEC2API) DescribeClientVpnRoutesWithContext(arg0 context.Context, ar
 
 // DescribeClientVpnRoutesWithContext indicates an expected call of DescribeClientVpnRoutesWithContext
 func (mr *MockEC2APIMockRecorder) DescribeClientVpnRoutesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeClientVpnRoutesWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeClientVpnRoutesWithContext), varargs...)
 }
 
 // DescribeClientVpnTargetNetworks mocks base method
 func (m *MockEC2API) DescribeClientVpnTargetNetworks(arg0 *ec2.DescribeClientVpnTargetNetworksInput) (*ec2.DescribeClientVpnTargetNetworksOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeClientVpnTargetNetworks", arg0)
 	ret0, _ := ret[0].(*ec2.DescribeClientVpnTargetNetworksOutput)
 	ret1, _ := ret[1].(error)
@@ -6810,13 +5999,11 @@ func (m *MockEC2API) DescribeClientVpnTargetNetworks(arg0 *ec2.DescribeClientVpn
 
 // DescribeClientVpnTargetNetworks indicates an expected call of DescribeClientVpnTargetNetworks
 func (mr *MockEC2APIMockRecorder) DescribeClientVpnTargetNetworks(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeClientVpnTargetNetworks", reflect.TypeOf((*MockEC2API)(nil).DescribeClientVpnTargetNetworks), arg0)
 }
 
 // DescribeClientVpnTargetNetworksRequest mocks base method
 func (m *MockEC2API) DescribeClientVpnTargetNetworksRequest(arg0 *ec2.DescribeClientVpnTargetNetworksInput) (*request.Request, *ec2.DescribeClientVpnTargetNetworksOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeClientVpnTargetNetworksRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DescribeClientVpnTargetNetworksOutput)
@@ -6825,13 +6012,11 @@ func (m *MockEC2API) DescribeClientVpnTargetNetworksRequest(arg0 *ec2.DescribeCl
 
 // DescribeClientVpnTargetNetworksRequest indicates an expected call of DescribeClientVpnTargetNetworksRequest
 func (mr *MockEC2APIMockRecorder) DescribeClientVpnTargetNetworksRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeClientVpnTargetNetworksRequest", reflect.TypeOf((*MockEC2API)(nil).DescribeClientVpnTargetNetworksRequest), arg0)
 }
 
 // DescribeClientVpnTargetNetworksWithContext mocks base method
 func (m *MockEC2API) DescribeClientVpnTargetNetworksWithContext(arg0 context.Context, arg1 *ec2.DescribeClientVpnTargetNetworksInput, arg2 ...request.Option) (*ec2.DescribeClientVpnTargetNetworksOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -6844,14 +6029,12 @@ func (m *MockEC2API) DescribeClientVpnTargetNetworksWithContext(arg0 context.Con
 
 // DescribeClientVpnTargetNetworksWithContext indicates an expected call of DescribeClientVpnTargetNetworksWithContext
 func (mr *MockEC2APIMockRecorder) DescribeClientVpnTargetNetworksWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeClientVpnTargetNetworksWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeClientVpnTargetNetworksWithContext), varargs...)
 }
 
 // DescribeConversionTasks mocks base method
 func (m *MockEC2API) DescribeConversionTasks(arg0 *ec2.DescribeConversionTasksInput) (*ec2.DescribeConversionTasksOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeConversionTasks", arg0)
 	ret0, _ := ret[0].(*ec2.DescribeConversionTasksOutput)
 	ret1, _ := ret[1].(error)
@@ -6860,13 +6043,11 @@ func (m *MockEC2API) DescribeConversionTasks(arg0 *ec2.DescribeConversionTasksIn
 
 // DescribeConversionTasks indicates an expected call of DescribeConversionTasks
 func (mr *MockEC2APIMockRecorder) DescribeConversionTasks(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeConversionTasks", reflect.TypeOf((*MockEC2API)(nil).DescribeConversionTasks), arg0)
 }
 
 // DescribeConversionTasksRequest mocks base method
 func (m *MockEC2API) DescribeConversionTasksRequest(arg0 *ec2.DescribeConversionTasksInput) (*request.Request, *ec2.DescribeConversionTasksOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeConversionTasksRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DescribeConversionTasksOutput)
@@ -6875,13 +6056,11 @@ func (m *MockEC2API) DescribeConversionTasksRequest(arg0 *ec2.DescribeConversion
 
 // DescribeConversionTasksRequest indicates an expected call of DescribeConversionTasksRequest
 func (mr *MockEC2APIMockRecorder) DescribeConversionTasksRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeConversionTasksRequest", reflect.TypeOf((*MockEC2API)(nil).DescribeConversionTasksRequest), arg0)
 }
 
 // DescribeConversionTasksWithContext mocks base method
 func (m *MockEC2API) DescribeConversionTasksWithContext(arg0 context.Context, arg1 *ec2.DescribeConversionTasksInput, arg2 ...request.Option) (*ec2.DescribeConversionTasksOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -6894,14 +6073,12 @@ func (m *MockEC2API) DescribeConversionTasksWithContext(arg0 context.Context, ar
 
 // DescribeConversionTasksWithContext indicates an expected call of DescribeConversionTasksWithContext
 func (mr *MockEC2APIMockRecorder) DescribeConversionTasksWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeConversionTasksWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeConversionTasksWithContext), varargs...)
 }
 
 // DescribeCustomerGateways mocks base method
 func (m *MockEC2API) DescribeCustomerGateways(arg0 *ec2.DescribeCustomerGatewaysInput) (*ec2.DescribeCustomerGatewaysOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeCustomerGateways", arg0)
 	ret0, _ := ret[0].(*ec2.DescribeCustomerGatewaysOutput)
 	ret1, _ := ret[1].(error)
@@ -6910,13 +6087,11 @@ func (m *MockEC2API) DescribeCustomerGateways(arg0 *ec2.DescribeCustomerGateways
 
 // DescribeCustomerGateways indicates an expected call of DescribeCustomerGateways
 func (mr *MockEC2APIMockRecorder) DescribeCustomerGateways(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeCustomerGateways", reflect.TypeOf((*MockEC2API)(nil).DescribeCustomerGateways), arg0)
 }
 
 // DescribeCustomerGatewaysRequest mocks base method
 func (m *MockEC2API) DescribeCustomerGatewaysRequest(arg0 *ec2.DescribeCustomerGatewaysInput) (*request.Request, *ec2.DescribeCustomerGatewaysOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeCustomerGatewaysRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DescribeCustomerGatewaysOutput)
@@ -6925,13 +6100,11 @@ func (m *MockEC2API) DescribeCustomerGatewaysRequest(arg0 *ec2.DescribeCustomerG
 
 // DescribeCustomerGatewaysRequest indicates an expected call of DescribeCustomerGatewaysRequest
 func (mr *MockEC2APIMockRecorder) DescribeCustomerGatewaysRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeCustomerGatewaysRequest", reflect.TypeOf((*MockEC2API)(nil).DescribeCustomerGatewaysRequest), arg0)
 }
 
 // DescribeCustomerGatewaysWithContext mocks base method
 func (m *MockEC2API) DescribeCustomerGatewaysWithContext(arg0 context.Context, arg1 *ec2.DescribeCustomerGatewaysInput, arg2 ...request.Option) (*ec2.DescribeCustomerGatewaysOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -6944,14 +6117,12 @@ func (m *MockEC2API) DescribeCustomerGatewaysWithContext(arg0 context.Context, a
 
 // DescribeCustomerGatewaysWithContext indicates an expected call of DescribeCustomerGatewaysWithContext
 func (mr *MockEC2APIMockRecorder) DescribeCustomerGatewaysWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeCustomerGatewaysWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeCustomerGatewaysWithContext), varargs...)
 }
 
 // DescribeDhcpOptions mocks base method
 func (m *MockEC2API) DescribeDhcpOptions(arg0 *ec2.DescribeDhcpOptionsInput) (*ec2.DescribeDhcpOptionsOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeDhcpOptions", arg0)
 	ret0, _ := ret[0].(*ec2.DescribeDhcpOptionsOutput)
 	ret1, _ := ret[1].(error)
@@ -6960,13 +6131,11 @@ func (m *MockEC2API) DescribeDhcpOptions(arg0 *ec2.DescribeDhcpOptionsInput) (*e
 
 // DescribeDhcpOptions indicates an expected call of DescribeDhcpOptions
 func (mr *MockEC2APIMockRecorder) DescribeDhcpOptions(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeDhcpOptions", reflect.TypeOf((*MockEC2API)(nil).DescribeDhcpOptions), arg0)
 }
 
 // DescribeDhcpOptionsRequest mocks base method
 func (m *MockEC2API) DescribeDhcpOptionsRequest(arg0 *ec2.DescribeDhcpOptionsInput) (*request.Request, *ec2.DescribeDhcpOptionsOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeDhcpOptionsRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DescribeDhcpOptionsOutput)
@@ -6975,13 +6144,11 @@ func (m *MockEC2API) DescribeDhcpOptionsRequest(arg0 *ec2.DescribeDhcpOptionsInp
 
 // DescribeDhcpOptionsRequest indicates an expected call of DescribeDhcpOptionsRequest
 func (mr *MockEC2APIMockRecorder) DescribeDhcpOptionsRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeDhcpOptionsRequest", reflect.TypeOf((*MockEC2API)(nil).DescribeDhcpOptionsRequest), arg0)
 }
 
 // DescribeDhcpOptionsWithContext mocks base method
 func (m *MockEC2API) DescribeDhcpOptionsWithContext(arg0 context.Context, arg1 *ec2.DescribeDhcpOptionsInput, arg2 ...request.Option) (*ec2.DescribeDhcpOptionsOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -6994,14 +6161,12 @@ func (m *MockEC2API) DescribeDhcpOptionsWithContext(arg0 context.Context, arg1 *
 
 // DescribeDhcpOptionsWithContext indicates an expected call of DescribeDhcpOptionsWithContext
 func (mr *MockEC2APIMockRecorder) DescribeDhcpOptionsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeDhcpOptionsWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeDhcpOptionsWithContext), varargs...)
 }
 
 // DescribeEgressOnlyInternetGateways mocks base method
 func (m *MockEC2API) DescribeEgressOnlyInternetGateways(arg0 *ec2.DescribeEgressOnlyInternetGatewaysInput) (*ec2.DescribeEgressOnlyInternetGatewaysOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeEgressOnlyInternetGateways", arg0)
 	ret0, _ := ret[0].(*ec2.DescribeEgressOnlyInternetGatewaysOutput)
 	ret1, _ := ret[1].(error)
@@ -7010,13 +6175,11 @@ func (m *MockEC2API) DescribeEgressOnlyInternetGateways(arg0 *ec2.DescribeEgress
 
 // DescribeEgressOnlyInternetGateways indicates an expected call of DescribeEgressOnlyInternetGateways
 func (mr *MockEC2APIMockRecorder) DescribeEgressOnlyInternetGateways(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeEgressOnlyInternetGateways", reflect.TypeOf((*MockEC2API)(nil).DescribeEgressOnlyInternetGateways), arg0)
 }
 
 // DescribeEgressOnlyInternetGatewaysRequest mocks base method
 func (m *MockEC2API) DescribeEgressOnlyInternetGatewaysRequest(arg0 *ec2.DescribeEgressOnlyInternetGatewaysInput) (*request.Request, *ec2.DescribeEgressOnlyInternetGatewaysOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeEgressOnlyInternetGatewaysRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DescribeEgressOnlyInternetGatewaysOutput)
@@ -7025,13 +6188,11 @@ func (m *MockEC2API) DescribeEgressOnlyInternetGatewaysRequest(arg0 *ec2.Describ
 
 // DescribeEgressOnlyInternetGatewaysRequest indicates an expected call of DescribeEgressOnlyInternetGatewaysRequest
 func (mr *MockEC2APIMockRecorder) DescribeEgressOnlyInternetGatewaysRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeEgressOnlyInternetGatewaysRequest", reflect.TypeOf((*MockEC2API)(nil).DescribeEgressOnlyInternetGatewaysRequest), arg0)
 }
 
 // DescribeEgressOnlyInternetGatewaysWithContext mocks base method
 func (m *MockEC2API) DescribeEgressOnlyInternetGatewaysWithContext(arg0 context.Context, arg1 *ec2.DescribeEgressOnlyInternetGatewaysInput, arg2 ...request.Option) (*ec2.DescribeEgressOnlyInternetGatewaysOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -7044,14 +6205,12 @@ func (m *MockEC2API) DescribeEgressOnlyInternetGatewaysWithContext(arg0 context.
 
 // DescribeEgressOnlyInternetGatewaysWithContext indicates an expected call of DescribeEgressOnlyInternetGatewaysWithContext
 func (mr *MockEC2APIMockRecorder) DescribeEgressOnlyInternetGatewaysWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeEgressOnlyInternetGatewaysWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeEgressOnlyInternetGatewaysWithContext), varargs...)
 }
 
 // DescribeElasticGpus mocks base method
 func (m *MockEC2API) DescribeElasticGpus(arg0 *ec2.DescribeElasticGpusInput) (*ec2.DescribeElasticGpusOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeElasticGpus", arg0)
 	ret0, _ := ret[0].(*ec2.DescribeElasticGpusOutput)
 	ret1, _ := ret[1].(error)
@@ -7060,13 +6219,11 @@ func (m *MockEC2API) DescribeElasticGpus(arg0 *ec2.DescribeElasticGpusInput) (*e
 
 // DescribeElasticGpus indicates an expected call of DescribeElasticGpus
 func (mr *MockEC2APIMockRecorder) DescribeElasticGpus(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeElasticGpus", reflect.TypeOf((*MockEC2API)(nil).DescribeElasticGpus), arg0)
 }
 
 // DescribeElasticGpusRequest mocks base method
 func (m *MockEC2API) DescribeElasticGpusRequest(arg0 *ec2.DescribeElasticGpusInput) (*request.Request, *ec2.DescribeElasticGpusOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeElasticGpusRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DescribeElasticGpusOutput)
@@ -7075,13 +6232,11 @@ func (m *MockEC2API) DescribeElasticGpusRequest(arg0 *ec2.DescribeElasticGpusInp
 
 // DescribeElasticGpusRequest indicates an expected call of DescribeElasticGpusRequest
 func (mr *MockEC2APIMockRecorder) DescribeElasticGpusRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeElasticGpusRequest", reflect.TypeOf((*MockEC2API)(nil).DescribeElasticGpusRequest), arg0)
 }
 
 // DescribeElasticGpusWithContext mocks base method
 func (m *MockEC2API) DescribeElasticGpusWithContext(arg0 context.Context, arg1 *ec2.DescribeElasticGpusInput, arg2 ...request.Option) (*ec2.DescribeElasticGpusOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -7094,14 +6249,12 @@ func (m *MockEC2API) DescribeElasticGpusWithContext(arg0 context.Context, arg1 *
 
 // DescribeElasticGpusWithContext indicates an expected call of DescribeElasticGpusWithContext
 func (mr *MockEC2APIMockRecorder) DescribeElasticGpusWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeElasticGpusWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeElasticGpusWithContext), varargs...)
 }
 
 // DescribeExportTasks mocks base method
 func (m *MockEC2API) DescribeExportTasks(arg0 *ec2.DescribeExportTasksInput) (*ec2.DescribeExportTasksOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeExportTasks", arg0)
 	ret0, _ := ret[0].(*ec2.DescribeExportTasksOutput)
 	ret1, _ := ret[1].(error)
@@ -7110,13 +6263,11 @@ func (m *MockEC2API) DescribeExportTasks(arg0 *ec2.DescribeExportTasksInput) (*e
 
 // DescribeExportTasks indicates an expected call of DescribeExportTasks
 func (mr *MockEC2APIMockRecorder) DescribeExportTasks(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeExportTasks", reflect.TypeOf((*MockEC2API)(nil).DescribeExportTasks), arg0)
 }
 
 // DescribeExportTasksRequest mocks base method
 func (m *MockEC2API) DescribeExportTasksRequest(arg0 *ec2.DescribeExportTasksInput) (*request.Request, *ec2.DescribeExportTasksOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeExportTasksRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DescribeExportTasksOutput)
@@ -7125,13 +6276,11 @@ func (m *MockEC2API) DescribeExportTasksRequest(arg0 *ec2.DescribeExportTasksInp
 
 // DescribeExportTasksRequest indicates an expected call of DescribeExportTasksRequest
 func (mr *MockEC2APIMockRecorder) DescribeExportTasksRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeExportTasksRequest", reflect.TypeOf((*MockEC2API)(nil).DescribeExportTasksRequest), arg0)
 }
 
 // DescribeExportTasksWithContext mocks base method
 func (m *MockEC2API) DescribeExportTasksWithContext(arg0 context.Context, arg1 *ec2.DescribeExportTasksInput, arg2 ...request.Option) (*ec2.DescribeExportTasksOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -7144,14 +6293,12 @@ func (m *MockEC2API) DescribeExportTasksWithContext(arg0 context.Context, arg1 *
 
 // DescribeExportTasksWithContext indicates an expected call of DescribeExportTasksWithContext
 func (mr *MockEC2APIMockRecorder) DescribeExportTasksWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeExportTasksWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeExportTasksWithContext), varargs...)
 }
 
 // DescribeFleetHistory mocks base method
 func (m *MockEC2API) DescribeFleetHistory(arg0 *ec2.DescribeFleetHistoryInput) (*ec2.DescribeFleetHistoryOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeFleetHistory", arg0)
 	ret0, _ := ret[0].(*ec2.DescribeFleetHistoryOutput)
 	ret1, _ := ret[1].(error)
@@ -7160,13 +6307,11 @@ func (m *MockEC2API) DescribeFleetHistory(arg0 *ec2.DescribeFleetHistoryInput) (
 
 // DescribeFleetHistory indicates an expected call of DescribeFleetHistory
 func (mr *MockEC2APIMockRecorder) DescribeFleetHistory(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeFleetHistory", reflect.TypeOf((*MockEC2API)(nil).DescribeFleetHistory), arg0)
 }
 
 // DescribeFleetHistoryRequest mocks base method
 func (m *MockEC2API) DescribeFleetHistoryRequest(arg0 *ec2.DescribeFleetHistoryInput) (*request.Request, *ec2.DescribeFleetHistoryOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeFleetHistoryRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DescribeFleetHistoryOutput)
@@ -7175,13 +6320,11 @@ func (m *MockEC2API) DescribeFleetHistoryRequest(arg0 *ec2.DescribeFleetHistoryI
 
 // DescribeFleetHistoryRequest indicates an expected call of DescribeFleetHistoryRequest
 func (mr *MockEC2APIMockRecorder) DescribeFleetHistoryRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeFleetHistoryRequest", reflect.TypeOf((*MockEC2API)(nil).DescribeFleetHistoryRequest), arg0)
 }
 
 // DescribeFleetHistoryWithContext mocks base method
 func (m *MockEC2API) DescribeFleetHistoryWithContext(arg0 context.Context, arg1 *ec2.DescribeFleetHistoryInput, arg2 ...request.Option) (*ec2.DescribeFleetHistoryOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -7194,14 +6337,12 @@ func (m *MockEC2API) DescribeFleetHistoryWithContext(arg0 context.Context, arg1 
 
 // DescribeFleetHistoryWithContext indicates an expected call of DescribeFleetHistoryWithContext
 func (mr *MockEC2APIMockRecorder) DescribeFleetHistoryWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeFleetHistoryWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeFleetHistoryWithContext), varargs...)
 }
 
 // DescribeFleetInstances mocks base method
 func (m *MockEC2API) DescribeFleetInstances(arg0 *ec2.DescribeFleetInstancesInput) (*ec2.DescribeFleetInstancesOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeFleetInstances", arg0)
 	ret0, _ := ret[0].(*ec2.DescribeFleetInstancesOutput)
 	ret1, _ := ret[1].(error)
@@ -7210,13 +6351,11 @@ func (m *MockEC2API) DescribeFleetInstances(arg0 *ec2.DescribeFleetInstancesInpu
 
 // DescribeFleetInstances indicates an expected call of DescribeFleetInstances
 func (mr *MockEC2APIMockRecorder) DescribeFleetInstances(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeFleetInstances", reflect.TypeOf((*MockEC2API)(nil).DescribeFleetInstances), arg0)
 }
 
 // DescribeFleetInstancesRequest mocks base method
 func (m *MockEC2API) DescribeFleetInstancesRequest(arg0 *ec2.DescribeFleetInstancesInput) (*request.Request, *ec2.DescribeFleetInstancesOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeFleetInstancesRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DescribeFleetInstancesOutput)
@@ -7225,13 +6364,11 @@ func (m *MockEC2API) DescribeFleetInstancesRequest(arg0 *ec2.DescribeFleetInstan
 
 // DescribeFleetInstancesRequest indicates an expected call of DescribeFleetInstancesRequest
 func (mr *MockEC2APIMockRecorder) DescribeFleetInstancesRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeFleetInstancesRequest", reflect.TypeOf((*MockEC2API)(nil).DescribeFleetInstancesRequest), arg0)
 }
 
 // DescribeFleetInstancesWithContext mocks base method
 func (m *MockEC2API) DescribeFleetInstancesWithContext(arg0 context.Context, arg1 *ec2.DescribeFleetInstancesInput, arg2 ...request.Option) (*ec2.DescribeFleetInstancesOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -7244,14 +6381,12 @@ func (m *MockEC2API) DescribeFleetInstancesWithContext(arg0 context.Context, arg
 
 // DescribeFleetInstancesWithContext indicates an expected call of DescribeFleetInstancesWithContext
 func (mr *MockEC2APIMockRecorder) DescribeFleetInstancesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeFleetInstancesWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeFleetInstancesWithContext), varargs...)
 }
 
 // DescribeFleets mocks base method
 func (m *MockEC2API) DescribeFleets(arg0 *ec2.DescribeFleetsInput) (*ec2.DescribeFleetsOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeFleets", arg0)
 	ret0, _ := ret[0].(*ec2.DescribeFleetsOutput)
 	ret1, _ := ret[1].(error)
@@ -7260,13 +6395,11 @@ func (m *MockEC2API) DescribeFleets(arg0 *ec2.DescribeFleetsInput) (*ec2.Describ
 
 // DescribeFleets indicates an expected call of DescribeFleets
 func (mr *MockEC2APIMockRecorder) DescribeFleets(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeFleets", reflect.TypeOf((*MockEC2API)(nil).DescribeFleets), arg0)
 }
 
 // DescribeFleetsRequest mocks base method
 func (m *MockEC2API) DescribeFleetsRequest(arg0 *ec2.DescribeFleetsInput) (*request.Request, *ec2.DescribeFleetsOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeFleetsRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DescribeFleetsOutput)
@@ -7275,13 +6408,11 @@ func (m *MockEC2API) DescribeFleetsRequest(arg0 *ec2.DescribeFleetsInput) (*requ
 
 // DescribeFleetsRequest indicates an expected call of DescribeFleetsRequest
 func (mr *MockEC2APIMockRecorder) DescribeFleetsRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeFleetsRequest", reflect.TypeOf((*MockEC2API)(nil).DescribeFleetsRequest), arg0)
 }
 
 // DescribeFleetsWithContext mocks base method
 func (m *MockEC2API) DescribeFleetsWithContext(arg0 context.Context, arg1 *ec2.DescribeFleetsInput, arg2 ...request.Option) (*ec2.DescribeFleetsOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -7294,14 +6425,12 @@ func (m *MockEC2API) DescribeFleetsWithContext(arg0 context.Context, arg1 *ec2.D
 
 // DescribeFleetsWithContext indicates an expected call of DescribeFleetsWithContext
 func (mr *MockEC2APIMockRecorder) DescribeFleetsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeFleetsWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeFleetsWithContext), varargs...)
 }
 
 // DescribeFlowLogs mocks base method
 func (m *MockEC2API) DescribeFlowLogs(arg0 *ec2.DescribeFlowLogsInput) (*ec2.DescribeFlowLogsOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeFlowLogs", arg0)
 	ret0, _ := ret[0].(*ec2.DescribeFlowLogsOutput)
 	ret1, _ := ret[1].(error)
@@ -7310,13 +6439,11 @@ func (m *MockEC2API) DescribeFlowLogs(arg0 *ec2.DescribeFlowLogsInput) (*ec2.Des
 
 // DescribeFlowLogs indicates an expected call of DescribeFlowLogs
 func (mr *MockEC2APIMockRecorder) DescribeFlowLogs(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeFlowLogs", reflect.TypeOf((*MockEC2API)(nil).DescribeFlowLogs), arg0)
 }
 
 // DescribeFlowLogsRequest mocks base method
 func (m *MockEC2API) DescribeFlowLogsRequest(arg0 *ec2.DescribeFlowLogsInput) (*request.Request, *ec2.DescribeFlowLogsOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeFlowLogsRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DescribeFlowLogsOutput)
@@ -7325,13 +6452,11 @@ func (m *MockEC2API) DescribeFlowLogsRequest(arg0 *ec2.DescribeFlowLogsInput) (*
 
 // DescribeFlowLogsRequest indicates an expected call of DescribeFlowLogsRequest
 func (mr *MockEC2APIMockRecorder) DescribeFlowLogsRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeFlowLogsRequest", reflect.TypeOf((*MockEC2API)(nil).DescribeFlowLogsRequest), arg0)
 }
 
 // DescribeFlowLogsWithContext mocks base method
 func (m *MockEC2API) DescribeFlowLogsWithContext(arg0 context.Context, arg1 *ec2.DescribeFlowLogsInput, arg2 ...request.Option) (*ec2.DescribeFlowLogsOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -7344,14 +6469,12 @@ func (m *MockEC2API) DescribeFlowLogsWithContext(arg0 context.Context, arg1 *ec2
 
 // DescribeFlowLogsWithContext indicates an expected call of DescribeFlowLogsWithContext
 func (mr *MockEC2APIMockRecorder) DescribeFlowLogsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeFlowLogsWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeFlowLogsWithContext), varargs...)
 }
 
 // DescribeFpgaImageAttribute mocks base method
 func (m *MockEC2API) DescribeFpgaImageAttribute(arg0 *ec2.DescribeFpgaImageAttributeInput) (*ec2.DescribeFpgaImageAttributeOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeFpgaImageAttribute", arg0)
 	ret0, _ := ret[0].(*ec2.DescribeFpgaImageAttributeOutput)
 	ret1, _ := ret[1].(error)
@@ -7360,13 +6483,11 @@ func (m *MockEC2API) DescribeFpgaImageAttribute(arg0 *ec2.DescribeFpgaImageAttri
 
 // DescribeFpgaImageAttribute indicates an expected call of DescribeFpgaImageAttribute
 func (mr *MockEC2APIMockRecorder) DescribeFpgaImageAttribute(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeFpgaImageAttribute", reflect.TypeOf((*MockEC2API)(nil).DescribeFpgaImageAttribute), arg0)
 }
 
 // DescribeFpgaImageAttributeRequest mocks base method
 func (m *MockEC2API) DescribeFpgaImageAttributeRequest(arg0 *ec2.DescribeFpgaImageAttributeInput) (*request.Request, *ec2.DescribeFpgaImageAttributeOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeFpgaImageAttributeRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DescribeFpgaImageAttributeOutput)
@@ -7375,13 +6496,11 @@ func (m *MockEC2API) DescribeFpgaImageAttributeRequest(arg0 *ec2.DescribeFpgaIma
 
 // DescribeFpgaImageAttributeRequest indicates an expected call of DescribeFpgaImageAttributeRequest
 func (mr *MockEC2APIMockRecorder) DescribeFpgaImageAttributeRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeFpgaImageAttributeRequest", reflect.TypeOf((*MockEC2API)(nil).DescribeFpgaImageAttributeRequest), arg0)
 }
 
 // DescribeFpgaImageAttributeWithContext mocks base method
 func (m *MockEC2API) DescribeFpgaImageAttributeWithContext(arg0 context.Context, arg1 *ec2.DescribeFpgaImageAttributeInput, arg2 ...request.Option) (*ec2.DescribeFpgaImageAttributeOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -7394,14 +6513,12 @@ func (m *MockEC2API) DescribeFpgaImageAttributeWithContext(arg0 context.Context,
 
 // DescribeFpgaImageAttributeWithContext indicates an expected call of DescribeFpgaImageAttributeWithContext
 func (mr *MockEC2APIMockRecorder) DescribeFpgaImageAttributeWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeFpgaImageAttributeWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeFpgaImageAttributeWithContext), varargs...)
 }
 
 // DescribeFpgaImages mocks base method
 func (m *MockEC2API) DescribeFpgaImages(arg0 *ec2.DescribeFpgaImagesInput) (*ec2.DescribeFpgaImagesOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeFpgaImages", arg0)
 	ret0, _ := ret[0].(*ec2.DescribeFpgaImagesOutput)
 	ret1, _ := ret[1].(error)
@@ -7410,13 +6527,11 @@ func (m *MockEC2API) DescribeFpgaImages(arg0 *ec2.DescribeFpgaImagesInput) (*ec2
 
 // DescribeFpgaImages indicates an expected call of DescribeFpgaImages
 func (mr *MockEC2APIMockRecorder) DescribeFpgaImages(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeFpgaImages", reflect.TypeOf((*MockEC2API)(nil).DescribeFpgaImages), arg0)
 }
 
 // DescribeFpgaImagesRequest mocks base method
 func (m *MockEC2API) DescribeFpgaImagesRequest(arg0 *ec2.DescribeFpgaImagesInput) (*request.Request, *ec2.DescribeFpgaImagesOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeFpgaImagesRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DescribeFpgaImagesOutput)
@@ -7425,13 +6540,11 @@ func (m *MockEC2API) DescribeFpgaImagesRequest(arg0 *ec2.DescribeFpgaImagesInput
 
 // DescribeFpgaImagesRequest indicates an expected call of DescribeFpgaImagesRequest
 func (mr *MockEC2APIMockRecorder) DescribeFpgaImagesRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeFpgaImagesRequest", reflect.TypeOf((*MockEC2API)(nil).DescribeFpgaImagesRequest), arg0)
 }
 
 // DescribeFpgaImagesWithContext mocks base method
 func (m *MockEC2API) DescribeFpgaImagesWithContext(arg0 context.Context, arg1 *ec2.DescribeFpgaImagesInput, arg2 ...request.Option) (*ec2.DescribeFpgaImagesOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -7444,14 +6557,12 @@ func (m *MockEC2API) DescribeFpgaImagesWithContext(arg0 context.Context, arg1 *e
 
 // DescribeFpgaImagesWithContext indicates an expected call of DescribeFpgaImagesWithContext
 func (mr *MockEC2APIMockRecorder) DescribeFpgaImagesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeFpgaImagesWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeFpgaImagesWithContext), varargs...)
 }
 
 // DescribeHostReservationOfferings mocks base method
 func (m *MockEC2API) DescribeHostReservationOfferings(arg0 *ec2.DescribeHostReservationOfferingsInput) (*ec2.DescribeHostReservationOfferingsOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeHostReservationOfferings", arg0)
 	ret0, _ := ret[0].(*ec2.DescribeHostReservationOfferingsOutput)
 	ret1, _ := ret[1].(error)
@@ -7460,13 +6571,11 @@ func (m *MockEC2API) DescribeHostReservationOfferings(arg0 *ec2.DescribeHostRese
 
 // DescribeHostReservationOfferings indicates an expected call of DescribeHostReservationOfferings
 func (mr *MockEC2APIMockRecorder) DescribeHostReservationOfferings(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeHostReservationOfferings", reflect.TypeOf((*MockEC2API)(nil).DescribeHostReservationOfferings), arg0)
 }
 
 // DescribeHostReservationOfferingsRequest mocks base method
 func (m *MockEC2API) DescribeHostReservationOfferingsRequest(arg0 *ec2.DescribeHostReservationOfferingsInput) (*request.Request, *ec2.DescribeHostReservationOfferingsOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeHostReservationOfferingsRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DescribeHostReservationOfferingsOutput)
@@ -7475,13 +6584,11 @@ func (m *MockEC2API) DescribeHostReservationOfferingsRequest(arg0 *ec2.DescribeH
 
 // DescribeHostReservationOfferingsRequest indicates an expected call of DescribeHostReservationOfferingsRequest
 func (mr *MockEC2APIMockRecorder) DescribeHostReservationOfferingsRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeHostReservationOfferingsRequest", reflect.TypeOf((*MockEC2API)(nil).DescribeHostReservationOfferingsRequest), arg0)
 }
 
 // DescribeHostReservationOfferingsWithContext mocks base method
 func (m *MockEC2API) DescribeHostReservationOfferingsWithContext(arg0 context.Context, arg1 *ec2.DescribeHostReservationOfferingsInput, arg2 ...request.Option) (*ec2.DescribeHostReservationOfferingsOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -7494,14 +6601,12 @@ func (m *MockEC2API) DescribeHostReservationOfferingsWithContext(arg0 context.Co
 
 // DescribeHostReservationOfferingsWithContext indicates an expected call of DescribeHostReservationOfferingsWithContext
 func (mr *MockEC2APIMockRecorder) DescribeHostReservationOfferingsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeHostReservationOfferingsWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeHostReservationOfferingsWithContext), varargs...)
 }
 
 // DescribeHostReservations mocks base method
 func (m *MockEC2API) DescribeHostReservations(arg0 *ec2.DescribeHostReservationsInput) (*ec2.DescribeHostReservationsOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeHostReservations", arg0)
 	ret0, _ := ret[0].(*ec2.DescribeHostReservationsOutput)
 	ret1, _ := ret[1].(error)
@@ -7510,13 +6615,11 @@ func (m *MockEC2API) DescribeHostReservations(arg0 *ec2.DescribeHostReservations
 
 // DescribeHostReservations indicates an expected call of DescribeHostReservations
 func (mr *MockEC2APIMockRecorder) DescribeHostReservations(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeHostReservations", reflect.TypeOf((*MockEC2API)(nil).DescribeHostReservations), arg0)
 }
 
 // DescribeHostReservationsRequest mocks base method
 func (m *MockEC2API) DescribeHostReservationsRequest(arg0 *ec2.DescribeHostReservationsInput) (*request.Request, *ec2.DescribeHostReservationsOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeHostReservationsRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DescribeHostReservationsOutput)
@@ -7525,13 +6628,11 @@ func (m *MockEC2API) DescribeHostReservationsRequest(arg0 *ec2.DescribeHostReser
 
 // DescribeHostReservationsRequest indicates an expected call of DescribeHostReservationsRequest
 func (mr *MockEC2APIMockRecorder) DescribeHostReservationsRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeHostReservationsRequest", reflect.TypeOf((*MockEC2API)(nil).DescribeHostReservationsRequest), arg0)
 }
 
 // DescribeHostReservationsWithContext mocks base method
 func (m *MockEC2API) DescribeHostReservationsWithContext(arg0 context.Context, arg1 *ec2.DescribeHostReservationsInput, arg2 ...request.Option) (*ec2.DescribeHostReservationsOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -7544,14 +6645,12 @@ func (m *MockEC2API) DescribeHostReservationsWithContext(arg0 context.Context, a
 
 // DescribeHostReservationsWithContext indicates an expected call of DescribeHostReservationsWithContext
 func (mr *MockEC2APIMockRecorder) DescribeHostReservationsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeHostReservationsWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeHostReservationsWithContext), varargs...)
 }
 
 // DescribeHosts mocks base method
 func (m *MockEC2API) DescribeHosts(arg0 *ec2.DescribeHostsInput) (*ec2.DescribeHostsOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeHosts", arg0)
 	ret0, _ := ret[0].(*ec2.DescribeHostsOutput)
 	ret1, _ := ret[1].(error)
@@ -7560,13 +6659,11 @@ func (m *MockEC2API) DescribeHosts(arg0 *ec2.DescribeHostsInput) (*ec2.DescribeH
 
 // DescribeHosts indicates an expected call of DescribeHosts
 func (mr *MockEC2APIMockRecorder) DescribeHosts(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeHosts", reflect.TypeOf((*MockEC2API)(nil).DescribeHosts), arg0)
 }
 
 // DescribeHostsRequest mocks base method
 func (m *MockEC2API) DescribeHostsRequest(arg0 *ec2.DescribeHostsInput) (*request.Request, *ec2.DescribeHostsOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeHostsRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DescribeHostsOutput)
@@ -7575,13 +6672,11 @@ func (m *MockEC2API) DescribeHostsRequest(arg0 *ec2.DescribeHostsInput) (*reques
 
 // DescribeHostsRequest indicates an expected call of DescribeHostsRequest
 func (mr *MockEC2APIMockRecorder) DescribeHostsRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeHostsRequest", reflect.TypeOf((*MockEC2API)(nil).DescribeHostsRequest), arg0)
 }
 
 // DescribeHostsWithContext mocks base method
 func (m *MockEC2API) DescribeHostsWithContext(arg0 context.Context, arg1 *ec2.DescribeHostsInput, arg2 ...request.Option) (*ec2.DescribeHostsOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -7594,14 +6689,12 @@ func (m *MockEC2API) DescribeHostsWithContext(arg0 context.Context, arg1 *ec2.De
 
 // DescribeHostsWithContext indicates an expected call of DescribeHostsWithContext
 func (mr *MockEC2APIMockRecorder) DescribeHostsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeHostsWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeHostsWithContext), varargs...)
 }
 
 // DescribeIamInstanceProfileAssociations mocks base method
 func (m *MockEC2API) DescribeIamInstanceProfileAssociations(arg0 *ec2.DescribeIamInstanceProfileAssociationsInput) (*ec2.DescribeIamInstanceProfileAssociationsOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeIamInstanceProfileAssociations", arg0)
 	ret0, _ := ret[0].(*ec2.DescribeIamInstanceProfileAssociationsOutput)
 	ret1, _ := ret[1].(error)
@@ -7610,13 +6703,11 @@ func (m *MockEC2API) DescribeIamInstanceProfileAssociations(arg0 *ec2.DescribeIa
 
 // DescribeIamInstanceProfileAssociations indicates an expected call of DescribeIamInstanceProfileAssociations
 func (mr *MockEC2APIMockRecorder) DescribeIamInstanceProfileAssociations(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeIamInstanceProfileAssociations", reflect.TypeOf((*MockEC2API)(nil).DescribeIamInstanceProfileAssociations), arg0)
 }
 
 // DescribeIamInstanceProfileAssociationsRequest mocks base method
 func (m *MockEC2API) DescribeIamInstanceProfileAssociationsRequest(arg0 *ec2.DescribeIamInstanceProfileAssociationsInput) (*request.Request, *ec2.DescribeIamInstanceProfileAssociationsOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeIamInstanceProfileAssociationsRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DescribeIamInstanceProfileAssociationsOutput)
@@ -7625,13 +6716,11 @@ func (m *MockEC2API) DescribeIamInstanceProfileAssociationsRequest(arg0 *ec2.Des
 
 // DescribeIamInstanceProfileAssociationsRequest indicates an expected call of DescribeIamInstanceProfileAssociationsRequest
 func (mr *MockEC2APIMockRecorder) DescribeIamInstanceProfileAssociationsRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeIamInstanceProfileAssociationsRequest", reflect.TypeOf((*MockEC2API)(nil).DescribeIamInstanceProfileAssociationsRequest), arg0)
 }
 
 // DescribeIamInstanceProfileAssociationsWithContext mocks base method
 func (m *MockEC2API) DescribeIamInstanceProfileAssociationsWithContext(arg0 context.Context, arg1 *ec2.DescribeIamInstanceProfileAssociationsInput, arg2 ...request.Option) (*ec2.DescribeIamInstanceProfileAssociationsOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -7644,14 +6733,12 @@ func (m *MockEC2API) DescribeIamInstanceProfileAssociationsWithContext(arg0 cont
 
 // DescribeIamInstanceProfileAssociationsWithContext indicates an expected call of DescribeIamInstanceProfileAssociationsWithContext
 func (mr *MockEC2APIMockRecorder) DescribeIamInstanceProfileAssociationsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeIamInstanceProfileAssociationsWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeIamInstanceProfileAssociationsWithContext), varargs...)
 }
 
 // DescribeIdFormat mocks base method
 func (m *MockEC2API) DescribeIdFormat(arg0 *ec2.DescribeIdFormatInput) (*ec2.DescribeIdFormatOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeIdFormat", arg0)
 	ret0, _ := ret[0].(*ec2.DescribeIdFormatOutput)
 	ret1, _ := ret[1].(error)
@@ -7660,13 +6747,11 @@ func (m *MockEC2API) DescribeIdFormat(arg0 *ec2.DescribeIdFormatInput) (*ec2.Des
 
 // DescribeIdFormat indicates an expected call of DescribeIdFormat
 func (mr *MockEC2APIMockRecorder) DescribeIdFormat(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeIdFormat", reflect.TypeOf((*MockEC2API)(nil).DescribeIdFormat), arg0)
 }
 
 // DescribeIdFormatRequest mocks base method
 func (m *MockEC2API) DescribeIdFormatRequest(arg0 *ec2.DescribeIdFormatInput) (*request.Request, *ec2.DescribeIdFormatOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeIdFormatRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DescribeIdFormatOutput)
@@ -7675,13 +6760,11 @@ func (m *MockEC2API) DescribeIdFormatRequest(arg0 *ec2.DescribeIdFormatInput) (*
 
 // DescribeIdFormatRequest indicates an expected call of DescribeIdFormatRequest
 func (mr *MockEC2APIMockRecorder) DescribeIdFormatRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeIdFormatRequest", reflect.TypeOf((*MockEC2API)(nil).DescribeIdFormatRequest), arg0)
 }
 
 // DescribeIdFormatWithContext mocks base method
 func (m *MockEC2API) DescribeIdFormatWithContext(arg0 context.Context, arg1 *ec2.DescribeIdFormatInput, arg2 ...request.Option) (*ec2.DescribeIdFormatOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -7694,14 +6777,12 @@ func (m *MockEC2API) DescribeIdFormatWithContext(arg0 context.Context, arg1 *ec2
 
 // DescribeIdFormatWithContext indicates an expected call of DescribeIdFormatWithContext
 func (mr *MockEC2APIMockRecorder) DescribeIdFormatWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeIdFormatWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeIdFormatWithContext), varargs...)
 }
 
 // DescribeIdentityIdFormat mocks base method
 func (m *MockEC2API) DescribeIdentityIdFormat(arg0 *ec2.DescribeIdentityIdFormatInput) (*ec2.DescribeIdentityIdFormatOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeIdentityIdFormat", arg0)
 	ret0, _ := ret[0].(*ec2.DescribeIdentityIdFormatOutput)
 	ret1, _ := ret[1].(error)
@@ -7710,13 +6791,11 @@ func (m *MockEC2API) DescribeIdentityIdFormat(arg0 *ec2.DescribeIdentityIdFormat
 
 // DescribeIdentityIdFormat indicates an expected call of DescribeIdentityIdFormat
 func (mr *MockEC2APIMockRecorder) DescribeIdentityIdFormat(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeIdentityIdFormat", reflect.TypeOf((*MockEC2API)(nil).DescribeIdentityIdFormat), arg0)
 }
 
 // DescribeIdentityIdFormatRequest mocks base method
 func (m *MockEC2API) DescribeIdentityIdFormatRequest(arg0 *ec2.DescribeIdentityIdFormatInput) (*request.Request, *ec2.DescribeIdentityIdFormatOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeIdentityIdFormatRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DescribeIdentityIdFormatOutput)
@@ -7725,13 +6804,11 @@ func (m *MockEC2API) DescribeIdentityIdFormatRequest(arg0 *ec2.DescribeIdentityI
 
 // DescribeIdentityIdFormatRequest indicates an expected call of DescribeIdentityIdFormatRequest
 func (mr *MockEC2APIMockRecorder) DescribeIdentityIdFormatRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeIdentityIdFormatRequest", reflect.TypeOf((*MockEC2API)(nil).DescribeIdentityIdFormatRequest), arg0)
 }
 
 // DescribeIdentityIdFormatWithContext mocks base method
 func (m *MockEC2API) DescribeIdentityIdFormatWithContext(arg0 context.Context, arg1 *ec2.DescribeIdentityIdFormatInput, arg2 ...request.Option) (*ec2.DescribeIdentityIdFormatOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -7744,14 +6821,12 @@ func (m *MockEC2API) DescribeIdentityIdFormatWithContext(arg0 context.Context, a
 
 // DescribeIdentityIdFormatWithContext indicates an expected call of DescribeIdentityIdFormatWithContext
 func (mr *MockEC2APIMockRecorder) DescribeIdentityIdFormatWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeIdentityIdFormatWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeIdentityIdFormatWithContext), varargs...)
 }
 
 // DescribeImageAttribute mocks base method
 func (m *MockEC2API) DescribeImageAttribute(arg0 *ec2.DescribeImageAttributeInput) (*ec2.DescribeImageAttributeOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeImageAttribute", arg0)
 	ret0, _ := ret[0].(*ec2.DescribeImageAttributeOutput)
 	ret1, _ := ret[1].(error)
@@ -7760,13 +6835,11 @@ func (m *MockEC2API) DescribeImageAttribute(arg0 *ec2.DescribeImageAttributeInpu
 
 // DescribeImageAttribute indicates an expected call of DescribeImageAttribute
 func (mr *MockEC2APIMockRecorder) DescribeImageAttribute(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeImageAttribute", reflect.TypeOf((*MockEC2API)(nil).DescribeImageAttribute), arg0)
 }
 
 // DescribeImageAttributeRequest mocks base method
 func (m *MockEC2API) DescribeImageAttributeRequest(arg0 *ec2.DescribeImageAttributeInput) (*request.Request, *ec2.DescribeImageAttributeOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeImageAttributeRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DescribeImageAttributeOutput)
@@ -7775,13 +6848,11 @@ func (m *MockEC2API) DescribeImageAttributeRequest(arg0 *ec2.DescribeImageAttrib
 
 // DescribeImageAttributeRequest indicates an expected call of DescribeImageAttributeRequest
 func (mr *MockEC2APIMockRecorder) DescribeImageAttributeRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeImageAttributeRequest", reflect.TypeOf((*MockEC2API)(nil).DescribeImageAttributeRequest), arg0)
 }
 
 // DescribeImageAttributeWithContext mocks base method
 func (m *MockEC2API) DescribeImageAttributeWithContext(arg0 context.Context, arg1 *ec2.DescribeImageAttributeInput, arg2 ...request.Option) (*ec2.DescribeImageAttributeOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -7794,14 +6865,12 @@ func (m *MockEC2API) DescribeImageAttributeWithContext(arg0 context.Context, arg
 
 // DescribeImageAttributeWithContext indicates an expected call of DescribeImageAttributeWithContext
 func (mr *MockEC2APIMockRecorder) DescribeImageAttributeWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeImageAttributeWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeImageAttributeWithContext), varargs...)
 }
 
 // DescribeImages mocks base method
 func (m *MockEC2API) DescribeImages(arg0 *ec2.DescribeImagesInput) (*ec2.DescribeImagesOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeImages", arg0)
 	ret0, _ := ret[0].(*ec2.DescribeImagesOutput)
 	ret1, _ := ret[1].(error)
@@ -7810,13 +6879,11 @@ func (m *MockEC2API) DescribeImages(arg0 *ec2.DescribeImagesInput) (*ec2.Describ
 
 // DescribeImages indicates an expected call of DescribeImages
 func (mr *MockEC2APIMockRecorder) DescribeImages(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeImages", reflect.TypeOf((*MockEC2API)(nil).DescribeImages), arg0)
 }
 
 // DescribeImagesRequest mocks base method
 func (m *MockEC2API) DescribeImagesRequest(arg0 *ec2.DescribeImagesInput) (*request.Request, *ec2.DescribeImagesOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeImagesRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DescribeImagesOutput)
@@ -7825,13 +6892,11 @@ func (m *MockEC2API) DescribeImagesRequest(arg0 *ec2.DescribeImagesInput) (*requ
 
 // DescribeImagesRequest indicates an expected call of DescribeImagesRequest
 func (mr *MockEC2APIMockRecorder) DescribeImagesRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeImagesRequest", reflect.TypeOf((*MockEC2API)(nil).DescribeImagesRequest), arg0)
 }
 
 // DescribeImagesWithContext mocks base method
 func (m *MockEC2API) DescribeImagesWithContext(arg0 context.Context, arg1 *ec2.DescribeImagesInput, arg2 ...request.Option) (*ec2.DescribeImagesOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -7844,14 +6909,12 @@ func (m *MockEC2API) DescribeImagesWithContext(arg0 context.Context, arg1 *ec2.D
 
 // DescribeImagesWithContext indicates an expected call of DescribeImagesWithContext
 func (mr *MockEC2APIMockRecorder) DescribeImagesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeImagesWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeImagesWithContext), varargs...)
 }
 
 // DescribeImportImageTasks mocks base method
 func (m *MockEC2API) DescribeImportImageTasks(arg0 *ec2.DescribeImportImageTasksInput) (*ec2.DescribeImportImageTasksOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeImportImageTasks", arg0)
 	ret0, _ := ret[0].(*ec2.DescribeImportImageTasksOutput)
 	ret1, _ := ret[1].(error)
@@ -7860,13 +6923,11 @@ func (m *MockEC2API) DescribeImportImageTasks(arg0 *ec2.DescribeImportImageTasks
 
 // DescribeImportImageTasks indicates an expected call of DescribeImportImageTasks
 func (mr *MockEC2APIMockRecorder) DescribeImportImageTasks(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeImportImageTasks", reflect.TypeOf((*MockEC2API)(nil).DescribeImportImageTasks), arg0)
 }
 
 // DescribeImportImageTasksRequest mocks base method
 func (m *MockEC2API) DescribeImportImageTasksRequest(arg0 *ec2.DescribeImportImageTasksInput) (*request.Request, *ec2.DescribeImportImageTasksOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeImportImageTasksRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DescribeImportImageTasksOutput)
@@ -7875,13 +6936,11 @@ func (m *MockEC2API) DescribeImportImageTasksRequest(arg0 *ec2.DescribeImportIma
 
 // DescribeImportImageTasksRequest indicates an expected call of DescribeImportImageTasksRequest
 func (mr *MockEC2APIMockRecorder) DescribeImportImageTasksRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeImportImageTasksRequest", reflect.TypeOf((*MockEC2API)(nil).DescribeImportImageTasksRequest), arg0)
 }
 
 // DescribeImportImageTasksWithContext mocks base method
 func (m *MockEC2API) DescribeImportImageTasksWithContext(arg0 context.Context, arg1 *ec2.DescribeImportImageTasksInput, arg2 ...request.Option) (*ec2.DescribeImportImageTasksOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -7894,14 +6953,12 @@ func (m *MockEC2API) DescribeImportImageTasksWithContext(arg0 context.Context, a
 
 // DescribeImportImageTasksWithContext indicates an expected call of DescribeImportImageTasksWithContext
 func (mr *MockEC2APIMockRecorder) DescribeImportImageTasksWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeImportImageTasksWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeImportImageTasksWithContext), varargs...)
 }
 
 // DescribeImportSnapshotTasks mocks base method
 func (m *MockEC2API) DescribeImportSnapshotTasks(arg0 *ec2.DescribeImportSnapshotTasksInput) (*ec2.DescribeImportSnapshotTasksOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeImportSnapshotTasks", arg0)
 	ret0, _ := ret[0].(*ec2.DescribeImportSnapshotTasksOutput)
 	ret1, _ := ret[1].(error)
@@ -7910,13 +6967,11 @@ func (m *MockEC2API) DescribeImportSnapshotTasks(arg0 *ec2.DescribeImportSnapsho
 
 // DescribeImportSnapshotTasks indicates an expected call of DescribeImportSnapshotTasks
 func (mr *MockEC2APIMockRecorder) DescribeImportSnapshotTasks(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeImportSnapshotTasks", reflect.TypeOf((*MockEC2API)(nil).DescribeImportSnapshotTasks), arg0)
 }
 
 // DescribeImportSnapshotTasksRequest mocks base method
 func (m *MockEC2API) DescribeImportSnapshotTasksRequest(arg0 *ec2.DescribeImportSnapshotTasksInput) (*request.Request, *ec2.DescribeImportSnapshotTasksOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeImportSnapshotTasksRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DescribeImportSnapshotTasksOutput)
@@ -7925,13 +6980,11 @@ func (m *MockEC2API) DescribeImportSnapshotTasksRequest(arg0 *ec2.DescribeImport
 
 // DescribeImportSnapshotTasksRequest indicates an expected call of DescribeImportSnapshotTasksRequest
 func (mr *MockEC2APIMockRecorder) DescribeImportSnapshotTasksRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeImportSnapshotTasksRequest", reflect.TypeOf((*MockEC2API)(nil).DescribeImportSnapshotTasksRequest), arg0)
 }
 
 // DescribeImportSnapshotTasksWithContext mocks base method
 func (m *MockEC2API) DescribeImportSnapshotTasksWithContext(arg0 context.Context, arg1 *ec2.DescribeImportSnapshotTasksInput, arg2 ...request.Option) (*ec2.DescribeImportSnapshotTasksOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -7944,14 +6997,12 @@ func (m *MockEC2API) DescribeImportSnapshotTasksWithContext(arg0 context.Context
 
 // DescribeImportSnapshotTasksWithContext indicates an expected call of DescribeImportSnapshotTasksWithContext
 func (mr *MockEC2APIMockRecorder) DescribeImportSnapshotTasksWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeImportSnapshotTasksWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeImportSnapshotTasksWithContext), varargs...)
 }
 
 // DescribeInstanceAttribute mocks base method
 func (m *MockEC2API) DescribeInstanceAttribute(arg0 *ec2.DescribeInstanceAttributeInput) (*ec2.DescribeInstanceAttributeOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeInstanceAttribute", arg0)
 	ret0, _ := ret[0].(*ec2.DescribeInstanceAttributeOutput)
 	ret1, _ := ret[1].(error)
@@ -7960,13 +7011,11 @@ func (m *MockEC2API) DescribeInstanceAttribute(arg0 *ec2.DescribeInstanceAttribu
 
 // DescribeInstanceAttribute indicates an expected call of DescribeInstanceAttribute
 func (mr *MockEC2APIMockRecorder) DescribeInstanceAttribute(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeInstanceAttribute", reflect.TypeOf((*MockEC2API)(nil).DescribeInstanceAttribute), arg0)
 }
 
 // DescribeInstanceAttributeRequest mocks base method
 func (m *MockEC2API) DescribeInstanceAttributeRequest(arg0 *ec2.DescribeInstanceAttributeInput) (*request.Request, *ec2.DescribeInstanceAttributeOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeInstanceAttributeRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DescribeInstanceAttributeOutput)
@@ -7975,13 +7024,11 @@ func (m *MockEC2API) DescribeInstanceAttributeRequest(arg0 *ec2.DescribeInstance
 
 // DescribeInstanceAttributeRequest indicates an expected call of DescribeInstanceAttributeRequest
 func (mr *MockEC2APIMockRecorder) DescribeInstanceAttributeRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeInstanceAttributeRequest", reflect.TypeOf((*MockEC2API)(nil).DescribeInstanceAttributeRequest), arg0)
 }
 
 // DescribeInstanceAttributeWithContext mocks base method
 func (m *MockEC2API) DescribeInstanceAttributeWithContext(arg0 context.Context, arg1 *ec2.DescribeInstanceAttributeInput, arg2 ...request.Option) (*ec2.DescribeInstanceAttributeOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -7994,14 +7041,12 @@ func (m *MockEC2API) DescribeInstanceAttributeWithContext(arg0 context.Context, 
 
 // DescribeInstanceAttributeWithContext indicates an expected call of DescribeInstanceAttributeWithContext
 func (mr *MockEC2APIMockRecorder) DescribeInstanceAttributeWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeInstanceAttributeWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeInstanceAttributeWithContext), varargs...)
 }
 
 // DescribeInstanceCreditSpecifications mocks base method
 func (m *MockEC2API) DescribeInstanceCreditSpecifications(arg0 *ec2.DescribeInstanceCreditSpecificationsInput) (*ec2.DescribeInstanceCreditSpecificationsOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeInstanceCreditSpecifications", arg0)
 	ret0, _ := ret[0].(*ec2.DescribeInstanceCreditSpecificationsOutput)
 	ret1, _ := ret[1].(error)
@@ -8010,13 +7055,11 @@ func (m *MockEC2API) DescribeInstanceCreditSpecifications(arg0 *ec2.DescribeInst
 
 // DescribeInstanceCreditSpecifications indicates an expected call of DescribeInstanceCreditSpecifications
 func (mr *MockEC2APIMockRecorder) DescribeInstanceCreditSpecifications(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeInstanceCreditSpecifications", reflect.TypeOf((*MockEC2API)(nil).DescribeInstanceCreditSpecifications), arg0)
 }
 
 // DescribeInstanceCreditSpecificationsRequest mocks base method
 func (m *MockEC2API) DescribeInstanceCreditSpecificationsRequest(arg0 *ec2.DescribeInstanceCreditSpecificationsInput) (*request.Request, *ec2.DescribeInstanceCreditSpecificationsOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeInstanceCreditSpecificationsRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DescribeInstanceCreditSpecificationsOutput)
@@ -8025,13 +7068,11 @@ func (m *MockEC2API) DescribeInstanceCreditSpecificationsRequest(arg0 *ec2.Descr
 
 // DescribeInstanceCreditSpecificationsRequest indicates an expected call of DescribeInstanceCreditSpecificationsRequest
 func (mr *MockEC2APIMockRecorder) DescribeInstanceCreditSpecificationsRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeInstanceCreditSpecificationsRequest", reflect.TypeOf((*MockEC2API)(nil).DescribeInstanceCreditSpecificationsRequest), arg0)
 }
 
 // DescribeInstanceCreditSpecificationsWithContext mocks base method
 func (m *MockEC2API) DescribeInstanceCreditSpecificationsWithContext(arg0 context.Context, arg1 *ec2.DescribeInstanceCreditSpecificationsInput, arg2 ...request.Option) (*ec2.DescribeInstanceCreditSpecificationsOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -8044,14 +7085,12 @@ func (m *MockEC2API) DescribeInstanceCreditSpecificationsWithContext(arg0 contex
 
 // DescribeInstanceCreditSpecificationsWithContext indicates an expected call of DescribeInstanceCreditSpecificationsWithContext
 func (mr *MockEC2APIMockRecorder) DescribeInstanceCreditSpecificationsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeInstanceCreditSpecificationsWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeInstanceCreditSpecificationsWithContext), varargs...)
 }
 
 // DescribeInstanceStatus mocks base method
 func (m *MockEC2API) DescribeInstanceStatus(arg0 *ec2.DescribeInstanceStatusInput) (*ec2.DescribeInstanceStatusOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeInstanceStatus", arg0)
 	ret0, _ := ret[0].(*ec2.DescribeInstanceStatusOutput)
 	ret1, _ := ret[1].(error)
@@ -8060,13 +7099,11 @@ func (m *MockEC2API) DescribeInstanceStatus(arg0 *ec2.DescribeInstanceStatusInpu
 
 // DescribeInstanceStatus indicates an expected call of DescribeInstanceStatus
 func (mr *MockEC2APIMockRecorder) DescribeInstanceStatus(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeInstanceStatus", reflect.TypeOf((*MockEC2API)(nil).DescribeInstanceStatus), arg0)
 }
 
 // DescribeInstanceStatusPages mocks base method
 func (m *MockEC2API) DescribeInstanceStatusPages(arg0 *ec2.DescribeInstanceStatusInput, arg1 func(*ec2.DescribeInstanceStatusOutput, bool) bool) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeInstanceStatusPages", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -8074,13 +7111,11 @@ func (m *MockEC2API) DescribeInstanceStatusPages(arg0 *ec2.DescribeInstanceStatu
 
 // DescribeInstanceStatusPages indicates an expected call of DescribeInstanceStatusPages
 func (mr *MockEC2APIMockRecorder) DescribeInstanceStatusPages(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeInstanceStatusPages", reflect.TypeOf((*MockEC2API)(nil).DescribeInstanceStatusPages), arg0, arg1)
 }
 
 // DescribeInstanceStatusPagesWithContext mocks base method
 func (m *MockEC2API) DescribeInstanceStatusPagesWithContext(arg0 context.Context, arg1 *ec2.DescribeInstanceStatusInput, arg2 func(*ec2.DescribeInstanceStatusOutput, bool) bool, arg3 ...request.Option) error {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1, arg2}
 	for _, a := range arg3 {
 		varargs = append(varargs, a)
@@ -8092,14 +7127,12 @@ func (m *MockEC2API) DescribeInstanceStatusPagesWithContext(arg0 context.Context
 
 // DescribeInstanceStatusPagesWithContext indicates an expected call of DescribeInstanceStatusPagesWithContext
 func (mr *MockEC2APIMockRecorder) DescribeInstanceStatusPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeInstanceStatusPagesWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeInstanceStatusPagesWithContext), varargs...)
 }
 
 // DescribeInstanceStatusRequest mocks base method
 func (m *MockEC2API) DescribeInstanceStatusRequest(arg0 *ec2.DescribeInstanceStatusInput) (*request.Request, *ec2.DescribeInstanceStatusOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeInstanceStatusRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DescribeInstanceStatusOutput)
@@ -8108,13 +7141,11 @@ func (m *MockEC2API) DescribeInstanceStatusRequest(arg0 *ec2.DescribeInstanceSta
 
 // DescribeInstanceStatusRequest indicates an expected call of DescribeInstanceStatusRequest
 func (mr *MockEC2APIMockRecorder) DescribeInstanceStatusRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeInstanceStatusRequest", reflect.TypeOf((*MockEC2API)(nil).DescribeInstanceStatusRequest), arg0)
 }
 
 // DescribeInstanceStatusWithContext mocks base method
 func (m *MockEC2API) DescribeInstanceStatusWithContext(arg0 context.Context, arg1 *ec2.DescribeInstanceStatusInput, arg2 ...request.Option) (*ec2.DescribeInstanceStatusOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -8127,14 +7158,12 @@ func (m *MockEC2API) DescribeInstanceStatusWithContext(arg0 context.Context, arg
 
 // DescribeInstanceStatusWithContext indicates an expected call of DescribeInstanceStatusWithContext
 func (mr *MockEC2APIMockRecorder) DescribeInstanceStatusWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeInstanceStatusWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeInstanceStatusWithContext), varargs...)
 }
 
 // DescribeInstances mocks base method
 func (m *MockEC2API) DescribeInstances(arg0 *ec2.DescribeInstancesInput) (*ec2.DescribeInstancesOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeInstances", arg0)
 	ret0, _ := ret[0].(*ec2.DescribeInstancesOutput)
 	ret1, _ := ret[1].(error)
@@ -8143,13 +7172,11 @@ func (m *MockEC2API) DescribeInstances(arg0 *ec2.DescribeInstancesInput) (*ec2.D
 
 // DescribeInstances indicates an expected call of DescribeInstances
 func (mr *MockEC2APIMockRecorder) DescribeInstances(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeInstances", reflect.TypeOf((*MockEC2API)(nil).DescribeInstances), arg0)
 }
 
 // DescribeInstancesPages mocks base method
 func (m *MockEC2API) DescribeInstancesPages(arg0 *ec2.DescribeInstancesInput, arg1 func(*ec2.DescribeInstancesOutput, bool) bool) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeInstancesPages", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -8157,13 +7184,11 @@ func (m *MockEC2API) DescribeInstancesPages(arg0 *ec2.DescribeInstancesInput, ar
 
 // DescribeInstancesPages indicates an expected call of DescribeInstancesPages
 func (mr *MockEC2APIMockRecorder) DescribeInstancesPages(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeInstancesPages", reflect.TypeOf((*MockEC2API)(nil).DescribeInstancesPages), arg0, arg1)
 }
 
 // DescribeInstancesPagesWithContext mocks base method
 func (m *MockEC2API) DescribeInstancesPagesWithContext(arg0 context.Context, arg1 *ec2.DescribeInstancesInput, arg2 func(*ec2.DescribeInstancesOutput, bool) bool, arg3 ...request.Option) error {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1, arg2}
 	for _, a := range arg3 {
 		varargs = append(varargs, a)
@@ -8175,14 +7200,12 @@ func (m *MockEC2API) DescribeInstancesPagesWithContext(arg0 context.Context, arg
 
 // DescribeInstancesPagesWithContext indicates an expected call of DescribeInstancesPagesWithContext
 func (mr *MockEC2APIMockRecorder) DescribeInstancesPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeInstancesPagesWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeInstancesPagesWithContext), varargs...)
 }
 
 // DescribeInstancesRequest mocks base method
 func (m *MockEC2API) DescribeInstancesRequest(arg0 *ec2.DescribeInstancesInput) (*request.Request, *ec2.DescribeInstancesOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeInstancesRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DescribeInstancesOutput)
@@ -8191,13 +7214,11 @@ func (m *MockEC2API) DescribeInstancesRequest(arg0 *ec2.DescribeInstancesInput) 
 
 // DescribeInstancesRequest indicates an expected call of DescribeInstancesRequest
 func (mr *MockEC2APIMockRecorder) DescribeInstancesRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeInstancesRequest", reflect.TypeOf((*MockEC2API)(nil).DescribeInstancesRequest), arg0)
 }
 
 // DescribeInstancesWithContext mocks base method
 func (m *MockEC2API) DescribeInstancesWithContext(arg0 context.Context, arg1 *ec2.DescribeInstancesInput, arg2 ...request.Option) (*ec2.DescribeInstancesOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -8210,14 +7231,12 @@ func (m *MockEC2API) DescribeInstancesWithContext(arg0 context.Context, arg1 *ec
 
 // DescribeInstancesWithContext indicates an expected call of DescribeInstancesWithContext
 func (mr *MockEC2APIMockRecorder) DescribeInstancesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeInstancesWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeInstancesWithContext), varargs...)
 }
 
 // DescribeInternetGateways mocks base method
 func (m *MockEC2API) DescribeInternetGateways(arg0 *ec2.DescribeInternetGatewaysInput) (*ec2.DescribeInternetGatewaysOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeInternetGateways", arg0)
 	ret0, _ := ret[0].(*ec2.DescribeInternetGatewaysOutput)
 	ret1, _ := ret[1].(error)
@@ -8226,13 +7245,11 @@ func (m *MockEC2API) DescribeInternetGateways(arg0 *ec2.DescribeInternetGateways
 
 // DescribeInternetGateways indicates an expected call of DescribeInternetGateways
 func (mr *MockEC2APIMockRecorder) DescribeInternetGateways(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeInternetGateways", reflect.TypeOf((*MockEC2API)(nil).DescribeInternetGateways), arg0)
 }
 
 // DescribeInternetGatewaysPages mocks base method
 func (m *MockEC2API) DescribeInternetGatewaysPages(arg0 *ec2.DescribeInternetGatewaysInput, arg1 func(*ec2.DescribeInternetGatewaysOutput, bool) bool) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeInternetGatewaysPages", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -8240,13 +7257,11 @@ func (m *MockEC2API) DescribeInternetGatewaysPages(arg0 *ec2.DescribeInternetGat
 
 // DescribeInternetGatewaysPages indicates an expected call of DescribeInternetGatewaysPages
 func (mr *MockEC2APIMockRecorder) DescribeInternetGatewaysPages(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeInternetGatewaysPages", reflect.TypeOf((*MockEC2API)(nil).DescribeInternetGatewaysPages), arg0, arg1)
 }
 
 // DescribeInternetGatewaysPagesWithContext mocks base method
 func (m *MockEC2API) DescribeInternetGatewaysPagesWithContext(arg0 context.Context, arg1 *ec2.DescribeInternetGatewaysInput, arg2 func(*ec2.DescribeInternetGatewaysOutput, bool) bool, arg3 ...request.Option) error {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1, arg2}
 	for _, a := range arg3 {
 		varargs = append(varargs, a)
@@ -8258,14 +7273,12 @@ func (m *MockEC2API) DescribeInternetGatewaysPagesWithContext(arg0 context.Conte
 
 // DescribeInternetGatewaysPagesWithContext indicates an expected call of DescribeInternetGatewaysPagesWithContext
 func (mr *MockEC2APIMockRecorder) DescribeInternetGatewaysPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeInternetGatewaysPagesWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeInternetGatewaysPagesWithContext), varargs...)
 }
 
 // DescribeInternetGatewaysRequest mocks base method
 func (m *MockEC2API) DescribeInternetGatewaysRequest(arg0 *ec2.DescribeInternetGatewaysInput) (*request.Request, *ec2.DescribeInternetGatewaysOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeInternetGatewaysRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DescribeInternetGatewaysOutput)
@@ -8274,13 +7287,11 @@ func (m *MockEC2API) DescribeInternetGatewaysRequest(arg0 *ec2.DescribeInternetG
 
 // DescribeInternetGatewaysRequest indicates an expected call of DescribeInternetGatewaysRequest
 func (mr *MockEC2APIMockRecorder) DescribeInternetGatewaysRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeInternetGatewaysRequest", reflect.TypeOf((*MockEC2API)(nil).DescribeInternetGatewaysRequest), arg0)
 }
 
 // DescribeInternetGatewaysWithContext mocks base method
 func (m *MockEC2API) DescribeInternetGatewaysWithContext(arg0 context.Context, arg1 *ec2.DescribeInternetGatewaysInput, arg2 ...request.Option) (*ec2.DescribeInternetGatewaysOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -8293,14 +7304,12 @@ func (m *MockEC2API) DescribeInternetGatewaysWithContext(arg0 context.Context, a
 
 // DescribeInternetGatewaysWithContext indicates an expected call of DescribeInternetGatewaysWithContext
 func (mr *MockEC2APIMockRecorder) DescribeInternetGatewaysWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeInternetGatewaysWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeInternetGatewaysWithContext), varargs...)
 }
 
 // DescribeKeyPairs mocks base method
 func (m *MockEC2API) DescribeKeyPairs(arg0 *ec2.DescribeKeyPairsInput) (*ec2.DescribeKeyPairsOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeKeyPairs", arg0)
 	ret0, _ := ret[0].(*ec2.DescribeKeyPairsOutput)
 	ret1, _ := ret[1].(error)
@@ -8309,13 +7318,11 @@ func (m *MockEC2API) DescribeKeyPairs(arg0 *ec2.DescribeKeyPairsInput) (*ec2.Des
 
 // DescribeKeyPairs indicates an expected call of DescribeKeyPairs
 func (mr *MockEC2APIMockRecorder) DescribeKeyPairs(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeKeyPairs", reflect.TypeOf((*MockEC2API)(nil).DescribeKeyPairs), arg0)
 }
 
 // DescribeKeyPairsRequest mocks base method
 func (m *MockEC2API) DescribeKeyPairsRequest(arg0 *ec2.DescribeKeyPairsInput) (*request.Request, *ec2.DescribeKeyPairsOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeKeyPairsRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DescribeKeyPairsOutput)
@@ -8324,13 +7331,11 @@ func (m *MockEC2API) DescribeKeyPairsRequest(arg0 *ec2.DescribeKeyPairsInput) (*
 
 // DescribeKeyPairsRequest indicates an expected call of DescribeKeyPairsRequest
 func (mr *MockEC2APIMockRecorder) DescribeKeyPairsRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeKeyPairsRequest", reflect.TypeOf((*MockEC2API)(nil).DescribeKeyPairsRequest), arg0)
 }
 
 // DescribeKeyPairsWithContext mocks base method
 func (m *MockEC2API) DescribeKeyPairsWithContext(arg0 context.Context, arg1 *ec2.DescribeKeyPairsInput, arg2 ...request.Option) (*ec2.DescribeKeyPairsOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -8343,14 +7348,12 @@ func (m *MockEC2API) DescribeKeyPairsWithContext(arg0 context.Context, arg1 *ec2
 
 // DescribeKeyPairsWithContext indicates an expected call of DescribeKeyPairsWithContext
 func (mr *MockEC2APIMockRecorder) DescribeKeyPairsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeKeyPairsWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeKeyPairsWithContext), varargs...)
 }
 
 // DescribeLaunchTemplateVersions mocks base method
 func (m *MockEC2API) DescribeLaunchTemplateVersions(arg0 *ec2.DescribeLaunchTemplateVersionsInput) (*ec2.DescribeLaunchTemplateVersionsOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeLaunchTemplateVersions", arg0)
 	ret0, _ := ret[0].(*ec2.DescribeLaunchTemplateVersionsOutput)
 	ret1, _ := ret[1].(error)
@@ -8359,13 +7362,11 @@ func (m *MockEC2API) DescribeLaunchTemplateVersions(arg0 *ec2.DescribeLaunchTemp
 
 // DescribeLaunchTemplateVersions indicates an expected call of DescribeLaunchTemplateVersions
 func (mr *MockEC2APIMockRecorder) DescribeLaunchTemplateVersions(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeLaunchTemplateVersions", reflect.TypeOf((*MockEC2API)(nil).DescribeLaunchTemplateVersions), arg0)
 }
 
 // DescribeLaunchTemplateVersionsRequest mocks base method
 func (m *MockEC2API) DescribeLaunchTemplateVersionsRequest(arg0 *ec2.DescribeLaunchTemplateVersionsInput) (*request.Request, *ec2.DescribeLaunchTemplateVersionsOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeLaunchTemplateVersionsRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DescribeLaunchTemplateVersionsOutput)
@@ -8374,13 +7375,11 @@ func (m *MockEC2API) DescribeLaunchTemplateVersionsRequest(arg0 *ec2.DescribeLau
 
 // DescribeLaunchTemplateVersionsRequest indicates an expected call of DescribeLaunchTemplateVersionsRequest
 func (mr *MockEC2APIMockRecorder) DescribeLaunchTemplateVersionsRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeLaunchTemplateVersionsRequest", reflect.TypeOf((*MockEC2API)(nil).DescribeLaunchTemplateVersionsRequest), arg0)
 }
 
 // DescribeLaunchTemplateVersionsWithContext mocks base method
 func (m *MockEC2API) DescribeLaunchTemplateVersionsWithContext(arg0 context.Context, arg1 *ec2.DescribeLaunchTemplateVersionsInput, arg2 ...request.Option) (*ec2.DescribeLaunchTemplateVersionsOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -8393,14 +7392,12 @@ func (m *MockEC2API) DescribeLaunchTemplateVersionsWithContext(arg0 context.Cont
 
 // DescribeLaunchTemplateVersionsWithContext indicates an expected call of DescribeLaunchTemplateVersionsWithContext
 func (mr *MockEC2APIMockRecorder) DescribeLaunchTemplateVersionsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeLaunchTemplateVersionsWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeLaunchTemplateVersionsWithContext), varargs...)
 }
 
 // DescribeLaunchTemplates mocks base method
 func (m *MockEC2API) DescribeLaunchTemplates(arg0 *ec2.DescribeLaunchTemplatesInput) (*ec2.DescribeLaunchTemplatesOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeLaunchTemplates", arg0)
 	ret0, _ := ret[0].(*ec2.DescribeLaunchTemplatesOutput)
 	ret1, _ := ret[1].(error)
@@ -8409,13 +7406,11 @@ func (m *MockEC2API) DescribeLaunchTemplates(arg0 *ec2.DescribeLaunchTemplatesIn
 
 // DescribeLaunchTemplates indicates an expected call of DescribeLaunchTemplates
 func (mr *MockEC2APIMockRecorder) DescribeLaunchTemplates(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeLaunchTemplates", reflect.TypeOf((*MockEC2API)(nil).DescribeLaunchTemplates), arg0)
 }
 
 // DescribeLaunchTemplatesRequest mocks base method
 func (m *MockEC2API) DescribeLaunchTemplatesRequest(arg0 *ec2.DescribeLaunchTemplatesInput) (*request.Request, *ec2.DescribeLaunchTemplatesOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeLaunchTemplatesRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DescribeLaunchTemplatesOutput)
@@ -8424,13 +7419,11 @@ func (m *MockEC2API) DescribeLaunchTemplatesRequest(arg0 *ec2.DescribeLaunchTemp
 
 // DescribeLaunchTemplatesRequest indicates an expected call of DescribeLaunchTemplatesRequest
 func (mr *MockEC2APIMockRecorder) DescribeLaunchTemplatesRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeLaunchTemplatesRequest", reflect.TypeOf((*MockEC2API)(nil).DescribeLaunchTemplatesRequest), arg0)
 }
 
 // DescribeLaunchTemplatesWithContext mocks base method
 func (m *MockEC2API) DescribeLaunchTemplatesWithContext(arg0 context.Context, arg1 *ec2.DescribeLaunchTemplatesInput, arg2 ...request.Option) (*ec2.DescribeLaunchTemplatesOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -8443,14 +7436,12 @@ func (m *MockEC2API) DescribeLaunchTemplatesWithContext(arg0 context.Context, ar
 
 // DescribeLaunchTemplatesWithContext indicates an expected call of DescribeLaunchTemplatesWithContext
 func (mr *MockEC2APIMockRecorder) DescribeLaunchTemplatesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeLaunchTemplatesWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeLaunchTemplatesWithContext), varargs...)
 }
 
 // DescribeMovingAddresses mocks base method
 func (m *MockEC2API) DescribeMovingAddresses(arg0 *ec2.DescribeMovingAddressesInput) (*ec2.DescribeMovingAddressesOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeMovingAddresses", arg0)
 	ret0, _ := ret[0].(*ec2.DescribeMovingAddressesOutput)
 	ret1, _ := ret[1].(error)
@@ -8459,13 +7450,11 @@ func (m *MockEC2API) DescribeMovingAddresses(arg0 *ec2.DescribeMovingAddressesIn
 
 // DescribeMovingAddresses indicates an expected call of DescribeMovingAddresses
 func (mr *MockEC2APIMockRecorder) DescribeMovingAddresses(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeMovingAddresses", reflect.TypeOf((*MockEC2API)(nil).DescribeMovingAddresses), arg0)
 }
 
 // DescribeMovingAddressesRequest mocks base method
 func (m *MockEC2API) DescribeMovingAddressesRequest(arg0 *ec2.DescribeMovingAddressesInput) (*request.Request, *ec2.DescribeMovingAddressesOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeMovingAddressesRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DescribeMovingAddressesOutput)
@@ -8474,13 +7463,11 @@ func (m *MockEC2API) DescribeMovingAddressesRequest(arg0 *ec2.DescribeMovingAddr
 
 // DescribeMovingAddressesRequest indicates an expected call of DescribeMovingAddressesRequest
 func (mr *MockEC2APIMockRecorder) DescribeMovingAddressesRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeMovingAddressesRequest", reflect.TypeOf((*MockEC2API)(nil).DescribeMovingAddressesRequest), arg0)
 }
 
 // DescribeMovingAddressesWithContext mocks base method
 func (m *MockEC2API) DescribeMovingAddressesWithContext(arg0 context.Context, arg1 *ec2.DescribeMovingAddressesInput, arg2 ...request.Option) (*ec2.DescribeMovingAddressesOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -8493,14 +7480,12 @@ func (m *MockEC2API) DescribeMovingAddressesWithContext(arg0 context.Context, ar
 
 // DescribeMovingAddressesWithContext indicates an expected call of DescribeMovingAddressesWithContext
 func (mr *MockEC2APIMockRecorder) DescribeMovingAddressesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeMovingAddressesWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeMovingAddressesWithContext), varargs...)
 }
 
 // DescribeNatGateways mocks base method
 func (m *MockEC2API) DescribeNatGateways(arg0 *ec2.DescribeNatGatewaysInput) (*ec2.DescribeNatGatewaysOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeNatGateways", arg0)
 	ret0, _ := ret[0].(*ec2.DescribeNatGatewaysOutput)
 	ret1, _ := ret[1].(error)
@@ -8509,13 +7494,11 @@ func (m *MockEC2API) DescribeNatGateways(arg0 *ec2.DescribeNatGatewaysInput) (*e
 
 // DescribeNatGateways indicates an expected call of DescribeNatGateways
 func (mr *MockEC2APIMockRecorder) DescribeNatGateways(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeNatGateways", reflect.TypeOf((*MockEC2API)(nil).DescribeNatGateways), arg0)
 }
 
 // DescribeNatGatewaysPages mocks base method
 func (m *MockEC2API) DescribeNatGatewaysPages(arg0 *ec2.DescribeNatGatewaysInput, arg1 func(*ec2.DescribeNatGatewaysOutput, bool) bool) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeNatGatewaysPages", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -8523,13 +7506,11 @@ func (m *MockEC2API) DescribeNatGatewaysPages(arg0 *ec2.DescribeNatGatewaysInput
 
 // DescribeNatGatewaysPages indicates an expected call of DescribeNatGatewaysPages
 func (mr *MockEC2APIMockRecorder) DescribeNatGatewaysPages(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeNatGatewaysPages", reflect.TypeOf((*MockEC2API)(nil).DescribeNatGatewaysPages), arg0, arg1)
 }
 
 // DescribeNatGatewaysPagesWithContext mocks base method
 func (m *MockEC2API) DescribeNatGatewaysPagesWithContext(arg0 context.Context, arg1 *ec2.DescribeNatGatewaysInput, arg2 func(*ec2.DescribeNatGatewaysOutput, bool) bool, arg3 ...request.Option) error {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1, arg2}
 	for _, a := range arg3 {
 		varargs = append(varargs, a)
@@ -8541,14 +7522,12 @@ func (m *MockEC2API) DescribeNatGatewaysPagesWithContext(arg0 context.Context, a
 
 // DescribeNatGatewaysPagesWithContext indicates an expected call of DescribeNatGatewaysPagesWithContext
 func (mr *MockEC2APIMockRecorder) DescribeNatGatewaysPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeNatGatewaysPagesWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeNatGatewaysPagesWithContext), varargs...)
 }
 
 // DescribeNatGatewaysRequest mocks base method
 func (m *MockEC2API) DescribeNatGatewaysRequest(arg0 *ec2.DescribeNatGatewaysInput) (*request.Request, *ec2.DescribeNatGatewaysOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeNatGatewaysRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DescribeNatGatewaysOutput)
@@ -8557,13 +7536,11 @@ func (m *MockEC2API) DescribeNatGatewaysRequest(arg0 *ec2.DescribeNatGatewaysInp
 
 // DescribeNatGatewaysRequest indicates an expected call of DescribeNatGatewaysRequest
 func (mr *MockEC2APIMockRecorder) DescribeNatGatewaysRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeNatGatewaysRequest", reflect.TypeOf((*MockEC2API)(nil).DescribeNatGatewaysRequest), arg0)
 }
 
 // DescribeNatGatewaysWithContext mocks base method
 func (m *MockEC2API) DescribeNatGatewaysWithContext(arg0 context.Context, arg1 *ec2.DescribeNatGatewaysInput, arg2 ...request.Option) (*ec2.DescribeNatGatewaysOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -8576,14 +7553,12 @@ func (m *MockEC2API) DescribeNatGatewaysWithContext(arg0 context.Context, arg1 *
 
 // DescribeNatGatewaysWithContext indicates an expected call of DescribeNatGatewaysWithContext
 func (mr *MockEC2APIMockRecorder) DescribeNatGatewaysWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeNatGatewaysWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeNatGatewaysWithContext), varargs...)
 }
 
 // DescribeNetworkAcls mocks base method
 func (m *MockEC2API) DescribeNetworkAcls(arg0 *ec2.DescribeNetworkAclsInput) (*ec2.DescribeNetworkAclsOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeNetworkAcls", arg0)
 	ret0, _ := ret[0].(*ec2.DescribeNetworkAclsOutput)
 	ret1, _ := ret[1].(error)
@@ -8592,13 +7567,11 @@ func (m *MockEC2API) DescribeNetworkAcls(arg0 *ec2.DescribeNetworkAclsInput) (*e
 
 // DescribeNetworkAcls indicates an expected call of DescribeNetworkAcls
 func (mr *MockEC2APIMockRecorder) DescribeNetworkAcls(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeNetworkAcls", reflect.TypeOf((*MockEC2API)(nil).DescribeNetworkAcls), arg0)
 }
 
 // DescribeNetworkAclsPages mocks base method
 func (m *MockEC2API) DescribeNetworkAclsPages(arg0 *ec2.DescribeNetworkAclsInput, arg1 func(*ec2.DescribeNetworkAclsOutput, bool) bool) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeNetworkAclsPages", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -8606,13 +7579,11 @@ func (m *MockEC2API) DescribeNetworkAclsPages(arg0 *ec2.DescribeNetworkAclsInput
 
 // DescribeNetworkAclsPages indicates an expected call of DescribeNetworkAclsPages
 func (mr *MockEC2APIMockRecorder) DescribeNetworkAclsPages(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeNetworkAclsPages", reflect.TypeOf((*MockEC2API)(nil).DescribeNetworkAclsPages), arg0, arg1)
 }
 
 // DescribeNetworkAclsPagesWithContext mocks base method
 func (m *MockEC2API) DescribeNetworkAclsPagesWithContext(arg0 context.Context, arg1 *ec2.DescribeNetworkAclsInput, arg2 func(*ec2.DescribeNetworkAclsOutput, bool) bool, arg3 ...request.Option) error {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1, arg2}
 	for _, a := range arg3 {
 		varargs = append(varargs, a)
@@ -8624,14 +7595,12 @@ func (m *MockEC2API) DescribeNetworkAclsPagesWithContext(arg0 context.Context, a
 
 // DescribeNetworkAclsPagesWithContext indicates an expected call of DescribeNetworkAclsPagesWithContext
 func (mr *MockEC2APIMockRecorder) DescribeNetworkAclsPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeNetworkAclsPagesWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeNetworkAclsPagesWithContext), varargs...)
 }
 
 // DescribeNetworkAclsRequest mocks base method
 func (m *MockEC2API) DescribeNetworkAclsRequest(arg0 *ec2.DescribeNetworkAclsInput) (*request.Request, *ec2.DescribeNetworkAclsOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeNetworkAclsRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DescribeNetworkAclsOutput)
@@ -8640,13 +7609,11 @@ func (m *MockEC2API) DescribeNetworkAclsRequest(arg0 *ec2.DescribeNetworkAclsInp
 
 // DescribeNetworkAclsRequest indicates an expected call of DescribeNetworkAclsRequest
 func (mr *MockEC2APIMockRecorder) DescribeNetworkAclsRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeNetworkAclsRequest", reflect.TypeOf((*MockEC2API)(nil).DescribeNetworkAclsRequest), arg0)
 }
 
 // DescribeNetworkAclsWithContext mocks base method
 func (m *MockEC2API) DescribeNetworkAclsWithContext(arg0 context.Context, arg1 *ec2.DescribeNetworkAclsInput, arg2 ...request.Option) (*ec2.DescribeNetworkAclsOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -8659,14 +7626,12 @@ func (m *MockEC2API) DescribeNetworkAclsWithContext(arg0 context.Context, arg1 *
 
 // DescribeNetworkAclsWithContext indicates an expected call of DescribeNetworkAclsWithContext
 func (mr *MockEC2APIMockRecorder) DescribeNetworkAclsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeNetworkAclsWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeNetworkAclsWithContext), varargs...)
 }
 
 // DescribeNetworkInterfaceAttribute mocks base method
 func (m *MockEC2API) DescribeNetworkInterfaceAttribute(arg0 *ec2.DescribeNetworkInterfaceAttributeInput) (*ec2.DescribeNetworkInterfaceAttributeOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeNetworkInterfaceAttribute", arg0)
 	ret0, _ := ret[0].(*ec2.DescribeNetworkInterfaceAttributeOutput)
 	ret1, _ := ret[1].(error)
@@ -8675,13 +7640,11 @@ func (m *MockEC2API) DescribeNetworkInterfaceAttribute(arg0 *ec2.DescribeNetwork
 
 // DescribeNetworkInterfaceAttribute indicates an expected call of DescribeNetworkInterfaceAttribute
 func (mr *MockEC2APIMockRecorder) DescribeNetworkInterfaceAttribute(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeNetworkInterfaceAttribute", reflect.TypeOf((*MockEC2API)(nil).DescribeNetworkInterfaceAttribute), arg0)
 }
 
 // DescribeNetworkInterfaceAttributeRequest mocks base method
 func (m *MockEC2API) DescribeNetworkInterfaceAttributeRequest(arg0 *ec2.DescribeNetworkInterfaceAttributeInput) (*request.Request, *ec2.DescribeNetworkInterfaceAttributeOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeNetworkInterfaceAttributeRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DescribeNetworkInterfaceAttributeOutput)
@@ -8690,13 +7653,11 @@ func (m *MockEC2API) DescribeNetworkInterfaceAttributeRequest(arg0 *ec2.Describe
 
 // DescribeNetworkInterfaceAttributeRequest indicates an expected call of DescribeNetworkInterfaceAttributeRequest
 func (mr *MockEC2APIMockRecorder) DescribeNetworkInterfaceAttributeRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeNetworkInterfaceAttributeRequest", reflect.TypeOf((*MockEC2API)(nil).DescribeNetworkInterfaceAttributeRequest), arg0)
 }
 
 // DescribeNetworkInterfaceAttributeWithContext mocks base method
 func (m *MockEC2API) DescribeNetworkInterfaceAttributeWithContext(arg0 context.Context, arg1 *ec2.DescribeNetworkInterfaceAttributeInput, arg2 ...request.Option) (*ec2.DescribeNetworkInterfaceAttributeOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -8709,14 +7670,12 @@ func (m *MockEC2API) DescribeNetworkInterfaceAttributeWithContext(arg0 context.C
 
 // DescribeNetworkInterfaceAttributeWithContext indicates an expected call of DescribeNetworkInterfaceAttributeWithContext
 func (mr *MockEC2APIMockRecorder) DescribeNetworkInterfaceAttributeWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeNetworkInterfaceAttributeWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeNetworkInterfaceAttributeWithContext), varargs...)
 }
 
 // DescribeNetworkInterfacePermissions mocks base method
 func (m *MockEC2API) DescribeNetworkInterfacePermissions(arg0 *ec2.DescribeNetworkInterfacePermissionsInput) (*ec2.DescribeNetworkInterfacePermissionsOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeNetworkInterfacePermissions", arg0)
 	ret0, _ := ret[0].(*ec2.DescribeNetworkInterfacePermissionsOutput)
 	ret1, _ := ret[1].(error)
@@ -8725,13 +7684,11 @@ func (m *MockEC2API) DescribeNetworkInterfacePermissions(arg0 *ec2.DescribeNetwo
 
 // DescribeNetworkInterfacePermissions indicates an expected call of DescribeNetworkInterfacePermissions
 func (mr *MockEC2APIMockRecorder) DescribeNetworkInterfacePermissions(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeNetworkInterfacePermissions", reflect.TypeOf((*MockEC2API)(nil).DescribeNetworkInterfacePermissions), arg0)
 }
 
 // DescribeNetworkInterfacePermissionsRequest mocks base method
 func (m *MockEC2API) DescribeNetworkInterfacePermissionsRequest(arg0 *ec2.DescribeNetworkInterfacePermissionsInput) (*request.Request, *ec2.DescribeNetworkInterfacePermissionsOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeNetworkInterfacePermissionsRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DescribeNetworkInterfacePermissionsOutput)
@@ -8740,13 +7697,11 @@ func (m *MockEC2API) DescribeNetworkInterfacePermissionsRequest(arg0 *ec2.Descri
 
 // DescribeNetworkInterfacePermissionsRequest indicates an expected call of DescribeNetworkInterfacePermissionsRequest
 func (mr *MockEC2APIMockRecorder) DescribeNetworkInterfacePermissionsRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeNetworkInterfacePermissionsRequest", reflect.TypeOf((*MockEC2API)(nil).DescribeNetworkInterfacePermissionsRequest), arg0)
 }
 
 // DescribeNetworkInterfacePermissionsWithContext mocks base method
 func (m *MockEC2API) DescribeNetworkInterfacePermissionsWithContext(arg0 context.Context, arg1 *ec2.DescribeNetworkInterfacePermissionsInput, arg2 ...request.Option) (*ec2.DescribeNetworkInterfacePermissionsOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -8759,14 +7714,12 @@ func (m *MockEC2API) DescribeNetworkInterfacePermissionsWithContext(arg0 context
 
 // DescribeNetworkInterfacePermissionsWithContext indicates an expected call of DescribeNetworkInterfacePermissionsWithContext
 func (mr *MockEC2APIMockRecorder) DescribeNetworkInterfacePermissionsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeNetworkInterfacePermissionsWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeNetworkInterfacePermissionsWithContext), varargs...)
 }
 
 // DescribeNetworkInterfaces mocks base method
 func (m *MockEC2API) DescribeNetworkInterfaces(arg0 *ec2.DescribeNetworkInterfacesInput) (*ec2.DescribeNetworkInterfacesOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeNetworkInterfaces", arg0)
 	ret0, _ := ret[0].(*ec2.DescribeNetworkInterfacesOutput)
 	ret1, _ := ret[1].(error)
@@ -8775,13 +7728,11 @@ func (m *MockEC2API) DescribeNetworkInterfaces(arg0 *ec2.DescribeNetworkInterfac
 
 // DescribeNetworkInterfaces indicates an expected call of DescribeNetworkInterfaces
 func (mr *MockEC2APIMockRecorder) DescribeNetworkInterfaces(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeNetworkInterfaces", reflect.TypeOf((*MockEC2API)(nil).DescribeNetworkInterfaces), arg0)
 }
 
 // DescribeNetworkInterfacesPages mocks base method
 func (m *MockEC2API) DescribeNetworkInterfacesPages(arg0 *ec2.DescribeNetworkInterfacesInput, arg1 func(*ec2.DescribeNetworkInterfacesOutput, bool) bool) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeNetworkInterfacesPages", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -8789,13 +7740,11 @@ func (m *MockEC2API) DescribeNetworkInterfacesPages(arg0 *ec2.DescribeNetworkInt
 
 // DescribeNetworkInterfacesPages indicates an expected call of DescribeNetworkInterfacesPages
 func (mr *MockEC2APIMockRecorder) DescribeNetworkInterfacesPages(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeNetworkInterfacesPages", reflect.TypeOf((*MockEC2API)(nil).DescribeNetworkInterfacesPages), arg0, arg1)
 }
 
 // DescribeNetworkInterfacesPagesWithContext mocks base method
 func (m *MockEC2API) DescribeNetworkInterfacesPagesWithContext(arg0 context.Context, arg1 *ec2.DescribeNetworkInterfacesInput, arg2 func(*ec2.DescribeNetworkInterfacesOutput, bool) bool, arg3 ...request.Option) error {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1, arg2}
 	for _, a := range arg3 {
 		varargs = append(varargs, a)
@@ -8807,14 +7756,12 @@ func (m *MockEC2API) DescribeNetworkInterfacesPagesWithContext(arg0 context.Cont
 
 // DescribeNetworkInterfacesPagesWithContext indicates an expected call of DescribeNetworkInterfacesPagesWithContext
 func (mr *MockEC2APIMockRecorder) DescribeNetworkInterfacesPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeNetworkInterfacesPagesWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeNetworkInterfacesPagesWithContext), varargs...)
 }
 
 // DescribeNetworkInterfacesRequest mocks base method
 func (m *MockEC2API) DescribeNetworkInterfacesRequest(arg0 *ec2.DescribeNetworkInterfacesInput) (*request.Request, *ec2.DescribeNetworkInterfacesOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeNetworkInterfacesRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DescribeNetworkInterfacesOutput)
@@ -8823,13 +7770,11 @@ func (m *MockEC2API) DescribeNetworkInterfacesRequest(arg0 *ec2.DescribeNetworkI
 
 // DescribeNetworkInterfacesRequest indicates an expected call of DescribeNetworkInterfacesRequest
 func (mr *MockEC2APIMockRecorder) DescribeNetworkInterfacesRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeNetworkInterfacesRequest", reflect.TypeOf((*MockEC2API)(nil).DescribeNetworkInterfacesRequest), arg0)
 }
 
 // DescribeNetworkInterfacesWithContext mocks base method
 func (m *MockEC2API) DescribeNetworkInterfacesWithContext(arg0 context.Context, arg1 *ec2.DescribeNetworkInterfacesInput, arg2 ...request.Option) (*ec2.DescribeNetworkInterfacesOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -8842,14 +7787,12 @@ func (m *MockEC2API) DescribeNetworkInterfacesWithContext(arg0 context.Context, 
 
 // DescribeNetworkInterfacesWithContext indicates an expected call of DescribeNetworkInterfacesWithContext
 func (mr *MockEC2APIMockRecorder) DescribeNetworkInterfacesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeNetworkInterfacesWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeNetworkInterfacesWithContext), varargs...)
 }
 
 // DescribePlacementGroups mocks base method
 func (m *MockEC2API) DescribePlacementGroups(arg0 *ec2.DescribePlacementGroupsInput) (*ec2.DescribePlacementGroupsOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribePlacementGroups", arg0)
 	ret0, _ := ret[0].(*ec2.DescribePlacementGroupsOutput)
 	ret1, _ := ret[1].(error)
@@ -8858,13 +7801,11 @@ func (m *MockEC2API) DescribePlacementGroups(arg0 *ec2.DescribePlacementGroupsIn
 
 // DescribePlacementGroups indicates an expected call of DescribePlacementGroups
 func (mr *MockEC2APIMockRecorder) DescribePlacementGroups(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribePlacementGroups", reflect.TypeOf((*MockEC2API)(nil).DescribePlacementGroups), arg0)
 }
 
 // DescribePlacementGroupsRequest mocks base method
 func (m *MockEC2API) DescribePlacementGroupsRequest(arg0 *ec2.DescribePlacementGroupsInput) (*request.Request, *ec2.DescribePlacementGroupsOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribePlacementGroupsRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DescribePlacementGroupsOutput)
@@ -8873,13 +7814,11 @@ func (m *MockEC2API) DescribePlacementGroupsRequest(arg0 *ec2.DescribePlacementG
 
 // DescribePlacementGroupsRequest indicates an expected call of DescribePlacementGroupsRequest
 func (mr *MockEC2APIMockRecorder) DescribePlacementGroupsRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribePlacementGroupsRequest", reflect.TypeOf((*MockEC2API)(nil).DescribePlacementGroupsRequest), arg0)
 }
 
 // DescribePlacementGroupsWithContext mocks base method
 func (m *MockEC2API) DescribePlacementGroupsWithContext(arg0 context.Context, arg1 *ec2.DescribePlacementGroupsInput, arg2 ...request.Option) (*ec2.DescribePlacementGroupsOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -8892,14 +7831,12 @@ func (m *MockEC2API) DescribePlacementGroupsWithContext(arg0 context.Context, ar
 
 // DescribePlacementGroupsWithContext indicates an expected call of DescribePlacementGroupsWithContext
 func (mr *MockEC2APIMockRecorder) DescribePlacementGroupsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribePlacementGroupsWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribePlacementGroupsWithContext), varargs...)
 }
 
 // DescribePrefixLists mocks base method
 func (m *MockEC2API) DescribePrefixLists(arg0 *ec2.DescribePrefixListsInput) (*ec2.DescribePrefixListsOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribePrefixLists", arg0)
 	ret0, _ := ret[0].(*ec2.DescribePrefixListsOutput)
 	ret1, _ := ret[1].(error)
@@ -8908,13 +7845,11 @@ func (m *MockEC2API) DescribePrefixLists(arg0 *ec2.DescribePrefixListsInput) (*e
 
 // DescribePrefixLists indicates an expected call of DescribePrefixLists
 func (mr *MockEC2APIMockRecorder) DescribePrefixLists(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribePrefixLists", reflect.TypeOf((*MockEC2API)(nil).DescribePrefixLists), arg0)
 }
 
 // DescribePrefixListsRequest mocks base method
 func (m *MockEC2API) DescribePrefixListsRequest(arg0 *ec2.DescribePrefixListsInput) (*request.Request, *ec2.DescribePrefixListsOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribePrefixListsRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DescribePrefixListsOutput)
@@ -8923,13 +7858,11 @@ func (m *MockEC2API) DescribePrefixListsRequest(arg0 *ec2.DescribePrefixListsInp
 
 // DescribePrefixListsRequest indicates an expected call of DescribePrefixListsRequest
 func (mr *MockEC2APIMockRecorder) DescribePrefixListsRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribePrefixListsRequest", reflect.TypeOf((*MockEC2API)(nil).DescribePrefixListsRequest), arg0)
 }
 
 // DescribePrefixListsWithContext mocks base method
 func (m *MockEC2API) DescribePrefixListsWithContext(arg0 context.Context, arg1 *ec2.DescribePrefixListsInput, arg2 ...request.Option) (*ec2.DescribePrefixListsOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -8942,14 +7875,12 @@ func (m *MockEC2API) DescribePrefixListsWithContext(arg0 context.Context, arg1 *
 
 // DescribePrefixListsWithContext indicates an expected call of DescribePrefixListsWithContext
 func (mr *MockEC2APIMockRecorder) DescribePrefixListsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribePrefixListsWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribePrefixListsWithContext), varargs...)
 }
 
 // DescribePrincipalIdFormat mocks base method
 func (m *MockEC2API) DescribePrincipalIdFormat(arg0 *ec2.DescribePrincipalIdFormatInput) (*ec2.DescribePrincipalIdFormatOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribePrincipalIdFormat", arg0)
 	ret0, _ := ret[0].(*ec2.DescribePrincipalIdFormatOutput)
 	ret1, _ := ret[1].(error)
@@ -8958,13 +7889,11 @@ func (m *MockEC2API) DescribePrincipalIdFormat(arg0 *ec2.DescribePrincipalIdForm
 
 // DescribePrincipalIdFormat indicates an expected call of DescribePrincipalIdFormat
 func (mr *MockEC2APIMockRecorder) DescribePrincipalIdFormat(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribePrincipalIdFormat", reflect.TypeOf((*MockEC2API)(nil).DescribePrincipalIdFormat), arg0)
 }
 
 // DescribePrincipalIdFormatRequest mocks base method
 func (m *MockEC2API) DescribePrincipalIdFormatRequest(arg0 *ec2.DescribePrincipalIdFormatInput) (*request.Request, *ec2.DescribePrincipalIdFormatOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribePrincipalIdFormatRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DescribePrincipalIdFormatOutput)
@@ -8973,13 +7902,11 @@ func (m *MockEC2API) DescribePrincipalIdFormatRequest(arg0 *ec2.DescribePrincipa
 
 // DescribePrincipalIdFormatRequest indicates an expected call of DescribePrincipalIdFormatRequest
 func (mr *MockEC2APIMockRecorder) DescribePrincipalIdFormatRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribePrincipalIdFormatRequest", reflect.TypeOf((*MockEC2API)(nil).DescribePrincipalIdFormatRequest), arg0)
 }
 
 // DescribePrincipalIdFormatWithContext mocks base method
 func (m *MockEC2API) DescribePrincipalIdFormatWithContext(arg0 context.Context, arg1 *ec2.DescribePrincipalIdFormatInput, arg2 ...request.Option) (*ec2.DescribePrincipalIdFormatOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -8992,14 +7919,12 @@ func (m *MockEC2API) DescribePrincipalIdFormatWithContext(arg0 context.Context, 
 
 // DescribePrincipalIdFormatWithContext indicates an expected call of DescribePrincipalIdFormatWithContext
 func (mr *MockEC2APIMockRecorder) DescribePrincipalIdFormatWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribePrincipalIdFormatWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribePrincipalIdFormatWithContext), varargs...)
 }
 
 // DescribePublicIpv4Pools mocks base method
 func (m *MockEC2API) DescribePublicIpv4Pools(arg0 *ec2.DescribePublicIpv4PoolsInput) (*ec2.DescribePublicIpv4PoolsOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribePublicIpv4Pools", arg0)
 	ret0, _ := ret[0].(*ec2.DescribePublicIpv4PoolsOutput)
 	ret1, _ := ret[1].(error)
@@ -9008,13 +7933,11 @@ func (m *MockEC2API) DescribePublicIpv4Pools(arg0 *ec2.DescribePublicIpv4PoolsIn
 
 // DescribePublicIpv4Pools indicates an expected call of DescribePublicIpv4Pools
 func (mr *MockEC2APIMockRecorder) DescribePublicIpv4Pools(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribePublicIpv4Pools", reflect.TypeOf((*MockEC2API)(nil).DescribePublicIpv4Pools), arg0)
 }
 
 // DescribePublicIpv4PoolsRequest mocks base method
 func (m *MockEC2API) DescribePublicIpv4PoolsRequest(arg0 *ec2.DescribePublicIpv4PoolsInput) (*request.Request, *ec2.DescribePublicIpv4PoolsOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribePublicIpv4PoolsRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DescribePublicIpv4PoolsOutput)
@@ -9023,13 +7946,11 @@ func (m *MockEC2API) DescribePublicIpv4PoolsRequest(arg0 *ec2.DescribePublicIpv4
 
 // DescribePublicIpv4PoolsRequest indicates an expected call of DescribePublicIpv4PoolsRequest
 func (mr *MockEC2APIMockRecorder) DescribePublicIpv4PoolsRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribePublicIpv4PoolsRequest", reflect.TypeOf((*MockEC2API)(nil).DescribePublicIpv4PoolsRequest), arg0)
 }
 
 // DescribePublicIpv4PoolsWithContext mocks base method
 func (m *MockEC2API) DescribePublicIpv4PoolsWithContext(arg0 context.Context, arg1 *ec2.DescribePublicIpv4PoolsInput, arg2 ...request.Option) (*ec2.DescribePublicIpv4PoolsOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -9042,14 +7963,12 @@ func (m *MockEC2API) DescribePublicIpv4PoolsWithContext(arg0 context.Context, ar
 
 // DescribePublicIpv4PoolsWithContext indicates an expected call of DescribePublicIpv4PoolsWithContext
 func (mr *MockEC2APIMockRecorder) DescribePublicIpv4PoolsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribePublicIpv4PoolsWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribePublicIpv4PoolsWithContext), varargs...)
 }
 
 // DescribeRegions mocks base method
 func (m *MockEC2API) DescribeRegions(arg0 *ec2.DescribeRegionsInput) (*ec2.DescribeRegionsOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeRegions", arg0)
 	ret0, _ := ret[0].(*ec2.DescribeRegionsOutput)
 	ret1, _ := ret[1].(error)
@@ -9058,13 +7977,11 @@ func (m *MockEC2API) DescribeRegions(arg0 *ec2.DescribeRegionsInput) (*ec2.Descr
 
 // DescribeRegions indicates an expected call of DescribeRegions
 func (mr *MockEC2APIMockRecorder) DescribeRegions(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeRegions", reflect.TypeOf((*MockEC2API)(nil).DescribeRegions), arg0)
 }
 
 // DescribeRegionsRequest mocks base method
 func (m *MockEC2API) DescribeRegionsRequest(arg0 *ec2.DescribeRegionsInput) (*request.Request, *ec2.DescribeRegionsOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeRegionsRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DescribeRegionsOutput)
@@ -9073,13 +7990,11 @@ func (m *MockEC2API) DescribeRegionsRequest(arg0 *ec2.DescribeRegionsInput) (*re
 
 // DescribeRegionsRequest indicates an expected call of DescribeRegionsRequest
 func (mr *MockEC2APIMockRecorder) DescribeRegionsRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeRegionsRequest", reflect.TypeOf((*MockEC2API)(nil).DescribeRegionsRequest), arg0)
 }
 
 // DescribeRegionsWithContext mocks base method
 func (m *MockEC2API) DescribeRegionsWithContext(arg0 context.Context, arg1 *ec2.DescribeRegionsInput, arg2 ...request.Option) (*ec2.DescribeRegionsOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -9092,14 +8007,12 @@ func (m *MockEC2API) DescribeRegionsWithContext(arg0 context.Context, arg1 *ec2.
 
 // DescribeRegionsWithContext indicates an expected call of DescribeRegionsWithContext
 func (mr *MockEC2APIMockRecorder) DescribeRegionsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeRegionsWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeRegionsWithContext), varargs...)
 }
 
 // DescribeReservedInstances mocks base method
 func (m *MockEC2API) DescribeReservedInstances(arg0 *ec2.DescribeReservedInstancesInput) (*ec2.DescribeReservedInstancesOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeReservedInstances", arg0)
 	ret0, _ := ret[0].(*ec2.DescribeReservedInstancesOutput)
 	ret1, _ := ret[1].(error)
@@ -9108,13 +8021,11 @@ func (m *MockEC2API) DescribeReservedInstances(arg0 *ec2.DescribeReservedInstanc
 
 // DescribeReservedInstances indicates an expected call of DescribeReservedInstances
 func (mr *MockEC2APIMockRecorder) DescribeReservedInstances(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeReservedInstances", reflect.TypeOf((*MockEC2API)(nil).DescribeReservedInstances), arg0)
 }
 
 // DescribeReservedInstancesListings mocks base method
 func (m *MockEC2API) DescribeReservedInstancesListings(arg0 *ec2.DescribeReservedInstancesListingsInput) (*ec2.DescribeReservedInstancesListingsOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeReservedInstancesListings", arg0)
 	ret0, _ := ret[0].(*ec2.DescribeReservedInstancesListingsOutput)
 	ret1, _ := ret[1].(error)
@@ -9123,13 +8034,11 @@ func (m *MockEC2API) DescribeReservedInstancesListings(arg0 *ec2.DescribeReserve
 
 // DescribeReservedInstancesListings indicates an expected call of DescribeReservedInstancesListings
 func (mr *MockEC2APIMockRecorder) DescribeReservedInstancesListings(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeReservedInstancesListings", reflect.TypeOf((*MockEC2API)(nil).DescribeReservedInstancesListings), arg0)
 }
 
 // DescribeReservedInstancesListingsRequest mocks base method
 func (m *MockEC2API) DescribeReservedInstancesListingsRequest(arg0 *ec2.DescribeReservedInstancesListingsInput) (*request.Request, *ec2.DescribeReservedInstancesListingsOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeReservedInstancesListingsRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DescribeReservedInstancesListingsOutput)
@@ -9138,13 +8047,11 @@ func (m *MockEC2API) DescribeReservedInstancesListingsRequest(arg0 *ec2.Describe
 
 // DescribeReservedInstancesListingsRequest indicates an expected call of DescribeReservedInstancesListingsRequest
 func (mr *MockEC2APIMockRecorder) DescribeReservedInstancesListingsRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeReservedInstancesListingsRequest", reflect.TypeOf((*MockEC2API)(nil).DescribeReservedInstancesListingsRequest), arg0)
 }
 
 // DescribeReservedInstancesListingsWithContext mocks base method
 func (m *MockEC2API) DescribeReservedInstancesListingsWithContext(arg0 context.Context, arg1 *ec2.DescribeReservedInstancesListingsInput, arg2 ...request.Option) (*ec2.DescribeReservedInstancesListingsOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -9157,14 +8064,12 @@ func (m *MockEC2API) DescribeReservedInstancesListingsWithContext(arg0 context.C
 
 // DescribeReservedInstancesListingsWithContext indicates an expected call of DescribeReservedInstancesListingsWithContext
 func (mr *MockEC2APIMockRecorder) DescribeReservedInstancesListingsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeReservedInstancesListingsWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeReservedInstancesListingsWithContext), varargs...)
 }
 
 // DescribeReservedInstancesModifications mocks base method
 func (m *MockEC2API) DescribeReservedInstancesModifications(arg0 *ec2.DescribeReservedInstancesModificationsInput) (*ec2.DescribeReservedInstancesModificationsOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeReservedInstancesModifications", arg0)
 	ret0, _ := ret[0].(*ec2.DescribeReservedInstancesModificationsOutput)
 	ret1, _ := ret[1].(error)
@@ -9173,13 +8078,11 @@ func (m *MockEC2API) DescribeReservedInstancesModifications(arg0 *ec2.DescribeRe
 
 // DescribeReservedInstancesModifications indicates an expected call of DescribeReservedInstancesModifications
 func (mr *MockEC2APIMockRecorder) DescribeReservedInstancesModifications(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeReservedInstancesModifications", reflect.TypeOf((*MockEC2API)(nil).DescribeReservedInstancesModifications), arg0)
 }
 
 // DescribeReservedInstancesModificationsPages mocks base method
 func (m *MockEC2API) DescribeReservedInstancesModificationsPages(arg0 *ec2.DescribeReservedInstancesModificationsInput, arg1 func(*ec2.DescribeReservedInstancesModificationsOutput, bool) bool) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeReservedInstancesModificationsPages", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -9187,13 +8090,11 @@ func (m *MockEC2API) DescribeReservedInstancesModificationsPages(arg0 *ec2.Descr
 
 // DescribeReservedInstancesModificationsPages indicates an expected call of DescribeReservedInstancesModificationsPages
 func (mr *MockEC2APIMockRecorder) DescribeReservedInstancesModificationsPages(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeReservedInstancesModificationsPages", reflect.TypeOf((*MockEC2API)(nil).DescribeReservedInstancesModificationsPages), arg0, arg1)
 }
 
 // DescribeReservedInstancesModificationsPagesWithContext mocks base method
 func (m *MockEC2API) DescribeReservedInstancesModificationsPagesWithContext(arg0 context.Context, arg1 *ec2.DescribeReservedInstancesModificationsInput, arg2 func(*ec2.DescribeReservedInstancesModificationsOutput, bool) bool, arg3 ...request.Option) error {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1, arg2}
 	for _, a := range arg3 {
 		varargs = append(varargs, a)
@@ -9205,14 +8106,12 @@ func (m *MockEC2API) DescribeReservedInstancesModificationsPagesWithContext(arg0
 
 // DescribeReservedInstancesModificationsPagesWithContext indicates an expected call of DescribeReservedInstancesModificationsPagesWithContext
 func (mr *MockEC2APIMockRecorder) DescribeReservedInstancesModificationsPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeReservedInstancesModificationsPagesWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeReservedInstancesModificationsPagesWithContext), varargs...)
 }
 
 // DescribeReservedInstancesModificationsRequest mocks base method
 func (m *MockEC2API) DescribeReservedInstancesModificationsRequest(arg0 *ec2.DescribeReservedInstancesModificationsInput) (*request.Request, *ec2.DescribeReservedInstancesModificationsOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeReservedInstancesModificationsRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DescribeReservedInstancesModificationsOutput)
@@ -9221,13 +8120,11 @@ func (m *MockEC2API) DescribeReservedInstancesModificationsRequest(arg0 *ec2.Des
 
 // DescribeReservedInstancesModificationsRequest indicates an expected call of DescribeReservedInstancesModificationsRequest
 func (mr *MockEC2APIMockRecorder) DescribeReservedInstancesModificationsRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeReservedInstancesModificationsRequest", reflect.TypeOf((*MockEC2API)(nil).DescribeReservedInstancesModificationsRequest), arg0)
 }
 
 // DescribeReservedInstancesModificationsWithContext mocks base method
 func (m *MockEC2API) DescribeReservedInstancesModificationsWithContext(arg0 context.Context, arg1 *ec2.DescribeReservedInstancesModificationsInput, arg2 ...request.Option) (*ec2.DescribeReservedInstancesModificationsOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -9240,14 +8137,12 @@ func (m *MockEC2API) DescribeReservedInstancesModificationsWithContext(arg0 cont
 
 // DescribeReservedInstancesModificationsWithContext indicates an expected call of DescribeReservedInstancesModificationsWithContext
 func (mr *MockEC2APIMockRecorder) DescribeReservedInstancesModificationsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeReservedInstancesModificationsWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeReservedInstancesModificationsWithContext), varargs...)
 }
 
 // DescribeReservedInstancesOfferings mocks base method
 func (m *MockEC2API) DescribeReservedInstancesOfferings(arg0 *ec2.DescribeReservedInstancesOfferingsInput) (*ec2.DescribeReservedInstancesOfferingsOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeReservedInstancesOfferings", arg0)
 	ret0, _ := ret[0].(*ec2.DescribeReservedInstancesOfferingsOutput)
 	ret1, _ := ret[1].(error)
@@ -9256,13 +8151,11 @@ func (m *MockEC2API) DescribeReservedInstancesOfferings(arg0 *ec2.DescribeReserv
 
 // DescribeReservedInstancesOfferings indicates an expected call of DescribeReservedInstancesOfferings
 func (mr *MockEC2APIMockRecorder) DescribeReservedInstancesOfferings(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeReservedInstancesOfferings", reflect.TypeOf((*MockEC2API)(nil).DescribeReservedInstancesOfferings), arg0)
 }
 
 // DescribeReservedInstancesOfferingsPages mocks base method
 func (m *MockEC2API) DescribeReservedInstancesOfferingsPages(arg0 *ec2.DescribeReservedInstancesOfferingsInput, arg1 func(*ec2.DescribeReservedInstancesOfferingsOutput, bool) bool) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeReservedInstancesOfferingsPages", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -9270,13 +8163,11 @@ func (m *MockEC2API) DescribeReservedInstancesOfferingsPages(arg0 *ec2.DescribeR
 
 // DescribeReservedInstancesOfferingsPages indicates an expected call of DescribeReservedInstancesOfferingsPages
 func (mr *MockEC2APIMockRecorder) DescribeReservedInstancesOfferingsPages(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeReservedInstancesOfferingsPages", reflect.TypeOf((*MockEC2API)(nil).DescribeReservedInstancesOfferingsPages), arg0, arg1)
 }
 
 // DescribeReservedInstancesOfferingsPagesWithContext mocks base method
 func (m *MockEC2API) DescribeReservedInstancesOfferingsPagesWithContext(arg0 context.Context, arg1 *ec2.DescribeReservedInstancesOfferingsInput, arg2 func(*ec2.DescribeReservedInstancesOfferingsOutput, bool) bool, arg3 ...request.Option) error {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1, arg2}
 	for _, a := range arg3 {
 		varargs = append(varargs, a)
@@ -9288,14 +8179,12 @@ func (m *MockEC2API) DescribeReservedInstancesOfferingsPagesWithContext(arg0 con
 
 // DescribeReservedInstancesOfferingsPagesWithContext indicates an expected call of DescribeReservedInstancesOfferingsPagesWithContext
 func (mr *MockEC2APIMockRecorder) DescribeReservedInstancesOfferingsPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeReservedInstancesOfferingsPagesWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeReservedInstancesOfferingsPagesWithContext), varargs...)
 }
 
 // DescribeReservedInstancesOfferingsRequest mocks base method
 func (m *MockEC2API) DescribeReservedInstancesOfferingsRequest(arg0 *ec2.DescribeReservedInstancesOfferingsInput) (*request.Request, *ec2.DescribeReservedInstancesOfferingsOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeReservedInstancesOfferingsRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DescribeReservedInstancesOfferingsOutput)
@@ -9304,13 +8193,11 @@ func (m *MockEC2API) DescribeReservedInstancesOfferingsRequest(arg0 *ec2.Describ
 
 // DescribeReservedInstancesOfferingsRequest indicates an expected call of DescribeReservedInstancesOfferingsRequest
 func (mr *MockEC2APIMockRecorder) DescribeReservedInstancesOfferingsRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeReservedInstancesOfferingsRequest", reflect.TypeOf((*MockEC2API)(nil).DescribeReservedInstancesOfferingsRequest), arg0)
 }
 
 // DescribeReservedInstancesOfferingsWithContext mocks base method
 func (m *MockEC2API) DescribeReservedInstancesOfferingsWithContext(arg0 context.Context, arg1 *ec2.DescribeReservedInstancesOfferingsInput, arg2 ...request.Option) (*ec2.DescribeReservedInstancesOfferingsOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -9323,14 +8210,12 @@ func (m *MockEC2API) DescribeReservedInstancesOfferingsWithContext(arg0 context.
 
 // DescribeReservedInstancesOfferingsWithContext indicates an expected call of DescribeReservedInstancesOfferingsWithContext
 func (mr *MockEC2APIMockRecorder) DescribeReservedInstancesOfferingsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeReservedInstancesOfferingsWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeReservedInstancesOfferingsWithContext), varargs...)
 }
 
 // DescribeReservedInstancesRequest mocks base method
 func (m *MockEC2API) DescribeReservedInstancesRequest(arg0 *ec2.DescribeReservedInstancesInput) (*request.Request, *ec2.DescribeReservedInstancesOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeReservedInstancesRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DescribeReservedInstancesOutput)
@@ -9339,13 +8224,11 @@ func (m *MockEC2API) DescribeReservedInstancesRequest(arg0 *ec2.DescribeReserved
 
 // DescribeReservedInstancesRequest indicates an expected call of DescribeReservedInstancesRequest
 func (mr *MockEC2APIMockRecorder) DescribeReservedInstancesRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeReservedInstancesRequest", reflect.TypeOf((*MockEC2API)(nil).DescribeReservedInstancesRequest), arg0)
 }
 
 // DescribeReservedInstancesWithContext mocks base method
 func (m *MockEC2API) DescribeReservedInstancesWithContext(arg0 context.Context, arg1 *ec2.DescribeReservedInstancesInput, arg2 ...request.Option) (*ec2.DescribeReservedInstancesOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -9358,14 +8241,12 @@ func (m *MockEC2API) DescribeReservedInstancesWithContext(arg0 context.Context, 
 
 // DescribeReservedInstancesWithContext indicates an expected call of DescribeReservedInstancesWithContext
 func (mr *MockEC2APIMockRecorder) DescribeReservedInstancesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeReservedInstancesWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeReservedInstancesWithContext), varargs...)
 }
 
 // DescribeRouteTables mocks base method
 func (m *MockEC2API) DescribeRouteTables(arg0 *ec2.DescribeRouteTablesInput) (*ec2.DescribeRouteTablesOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeRouteTables", arg0)
 	ret0, _ := ret[0].(*ec2.DescribeRouteTablesOutput)
 	ret1, _ := ret[1].(error)
@@ -9374,13 +8255,11 @@ func (m *MockEC2API) DescribeRouteTables(arg0 *ec2.DescribeRouteTablesInput) (*e
 
 // DescribeRouteTables indicates an expected call of DescribeRouteTables
 func (mr *MockEC2APIMockRecorder) DescribeRouteTables(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeRouteTables", reflect.TypeOf((*MockEC2API)(nil).DescribeRouteTables), arg0)
 }
 
 // DescribeRouteTablesPages mocks base method
 func (m *MockEC2API) DescribeRouteTablesPages(arg0 *ec2.DescribeRouteTablesInput, arg1 func(*ec2.DescribeRouteTablesOutput, bool) bool) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeRouteTablesPages", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -9388,13 +8267,11 @@ func (m *MockEC2API) DescribeRouteTablesPages(arg0 *ec2.DescribeRouteTablesInput
 
 // DescribeRouteTablesPages indicates an expected call of DescribeRouteTablesPages
 func (mr *MockEC2APIMockRecorder) DescribeRouteTablesPages(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeRouteTablesPages", reflect.TypeOf((*MockEC2API)(nil).DescribeRouteTablesPages), arg0, arg1)
 }
 
 // DescribeRouteTablesPagesWithContext mocks base method
 func (m *MockEC2API) DescribeRouteTablesPagesWithContext(arg0 context.Context, arg1 *ec2.DescribeRouteTablesInput, arg2 func(*ec2.DescribeRouteTablesOutput, bool) bool, arg3 ...request.Option) error {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1, arg2}
 	for _, a := range arg3 {
 		varargs = append(varargs, a)
@@ -9406,14 +8283,12 @@ func (m *MockEC2API) DescribeRouteTablesPagesWithContext(arg0 context.Context, a
 
 // DescribeRouteTablesPagesWithContext indicates an expected call of DescribeRouteTablesPagesWithContext
 func (mr *MockEC2APIMockRecorder) DescribeRouteTablesPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeRouteTablesPagesWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeRouteTablesPagesWithContext), varargs...)
 }
 
 // DescribeRouteTablesRequest mocks base method
 func (m *MockEC2API) DescribeRouteTablesRequest(arg0 *ec2.DescribeRouteTablesInput) (*request.Request, *ec2.DescribeRouteTablesOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeRouteTablesRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DescribeRouteTablesOutput)
@@ -9422,13 +8297,11 @@ func (m *MockEC2API) DescribeRouteTablesRequest(arg0 *ec2.DescribeRouteTablesInp
 
 // DescribeRouteTablesRequest indicates an expected call of DescribeRouteTablesRequest
 func (mr *MockEC2APIMockRecorder) DescribeRouteTablesRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeRouteTablesRequest", reflect.TypeOf((*MockEC2API)(nil).DescribeRouteTablesRequest), arg0)
 }
 
 // DescribeRouteTablesWithContext mocks base method
 func (m *MockEC2API) DescribeRouteTablesWithContext(arg0 context.Context, arg1 *ec2.DescribeRouteTablesInput, arg2 ...request.Option) (*ec2.DescribeRouteTablesOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -9441,14 +8314,12 @@ func (m *MockEC2API) DescribeRouteTablesWithContext(arg0 context.Context, arg1 *
 
 // DescribeRouteTablesWithContext indicates an expected call of DescribeRouteTablesWithContext
 func (mr *MockEC2APIMockRecorder) DescribeRouteTablesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeRouteTablesWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeRouteTablesWithContext), varargs...)
 }
 
 // DescribeScheduledInstanceAvailability mocks base method
 func (m *MockEC2API) DescribeScheduledInstanceAvailability(arg0 *ec2.DescribeScheduledInstanceAvailabilityInput) (*ec2.DescribeScheduledInstanceAvailabilityOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeScheduledInstanceAvailability", arg0)
 	ret0, _ := ret[0].(*ec2.DescribeScheduledInstanceAvailabilityOutput)
 	ret1, _ := ret[1].(error)
@@ -9457,13 +8328,11 @@ func (m *MockEC2API) DescribeScheduledInstanceAvailability(arg0 *ec2.DescribeSch
 
 // DescribeScheduledInstanceAvailability indicates an expected call of DescribeScheduledInstanceAvailability
 func (mr *MockEC2APIMockRecorder) DescribeScheduledInstanceAvailability(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeScheduledInstanceAvailability", reflect.TypeOf((*MockEC2API)(nil).DescribeScheduledInstanceAvailability), arg0)
 }
 
 // DescribeScheduledInstanceAvailabilityRequest mocks base method
 func (m *MockEC2API) DescribeScheduledInstanceAvailabilityRequest(arg0 *ec2.DescribeScheduledInstanceAvailabilityInput) (*request.Request, *ec2.DescribeScheduledInstanceAvailabilityOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeScheduledInstanceAvailabilityRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DescribeScheduledInstanceAvailabilityOutput)
@@ -9472,13 +8341,11 @@ func (m *MockEC2API) DescribeScheduledInstanceAvailabilityRequest(arg0 *ec2.Desc
 
 // DescribeScheduledInstanceAvailabilityRequest indicates an expected call of DescribeScheduledInstanceAvailabilityRequest
 func (mr *MockEC2APIMockRecorder) DescribeScheduledInstanceAvailabilityRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeScheduledInstanceAvailabilityRequest", reflect.TypeOf((*MockEC2API)(nil).DescribeScheduledInstanceAvailabilityRequest), arg0)
 }
 
 // DescribeScheduledInstanceAvailabilityWithContext mocks base method
 func (m *MockEC2API) DescribeScheduledInstanceAvailabilityWithContext(arg0 context.Context, arg1 *ec2.DescribeScheduledInstanceAvailabilityInput, arg2 ...request.Option) (*ec2.DescribeScheduledInstanceAvailabilityOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -9491,14 +8358,12 @@ func (m *MockEC2API) DescribeScheduledInstanceAvailabilityWithContext(arg0 conte
 
 // DescribeScheduledInstanceAvailabilityWithContext indicates an expected call of DescribeScheduledInstanceAvailabilityWithContext
 func (mr *MockEC2APIMockRecorder) DescribeScheduledInstanceAvailabilityWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeScheduledInstanceAvailabilityWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeScheduledInstanceAvailabilityWithContext), varargs...)
 }
 
 // DescribeScheduledInstances mocks base method
 func (m *MockEC2API) DescribeScheduledInstances(arg0 *ec2.DescribeScheduledInstancesInput) (*ec2.DescribeScheduledInstancesOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeScheduledInstances", arg0)
 	ret0, _ := ret[0].(*ec2.DescribeScheduledInstancesOutput)
 	ret1, _ := ret[1].(error)
@@ -9507,13 +8372,11 @@ func (m *MockEC2API) DescribeScheduledInstances(arg0 *ec2.DescribeScheduledInsta
 
 // DescribeScheduledInstances indicates an expected call of DescribeScheduledInstances
 func (mr *MockEC2APIMockRecorder) DescribeScheduledInstances(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeScheduledInstances", reflect.TypeOf((*MockEC2API)(nil).DescribeScheduledInstances), arg0)
 }
 
 // DescribeScheduledInstancesRequest mocks base method
 func (m *MockEC2API) DescribeScheduledInstancesRequest(arg0 *ec2.DescribeScheduledInstancesInput) (*request.Request, *ec2.DescribeScheduledInstancesOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeScheduledInstancesRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DescribeScheduledInstancesOutput)
@@ -9522,13 +8385,11 @@ func (m *MockEC2API) DescribeScheduledInstancesRequest(arg0 *ec2.DescribeSchedul
 
 // DescribeScheduledInstancesRequest indicates an expected call of DescribeScheduledInstancesRequest
 func (mr *MockEC2APIMockRecorder) DescribeScheduledInstancesRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeScheduledInstancesRequest", reflect.TypeOf((*MockEC2API)(nil).DescribeScheduledInstancesRequest), arg0)
 }
 
 // DescribeScheduledInstancesWithContext mocks base method
 func (m *MockEC2API) DescribeScheduledInstancesWithContext(arg0 context.Context, arg1 *ec2.DescribeScheduledInstancesInput, arg2 ...request.Option) (*ec2.DescribeScheduledInstancesOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -9541,14 +8402,12 @@ func (m *MockEC2API) DescribeScheduledInstancesWithContext(arg0 context.Context,
 
 // DescribeScheduledInstancesWithContext indicates an expected call of DescribeScheduledInstancesWithContext
 func (mr *MockEC2APIMockRecorder) DescribeScheduledInstancesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeScheduledInstancesWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeScheduledInstancesWithContext), varargs...)
 }
 
 // DescribeSecurityGroupReferences mocks base method
 func (m *MockEC2API) DescribeSecurityGroupReferences(arg0 *ec2.DescribeSecurityGroupReferencesInput) (*ec2.DescribeSecurityGroupReferencesOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeSecurityGroupReferences", arg0)
 	ret0, _ := ret[0].(*ec2.DescribeSecurityGroupReferencesOutput)
 	ret1, _ := ret[1].(error)
@@ -9557,13 +8416,11 @@ func (m *MockEC2API) DescribeSecurityGroupReferences(arg0 *ec2.DescribeSecurityG
 
 // DescribeSecurityGroupReferences indicates an expected call of DescribeSecurityGroupReferences
 func (mr *MockEC2APIMockRecorder) DescribeSecurityGroupReferences(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeSecurityGroupReferences", reflect.TypeOf((*MockEC2API)(nil).DescribeSecurityGroupReferences), arg0)
 }
 
 // DescribeSecurityGroupReferencesRequest mocks base method
 func (m *MockEC2API) DescribeSecurityGroupReferencesRequest(arg0 *ec2.DescribeSecurityGroupReferencesInput) (*request.Request, *ec2.DescribeSecurityGroupReferencesOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeSecurityGroupReferencesRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DescribeSecurityGroupReferencesOutput)
@@ -9572,13 +8429,11 @@ func (m *MockEC2API) DescribeSecurityGroupReferencesRequest(arg0 *ec2.DescribeSe
 
 // DescribeSecurityGroupReferencesRequest indicates an expected call of DescribeSecurityGroupReferencesRequest
 func (mr *MockEC2APIMockRecorder) DescribeSecurityGroupReferencesRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeSecurityGroupReferencesRequest", reflect.TypeOf((*MockEC2API)(nil).DescribeSecurityGroupReferencesRequest), arg0)
 }
 
 // DescribeSecurityGroupReferencesWithContext mocks base method
 func (m *MockEC2API) DescribeSecurityGroupReferencesWithContext(arg0 context.Context, arg1 *ec2.DescribeSecurityGroupReferencesInput, arg2 ...request.Option) (*ec2.DescribeSecurityGroupReferencesOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -9591,14 +8446,12 @@ func (m *MockEC2API) DescribeSecurityGroupReferencesWithContext(arg0 context.Con
 
 // DescribeSecurityGroupReferencesWithContext indicates an expected call of DescribeSecurityGroupReferencesWithContext
 func (mr *MockEC2APIMockRecorder) DescribeSecurityGroupReferencesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeSecurityGroupReferencesWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeSecurityGroupReferencesWithContext), varargs...)
 }
 
 // DescribeSecurityGroups mocks base method
 func (m *MockEC2API) DescribeSecurityGroups(arg0 *ec2.DescribeSecurityGroupsInput) (*ec2.DescribeSecurityGroupsOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeSecurityGroups", arg0)
 	ret0, _ := ret[0].(*ec2.DescribeSecurityGroupsOutput)
 	ret1, _ := ret[1].(error)
@@ -9607,13 +8460,11 @@ func (m *MockEC2API) DescribeSecurityGroups(arg0 *ec2.DescribeSecurityGroupsInpu
 
 // DescribeSecurityGroups indicates an expected call of DescribeSecurityGroups
 func (mr *MockEC2APIMockRecorder) DescribeSecurityGroups(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeSecurityGroups", reflect.TypeOf((*MockEC2API)(nil).DescribeSecurityGroups), arg0)
 }
 
 // DescribeSecurityGroupsPages mocks base method
 func (m *MockEC2API) DescribeSecurityGroupsPages(arg0 *ec2.DescribeSecurityGroupsInput, arg1 func(*ec2.DescribeSecurityGroupsOutput, bool) bool) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeSecurityGroupsPages", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -9621,13 +8472,11 @@ func (m *MockEC2API) DescribeSecurityGroupsPages(arg0 *ec2.DescribeSecurityGroup
 
 // DescribeSecurityGroupsPages indicates an expected call of DescribeSecurityGroupsPages
 func (mr *MockEC2APIMockRecorder) DescribeSecurityGroupsPages(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeSecurityGroupsPages", reflect.TypeOf((*MockEC2API)(nil).DescribeSecurityGroupsPages), arg0, arg1)
 }
 
 // DescribeSecurityGroupsPagesWithContext mocks base method
 func (m *MockEC2API) DescribeSecurityGroupsPagesWithContext(arg0 context.Context, arg1 *ec2.DescribeSecurityGroupsInput, arg2 func(*ec2.DescribeSecurityGroupsOutput, bool) bool, arg3 ...request.Option) error {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1, arg2}
 	for _, a := range arg3 {
 		varargs = append(varargs, a)
@@ -9639,14 +8488,12 @@ func (m *MockEC2API) DescribeSecurityGroupsPagesWithContext(arg0 context.Context
 
 // DescribeSecurityGroupsPagesWithContext indicates an expected call of DescribeSecurityGroupsPagesWithContext
 func (mr *MockEC2APIMockRecorder) DescribeSecurityGroupsPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeSecurityGroupsPagesWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeSecurityGroupsPagesWithContext), varargs...)
 }
 
 // DescribeSecurityGroupsRequest mocks base method
 func (m *MockEC2API) DescribeSecurityGroupsRequest(arg0 *ec2.DescribeSecurityGroupsInput) (*request.Request, *ec2.DescribeSecurityGroupsOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeSecurityGroupsRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DescribeSecurityGroupsOutput)
@@ -9655,13 +8502,11 @@ func (m *MockEC2API) DescribeSecurityGroupsRequest(arg0 *ec2.DescribeSecurityGro
 
 // DescribeSecurityGroupsRequest indicates an expected call of DescribeSecurityGroupsRequest
 func (mr *MockEC2APIMockRecorder) DescribeSecurityGroupsRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeSecurityGroupsRequest", reflect.TypeOf((*MockEC2API)(nil).DescribeSecurityGroupsRequest), arg0)
 }
 
 // DescribeSecurityGroupsWithContext mocks base method
 func (m *MockEC2API) DescribeSecurityGroupsWithContext(arg0 context.Context, arg1 *ec2.DescribeSecurityGroupsInput, arg2 ...request.Option) (*ec2.DescribeSecurityGroupsOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -9674,14 +8519,12 @@ func (m *MockEC2API) DescribeSecurityGroupsWithContext(arg0 context.Context, arg
 
 // DescribeSecurityGroupsWithContext indicates an expected call of DescribeSecurityGroupsWithContext
 func (mr *MockEC2APIMockRecorder) DescribeSecurityGroupsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeSecurityGroupsWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeSecurityGroupsWithContext), varargs...)
 }
 
 // DescribeSnapshotAttribute mocks base method
 func (m *MockEC2API) DescribeSnapshotAttribute(arg0 *ec2.DescribeSnapshotAttributeInput) (*ec2.DescribeSnapshotAttributeOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeSnapshotAttribute", arg0)
 	ret0, _ := ret[0].(*ec2.DescribeSnapshotAttributeOutput)
 	ret1, _ := ret[1].(error)
@@ -9690,13 +8533,11 @@ func (m *MockEC2API) DescribeSnapshotAttribute(arg0 *ec2.DescribeSnapshotAttribu
 
 // DescribeSnapshotAttribute indicates an expected call of DescribeSnapshotAttribute
 func (mr *MockEC2APIMockRecorder) DescribeSnapshotAttribute(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeSnapshotAttribute", reflect.TypeOf((*MockEC2API)(nil).DescribeSnapshotAttribute), arg0)
 }
 
 // DescribeSnapshotAttributeRequest mocks base method
 func (m *MockEC2API) DescribeSnapshotAttributeRequest(arg0 *ec2.DescribeSnapshotAttributeInput) (*request.Request, *ec2.DescribeSnapshotAttributeOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeSnapshotAttributeRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DescribeSnapshotAttributeOutput)
@@ -9705,13 +8546,11 @@ func (m *MockEC2API) DescribeSnapshotAttributeRequest(arg0 *ec2.DescribeSnapshot
 
 // DescribeSnapshotAttributeRequest indicates an expected call of DescribeSnapshotAttributeRequest
 func (mr *MockEC2APIMockRecorder) DescribeSnapshotAttributeRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeSnapshotAttributeRequest", reflect.TypeOf((*MockEC2API)(nil).DescribeSnapshotAttributeRequest), arg0)
 }
 
 // DescribeSnapshotAttributeWithContext mocks base method
 func (m *MockEC2API) DescribeSnapshotAttributeWithContext(arg0 context.Context, arg1 *ec2.DescribeSnapshotAttributeInput, arg2 ...request.Option) (*ec2.DescribeSnapshotAttributeOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -9724,14 +8563,12 @@ func (m *MockEC2API) DescribeSnapshotAttributeWithContext(arg0 context.Context, 
 
 // DescribeSnapshotAttributeWithContext indicates an expected call of DescribeSnapshotAttributeWithContext
 func (mr *MockEC2APIMockRecorder) DescribeSnapshotAttributeWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeSnapshotAttributeWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeSnapshotAttributeWithContext), varargs...)
 }
 
 // DescribeSnapshots mocks base method
 func (m *MockEC2API) DescribeSnapshots(arg0 *ec2.DescribeSnapshotsInput) (*ec2.DescribeSnapshotsOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeSnapshots", arg0)
 	ret0, _ := ret[0].(*ec2.DescribeSnapshotsOutput)
 	ret1, _ := ret[1].(error)
@@ -9740,13 +8577,11 @@ func (m *MockEC2API) DescribeSnapshots(arg0 *ec2.DescribeSnapshotsInput) (*ec2.D
 
 // DescribeSnapshots indicates an expected call of DescribeSnapshots
 func (mr *MockEC2APIMockRecorder) DescribeSnapshots(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeSnapshots", reflect.TypeOf((*MockEC2API)(nil).DescribeSnapshots), arg0)
 }
 
 // DescribeSnapshotsPages mocks base method
 func (m *MockEC2API) DescribeSnapshotsPages(arg0 *ec2.DescribeSnapshotsInput, arg1 func(*ec2.DescribeSnapshotsOutput, bool) bool) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeSnapshotsPages", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -9754,13 +8589,11 @@ func (m *MockEC2API) DescribeSnapshotsPages(arg0 *ec2.DescribeSnapshotsInput, ar
 
 // DescribeSnapshotsPages indicates an expected call of DescribeSnapshotsPages
 func (mr *MockEC2APIMockRecorder) DescribeSnapshotsPages(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeSnapshotsPages", reflect.TypeOf((*MockEC2API)(nil).DescribeSnapshotsPages), arg0, arg1)
 }
 
 // DescribeSnapshotsPagesWithContext mocks base method
 func (m *MockEC2API) DescribeSnapshotsPagesWithContext(arg0 context.Context, arg1 *ec2.DescribeSnapshotsInput, arg2 func(*ec2.DescribeSnapshotsOutput, bool) bool, arg3 ...request.Option) error {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1, arg2}
 	for _, a := range arg3 {
 		varargs = append(varargs, a)
@@ -9772,14 +8605,12 @@ func (m *MockEC2API) DescribeSnapshotsPagesWithContext(arg0 context.Context, arg
 
 // DescribeSnapshotsPagesWithContext indicates an expected call of DescribeSnapshotsPagesWithContext
 func (mr *MockEC2APIMockRecorder) DescribeSnapshotsPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeSnapshotsPagesWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeSnapshotsPagesWithContext), varargs...)
 }
 
 // DescribeSnapshotsRequest mocks base method
 func (m *MockEC2API) DescribeSnapshotsRequest(arg0 *ec2.DescribeSnapshotsInput) (*request.Request, *ec2.DescribeSnapshotsOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeSnapshotsRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DescribeSnapshotsOutput)
@@ -9788,13 +8619,11 @@ func (m *MockEC2API) DescribeSnapshotsRequest(arg0 *ec2.DescribeSnapshotsInput) 
 
 // DescribeSnapshotsRequest indicates an expected call of DescribeSnapshotsRequest
 func (mr *MockEC2APIMockRecorder) DescribeSnapshotsRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeSnapshotsRequest", reflect.TypeOf((*MockEC2API)(nil).DescribeSnapshotsRequest), arg0)
 }
 
 // DescribeSnapshotsWithContext mocks base method
 func (m *MockEC2API) DescribeSnapshotsWithContext(arg0 context.Context, arg1 *ec2.DescribeSnapshotsInput, arg2 ...request.Option) (*ec2.DescribeSnapshotsOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -9807,14 +8636,12 @@ func (m *MockEC2API) DescribeSnapshotsWithContext(arg0 context.Context, arg1 *ec
 
 // DescribeSnapshotsWithContext indicates an expected call of DescribeSnapshotsWithContext
 func (mr *MockEC2APIMockRecorder) DescribeSnapshotsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeSnapshotsWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeSnapshotsWithContext), varargs...)
 }
 
 // DescribeSpotDatafeedSubscription mocks base method
 func (m *MockEC2API) DescribeSpotDatafeedSubscription(arg0 *ec2.DescribeSpotDatafeedSubscriptionInput) (*ec2.DescribeSpotDatafeedSubscriptionOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeSpotDatafeedSubscription", arg0)
 	ret0, _ := ret[0].(*ec2.DescribeSpotDatafeedSubscriptionOutput)
 	ret1, _ := ret[1].(error)
@@ -9823,13 +8650,11 @@ func (m *MockEC2API) DescribeSpotDatafeedSubscription(arg0 *ec2.DescribeSpotData
 
 // DescribeSpotDatafeedSubscription indicates an expected call of DescribeSpotDatafeedSubscription
 func (mr *MockEC2APIMockRecorder) DescribeSpotDatafeedSubscription(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeSpotDatafeedSubscription", reflect.TypeOf((*MockEC2API)(nil).DescribeSpotDatafeedSubscription), arg0)
 }
 
 // DescribeSpotDatafeedSubscriptionRequest mocks base method
 func (m *MockEC2API) DescribeSpotDatafeedSubscriptionRequest(arg0 *ec2.DescribeSpotDatafeedSubscriptionInput) (*request.Request, *ec2.DescribeSpotDatafeedSubscriptionOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeSpotDatafeedSubscriptionRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DescribeSpotDatafeedSubscriptionOutput)
@@ -9838,13 +8663,11 @@ func (m *MockEC2API) DescribeSpotDatafeedSubscriptionRequest(arg0 *ec2.DescribeS
 
 // DescribeSpotDatafeedSubscriptionRequest indicates an expected call of DescribeSpotDatafeedSubscriptionRequest
 func (mr *MockEC2APIMockRecorder) DescribeSpotDatafeedSubscriptionRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeSpotDatafeedSubscriptionRequest", reflect.TypeOf((*MockEC2API)(nil).DescribeSpotDatafeedSubscriptionRequest), arg0)
 }
 
 // DescribeSpotDatafeedSubscriptionWithContext mocks base method
 func (m *MockEC2API) DescribeSpotDatafeedSubscriptionWithContext(arg0 context.Context, arg1 *ec2.DescribeSpotDatafeedSubscriptionInput, arg2 ...request.Option) (*ec2.DescribeSpotDatafeedSubscriptionOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -9857,14 +8680,12 @@ func (m *MockEC2API) DescribeSpotDatafeedSubscriptionWithContext(arg0 context.Co
 
 // DescribeSpotDatafeedSubscriptionWithContext indicates an expected call of DescribeSpotDatafeedSubscriptionWithContext
 func (mr *MockEC2APIMockRecorder) DescribeSpotDatafeedSubscriptionWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeSpotDatafeedSubscriptionWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeSpotDatafeedSubscriptionWithContext), varargs...)
 }
 
 // DescribeSpotFleetInstances mocks base method
 func (m *MockEC2API) DescribeSpotFleetInstances(arg0 *ec2.DescribeSpotFleetInstancesInput) (*ec2.DescribeSpotFleetInstancesOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeSpotFleetInstances", arg0)
 	ret0, _ := ret[0].(*ec2.DescribeSpotFleetInstancesOutput)
 	ret1, _ := ret[1].(error)
@@ -9873,13 +8694,11 @@ func (m *MockEC2API) DescribeSpotFleetInstances(arg0 *ec2.DescribeSpotFleetInsta
 
 // DescribeSpotFleetInstances indicates an expected call of DescribeSpotFleetInstances
 func (mr *MockEC2APIMockRecorder) DescribeSpotFleetInstances(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeSpotFleetInstances", reflect.TypeOf((*MockEC2API)(nil).DescribeSpotFleetInstances), arg0)
 }
 
 // DescribeSpotFleetInstancesRequest mocks base method
 func (m *MockEC2API) DescribeSpotFleetInstancesRequest(arg0 *ec2.DescribeSpotFleetInstancesInput) (*request.Request, *ec2.DescribeSpotFleetInstancesOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeSpotFleetInstancesRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DescribeSpotFleetInstancesOutput)
@@ -9888,13 +8707,11 @@ func (m *MockEC2API) DescribeSpotFleetInstancesRequest(arg0 *ec2.DescribeSpotFle
 
 // DescribeSpotFleetInstancesRequest indicates an expected call of DescribeSpotFleetInstancesRequest
 func (mr *MockEC2APIMockRecorder) DescribeSpotFleetInstancesRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeSpotFleetInstancesRequest", reflect.TypeOf((*MockEC2API)(nil).DescribeSpotFleetInstancesRequest), arg0)
 }
 
 // DescribeSpotFleetInstancesWithContext mocks base method
 func (m *MockEC2API) DescribeSpotFleetInstancesWithContext(arg0 context.Context, arg1 *ec2.DescribeSpotFleetInstancesInput, arg2 ...request.Option) (*ec2.DescribeSpotFleetInstancesOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -9907,14 +8724,12 @@ func (m *MockEC2API) DescribeSpotFleetInstancesWithContext(arg0 context.Context,
 
 // DescribeSpotFleetInstancesWithContext indicates an expected call of DescribeSpotFleetInstancesWithContext
 func (mr *MockEC2APIMockRecorder) DescribeSpotFleetInstancesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeSpotFleetInstancesWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeSpotFleetInstancesWithContext), varargs...)
 }
 
 // DescribeSpotFleetRequestHistory mocks base method
 func (m *MockEC2API) DescribeSpotFleetRequestHistory(arg0 *ec2.DescribeSpotFleetRequestHistoryInput) (*ec2.DescribeSpotFleetRequestHistoryOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeSpotFleetRequestHistory", arg0)
 	ret0, _ := ret[0].(*ec2.DescribeSpotFleetRequestHistoryOutput)
 	ret1, _ := ret[1].(error)
@@ -9923,13 +8738,11 @@ func (m *MockEC2API) DescribeSpotFleetRequestHistory(arg0 *ec2.DescribeSpotFleet
 
 // DescribeSpotFleetRequestHistory indicates an expected call of DescribeSpotFleetRequestHistory
 func (mr *MockEC2APIMockRecorder) DescribeSpotFleetRequestHistory(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeSpotFleetRequestHistory", reflect.TypeOf((*MockEC2API)(nil).DescribeSpotFleetRequestHistory), arg0)
 }
 
 // DescribeSpotFleetRequestHistoryRequest mocks base method
 func (m *MockEC2API) DescribeSpotFleetRequestHistoryRequest(arg0 *ec2.DescribeSpotFleetRequestHistoryInput) (*request.Request, *ec2.DescribeSpotFleetRequestHistoryOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeSpotFleetRequestHistoryRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DescribeSpotFleetRequestHistoryOutput)
@@ -9938,13 +8751,11 @@ func (m *MockEC2API) DescribeSpotFleetRequestHistoryRequest(arg0 *ec2.DescribeSp
 
 // DescribeSpotFleetRequestHistoryRequest indicates an expected call of DescribeSpotFleetRequestHistoryRequest
 func (mr *MockEC2APIMockRecorder) DescribeSpotFleetRequestHistoryRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeSpotFleetRequestHistoryRequest", reflect.TypeOf((*MockEC2API)(nil).DescribeSpotFleetRequestHistoryRequest), arg0)
 }
 
 // DescribeSpotFleetRequestHistoryWithContext mocks base method
 func (m *MockEC2API) DescribeSpotFleetRequestHistoryWithContext(arg0 context.Context, arg1 *ec2.DescribeSpotFleetRequestHistoryInput, arg2 ...request.Option) (*ec2.DescribeSpotFleetRequestHistoryOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -9957,14 +8768,12 @@ func (m *MockEC2API) DescribeSpotFleetRequestHistoryWithContext(arg0 context.Con
 
 // DescribeSpotFleetRequestHistoryWithContext indicates an expected call of DescribeSpotFleetRequestHistoryWithContext
 func (mr *MockEC2APIMockRecorder) DescribeSpotFleetRequestHistoryWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeSpotFleetRequestHistoryWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeSpotFleetRequestHistoryWithContext), varargs...)
 }
 
 // DescribeSpotFleetRequests mocks base method
 func (m *MockEC2API) DescribeSpotFleetRequests(arg0 *ec2.DescribeSpotFleetRequestsInput) (*ec2.DescribeSpotFleetRequestsOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeSpotFleetRequests", arg0)
 	ret0, _ := ret[0].(*ec2.DescribeSpotFleetRequestsOutput)
 	ret1, _ := ret[1].(error)
@@ -9973,13 +8782,11 @@ func (m *MockEC2API) DescribeSpotFleetRequests(arg0 *ec2.DescribeSpotFleetReques
 
 // DescribeSpotFleetRequests indicates an expected call of DescribeSpotFleetRequests
 func (mr *MockEC2APIMockRecorder) DescribeSpotFleetRequests(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeSpotFleetRequests", reflect.TypeOf((*MockEC2API)(nil).DescribeSpotFleetRequests), arg0)
 }
 
 // DescribeSpotFleetRequestsPages mocks base method
 func (m *MockEC2API) DescribeSpotFleetRequestsPages(arg0 *ec2.DescribeSpotFleetRequestsInput, arg1 func(*ec2.DescribeSpotFleetRequestsOutput, bool) bool) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeSpotFleetRequestsPages", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -9987,13 +8794,11 @@ func (m *MockEC2API) DescribeSpotFleetRequestsPages(arg0 *ec2.DescribeSpotFleetR
 
 // DescribeSpotFleetRequestsPages indicates an expected call of DescribeSpotFleetRequestsPages
 func (mr *MockEC2APIMockRecorder) DescribeSpotFleetRequestsPages(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeSpotFleetRequestsPages", reflect.TypeOf((*MockEC2API)(nil).DescribeSpotFleetRequestsPages), arg0, arg1)
 }
 
 // DescribeSpotFleetRequestsPagesWithContext mocks base method
 func (m *MockEC2API) DescribeSpotFleetRequestsPagesWithContext(arg0 context.Context, arg1 *ec2.DescribeSpotFleetRequestsInput, arg2 func(*ec2.DescribeSpotFleetRequestsOutput, bool) bool, arg3 ...request.Option) error {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1, arg2}
 	for _, a := range arg3 {
 		varargs = append(varargs, a)
@@ -10005,14 +8810,12 @@ func (m *MockEC2API) DescribeSpotFleetRequestsPagesWithContext(arg0 context.Cont
 
 // DescribeSpotFleetRequestsPagesWithContext indicates an expected call of DescribeSpotFleetRequestsPagesWithContext
 func (mr *MockEC2APIMockRecorder) DescribeSpotFleetRequestsPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeSpotFleetRequestsPagesWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeSpotFleetRequestsPagesWithContext), varargs...)
 }
 
 // DescribeSpotFleetRequestsRequest mocks base method
 func (m *MockEC2API) DescribeSpotFleetRequestsRequest(arg0 *ec2.DescribeSpotFleetRequestsInput) (*request.Request, *ec2.DescribeSpotFleetRequestsOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeSpotFleetRequestsRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DescribeSpotFleetRequestsOutput)
@@ -10021,13 +8824,11 @@ func (m *MockEC2API) DescribeSpotFleetRequestsRequest(arg0 *ec2.DescribeSpotFlee
 
 // DescribeSpotFleetRequestsRequest indicates an expected call of DescribeSpotFleetRequestsRequest
 func (mr *MockEC2APIMockRecorder) DescribeSpotFleetRequestsRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeSpotFleetRequestsRequest", reflect.TypeOf((*MockEC2API)(nil).DescribeSpotFleetRequestsRequest), arg0)
 }
 
 // DescribeSpotFleetRequestsWithContext mocks base method
 func (m *MockEC2API) DescribeSpotFleetRequestsWithContext(arg0 context.Context, arg1 *ec2.DescribeSpotFleetRequestsInput, arg2 ...request.Option) (*ec2.DescribeSpotFleetRequestsOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -10040,14 +8841,12 @@ func (m *MockEC2API) DescribeSpotFleetRequestsWithContext(arg0 context.Context, 
 
 // DescribeSpotFleetRequestsWithContext indicates an expected call of DescribeSpotFleetRequestsWithContext
 func (mr *MockEC2APIMockRecorder) DescribeSpotFleetRequestsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeSpotFleetRequestsWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeSpotFleetRequestsWithContext), varargs...)
 }
 
 // DescribeSpotInstanceRequests mocks base method
 func (m *MockEC2API) DescribeSpotInstanceRequests(arg0 *ec2.DescribeSpotInstanceRequestsInput) (*ec2.DescribeSpotInstanceRequestsOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeSpotInstanceRequests", arg0)
 	ret0, _ := ret[0].(*ec2.DescribeSpotInstanceRequestsOutput)
 	ret1, _ := ret[1].(error)
@@ -10056,13 +8855,11 @@ func (m *MockEC2API) DescribeSpotInstanceRequests(arg0 *ec2.DescribeSpotInstance
 
 // DescribeSpotInstanceRequests indicates an expected call of DescribeSpotInstanceRequests
 func (mr *MockEC2APIMockRecorder) DescribeSpotInstanceRequests(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeSpotInstanceRequests", reflect.TypeOf((*MockEC2API)(nil).DescribeSpotInstanceRequests), arg0)
 }
 
 // DescribeSpotInstanceRequestsRequest mocks base method
 func (m *MockEC2API) DescribeSpotInstanceRequestsRequest(arg0 *ec2.DescribeSpotInstanceRequestsInput) (*request.Request, *ec2.DescribeSpotInstanceRequestsOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeSpotInstanceRequestsRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DescribeSpotInstanceRequestsOutput)
@@ -10071,13 +8868,11 @@ func (m *MockEC2API) DescribeSpotInstanceRequestsRequest(arg0 *ec2.DescribeSpotI
 
 // DescribeSpotInstanceRequestsRequest indicates an expected call of DescribeSpotInstanceRequestsRequest
 func (mr *MockEC2APIMockRecorder) DescribeSpotInstanceRequestsRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeSpotInstanceRequestsRequest", reflect.TypeOf((*MockEC2API)(nil).DescribeSpotInstanceRequestsRequest), arg0)
 }
 
 // DescribeSpotInstanceRequestsWithContext mocks base method
 func (m *MockEC2API) DescribeSpotInstanceRequestsWithContext(arg0 context.Context, arg1 *ec2.DescribeSpotInstanceRequestsInput, arg2 ...request.Option) (*ec2.DescribeSpotInstanceRequestsOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -10090,14 +8885,12 @@ func (m *MockEC2API) DescribeSpotInstanceRequestsWithContext(arg0 context.Contex
 
 // DescribeSpotInstanceRequestsWithContext indicates an expected call of DescribeSpotInstanceRequestsWithContext
 func (mr *MockEC2APIMockRecorder) DescribeSpotInstanceRequestsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeSpotInstanceRequestsWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeSpotInstanceRequestsWithContext), varargs...)
 }
 
 // DescribeSpotPriceHistory mocks base method
 func (m *MockEC2API) DescribeSpotPriceHistory(arg0 *ec2.DescribeSpotPriceHistoryInput) (*ec2.DescribeSpotPriceHistoryOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeSpotPriceHistory", arg0)
 	ret0, _ := ret[0].(*ec2.DescribeSpotPriceHistoryOutput)
 	ret1, _ := ret[1].(error)
@@ -10106,13 +8899,11 @@ func (m *MockEC2API) DescribeSpotPriceHistory(arg0 *ec2.DescribeSpotPriceHistory
 
 // DescribeSpotPriceHistory indicates an expected call of DescribeSpotPriceHistory
 func (mr *MockEC2APIMockRecorder) DescribeSpotPriceHistory(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeSpotPriceHistory", reflect.TypeOf((*MockEC2API)(nil).DescribeSpotPriceHistory), arg0)
 }
 
 // DescribeSpotPriceHistoryPages mocks base method
 func (m *MockEC2API) DescribeSpotPriceHistoryPages(arg0 *ec2.DescribeSpotPriceHistoryInput, arg1 func(*ec2.DescribeSpotPriceHistoryOutput, bool) bool) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeSpotPriceHistoryPages", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -10120,13 +8911,11 @@ func (m *MockEC2API) DescribeSpotPriceHistoryPages(arg0 *ec2.DescribeSpotPriceHi
 
 // DescribeSpotPriceHistoryPages indicates an expected call of DescribeSpotPriceHistoryPages
 func (mr *MockEC2APIMockRecorder) DescribeSpotPriceHistoryPages(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeSpotPriceHistoryPages", reflect.TypeOf((*MockEC2API)(nil).DescribeSpotPriceHistoryPages), arg0, arg1)
 }
 
 // DescribeSpotPriceHistoryPagesWithContext mocks base method
 func (m *MockEC2API) DescribeSpotPriceHistoryPagesWithContext(arg0 context.Context, arg1 *ec2.DescribeSpotPriceHistoryInput, arg2 func(*ec2.DescribeSpotPriceHistoryOutput, bool) bool, arg3 ...request.Option) error {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1, arg2}
 	for _, a := range arg3 {
 		varargs = append(varargs, a)
@@ -10138,14 +8927,12 @@ func (m *MockEC2API) DescribeSpotPriceHistoryPagesWithContext(arg0 context.Conte
 
 // DescribeSpotPriceHistoryPagesWithContext indicates an expected call of DescribeSpotPriceHistoryPagesWithContext
 func (mr *MockEC2APIMockRecorder) DescribeSpotPriceHistoryPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeSpotPriceHistoryPagesWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeSpotPriceHistoryPagesWithContext), varargs...)
 }
 
 // DescribeSpotPriceHistoryRequest mocks base method
 func (m *MockEC2API) DescribeSpotPriceHistoryRequest(arg0 *ec2.DescribeSpotPriceHistoryInput) (*request.Request, *ec2.DescribeSpotPriceHistoryOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeSpotPriceHistoryRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DescribeSpotPriceHistoryOutput)
@@ -10154,13 +8941,11 @@ func (m *MockEC2API) DescribeSpotPriceHistoryRequest(arg0 *ec2.DescribeSpotPrice
 
 // DescribeSpotPriceHistoryRequest indicates an expected call of DescribeSpotPriceHistoryRequest
 func (mr *MockEC2APIMockRecorder) DescribeSpotPriceHistoryRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeSpotPriceHistoryRequest", reflect.TypeOf((*MockEC2API)(nil).DescribeSpotPriceHistoryRequest), arg0)
 }
 
 // DescribeSpotPriceHistoryWithContext mocks base method
 func (m *MockEC2API) DescribeSpotPriceHistoryWithContext(arg0 context.Context, arg1 *ec2.DescribeSpotPriceHistoryInput, arg2 ...request.Option) (*ec2.DescribeSpotPriceHistoryOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -10173,14 +8958,12 @@ func (m *MockEC2API) DescribeSpotPriceHistoryWithContext(arg0 context.Context, a
 
 // DescribeSpotPriceHistoryWithContext indicates an expected call of DescribeSpotPriceHistoryWithContext
 func (mr *MockEC2APIMockRecorder) DescribeSpotPriceHistoryWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeSpotPriceHistoryWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeSpotPriceHistoryWithContext), varargs...)
 }
 
 // DescribeStaleSecurityGroups mocks base method
 func (m *MockEC2API) DescribeStaleSecurityGroups(arg0 *ec2.DescribeStaleSecurityGroupsInput) (*ec2.DescribeStaleSecurityGroupsOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeStaleSecurityGroups", arg0)
 	ret0, _ := ret[0].(*ec2.DescribeStaleSecurityGroupsOutput)
 	ret1, _ := ret[1].(error)
@@ -10189,13 +8972,11 @@ func (m *MockEC2API) DescribeStaleSecurityGroups(arg0 *ec2.DescribeStaleSecurity
 
 // DescribeStaleSecurityGroups indicates an expected call of DescribeStaleSecurityGroups
 func (mr *MockEC2APIMockRecorder) DescribeStaleSecurityGroups(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeStaleSecurityGroups", reflect.TypeOf((*MockEC2API)(nil).DescribeStaleSecurityGroups), arg0)
 }
 
 // DescribeStaleSecurityGroupsRequest mocks base method
 func (m *MockEC2API) DescribeStaleSecurityGroupsRequest(arg0 *ec2.DescribeStaleSecurityGroupsInput) (*request.Request, *ec2.DescribeStaleSecurityGroupsOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeStaleSecurityGroupsRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DescribeStaleSecurityGroupsOutput)
@@ -10204,13 +8985,11 @@ func (m *MockEC2API) DescribeStaleSecurityGroupsRequest(arg0 *ec2.DescribeStaleS
 
 // DescribeStaleSecurityGroupsRequest indicates an expected call of DescribeStaleSecurityGroupsRequest
 func (mr *MockEC2APIMockRecorder) DescribeStaleSecurityGroupsRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeStaleSecurityGroupsRequest", reflect.TypeOf((*MockEC2API)(nil).DescribeStaleSecurityGroupsRequest), arg0)
 }
 
 // DescribeStaleSecurityGroupsWithContext mocks base method
 func (m *MockEC2API) DescribeStaleSecurityGroupsWithContext(arg0 context.Context, arg1 *ec2.DescribeStaleSecurityGroupsInput, arg2 ...request.Option) (*ec2.DescribeStaleSecurityGroupsOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -10223,14 +9002,12 @@ func (m *MockEC2API) DescribeStaleSecurityGroupsWithContext(arg0 context.Context
 
 // DescribeStaleSecurityGroupsWithContext indicates an expected call of DescribeStaleSecurityGroupsWithContext
 func (mr *MockEC2APIMockRecorder) DescribeStaleSecurityGroupsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeStaleSecurityGroupsWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeStaleSecurityGroupsWithContext), varargs...)
 }
 
 // DescribeSubnets mocks base method
 func (m *MockEC2API) DescribeSubnets(arg0 *ec2.DescribeSubnetsInput) (*ec2.DescribeSubnetsOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeSubnets", arg0)
 	ret0, _ := ret[0].(*ec2.DescribeSubnetsOutput)
 	ret1, _ := ret[1].(error)
@@ -10239,13 +9016,11 @@ func (m *MockEC2API) DescribeSubnets(arg0 *ec2.DescribeSubnetsInput) (*ec2.Descr
 
 // DescribeSubnets indicates an expected call of DescribeSubnets
 func (mr *MockEC2APIMockRecorder) DescribeSubnets(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeSubnets", reflect.TypeOf((*MockEC2API)(nil).DescribeSubnets), arg0)
 }
 
 // DescribeSubnetsRequest mocks base method
 func (m *MockEC2API) DescribeSubnetsRequest(arg0 *ec2.DescribeSubnetsInput) (*request.Request, *ec2.DescribeSubnetsOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeSubnetsRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DescribeSubnetsOutput)
@@ -10254,13 +9029,11 @@ func (m *MockEC2API) DescribeSubnetsRequest(arg0 *ec2.DescribeSubnetsInput) (*re
 
 // DescribeSubnetsRequest indicates an expected call of DescribeSubnetsRequest
 func (mr *MockEC2APIMockRecorder) DescribeSubnetsRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeSubnetsRequest", reflect.TypeOf((*MockEC2API)(nil).DescribeSubnetsRequest), arg0)
 }
 
 // DescribeSubnetsWithContext mocks base method
 func (m *MockEC2API) DescribeSubnetsWithContext(arg0 context.Context, arg1 *ec2.DescribeSubnetsInput, arg2 ...request.Option) (*ec2.DescribeSubnetsOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -10273,14 +9046,12 @@ func (m *MockEC2API) DescribeSubnetsWithContext(arg0 context.Context, arg1 *ec2.
 
 // DescribeSubnetsWithContext indicates an expected call of DescribeSubnetsWithContext
 func (mr *MockEC2APIMockRecorder) DescribeSubnetsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeSubnetsWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeSubnetsWithContext), varargs...)
 }
 
 // DescribeTags mocks base method
 func (m *MockEC2API) DescribeTags(arg0 *ec2.DescribeTagsInput) (*ec2.DescribeTagsOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeTags", arg0)
 	ret0, _ := ret[0].(*ec2.DescribeTagsOutput)
 	ret1, _ := ret[1].(error)
@@ -10289,13 +9060,11 @@ func (m *MockEC2API) DescribeTags(arg0 *ec2.DescribeTagsInput) (*ec2.DescribeTag
 
 // DescribeTags indicates an expected call of DescribeTags
 func (mr *MockEC2APIMockRecorder) DescribeTags(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeTags", reflect.TypeOf((*MockEC2API)(nil).DescribeTags), arg0)
 }
 
 // DescribeTagsPages mocks base method
 func (m *MockEC2API) DescribeTagsPages(arg0 *ec2.DescribeTagsInput, arg1 func(*ec2.DescribeTagsOutput, bool) bool) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeTagsPages", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -10303,13 +9072,11 @@ func (m *MockEC2API) DescribeTagsPages(arg0 *ec2.DescribeTagsInput, arg1 func(*e
 
 // DescribeTagsPages indicates an expected call of DescribeTagsPages
 func (mr *MockEC2APIMockRecorder) DescribeTagsPages(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeTagsPages", reflect.TypeOf((*MockEC2API)(nil).DescribeTagsPages), arg0, arg1)
 }
 
 // DescribeTagsPagesWithContext mocks base method
 func (m *MockEC2API) DescribeTagsPagesWithContext(arg0 context.Context, arg1 *ec2.DescribeTagsInput, arg2 func(*ec2.DescribeTagsOutput, bool) bool, arg3 ...request.Option) error {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1, arg2}
 	for _, a := range arg3 {
 		varargs = append(varargs, a)
@@ -10321,14 +9088,12 @@ func (m *MockEC2API) DescribeTagsPagesWithContext(arg0 context.Context, arg1 *ec
 
 // DescribeTagsPagesWithContext indicates an expected call of DescribeTagsPagesWithContext
 func (mr *MockEC2APIMockRecorder) DescribeTagsPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeTagsPagesWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeTagsPagesWithContext), varargs...)
 }
 
 // DescribeTagsRequest mocks base method
 func (m *MockEC2API) DescribeTagsRequest(arg0 *ec2.DescribeTagsInput) (*request.Request, *ec2.DescribeTagsOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeTagsRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DescribeTagsOutput)
@@ -10337,13 +9102,11 @@ func (m *MockEC2API) DescribeTagsRequest(arg0 *ec2.DescribeTagsInput) (*request.
 
 // DescribeTagsRequest indicates an expected call of DescribeTagsRequest
 func (mr *MockEC2APIMockRecorder) DescribeTagsRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeTagsRequest", reflect.TypeOf((*MockEC2API)(nil).DescribeTagsRequest), arg0)
 }
 
 // DescribeTagsWithContext mocks base method
 func (m *MockEC2API) DescribeTagsWithContext(arg0 context.Context, arg1 *ec2.DescribeTagsInput, arg2 ...request.Option) (*ec2.DescribeTagsOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -10356,14 +9119,12 @@ func (m *MockEC2API) DescribeTagsWithContext(arg0 context.Context, arg1 *ec2.Des
 
 // DescribeTagsWithContext indicates an expected call of DescribeTagsWithContext
 func (mr *MockEC2APIMockRecorder) DescribeTagsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeTagsWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeTagsWithContext), varargs...)
 }
 
 // DescribeTransitGatewayAttachments mocks base method
 func (m *MockEC2API) DescribeTransitGatewayAttachments(arg0 *ec2.DescribeTransitGatewayAttachmentsInput) (*ec2.DescribeTransitGatewayAttachmentsOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeTransitGatewayAttachments", arg0)
 	ret0, _ := ret[0].(*ec2.DescribeTransitGatewayAttachmentsOutput)
 	ret1, _ := ret[1].(error)
@@ -10372,13 +9133,11 @@ func (m *MockEC2API) DescribeTransitGatewayAttachments(arg0 *ec2.DescribeTransit
 
 // DescribeTransitGatewayAttachments indicates an expected call of DescribeTransitGatewayAttachments
 func (mr *MockEC2APIMockRecorder) DescribeTransitGatewayAttachments(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeTransitGatewayAttachments", reflect.TypeOf((*MockEC2API)(nil).DescribeTransitGatewayAttachments), arg0)
 }
 
 // DescribeTransitGatewayAttachmentsRequest mocks base method
 func (m *MockEC2API) DescribeTransitGatewayAttachmentsRequest(arg0 *ec2.DescribeTransitGatewayAttachmentsInput) (*request.Request, *ec2.DescribeTransitGatewayAttachmentsOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeTransitGatewayAttachmentsRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DescribeTransitGatewayAttachmentsOutput)
@@ -10387,13 +9146,11 @@ func (m *MockEC2API) DescribeTransitGatewayAttachmentsRequest(arg0 *ec2.Describe
 
 // DescribeTransitGatewayAttachmentsRequest indicates an expected call of DescribeTransitGatewayAttachmentsRequest
 func (mr *MockEC2APIMockRecorder) DescribeTransitGatewayAttachmentsRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeTransitGatewayAttachmentsRequest", reflect.TypeOf((*MockEC2API)(nil).DescribeTransitGatewayAttachmentsRequest), arg0)
 }
 
 // DescribeTransitGatewayAttachmentsWithContext mocks base method
 func (m *MockEC2API) DescribeTransitGatewayAttachmentsWithContext(arg0 context.Context, arg1 *ec2.DescribeTransitGatewayAttachmentsInput, arg2 ...request.Option) (*ec2.DescribeTransitGatewayAttachmentsOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -10406,14 +9163,12 @@ func (m *MockEC2API) DescribeTransitGatewayAttachmentsWithContext(arg0 context.C
 
 // DescribeTransitGatewayAttachmentsWithContext indicates an expected call of DescribeTransitGatewayAttachmentsWithContext
 func (mr *MockEC2APIMockRecorder) DescribeTransitGatewayAttachmentsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeTransitGatewayAttachmentsWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeTransitGatewayAttachmentsWithContext), varargs...)
 }
 
 // DescribeTransitGatewayRouteTables mocks base method
 func (m *MockEC2API) DescribeTransitGatewayRouteTables(arg0 *ec2.DescribeTransitGatewayRouteTablesInput) (*ec2.DescribeTransitGatewayRouteTablesOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeTransitGatewayRouteTables", arg0)
 	ret0, _ := ret[0].(*ec2.DescribeTransitGatewayRouteTablesOutput)
 	ret1, _ := ret[1].(error)
@@ -10422,13 +9177,11 @@ func (m *MockEC2API) DescribeTransitGatewayRouteTables(arg0 *ec2.DescribeTransit
 
 // DescribeTransitGatewayRouteTables indicates an expected call of DescribeTransitGatewayRouteTables
 func (mr *MockEC2APIMockRecorder) DescribeTransitGatewayRouteTables(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeTransitGatewayRouteTables", reflect.TypeOf((*MockEC2API)(nil).DescribeTransitGatewayRouteTables), arg0)
 }
 
 // DescribeTransitGatewayRouteTablesRequest mocks base method
 func (m *MockEC2API) DescribeTransitGatewayRouteTablesRequest(arg0 *ec2.DescribeTransitGatewayRouteTablesInput) (*request.Request, *ec2.DescribeTransitGatewayRouteTablesOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeTransitGatewayRouteTablesRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DescribeTransitGatewayRouteTablesOutput)
@@ -10437,13 +9190,11 @@ func (m *MockEC2API) DescribeTransitGatewayRouteTablesRequest(arg0 *ec2.Describe
 
 // DescribeTransitGatewayRouteTablesRequest indicates an expected call of DescribeTransitGatewayRouteTablesRequest
 func (mr *MockEC2APIMockRecorder) DescribeTransitGatewayRouteTablesRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeTransitGatewayRouteTablesRequest", reflect.TypeOf((*MockEC2API)(nil).DescribeTransitGatewayRouteTablesRequest), arg0)
 }
 
 // DescribeTransitGatewayRouteTablesWithContext mocks base method
 func (m *MockEC2API) DescribeTransitGatewayRouteTablesWithContext(arg0 context.Context, arg1 *ec2.DescribeTransitGatewayRouteTablesInput, arg2 ...request.Option) (*ec2.DescribeTransitGatewayRouteTablesOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -10456,14 +9207,12 @@ func (m *MockEC2API) DescribeTransitGatewayRouteTablesWithContext(arg0 context.C
 
 // DescribeTransitGatewayRouteTablesWithContext indicates an expected call of DescribeTransitGatewayRouteTablesWithContext
 func (mr *MockEC2APIMockRecorder) DescribeTransitGatewayRouteTablesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeTransitGatewayRouteTablesWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeTransitGatewayRouteTablesWithContext), varargs...)
 }
 
 // DescribeTransitGatewayVpcAttachments mocks base method
 func (m *MockEC2API) DescribeTransitGatewayVpcAttachments(arg0 *ec2.DescribeTransitGatewayVpcAttachmentsInput) (*ec2.DescribeTransitGatewayVpcAttachmentsOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeTransitGatewayVpcAttachments", arg0)
 	ret0, _ := ret[0].(*ec2.DescribeTransitGatewayVpcAttachmentsOutput)
 	ret1, _ := ret[1].(error)
@@ -10472,13 +9221,11 @@ func (m *MockEC2API) DescribeTransitGatewayVpcAttachments(arg0 *ec2.DescribeTran
 
 // DescribeTransitGatewayVpcAttachments indicates an expected call of DescribeTransitGatewayVpcAttachments
 func (mr *MockEC2APIMockRecorder) DescribeTransitGatewayVpcAttachments(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeTransitGatewayVpcAttachments", reflect.TypeOf((*MockEC2API)(nil).DescribeTransitGatewayVpcAttachments), arg0)
 }
 
 // DescribeTransitGatewayVpcAttachmentsRequest mocks base method
 func (m *MockEC2API) DescribeTransitGatewayVpcAttachmentsRequest(arg0 *ec2.DescribeTransitGatewayVpcAttachmentsInput) (*request.Request, *ec2.DescribeTransitGatewayVpcAttachmentsOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeTransitGatewayVpcAttachmentsRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DescribeTransitGatewayVpcAttachmentsOutput)
@@ -10487,13 +9234,11 @@ func (m *MockEC2API) DescribeTransitGatewayVpcAttachmentsRequest(arg0 *ec2.Descr
 
 // DescribeTransitGatewayVpcAttachmentsRequest indicates an expected call of DescribeTransitGatewayVpcAttachmentsRequest
 func (mr *MockEC2APIMockRecorder) DescribeTransitGatewayVpcAttachmentsRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeTransitGatewayVpcAttachmentsRequest", reflect.TypeOf((*MockEC2API)(nil).DescribeTransitGatewayVpcAttachmentsRequest), arg0)
 }
 
 // DescribeTransitGatewayVpcAttachmentsWithContext mocks base method
 func (m *MockEC2API) DescribeTransitGatewayVpcAttachmentsWithContext(arg0 context.Context, arg1 *ec2.DescribeTransitGatewayVpcAttachmentsInput, arg2 ...request.Option) (*ec2.DescribeTransitGatewayVpcAttachmentsOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -10506,14 +9251,12 @@ func (m *MockEC2API) DescribeTransitGatewayVpcAttachmentsWithContext(arg0 contex
 
 // DescribeTransitGatewayVpcAttachmentsWithContext indicates an expected call of DescribeTransitGatewayVpcAttachmentsWithContext
 func (mr *MockEC2APIMockRecorder) DescribeTransitGatewayVpcAttachmentsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeTransitGatewayVpcAttachmentsWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeTransitGatewayVpcAttachmentsWithContext), varargs...)
 }
 
 // DescribeTransitGateways mocks base method
 func (m *MockEC2API) DescribeTransitGateways(arg0 *ec2.DescribeTransitGatewaysInput) (*ec2.DescribeTransitGatewaysOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeTransitGateways", arg0)
 	ret0, _ := ret[0].(*ec2.DescribeTransitGatewaysOutput)
 	ret1, _ := ret[1].(error)
@@ -10522,13 +9265,11 @@ func (m *MockEC2API) DescribeTransitGateways(arg0 *ec2.DescribeTransitGatewaysIn
 
 // DescribeTransitGateways indicates an expected call of DescribeTransitGateways
 func (mr *MockEC2APIMockRecorder) DescribeTransitGateways(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeTransitGateways", reflect.TypeOf((*MockEC2API)(nil).DescribeTransitGateways), arg0)
 }
 
 // DescribeTransitGatewaysRequest mocks base method
 func (m *MockEC2API) DescribeTransitGatewaysRequest(arg0 *ec2.DescribeTransitGatewaysInput) (*request.Request, *ec2.DescribeTransitGatewaysOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeTransitGatewaysRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DescribeTransitGatewaysOutput)
@@ -10537,13 +9278,11 @@ func (m *MockEC2API) DescribeTransitGatewaysRequest(arg0 *ec2.DescribeTransitGat
 
 // DescribeTransitGatewaysRequest indicates an expected call of DescribeTransitGatewaysRequest
 func (mr *MockEC2APIMockRecorder) DescribeTransitGatewaysRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeTransitGatewaysRequest", reflect.TypeOf((*MockEC2API)(nil).DescribeTransitGatewaysRequest), arg0)
 }
 
 // DescribeTransitGatewaysWithContext mocks base method
 func (m *MockEC2API) DescribeTransitGatewaysWithContext(arg0 context.Context, arg1 *ec2.DescribeTransitGatewaysInput, arg2 ...request.Option) (*ec2.DescribeTransitGatewaysOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -10556,14 +9295,12 @@ func (m *MockEC2API) DescribeTransitGatewaysWithContext(arg0 context.Context, ar
 
 // DescribeTransitGatewaysWithContext indicates an expected call of DescribeTransitGatewaysWithContext
 func (mr *MockEC2APIMockRecorder) DescribeTransitGatewaysWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeTransitGatewaysWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeTransitGatewaysWithContext), varargs...)
 }
 
 // DescribeVolumeAttribute mocks base method
 func (m *MockEC2API) DescribeVolumeAttribute(arg0 *ec2.DescribeVolumeAttributeInput) (*ec2.DescribeVolumeAttributeOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeVolumeAttribute", arg0)
 	ret0, _ := ret[0].(*ec2.DescribeVolumeAttributeOutput)
 	ret1, _ := ret[1].(error)
@@ -10572,13 +9309,11 @@ func (m *MockEC2API) DescribeVolumeAttribute(arg0 *ec2.DescribeVolumeAttributeIn
 
 // DescribeVolumeAttribute indicates an expected call of DescribeVolumeAttribute
 func (mr *MockEC2APIMockRecorder) DescribeVolumeAttribute(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeVolumeAttribute", reflect.TypeOf((*MockEC2API)(nil).DescribeVolumeAttribute), arg0)
 }
 
 // DescribeVolumeAttributeRequest mocks base method
 func (m *MockEC2API) DescribeVolumeAttributeRequest(arg0 *ec2.DescribeVolumeAttributeInput) (*request.Request, *ec2.DescribeVolumeAttributeOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeVolumeAttributeRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DescribeVolumeAttributeOutput)
@@ -10587,13 +9322,11 @@ func (m *MockEC2API) DescribeVolumeAttributeRequest(arg0 *ec2.DescribeVolumeAttr
 
 // DescribeVolumeAttributeRequest indicates an expected call of DescribeVolumeAttributeRequest
 func (mr *MockEC2APIMockRecorder) DescribeVolumeAttributeRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeVolumeAttributeRequest", reflect.TypeOf((*MockEC2API)(nil).DescribeVolumeAttributeRequest), arg0)
 }
 
 // DescribeVolumeAttributeWithContext mocks base method
 func (m *MockEC2API) DescribeVolumeAttributeWithContext(arg0 context.Context, arg1 *ec2.DescribeVolumeAttributeInput, arg2 ...request.Option) (*ec2.DescribeVolumeAttributeOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -10606,14 +9339,12 @@ func (m *MockEC2API) DescribeVolumeAttributeWithContext(arg0 context.Context, ar
 
 // DescribeVolumeAttributeWithContext indicates an expected call of DescribeVolumeAttributeWithContext
 func (mr *MockEC2APIMockRecorder) DescribeVolumeAttributeWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeVolumeAttributeWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeVolumeAttributeWithContext), varargs...)
 }
 
 // DescribeVolumeStatus mocks base method
 func (m *MockEC2API) DescribeVolumeStatus(arg0 *ec2.DescribeVolumeStatusInput) (*ec2.DescribeVolumeStatusOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeVolumeStatus", arg0)
 	ret0, _ := ret[0].(*ec2.DescribeVolumeStatusOutput)
 	ret1, _ := ret[1].(error)
@@ -10622,13 +9353,11 @@ func (m *MockEC2API) DescribeVolumeStatus(arg0 *ec2.DescribeVolumeStatusInput) (
 
 // DescribeVolumeStatus indicates an expected call of DescribeVolumeStatus
 func (mr *MockEC2APIMockRecorder) DescribeVolumeStatus(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeVolumeStatus", reflect.TypeOf((*MockEC2API)(nil).DescribeVolumeStatus), arg0)
 }
 
 // DescribeVolumeStatusPages mocks base method
 func (m *MockEC2API) DescribeVolumeStatusPages(arg0 *ec2.DescribeVolumeStatusInput, arg1 func(*ec2.DescribeVolumeStatusOutput, bool) bool) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeVolumeStatusPages", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -10636,13 +9365,11 @@ func (m *MockEC2API) DescribeVolumeStatusPages(arg0 *ec2.DescribeVolumeStatusInp
 
 // DescribeVolumeStatusPages indicates an expected call of DescribeVolumeStatusPages
 func (mr *MockEC2APIMockRecorder) DescribeVolumeStatusPages(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeVolumeStatusPages", reflect.TypeOf((*MockEC2API)(nil).DescribeVolumeStatusPages), arg0, arg1)
 }
 
 // DescribeVolumeStatusPagesWithContext mocks base method
 func (m *MockEC2API) DescribeVolumeStatusPagesWithContext(arg0 context.Context, arg1 *ec2.DescribeVolumeStatusInput, arg2 func(*ec2.DescribeVolumeStatusOutput, bool) bool, arg3 ...request.Option) error {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1, arg2}
 	for _, a := range arg3 {
 		varargs = append(varargs, a)
@@ -10654,14 +9381,12 @@ func (m *MockEC2API) DescribeVolumeStatusPagesWithContext(arg0 context.Context, 
 
 // DescribeVolumeStatusPagesWithContext indicates an expected call of DescribeVolumeStatusPagesWithContext
 func (mr *MockEC2APIMockRecorder) DescribeVolumeStatusPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeVolumeStatusPagesWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeVolumeStatusPagesWithContext), varargs...)
 }
 
 // DescribeVolumeStatusRequest mocks base method
 func (m *MockEC2API) DescribeVolumeStatusRequest(arg0 *ec2.DescribeVolumeStatusInput) (*request.Request, *ec2.DescribeVolumeStatusOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeVolumeStatusRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DescribeVolumeStatusOutput)
@@ -10670,13 +9395,11 @@ func (m *MockEC2API) DescribeVolumeStatusRequest(arg0 *ec2.DescribeVolumeStatusI
 
 // DescribeVolumeStatusRequest indicates an expected call of DescribeVolumeStatusRequest
 func (mr *MockEC2APIMockRecorder) DescribeVolumeStatusRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeVolumeStatusRequest", reflect.TypeOf((*MockEC2API)(nil).DescribeVolumeStatusRequest), arg0)
 }
 
 // DescribeVolumeStatusWithContext mocks base method
 func (m *MockEC2API) DescribeVolumeStatusWithContext(arg0 context.Context, arg1 *ec2.DescribeVolumeStatusInput, arg2 ...request.Option) (*ec2.DescribeVolumeStatusOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -10689,14 +9412,12 @@ func (m *MockEC2API) DescribeVolumeStatusWithContext(arg0 context.Context, arg1 
 
 // DescribeVolumeStatusWithContext indicates an expected call of DescribeVolumeStatusWithContext
 func (mr *MockEC2APIMockRecorder) DescribeVolumeStatusWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeVolumeStatusWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeVolumeStatusWithContext), varargs...)
 }
 
 // DescribeVolumes mocks base method
 func (m *MockEC2API) DescribeVolumes(arg0 *ec2.DescribeVolumesInput) (*ec2.DescribeVolumesOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeVolumes", arg0)
 	ret0, _ := ret[0].(*ec2.DescribeVolumesOutput)
 	ret1, _ := ret[1].(error)
@@ -10705,13 +9426,11 @@ func (m *MockEC2API) DescribeVolumes(arg0 *ec2.DescribeVolumesInput) (*ec2.Descr
 
 // DescribeVolumes indicates an expected call of DescribeVolumes
 func (mr *MockEC2APIMockRecorder) DescribeVolumes(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeVolumes", reflect.TypeOf((*MockEC2API)(nil).DescribeVolumes), arg0)
 }
 
 // DescribeVolumesModifications mocks base method
 func (m *MockEC2API) DescribeVolumesModifications(arg0 *ec2.DescribeVolumesModificationsInput) (*ec2.DescribeVolumesModificationsOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeVolumesModifications", arg0)
 	ret0, _ := ret[0].(*ec2.DescribeVolumesModificationsOutput)
 	ret1, _ := ret[1].(error)
@@ -10720,13 +9439,11 @@ func (m *MockEC2API) DescribeVolumesModifications(arg0 *ec2.DescribeVolumesModif
 
 // DescribeVolumesModifications indicates an expected call of DescribeVolumesModifications
 func (mr *MockEC2APIMockRecorder) DescribeVolumesModifications(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeVolumesModifications", reflect.TypeOf((*MockEC2API)(nil).DescribeVolumesModifications), arg0)
 }
 
 // DescribeVolumesModificationsRequest mocks base method
 func (m *MockEC2API) DescribeVolumesModificationsRequest(arg0 *ec2.DescribeVolumesModificationsInput) (*request.Request, *ec2.DescribeVolumesModificationsOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeVolumesModificationsRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DescribeVolumesModificationsOutput)
@@ -10735,13 +9452,11 @@ func (m *MockEC2API) DescribeVolumesModificationsRequest(arg0 *ec2.DescribeVolum
 
 // DescribeVolumesModificationsRequest indicates an expected call of DescribeVolumesModificationsRequest
 func (mr *MockEC2APIMockRecorder) DescribeVolumesModificationsRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeVolumesModificationsRequest", reflect.TypeOf((*MockEC2API)(nil).DescribeVolumesModificationsRequest), arg0)
 }
 
 // DescribeVolumesModificationsWithContext mocks base method
 func (m *MockEC2API) DescribeVolumesModificationsWithContext(arg0 context.Context, arg1 *ec2.DescribeVolumesModificationsInput, arg2 ...request.Option) (*ec2.DescribeVolumesModificationsOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -10754,14 +9469,12 @@ func (m *MockEC2API) DescribeVolumesModificationsWithContext(arg0 context.Contex
 
 // DescribeVolumesModificationsWithContext indicates an expected call of DescribeVolumesModificationsWithContext
 func (mr *MockEC2APIMockRecorder) DescribeVolumesModificationsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeVolumesModificationsWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeVolumesModificationsWithContext), varargs...)
 }
 
 // DescribeVolumesPages mocks base method
 func (m *MockEC2API) DescribeVolumesPages(arg0 *ec2.DescribeVolumesInput, arg1 func(*ec2.DescribeVolumesOutput, bool) bool) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeVolumesPages", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -10769,13 +9482,11 @@ func (m *MockEC2API) DescribeVolumesPages(arg0 *ec2.DescribeVolumesInput, arg1 f
 
 // DescribeVolumesPages indicates an expected call of DescribeVolumesPages
 func (mr *MockEC2APIMockRecorder) DescribeVolumesPages(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeVolumesPages", reflect.TypeOf((*MockEC2API)(nil).DescribeVolumesPages), arg0, arg1)
 }
 
 // DescribeVolumesPagesWithContext mocks base method
 func (m *MockEC2API) DescribeVolumesPagesWithContext(arg0 context.Context, arg1 *ec2.DescribeVolumesInput, arg2 func(*ec2.DescribeVolumesOutput, bool) bool, arg3 ...request.Option) error {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1, arg2}
 	for _, a := range arg3 {
 		varargs = append(varargs, a)
@@ -10787,14 +9498,12 @@ func (m *MockEC2API) DescribeVolumesPagesWithContext(arg0 context.Context, arg1 
 
 // DescribeVolumesPagesWithContext indicates an expected call of DescribeVolumesPagesWithContext
 func (mr *MockEC2APIMockRecorder) DescribeVolumesPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeVolumesPagesWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeVolumesPagesWithContext), varargs...)
 }
 
 // DescribeVolumesRequest mocks base method
 func (m *MockEC2API) DescribeVolumesRequest(arg0 *ec2.DescribeVolumesInput) (*request.Request, *ec2.DescribeVolumesOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeVolumesRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DescribeVolumesOutput)
@@ -10803,13 +9512,11 @@ func (m *MockEC2API) DescribeVolumesRequest(arg0 *ec2.DescribeVolumesInput) (*re
 
 // DescribeVolumesRequest indicates an expected call of DescribeVolumesRequest
 func (mr *MockEC2APIMockRecorder) DescribeVolumesRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeVolumesRequest", reflect.TypeOf((*MockEC2API)(nil).DescribeVolumesRequest), arg0)
 }
 
 // DescribeVolumesWithContext mocks base method
 func (m *MockEC2API) DescribeVolumesWithContext(arg0 context.Context, arg1 *ec2.DescribeVolumesInput, arg2 ...request.Option) (*ec2.DescribeVolumesOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -10822,14 +9529,12 @@ func (m *MockEC2API) DescribeVolumesWithContext(arg0 context.Context, arg1 *ec2.
 
 // DescribeVolumesWithContext indicates an expected call of DescribeVolumesWithContext
 func (mr *MockEC2APIMockRecorder) DescribeVolumesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeVolumesWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeVolumesWithContext), varargs...)
 }
 
 // DescribeVpcAttribute mocks base method
 func (m *MockEC2API) DescribeVpcAttribute(arg0 *ec2.DescribeVpcAttributeInput) (*ec2.DescribeVpcAttributeOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeVpcAttribute", arg0)
 	ret0, _ := ret[0].(*ec2.DescribeVpcAttributeOutput)
 	ret1, _ := ret[1].(error)
@@ -10838,13 +9543,11 @@ func (m *MockEC2API) DescribeVpcAttribute(arg0 *ec2.DescribeVpcAttributeInput) (
 
 // DescribeVpcAttribute indicates an expected call of DescribeVpcAttribute
 func (mr *MockEC2APIMockRecorder) DescribeVpcAttribute(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeVpcAttribute", reflect.TypeOf((*MockEC2API)(nil).DescribeVpcAttribute), arg0)
 }
 
 // DescribeVpcAttributeRequest mocks base method
 func (m *MockEC2API) DescribeVpcAttributeRequest(arg0 *ec2.DescribeVpcAttributeInput) (*request.Request, *ec2.DescribeVpcAttributeOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeVpcAttributeRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DescribeVpcAttributeOutput)
@@ -10853,13 +9556,11 @@ func (m *MockEC2API) DescribeVpcAttributeRequest(arg0 *ec2.DescribeVpcAttributeI
 
 // DescribeVpcAttributeRequest indicates an expected call of DescribeVpcAttributeRequest
 func (mr *MockEC2APIMockRecorder) DescribeVpcAttributeRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeVpcAttributeRequest", reflect.TypeOf((*MockEC2API)(nil).DescribeVpcAttributeRequest), arg0)
 }
 
 // DescribeVpcAttributeWithContext mocks base method
 func (m *MockEC2API) DescribeVpcAttributeWithContext(arg0 context.Context, arg1 *ec2.DescribeVpcAttributeInput, arg2 ...request.Option) (*ec2.DescribeVpcAttributeOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -10872,14 +9573,12 @@ func (m *MockEC2API) DescribeVpcAttributeWithContext(arg0 context.Context, arg1 
 
 // DescribeVpcAttributeWithContext indicates an expected call of DescribeVpcAttributeWithContext
 func (mr *MockEC2APIMockRecorder) DescribeVpcAttributeWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeVpcAttributeWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeVpcAttributeWithContext), varargs...)
 }
 
 // DescribeVpcClassicLink mocks base method
 func (m *MockEC2API) DescribeVpcClassicLink(arg0 *ec2.DescribeVpcClassicLinkInput) (*ec2.DescribeVpcClassicLinkOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeVpcClassicLink", arg0)
 	ret0, _ := ret[0].(*ec2.DescribeVpcClassicLinkOutput)
 	ret1, _ := ret[1].(error)
@@ -10888,13 +9587,11 @@ func (m *MockEC2API) DescribeVpcClassicLink(arg0 *ec2.DescribeVpcClassicLinkInpu
 
 // DescribeVpcClassicLink indicates an expected call of DescribeVpcClassicLink
 func (mr *MockEC2APIMockRecorder) DescribeVpcClassicLink(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeVpcClassicLink", reflect.TypeOf((*MockEC2API)(nil).DescribeVpcClassicLink), arg0)
 }
 
 // DescribeVpcClassicLinkDnsSupport mocks base method
 func (m *MockEC2API) DescribeVpcClassicLinkDnsSupport(arg0 *ec2.DescribeVpcClassicLinkDnsSupportInput) (*ec2.DescribeVpcClassicLinkDnsSupportOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeVpcClassicLinkDnsSupport", arg0)
 	ret0, _ := ret[0].(*ec2.DescribeVpcClassicLinkDnsSupportOutput)
 	ret1, _ := ret[1].(error)
@@ -10903,13 +9600,11 @@ func (m *MockEC2API) DescribeVpcClassicLinkDnsSupport(arg0 *ec2.DescribeVpcClass
 
 // DescribeVpcClassicLinkDnsSupport indicates an expected call of DescribeVpcClassicLinkDnsSupport
 func (mr *MockEC2APIMockRecorder) DescribeVpcClassicLinkDnsSupport(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeVpcClassicLinkDnsSupport", reflect.TypeOf((*MockEC2API)(nil).DescribeVpcClassicLinkDnsSupport), arg0)
 }
 
 // DescribeVpcClassicLinkDnsSupportRequest mocks base method
 func (m *MockEC2API) DescribeVpcClassicLinkDnsSupportRequest(arg0 *ec2.DescribeVpcClassicLinkDnsSupportInput) (*request.Request, *ec2.DescribeVpcClassicLinkDnsSupportOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeVpcClassicLinkDnsSupportRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DescribeVpcClassicLinkDnsSupportOutput)
@@ -10918,13 +9613,11 @@ func (m *MockEC2API) DescribeVpcClassicLinkDnsSupportRequest(arg0 *ec2.DescribeV
 
 // DescribeVpcClassicLinkDnsSupportRequest indicates an expected call of DescribeVpcClassicLinkDnsSupportRequest
 func (mr *MockEC2APIMockRecorder) DescribeVpcClassicLinkDnsSupportRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeVpcClassicLinkDnsSupportRequest", reflect.TypeOf((*MockEC2API)(nil).DescribeVpcClassicLinkDnsSupportRequest), arg0)
 }
 
 // DescribeVpcClassicLinkDnsSupportWithContext mocks base method
 func (m *MockEC2API) DescribeVpcClassicLinkDnsSupportWithContext(arg0 context.Context, arg1 *ec2.DescribeVpcClassicLinkDnsSupportInput, arg2 ...request.Option) (*ec2.DescribeVpcClassicLinkDnsSupportOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -10937,14 +9630,12 @@ func (m *MockEC2API) DescribeVpcClassicLinkDnsSupportWithContext(arg0 context.Co
 
 // DescribeVpcClassicLinkDnsSupportWithContext indicates an expected call of DescribeVpcClassicLinkDnsSupportWithContext
 func (mr *MockEC2APIMockRecorder) DescribeVpcClassicLinkDnsSupportWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeVpcClassicLinkDnsSupportWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeVpcClassicLinkDnsSupportWithContext), varargs...)
 }
 
 // DescribeVpcClassicLinkRequest mocks base method
 func (m *MockEC2API) DescribeVpcClassicLinkRequest(arg0 *ec2.DescribeVpcClassicLinkInput) (*request.Request, *ec2.DescribeVpcClassicLinkOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeVpcClassicLinkRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DescribeVpcClassicLinkOutput)
@@ -10953,13 +9644,11 @@ func (m *MockEC2API) DescribeVpcClassicLinkRequest(arg0 *ec2.DescribeVpcClassicL
 
 // DescribeVpcClassicLinkRequest indicates an expected call of DescribeVpcClassicLinkRequest
 func (mr *MockEC2APIMockRecorder) DescribeVpcClassicLinkRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeVpcClassicLinkRequest", reflect.TypeOf((*MockEC2API)(nil).DescribeVpcClassicLinkRequest), arg0)
 }
 
 // DescribeVpcClassicLinkWithContext mocks base method
 func (m *MockEC2API) DescribeVpcClassicLinkWithContext(arg0 context.Context, arg1 *ec2.DescribeVpcClassicLinkInput, arg2 ...request.Option) (*ec2.DescribeVpcClassicLinkOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -10972,14 +9661,12 @@ func (m *MockEC2API) DescribeVpcClassicLinkWithContext(arg0 context.Context, arg
 
 // DescribeVpcClassicLinkWithContext indicates an expected call of DescribeVpcClassicLinkWithContext
 func (mr *MockEC2APIMockRecorder) DescribeVpcClassicLinkWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeVpcClassicLinkWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeVpcClassicLinkWithContext), varargs...)
 }
 
 // DescribeVpcEndpointConnectionNotifications mocks base method
 func (m *MockEC2API) DescribeVpcEndpointConnectionNotifications(arg0 *ec2.DescribeVpcEndpointConnectionNotificationsInput) (*ec2.DescribeVpcEndpointConnectionNotificationsOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeVpcEndpointConnectionNotifications", arg0)
 	ret0, _ := ret[0].(*ec2.DescribeVpcEndpointConnectionNotificationsOutput)
 	ret1, _ := ret[1].(error)
@@ -10988,13 +9675,11 @@ func (m *MockEC2API) DescribeVpcEndpointConnectionNotifications(arg0 *ec2.Descri
 
 // DescribeVpcEndpointConnectionNotifications indicates an expected call of DescribeVpcEndpointConnectionNotifications
 func (mr *MockEC2APIMockRecorder) DescribeVpcEndpointConnectionNotifications(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeVpcEndpointConnectionNotifications", reflect.TypeOf((*MockEC2API)(nil).DescribeVpcEndpointConnectionNotifications), arg0)
 }
 
 // DescribeVpcEndpointConnectionNotificationsRequest mocks base method
 func (m *MockEC2API) DescribeVpcEndpointConnectionNotificationsRequest(arg0 *ec2.DescribeVpcEndpointConnectionNotificationsInput) (*request.Request, *ec2.DescribeVpcEndpointConnectionNotificationsOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeVpcEndpointConnectionNotificationsRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DescribeVpcEndpointConnectionNotificationsOutput)
@@ -11003,13 +9688,11 @@ func (m *MockEC2API) DescribeVpcEndpointConnectionNotificationsRequest(arg0 *ec2
 
 // DescribeVpcEndpointConnectionNotificationsRequest indicates an expected call of DescribeVpcEndpointConnectionNotificationsRequest
 func (mr *MockEC2APIMockRecorder) DescribeVpcEndpointConnectionNotificationsRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeVpcEndpointConnectionNotificationsRequest", reflect.TypeOf((*MockEC2API)(nil).DescribeVpcEndpointConnectionNotificationsRequest), arg0)
 }
 
 // DescribeVpcEndpointConnectionNotificationsWithContext mocks base method
 func (m *MockEC2API) DescribeVpcEndpointConnectionNotificationsWithContext(arg0 context.Context, arg1 *ec2.DescribeVpcEndpointConnectionNotificationsInput, arg2 ...request.Option) (*ec2.DescribeVpcEndpointConnectionNotificationsOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -11022,14 +9705,12 @@ func (m *MockEC2API) DescribeVpcEndpointConnectionNotificationsWithContext(arg0 
 
 // DescribeVpcEndpointConnectionNotificationsWithContext indicates an expected call of DescribeVpcEndpointConnectionNotificationsWithContext
 func (mr *MockEC2APIMockRecorder) DescribeVpcEndpointConnectionNotificationsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeVpcEndpointConnectionNotificationsWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeVpcEndpointConnectionNotificationsWithContext), varargs...)
 }
 
 // DescribeVpcEndpointConnections mocks base method
 func (m *MockEC2API) DescribeVpcEndpointConnections(arg0 *ec2.DescribeVpcEndpointConnectionsInput) (*ec2.DescribeVpcEndpointConnectionsOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeVpcEndpointConnections", arg0)
 	ret0, _ := ret[0].(*ec2.DescribeVpcEndpointConnectionsOutput)
 	ret1, _ := ret[1].(error)
@@ -11038,13 +9719,11 @@ func (m *MockEC2API) DescribeVpcEndpointConnections(arg0 *ec2.DescribeVpcEndpoin
 
 // DescribeVpcEndpointConnections indicates an expected call of DescribeVpcEndpointConnections
 func (mr *MockEC2APIMockRecorder) DescribeVpcEndpointConnections(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeVpcEndpointConnections", reflect.TypeOf((*MockEC2API)(nil).DescribeVpcEndpointConnections), arg0)
 }
 
 // DescribeVpcEndpointConnectionsRequest mocks base method
 func (m *MockEC2API) DescribeVpcEndpointConnectionsRequest(arg0 *ec2.DescribeVpcEndpointConnectionsInput) (*request.Request, *ec2.DescribeVpcEndpointConnectionsOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeVpcEndpointConnectionsRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DescribeVpcEndpointConnectionsOutput)
@@ -11053,13 +9732,11 @@ func (m *MockEC2API) DescribeVpcEndpointConnectionsRequest(arg0 *ec2.DescribeVpc
 
 // DescribeVpcEndpointConnectionsRequest indicates an expected call of DescribeVpcEndpointConnectionsRequest
 func (mr *MockEC2APIMockRecorder) DescribeVpcEndpointConnectionsRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeVpcEndpointConnectionsRequest", reflect.TypeOf((*MockEC2API)(nil).DescribeVpcEndpointConnectionsRequest), arg0)
 }
 
 // DescribeVpcEndpointConnectionsWithContext mocks base method
 func (m *MockEC2API) DescribeVpcEndpointConnectionsWithContext(arg0 context.Context, arg1 *ec2.DescribeVpcEndpointConnectionsInput, arg2 ...request.Option) (*ec2.DescribeVpcEndpointConnectionsOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -11072,14 +9749,12 @@ func (m *MockEC2API) DescribeVpcEndpointConnectionsWithContext(arg0 context.Cont
 
 // DescribeVpcEndpointConnectionsWithContext indicates an expected call of DescribeVpcEndpointConnectionsWithContext
 func (mr *MockEC2APIMockRecorder) DescribeVpcEndpointConnectionsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeVpcEndpointConnectionsWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeVpcEndpointConnectionsWithContext), varargs...)
 }
 
 // DescribeVpcEndpointServiceConfigurations mocks base method
 func (m *MockEC2API) DescribeVpcEndpointServiceConfigurations(arg0 *ec2.DescribeVpcEndpointServiceConfigurationsInput) (*ec2.DescribeVpcEndpointServiceConfigurationsOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeVpcEndpointServiceConfigurations", arg0)
 	ret0, _ := ret[0].(*ec2.DescribeVpcEndpointServiceConfigurationsOutput)
 	ret1, _ := ret[1].(error)
@@ -11088,13 +9763,11 @@ func (m *MockEC2API) DescribeVpcEndpointServiceConfigurations(arg0 *ec2.Describe
 
 // DescribeVpcEndpointServiceConfigurations indicates an expected call of DescribeVpcEndpointServiceConfigurations
 func (mr *MockEC2APIMockRecorder) DescribeVpcEndpointServiceConfigurations(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeVpcEndpointServiceConfigurations", reflect.TypeOf((*MockEC2API)(nil).DescribeVpcEndpointServiceConfigurations), arg0)
 }
 
 // DescribeVpcEndpointServiceConfigurationsRequest mocks base method
 func (m *MockEC2API) DescribeVpcEndpointServiceConfigurationsRequest(arg0 *ec2.DescribeVpcEndpointServiceConfigurationsInput) (*request.Request, *ec2.DescribeVpcEndpointServiceConfigurationsOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeVpcEndpointServiceConfigurationsRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DescribeVpcEndpointServiceConfigurationsOutput)
@@ -11103,13 +9776,11 @@ func (m *MockEC2API) DescribeVpcEndpointServiceConfigurationsRequest(arg0 *ec2.D
 
 // DescribeVpcEndpointServiceConfigurationsRequest indicates an expected call of DescribeVpcEndpointServiceConfigurationsRequest
 func (mr *MockEC2APIMockRecorder) DescribeVpcEndpointServiceConfigurationsRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeVpcEndpointServiceConfigurationsRequest", reflect.TypeOf((*MockEC2API)(nil).DescribeVpcEndpointServiceConfigurationsRequest), arg0)
 }
 
 // DescribeVpcEndpointServiceConfigurationsWithContext mocks base method
 func (m *MockEC2API) DescribeVpcEndpointServiceConfigurationsWithContext(arg0 context.Context, arg1 *ec2.DescribeVpcEndpointServiceConfigurationsInput, arg2 ...request.Option) (*ec2.DescribeVpcEndpointServiceConfigurationsOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -11122,14 +9793,12 @@ func (m *MockEC2API) DescribeVpcEndpointServiceConfigurationsWithContext(arg0 co
 
 // DescribeVpcEndpointServiceConfigurationsWithContext indicates an expected call of DescribeVpcEndpointServiceConfigurationsWithContext
 func (mr *MockEC2APIMockRecorder) DescribeVpcEndpointServiceConfigurationsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeVpcEndpointServiceConfigurationsWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeVpcEndpointServiceConfigurationsWithContext), varargs...)
 }
 
 // DescribeVpcEndpointServicePermissions mocks base method
 func (m *MockEC2API) DescribeVpcEndpointServicePermissions(arg0 *ec2.DescribeVpcEndpointServicePermissionsInput) (*ec2.DescribeVpcEndpointServicePermissionsOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeVpcEndpointServicePermissions", arg0)
 	ret0, _ := ret[0].(*ec2.DescribeVpcEndpointServicePermissionsOutput)
 	ret1, _ := ret[1].(error)
@@ -11138,13 +9807,11 @@ func (m *MockEC2API) DescribeVpcEndpointServicePermissions(arg0 *ec2.DescribeVpc
 
 // DescribeVpcEndpointServicePermissions indicates an expected call of DescribeVpcEndpointServicePermissions
 func (mr *MockEC2APIMockRecorder) DescribeVpcEndpointServicePermissions(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeVpcEndpointServicePermissions", reflect.TypeOf((*MockEC2API)(nil).DescribeVpcEndpointServicePermissions), arg0)
 }
 
 // DescribeVpcEndpointServicePermissionsRequest mocks base method
 func (m *MockEC2API) DescribeVpcEndpointServicePermissionsRequest(arg0 *ec2.DescribeVpcEndpointServicePermissionsInput) (*request.Request, *ec2.DescribeVpcEndpointServicePermissionsOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeVpcEndpointServicePermissionsRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DescribeVpcEndpointServicePermissionsOutput)
@@ -11153,13 +9820,11 @@ func (m *MockEC2API) DescribeVpcEndpointServicePermissionsRequest(arg0 *ec2.Desc
 
 // DescribeVpcEndpointServicePermissionsRequest indicates an expected call of DescribeVpcEndpointServicePermissionsRequest
 func (mr *MockEC2APIMockRecorder) DescribeVpcEndpointServicePermissionsRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeVpcEndpointServicePermissionsRequest", reflect.TypeOf((*MockEC2API)(nil).DescribeVpcEndpointServicePermissionsRequest), arg0)
 }
 
 // DescribeVpcEndpointServicePermissionsWithContext mocks base method
 func (m *MockEC2API) DescribeVpcEndpointServicePermissionsWithContext(arg0 context.Context, arg1 *ec2.DescribeVpcEndpointServicePermissionsInput, arg2 ...request.Option) (*ec2.DescribeVpcEndpointServicePermissionsOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -11172,14 +9837,12 @@ func (m *MockEC2API) DescribeVpcEndpointServicePermissionsWithContext(arg0 conte
 
 // DescribeVpcEndpointServicePermissionsWithContext indicates an expected call of DescribeVpcEndpointServicePermissionsWithContext
 func (mr *MockEC2APIMockRecorder) DescribeVpcEndpointServicePermissionsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeVpcEndpointServicePermissionsWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeVpcEndpointServicePermissionsWithContext), varargs...)
 }
 
 // DescribeVpcEndpointServices mocks base method
 func (m *MockEC2API) DescribeVpcEndpointServices(arg0 *ec2.DescribeVpcEndpointServicesInput) (*ec2.DescribeVpcEndpointServicesOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeVpcEndpointServices", arg0)
 	ret0, _ := ret[0].(*ec2.DescribeVpcEndpointServicesOutput)
 	ret1, _ := ret[1].(error)
@@ -11188,13 +9851,11 @@ func (m *MockEC2API) DescribeVpcEndpointServices(arg0 *ec2.DescribeVpcEndpointSe
 
 // DescribeVpcEndpointServices indicates an expected call of DescribeVpcEndpointServices
 func (mr *MockEC2APIMockRecorder) DescribeVpcEndpointServices(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeVpcEndpointServices", reflect.TypeOf((*MockEC2API)(nil).DescribeVpcEndpointServices), arg0)
 }
 
 // DescribeVpcEndpointServicesRequest mocks base method
 func (m *MockEC2API) DescribeVpcEndpointServicesRequest(arg0 *ec2.DescribeVpcEndpointServicesInput) (*request.Request, *ec2.DescribeVpcEndpointServicesOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeVpcEndpointServicesRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DescribeVpcEndpointServicesOutput)
@@ -11203,13 +9864,11 @@ func (m *MockEC2API) DescribeVpcEndpointServicesRequest(arg0 *ec2.DescribeVpcEnd
 
 // DescribeVpcEndpointServicesRequest indicates an expected call of DescribeVpcEndpointServicesRequest
 func (mr *MockEC2APIMockRecorder) DescribeVpcEndpointServicesRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeVpcEndpointServicesRequest", reflect.TypeOf((*MockEC2API)(nil).DescribeVpcEndpointServicesRequest), arg0)
 }
 
 // DescribeVpcEndpointServicesWithContext mocks base method
 func (m *MockEC2API) DescribeVpcEndpointServicesWithContext(arg0 context.Context, arg1 *ec2.DescribeVpcEndpointServicesInput, arg2 ...request.Option) (*ec2.DescribeVpcEndpointServicesOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -11222,14 +9881,12 @@ func (m *MockEC2API) DescribeVpcEndpointServicesWithContext(arg0 context.Context
 
 // DescribeVpcEndpointServicesWithContext indicates an expected call of DescribeVpcEndpointServicesWithContext
 func (mr *MockEC2APIMockRecorder) DescribeVpcEndpointServicesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeVpcEndpointServicesWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeVpcEndpointServicesWithContext), varargs...)
 }
 
 // DescribeVpcEndpoints mocks base method
 func (m *MockEC2API) DescribeVpcEndpoints(arg0 *ec2.DescribeVpcEndpointsInput) (*ec2.DescribeVpcEndpointsOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeVpcEndpoints", arg0)
 	ret0, _ := ret[0].(*ec2.DescribeVpcEndpointsOutput)
 	ret1, _ := ret[1].(error)
@@ -11238,13 +9895,11 @@ func (m *MockEC2API) DescribeVpcEndpoints(arg0 *ec2.DescribeVpcEndpointsInput) (
 
 // DescribeVpcEndpoints indicates an expected call of DescribeVpcEndpoints
 func (mr *MockEC2APIMockRecorder) DescribeVpcEndpoints(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeVpcEndpoints", reflect.TypeOf((*MockEC2API)(nil).DescribeVpcEndpoints), arg0)
 }
 
 // DescribeVpcEndpointsRequest mocks base method
 func (m *MockEC2API) DescribeVpcEndpointsRequest(arg0 *ec2.DescribeVpcEndpointsInput) (*request.Request, *ec2.DescribeVpcEndpointsOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeVpcEndpointsRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DescribeVpcEndpointsOutput)
@@ -11253,13 +9908,11 @@ func (m *MockEC2API) DescribeVpcEndpointsRequest(arg0 *ec2.DescribeVpcEndpointsI
 
 // DescribeVpcEndpointsRequest indicates an expected call of DescribeVpcEndpointsRequest
 func (mr *MockEC2APIMockRecorder) DescribeVpcEndpointsRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeVpcEndpointsRequest", reflect.TypeOf((*MockEC2API)(nil).DescribeVpcEndpointsRequest), arg0)
 }
 
 // DescribeVpcEndpointsWithContext mocks base method
 func (m *MockEC2API) DescribeVpcEndpointsWithContext(arg0 context.Context, arg1 *ec2.DescribeVpcEndpointsInput, arg2 ...request.Option) (*ec2.DescribeVpcEndpointsOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -11272,14 +9925,12 @@ func (m *MockEC2API) DescribeVpcEndpointsWithContext(arg0 context.Context, arg1 
 
 // DescribeVpcEndpointsWithContext indicates an expected call of DescribeVpcEndpointsWithContext
 func (mr *MockEC2APIMockRecorder) DescribeVpcEndpointsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeVpcEndpointsWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeVpcEndpointsWithContext), varargs...)
 }
 
 // DescribeVpcPeeringConnections mocks base method
 func (m *MockEC2API) DescribeVpcPeeringConnections(arg0 *ec2.DescribeVpcPeeringConnectionsInput) (*ec2.DescribeVpcPeeringConnectionsOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeVpcPeeringConnections", arg0)
 	ret0, _ := ret[0].(*ec2.DescribeVpcPeeringConnectionsOutput)
 	ret1, _ := ret[1].(error)
@@ -11288,13 +9939,11 @@ func (m *MockEC2API) DescribeVpcPeeringConnections(arg0 *ec2.DescribeVpcPeeringC
 
 // DescribeVpcPeeringConnections indicates an expected call of DescribeVpcPeeringConnections
 func (mr *MockEC2APIMockRecorder) DescribeVpcPeeringConnections(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeVpcPeeringConnections", reflect.TypeOf((*MockEC2API)(nil).DescribeVpcPeeringConnections), arg0)
 }
 
 // DescribeVpcPeeringConnectionsPages mocks base method
 func (m *MockEC2API) DescribeVpcPeeringConnectionsPages(arg0 *ec2.DescribeVpcPeeringConnectionsInput, arg1 func(*ec2.DescribeVpcPeeringConnectionsOutput, bool) bool) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeVpcPeeringConnectionsPages", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -11302,13 +9951,11 @@ func (m *MockEC2API) DescribeVpcPeeringConnectionsPages(arg0 *ec2.DescribeVpcPee
 
 // DescribeVpcPeeringConnectionsPages indicates an expected call of DescribeVpcPeeringConnectionsPages
 func (mr *MockEC2APIMockRecorder) DescribeVpcPeeringConnectionsPages(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeVpcPeeringConnectionsPages", reflect.TypeOf((*MockEC2API)(nil).DescribeVpcPeeringConnectionsPages), arg0, arg1)
 }
 
 // DescribeVpcPeeringConnectionsPagesWithContext mocks base method
 func (m *MockEC2API) DescribeVpcPeeringConnectionsPagesWithContext(arg0 context.Context, arg1 *ec2.DescribeVpcPeeringConnectionsInput, arg2 func(*ec2.DescribeVpcPeeringConnectionsOutput, bool) bool, arg3 ...request.Option) error {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1, arg2}
 	for _, a := range arg3 {
 		varargs = append(varargs, a)
@@ -11320,14 +9967,12 @@ func (m *MockEC2API) DescribeVpcPeeringConnectionsPagesWithContext(arg0 context.
 
 // DescribeVpcPeeringConnectionsPagesWithContext indicates an expected call of DescribeVpcPeeringConnectionsPagesWithContext
 func (mr *MockEC2APIMockRecorder) DescribeVpcPeeringConnectionsPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeVpcPeeringConnectionsPagesWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeVpcPeeringConnectionsPagesWithContext), varargs...)
 }
 
 // DescribeVpcPeeringConnectionsRequest mocks base method
 func (m *MockEC2API) DescribeVpcPeeringConnectionsRequest(arg0 *ec2.DescribeVpcPeeringConnectionsInput) (*request.Request, *ec2.DescribeVpcPeeringConnectionsOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeVpcPeeringConnectionsRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DescribeVpcPeeringConnectionsOutput)
@@ -11336,13 +9981,11 @@ func (m *MockEC2API) DescribeVpcPeeringConnectionsRequest(arg0 *ec2.DescribeVpcP
 
 // DescribeVpcPeeringConnectionsRequest indicates an expected call of DescribeVpcPeeringConnectionsRequest
 func (mr *MockEC2APIMockRecorder) DescribeVpcPeeringConnectionsRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeVpcPeeringConnectionsRequest", reflect.TypeOf((*MockEC2API)(nil).DescribeVpcPeeringConnectionsRequest), arg0)
 }
 
 // DescribeVpcPeeringConnectionsWithContext mocks base method
 func (m *MockEC2API) DescribeVpcPeeringConnectionsWithContext(arg0 context.Context, arg1 *ec2.DescribeVpcPeeringConnectionsInput, arg2 ...request.Option) (*ec2.DescribeVpcPeeringConnectionsOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -11355,14 +9998,12 @@ func (m *MockEC2API) DescribeVpcPeeringConnectionsWithContext(arg0 context.Conte
 
 // DescribeVpcPeeringConnectionsWithContext indicates an expected call of DescribeVpcPeeringConnectionsWithContext
 func (mr *MockEC2APIMockRecorder) DescribeVpcPeeringConnectionsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeVpcPeeringConnectionsWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeVpcPeeringConnectionsWithContext), varargs...)
 }
 
 // DescribeVpcs mocks base method
 func (m *MockEC2API) DescribeVpcs(arg0 *ec2.DescribeVpcsInput) (*ec2.DescribeVpcsOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeVpcs", arg0)
 	ret0, _ := ret[0].(*ec2.DescribeVpcsOutput)
 	ret1, _ := ret[1].(error)
@@ -11371,13 +10012,11 @@ func (m *MockEC2API) DescribeVpcs(arg0 *ec2.DescribeVpcsInput) (*ec2.DescribeVpc
 
 // DescribeVpcs indicates an expected call of DescribeVpcs
 func (mr *MockEC2APIMockRecorder) DescribeVpcs(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeVpcs", reflect.TypeOf((*MockEC2API)(nil).DescribeVpcs), arg0)
 }
 
 // DescribeVpcsPages mocks base method
 func (m *MockEC2API) DescribeVpcsPages(arg0 *ec2.DescribeVpcsInput, arg1 func(*ec2.DescribeVpcsOutput, bool) bool) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeVpcsPages", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -11385,13 +10024,11 @@ func (m *MockEC2API) DescribeVpcsPages(arg0 *ec2.DescribeVpcsInput, arg1 func(*e
 
 // DescribeVpcsPages indicates an expected call of DescribeVpcsPages
 func (mr *MockEC2APIMockRecorder) DescribeVpcsPages(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeVpcsPages", reflect.TypeOf((*MockEC2API)(nil).DescribeVpcsPages), arg0, arg1)
 }
 
 // DescribeVpcsPagesWithContext mocks base method
 func (m *MockEC2API) DescribeVpcsPagesWithContext(arg0 context.Context, arg1 *ec2.DescribeVpcsInput, arg2 func(*ec2.DescribeVpcsOutput, bool) bool, arg3 ...request.Option) error {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1, arg2}
 	for _, a := range arg3 {
 		varargs = append(varargs, a)
@@ -11403,14 +10040,12 @@ func (m *MockEC2API) DescribeVpcsPagesWithContext(arg0 context.Context, arg1 *ec
 
 // DescribeVpcsPagesWithContext indicates an expected call of DescribeVpcsPagesWithContext
 func (mr *MockEC2APIMockRecorder) DescribeVpcsPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeVpcsPagesWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeVpcsPagesWithContext), varargs...)
 }
 
 // DescribeVpcsRequest mocks base method
 func (m *MockEC2API) DescribeVpcsRequest(arg0 *ec2.DescribeVpcsInput) (*request.Request, *ec2.DescribeVpcsOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeVpcsRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DescribeVpcsOutput)
@@ -11419,13 +10054,11 @@ func (m *MockEC2API) DescribeVpcsRequest(arg0 *ec2.DescribeVpcsInput) (*request.
 
 // DescribeVpcsRequest indicates an expected call of DescribeVpcsRequest
 func (mr *MockEC2APIMockRecorder) DescribeVpcsRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeVpcsRequest", reflect.TypeOf((*MockEC2API)(nil).DescribeVpcsRequest), arg0)
 }
 
 // DescribeVpcsWithContext mocks base method
 func (m *MockEC2API) DescribeVpcsWithContext(arg0 context.Context, arg1 *ec2.DescribeVpcsInput, arg2 ...request.Option) (*ec2.DescribeVpcsOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -11438,14 +10071,12 @@ func (m *MockEC2API) DescribeVpcsWithContext(arg0 context.Context, arg1 *ec2.Des
 
 // DescribeVpcsWithContext indicates an expected call of DescribeVpcsWithContext
 func (mr *MockEC2APIMockRecorder) DescribeVpcsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeVpcsWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeVpcsWithContext), varargs...)
 }
 
 // DescribeVpnConnections mocks base method
 func (m *MockEC2API) DescribeVpnConnections(arg0 *ec2.DescribeVpnConnectionsInput) (*ec2.DescribeVpnConnectionsOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeVpnConnections", arg0)
 	ret0, _ := ret[0].(*ec2.DescribeVpnConnectionsOutput)
 	ret1, _ := ret[1].(error)
@@ -11454,13 +10085,11 @@ func (m *MockEC2API) DescribeVpnConnections(arg0 *ec2.DescribeVpnConnectionsInpu
 
 // DescribeVpnConnections indicates an expected call of DescribeVpnConnections
 func (mr *MockEC2APIMockRecorder) DescribeVpnConnections(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeVpnConnections", reflect.TypeOf((*MockEC2API)(nil).DescribeVpnConnections), arg0)
 }
 
 // DescribeVpnConnectionsRequest mocks base method
 func (m *MockEC2API) DescribeVpnConnectionsRequest(arg0 *ec2.DescribeVpnConnectionsInput) (*request.Request, *ec2.DescribeVpnConnectionsOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeVpnConnectionsRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DescribeVpnConnectionsOutput)
@@ -11469,13 +10098,11 @@ func (m *MockEC2API) DescribeVpnConnectionsRequest(arg0 *ec2.DescribeVpnConnecti
 
 // DescribeVpnConnectionsRequest indicates an expected call of DescribeVpnConnectionsRequest
 func (mr *MockEC2APIMockRecorder) DescribeVpnConnectionsRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeVpnConnectionsRequest", reflect.TypeOf((*MockEC2API)(nil).DescribeVpnConnectionsRequest), arg0)
 }
 
 // DescribeVpnConnectionsWithContext mocks base method
 func (m *MockEC2API) DescribeVpnConnectionsWithContext(arg0 context.Context, arg1 *ec2.DescribeVpnConnectionsInput, arg2 ...request.Option) (*ec2.DescribeVpnConnectionsOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -11488,14 +10115,12 @@ func (m *MockEC2API) DescribeVpnConnectionsWithContext(arg0 context.Context, arg
 
 // DescribeVpnConnectionsWithContext indicates an expected call of DescribeVpnConnectionsWithContext
 func (mr *MockEC2APIMockRecorder) DescribeVpnConnectionsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeVpnConnectionsWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeVpnConnectionsWithContext), varargs...)
 }
 
 // DescribeVpnGateways mocks base method
 func (m *MockEC2API) DescribeVpnGateways(arg0 *ec2.DescribeVpnGatewaysInput) (*ec2.DescribeVpnGatewaysOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeVpnGateways", arg0)
 	ret0, _ := ret[0].(*ec2.DescribeVpnGatewaysOutput)
 	ret1, _ := ret[1].(error)
@@ -11504,13 +10129,11 @@ func (m *MockEC2API) DescribeVpnGateways(arg0 *ec2.DescribeVpnGatewaysInput) (*e
 
 // DescribeVpnGateways indicates an expected call of DescribeVpnGateways
 func (mr *MockEC2APIMockRecorder) DescribeVpnGateways(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeVpnGateways", reflect.TypeOf((*MockEC2API)(nil).DescribeVpnGateways), arg0)
 }
 
 // DescribeVpnGatewaysRequest mocks base method
 func (m *MockEC2API) DescribeVpnGatewaysRequest(arg0 *ec2.DescribeVpnGatewaysInput) (*request.Request, *ec2.DescribeVpnGatewaysOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeVpnGatewaysRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DescribeVpnGatewaysOutput)
@@ -11519,13 +10142,11 @@ func (m *MockEC2API) DescribeVpnGatewaysRequest(arg0 *ec2.DescribeVpnGatewaysInp
 
 // DescribeVpnGatewaysRequest indicates an expected call of DescribeVpnGatewaysRequest
 func (mr *MockEC2APIMockRecorder) DescribeVpnGatewaysRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeVpnGatewaysRequest", reflect.TypeOf((*MockEC2API)(nil).DescribeVpnGatewaysRequest), arg0)
 }
 
 // DescribeVpnGatewaysWithContext mocks base method
 func (m *MockEC2API) DescribeVpnGatewaysWithContext(arg0 context.Context, arg1 *ec2.DescribeVpnGatewaysInput, arg2 ...request.Option) (*ec2.DescribeVpnGatewaysOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -11538,14 +10159,12 @@ func (m *MockEC2API) DescribeVpnGatewaysWithContext(arg0 context.Context, arg1 *
 
 // DescribeVpnGatewaysWithContext indicates an expected call of DescribeVpnGatewaysWithContext
 func (mr *MockEC2APIMockRecorder) DescribeVpnGatewaysWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeVpnGatewaysWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeVpnGatewaysWithContext), varargs...)
 }
 
 // DetachClassicLinkVpc mocks base method
 func (m *MockEC2API) DetachClassicLinkVpc(arg0 *ec2.DetachClassicLinkVpcInput) (*ec2.DetachClassicLinkVpcOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DetachClassicLinkVpc", arg0)
 	ret0, _ := ret[0].(*ec2.DetachClassicLinkVpcOutput)
 	ret1, _ := ret[1].(error)
@@ -11554,13 +10173,11 @@ func (m *MockEC2API) DetachClassicLinkVpc(arg0 *ec2.DetachClassicLinkVpcInput) (
 
 // DetachClassicLinkVpc indicates an expected call of DetachClassicLinkVpc
 func (mr *MockEC2APIMockRecorder) DetachClassicLinkVpc(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DetachClassicLinkVpc", reflect.TypeOf((*MockEC2API)(nil).DetachClassicLinkVpc), arg0)
 }
 
 // DetachClassicLinkVpcRequest mocks base method
 func (m *MockEC2API) DetachClassicLinkVpcRequest(arg0 *ec2.DetachClassicLinkVpcInput) (*request.Request, *ec2.DetachClassicLinkVpcOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DetachClassicLinkVpcRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DetachClassicLinkVpcOutput)
@@ -11569,13 +10186,11 @@ func (m *MockEC2API) DetachClassicLinkVpcRequest(arg0 *ec2.DetachClassicLinkVpcI
 
 // DetachClassicLinkVpcRequest indicates an expected call of DetachClassicLinkVpcRequest
 func (mr *MockEC2APIMockRecorder) DetachClassicLinkVpcRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DetachClassicLinkVpcRequest", reflect.TypeOf((*MockEC2API)(nil).DetachClassicLinkVpcRequest), arg0)
 }
 
 // DetachClassicLinkVpcWithContext mocks base method
 func (m *MockEC2API) DetachClassicLinkVpcWithContext(arg0 context.Context, arg1 *ec2.DetachClassicLinkVpcInput, arg2 ...request.Option) (*ec2.DetachClassicLinkVpcOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -11588,14 +10203,12 @@ func (m *MockEC2API) DetachClassicLinkVpcWithContext(arg0 context.Context, arg1 
 
 // DetachClassicLinkVpcWithContext indicates an expected call of DetachClassicLinkVpcWithContext
 func (mr *MockEC2APIMockRecorder) DetachClassicLinkVpcWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DetachClassicLinkVpcWithContext", reflect.TypeOf((*MockEC2API)(nil).DetachClassicLinkVpcWithContext), varargs...)
 }
 
 // DetachInternetGateway mocks base method
 func (m *MockEC2API) DetachInternetGateway(arg0 *ec2.DetachInternetGatewayInput) (*ec2.DetachInternetGatewayOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DetachInternetGateway", arg0)
 	ret0, _ := ret[0].(*ec2.DetachInternetGatewayOutput)
 	ret1, _ := ret[1].(error)
@@ -11604,13 +10217,11 @@ func (m *MockEC2API) DetachInternetGateway(arg0 *ec2.DetachInternetGatewayInput)
 
 // DetachInternetGateway indicates an expected call of DetachInternetGateway
 func (mr *MockEC2APIMockRecorder) DetachInternetGateway(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DetachInternetGateway", reflect.TypeOf((*MockEC2API)(nil).DetachInternetGateway), arg0)
 }
 
 // DetachInternetGatewayRequest mocks base method
 func (m *MockEC2API) DetachInternetGatewayRequest(arg0 *ec2.DetachInternetGatewayInput) (*request.Request, *ec2.DetachInternetGatewayOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DetachInternetGatewayRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DetachInternetGatewayOutput)
@@ -11619,13 +10230,11 @@ func (m *MockEC2API) DetachInternetGatewayRequest(arg0 *ec2.DetachInternetGatewa
 
 // DetachInternetGatewayRequest indicates an expected call of DetachInternetGatewayRequest
 func (mr *MockEC2APIMockRecorder) DetachInternetGatewayRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DetachInternetGatewayRequest", reflect.TypeOf((*MockEC2API)(nil).DetachInternetGatewayRequest), arg0)
 }
 
 // DetachInternetGatewayWithContext mocks base method
 func (m *MockEC2API) DetachInternetGatewayWithContext(arg0 context.Context, arg1 *ec2.DetachInternetGatewayInput, arg2 ...request.Option) (*ec2.DetachInternetGatewayOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -11638,14 +10247,12 @@ func (m *MockEC2API) DetachInternetGatewayWithContext(arg0 context.Context, arg1
 
 // DetachInternetGatewayWithContext indicates an expected call of DetachInternetGatewayWithContext
 func (mr *MockEC2APIMockRecorder) DetachInternetGatewayWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DetachInternetGatewayWithContext", reflect.TypeOf((*MockEC2API)(nil).DetachInternetGatewayWithContext), varargs...)
 }
 
 // DetachNetworkInterface mocks base method
 func (m *MockEC2API) DetachNetworkInterface(arg0 *ec2.DetachNetworkInterfaceInput) (*ec2.DetachNetworkInterfaceOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DetachNetworkInterface", arg0)
 	ret0, _ := ret[0].(*ec2.DetachNetworkInterfaceOutput)
 	ret1, _ := ret[1].(error)
@@ -11654,13 +10261,11 @@ func (m *MockEC2API) DetachNetworkInterface(arg0 *ec2.DetachNetworkInterfaceInpu
 
 // DetachNetworkInterface indicates an expected call of DetachNetworkInterface
 func (mr *MockEC2APIMockRecorder) DetachNetworkInterface(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DetachNetworkInterface", reflect.TypeOf((*MockEC2API)(nil).DetachNetworkInterface), arg0)
 }
 
 // DetachNetworkInterfaceRequest mocks base method
 func (m *MockEC2API) DetachNetworkInterfaceRequest(arg0 *ec2.DetachNetworkInterfaceInput) (*request.Request, *ec2.DetachNetworkInterfaceOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DetachNetworkInterfaceRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DetachNetworkInterfaceOutput)
@@ -11669,13 +10274,11 @@ func (m *MockEC2API) DetachNetworkInterfaceRequest(arg0 *ec2.DetachNetworkInterf
 
 // DetachNetworkInterfaceRequest indicates an expected call of DetachNetworkInterfaceRequest
 func (mr *MockEC2APIMockRecorder) DetachNetworkInterfaceRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DetachNetworkInterfaceRequest", reflect.TypeOf((*MockEC2API)(nil).DetachNetworkInterfaceRequest), arg0)
 }
 
 // DetachNetworkInterfaceWithContext mocks base method
 func (m *MockEC2API) DetachNetworkInterfaceWithContext(arg0 context.Context, arg1 *ec2.DetachNetworkInterfaceInput, arg2 ...request.Option) (*ec2.DetachNetworkInterfaceOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -11688,14 +10291,12 @@ func (m *MockEC2API) DetachNetworkInterfaceWithContext(arg0 context.Context, arg
 
 // DetachNetworkInterfaceWithContext indicates an expected call of DetachNetworkInterfaceWithContext
 func (mr *MockEC2APIMockRecorder) DetachNetworkInterfaceWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DetachNetworkInterfaceWithContext", reflect.TypeOf((*MockEC2API)(nil).DetachNetworkInterfaceWithContext), varargs...)
 }
 
 // DetachVolume mocks base method
 func (m *MockEC2API) DetachVolume(arg0 *ec2.DetachVolumeInput) (*ec2.VolumeAttachment, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DetachVolume", arg0)
 	ret0, _ := ret[0].(*ec2.VolumeAttachment)
 	ret1, _ := ret[1].(error)
@@ -11704,13 +10305,11 @@ func (m *MockEC2API) DetachVolume(arg0 *ec2.DetachVolumeInput) (*ec2.VolumeAttac
 
 // DetachVolume indicates an expected call of DetachVolume
 func (mr *MockEC2APIMockRecorder) DetachVolume(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DetachVolume", reflect.TypeOf((*MockEC2API)(nil).DetachVolume), arg0)
 }
 
 // DetachVolumeRequest mocks base method
 func (m *MockEC2API) DetachVolumeRequest(arg0 *ec2.DetachVolumeInput) (*request.Request, *ec2.VolumeAttachment) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DetachVolumeRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.VolumeAttachment)
@@ -11719,13 +10318,11 @@ func (m *MockEC2API) DetachVolumeRequest(arg0 *ec2.DetachVolumeInput) (*request.
 
 // DetachVolumeRequest indicates an expected call of DetachVolumeRequest
 func (mr *MockEC2APIMockRecorder) DetachVolumeRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DetachVolumeRequest", reflect.TypeOf((*MockEC2API)(nil).DetachVolumeRequest), arg0)
 }
 
 // DetachVolumeWithContext mocks base method
 func (m *MockEC2API) DetachVolumeWithContext(arg0 context.Context, arg1 *ec2.DetachVolumeInput, arg2 ...request.Option) (*ec2.VolumeAttachment, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -11738,14 +10335,12 @@ func (m *MockEC2API) DetachVolumeWithContext(arg0 context.Context, arg1 *ec2.Det
 
 // DetachVolumeWithContext indicates an expected call of DetachVolumeWithContext
 func (mr *MockEC2APIMockRecorder) DetachVolumeWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DetachVolumeWithContext", reflect.TypeOf((*MockEC2API)(nil).DetachVolumeWithContext), varargs...)
 }
 
 // DetachVpnGateway mocks base method
 func (m *MockEC2API) DetachVpnGateway(arg0 *ec2.DetachVpnGatewayInput) (*ec2.DetachVpnGatewayOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DetachVpnGateway", arg0)
 	ret0, _ := ret[0].(*ec2.DetachVpnGatewayOutput)
 	ret1, _ := ret[1].(error)
@@ -11754,13 +10349,11 @@ func (m *MockEC2API) DetachVpnGateway(arg0 *ec2.DetachVpnGatewayInput) (*ec2.Det
 
 // DetachVpnGateway indicates an expected call of DetachVpnGateway
 func (mr *MockEC2APIMockRecorder) DetachVpnGateway(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DetachVpnGateway", reflect.TypeOf((*MockEC2API)(nil).DetachVpnGateway), arg0)
 }
 
 // DetachVpnGatewayRequest mocks base method
 func (m *MockEC2API) DetachVpnGatewayRequest(arg0 *ec2.DetachVpnGatewayInput) (*request.Request, *ec2.DetachVpnGatewayOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DetachVpnGatewayRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DetachVpnGatewayOutput)
@@ -11769,13 +10362,11 @@ func (m *MockEC2API) DetachVpnGatewayRequest(arg0 *ec2.DetachVpnGatewayInput) (*
 
 // DetachVpnGatewayRequest indicates an expected call of DetachVpnGatewayRequest
 func (mr *MockEC2APIMockRecorder) DetachVpnGatewayRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DetachVpnGatewayRequest", reflect.TypeOf((*MockEC2API)(nil).DetachVpnGatewayRequest), arg0)
 }
 
 // DetachVpnGatewayWithContext mocks base method
 func (m *MockEC2API) DetachVpnGatewayWithContext(arg0 context.Context, arg1 *ec2.DetachVpnGatewayInput, arg2 ...request.Option) (*ec2.DetachVpnGatewayOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -11788,14 +10379,12 @@ func (m *MockEC2API) DetachVpnGatewayWithContext(arg0 context.Context, arg1 *ec2
 
 // DetachVpnGatewayWithContext indicates an expected call of DetachVpnGatewayWithContext
 func (mr *MockEC2APIMockRecorder) DetachVpnGatewayWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DetachVpnGatewayWithContext", reflect.TypeOf((*MockEC2API)(nil).DetachVpnGatewayWithContext), varargs...)
 }
 
 // DisableTransitGatewayRouteTablePropagation mocks base method
 func (m *MockEC2API) DisableTransitGatewayRouteTablePropagation(arg0 *ec2.DisableTransitGatewayRouteTablePropagationInput) (*ec2.DisableTransitGatewayRouteTablePropagationOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DisableTransitGatewayRouteTablePropagation", arg0)
 	ret0, _ := ret[0].(*ec2.DisableTransitGatewayRouteTablePropagationOutput)
 	ret1, _ := ret[1].(error)
@@ -11804,13 +10393,11 @@ func (m *MockEC2API) DisableTransitGatewayRouteTablePropagation(arg0 *ec2.Disabl
 
 // DisableTransitGatewayRouteTablePropagation indicates an expected call of DisableTransitGatewayRouteTablePropagation
 func (mr *MockEC2APIMockRecorder) DisableTransitGatewayRouteTablePropagation(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DisableTransitGatewayRouteTablePropagation", reflect.TypeOf((*MockEC2API)(nil).DisableTransitGatewayRouteTablePropagation), arg0)
 }
 
 // DisableTransitGatewayRouteTablePropagationRequest mocks base method
 func (m *MockEC2API) DisableTransitGatewayRouteTablePropagationRequest(arg0 *ec2.DisableTransitGatewayRouteTablePropagationInput) (*request.Request, *ec2.DisableTransitGatewayRouteTablePropagationOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DisableTransitGatewayRouteTablePropagationRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DisableTransitGatewayRouteTablePropagationOutput)
@@ -11819,13 +10406,11 @@ func (m *MockEC2API) DisableTransitGatewayRouteTablePropagationRequest(arg0 *ec2
 
 // DisableTransitGatewayRouteTablePropagationRequest indicates an expected call of DisableTransitGatewayRouteTablePropagationRequest
 func (mr *MockEC2APIMockRecorder) DisableTransitGatewayRouteTablePropagationRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DisableTransitGatewayRouteTablePropagationRequest", reflect.TypeOf((*MockEC2API)(nil).DisableTransitGatewayRouteTablePropagationRequest), arg0)
 }
 
 // DisableTransitGatewayRouteTablePropagationWithContext mocks base method
 func (m *MockEC2API) DisableTransitGatewayRouteTablePropagationWithContext(arg0 context.Context, arg1 *ec2.DisableTransitGatewayRouteTablePropagationInput, arg2 ...request.Option) (*ec2.DisableTransitGatewayRouteTablePropagationOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -11838,14 +10423,12 @@ func (m *MockEC2API) DisableTransitGatewayRouteTablePropagationWithContext(arg0 
 
 // DisableTransitGatewayRouteTablePropagationWithContext indicates an expected call of DisableTransitGatewayRouteTablePropagationWithContext
 func (mr *MockEC2APIMockRecorder) DisableTransitGatewayRouteTablePropagationWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DisableTransitGatewayRouteTablePropagationWithContext", reflect.TypeOf((*MockEC2API)(nil).DisableTransitGatewayRouteTablePropagationWithContext), varargs...)
 }
 
 // DisableVgwRoutePropagation mocks base method
 func (m *MockEC2API) DisableVgwRoutePropagation(arg0 *ec2.DisableVgwRoutePropagationInput) (*ec2.DisableVgwRoutePropagationOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DisableVgwRoutePropagation", arg0)
 	ret0, _ := ret[0].(*ec2.DisableVgwRoutePropagationOutput)
 	ret1, _ := ret[1].(error)
@@ -11854,13 +10437,11 @@ func (m *MockEC2API) DisableVgwRoutePropagation(arg0 *ec2.DisableVgwRoutePropaga
 
 // DisableVgwRoutePropagation indicates an expected call of DisableVgwRoutePropagation
 func (mr *MockEC2APIMockRecorder) DisableVgwRoutePropagation(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DisableVgwRoutePropagation", reflect.TypeOf((*MockEC2API)(nil).DisableVgwRoutePropagation), arg0)
 }
 
 // DisableVgwRoutePropagationRequest mocks base method
 func (m *MockEC2API) DisableVgwRoutePropagationRequest(arg0 *ec2.DisableVgwRoutePropagationInput) (*request.Request, *ec2.DisableVgwRoutePropagationOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DisableVgwRoutePropagationRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DisableVgwRoutePropagationOutput)
@@ -11869,13 +10450,11 @@ func (m *MockEC2API) DisableVgwRoutePropagationRequest(arg0 *ec2.DisableVgwRoute
 
 // DisableVgwRoutePropagationRequest indicates an expected call of DisableVgwRoutePropagationRequest
 func (mr *MockEC2APIMockRecorder) DisableVgwRoutePropagationRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DisableVgwRoutePropagationRequest", reflect.TypeOf((*MockEC2API)(nil).DisableVgwRoutePropagationRequest), arg0)
 }
 
 // DisableVgwRoutePropagationWithContext mocks base method
 func (m *MockEC2API) DisableVgwRoutePropagationWithContext(arg0 context.Context, arg1 *ec2.DisableVgwRoutePropagationInput, arg2 ...request.Option) (*ec2.DisableVgwRoutePropagationOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -11888,14 +10467,12 @@ func (m *MockEC2API) DisableVgwRoutePropagationWithContext(arg0 context.Context,
 
 // DisableVgwRoutePropagationWithContext indicates an expected call of DisableVgwRoutePropagationWithContext
 func (mr *MockEC2APIMockRecorder) DisableVgwRoutePropagationWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DisableVgwRoutePropagationWithContext", reflect.TypeOf((*MockEC2API)(nil).DisableVgwRoutePropagationWithContext), varargs...)
 }
 
 // DisableVpcClassicLink mocks base method
 func (m *MockEC2API) DisableVpcClassicLink(arg0 *ec2.DisableVpcClassicLinkInput) (*ec2.DisableVpcClassicLinkOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DisableVpcClassicLink", arg0)
 	ret0, _ := ret[0].(*ec2.DisableVpcClassicLinkOutput)
 	ret1, _ := ret[1].(error)
@@ -11904,13 +10481,11 @@ func (m *MockEC2API) DisableVpcClassicLink(arg0 *ec2.DisableVpcClassicLinkInput)
 
 // DisableVpcClassicLink indicates an expected call of DisableVpcClassicLink
 func (mr *MockEC2APIMockRecorder) DisableVpcClassicLink(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DisableVpcClassicLink", reflect.TypeOf((*MockEC2API)(nil).DisableVpcClassicLink), arg0)
 }
 
 // DisableVpcClassicLinkDnsSupport mocks base method
 func (m *MockEC2API) DisableVpcClassicLinkDnsSupport(arg0 *ec2.DisableVpcClassicLinkDnsSupportInput) (*ec2.DisableVpcClassicLinkDnsSupportOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DisableVpcClassicLinkDnsSupport", arg0)
 	ret0, _ := ret[0].(*ec2.DisableVpcClassicLinkDnsSupportOutput)
 	ret1, _ := ret[1].(error)
@@ -11919,13 +10494,11 @@ func (m *MockEC2API) DisableVpcClassicLinkDnsSupport(arg0 *ec2.DisableVpcClassic
 
 // DisableVpcClassicLinkDnsSupport indicates an expected call of DisableVpcClassicLinkDnsSupport
 func (mr *MockEC2APIMockRecorder) DisableVpcClassicLinkDnsSupport(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DisableVpcClassicLinkDnsSupport", reflect.TypeOf((*MockEC2API)(nil).DisableVpcClassicLinkDnsSupport), arg0)
 }
 
 // DisableVpcClassicLinkDnsSupportRequest mocks base method
 func (m *MockEC2API) DisableVpcClassicLinkDnsSupportRequest(arg0 *ec2.DisableVpcClassicLinkDnsSupportInput) (*request.Request, *ec2.DisableVpcClassicLinkDnsSupportOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DisableVpcClassicLinkDnsSupportRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DisableVpcClassicLinkDnsSupportOutput)
@@ -11934,13 +10507,11 @@ func (m *MockEC2API) DisableVpcClassicLinkDnsSupportRequest(arg0 *ec2.DisableVpc
 
 // DisableVpcClassicLinkDnsSupportRequest indicates an expected call of DisableVpcClassicLinkDnsSupportRequest
 func (mr *MockEC2APIMockRecorder) DisableVpcClassicLinkDnsSupportRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DisableVpcClassicLinkDnsSupportRequest", reflect.TypeOf((*MockEC2API)(nil).DisableVpcClassicLinkDnsSupportRequest), arg0)
 }
 
 // DisableVpcClassicLinkDnsSupportWithContext mocks base method
 func (m *MockEC2API) DisableVpcClassicLinkDnsSupportWithContext(arg0 context.Context, arg1 *ec2.DisableVpcClassicLinkDnsSupportInput, arg2 ...request.Option) (*ec2.DisableVpcClassicLinkDnsSupportOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -11953,14 +10524,12 @@ func (m *MockEC2API) DisableVpcClassicLinkDnsSupportWithContext(arg0 context.Con
 
 // DisableVpcClassicLinkDnsSupportWithContext indicates an expected call of DisableVpcClassicLinkDnsSupportWithContext
 func (mr *MockEC2APIMockRecorder) DisableVpcClassicLinkDnsSupportWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DisableVpcClassicLinkDnsSupportWithContext", reflect.TypeOf((*MockEC2API)(nil).DisableVpcClassicLinkDnsSupportWithContext), varargs...)
 }
 
 // DisableVpcClassicLinkRequest mocks base method
 func (m *MockEC2API) DisableVpcClassicLinkRequest(arg0 *ec2.DisableVpcClassicLinkInput) (*request.Request, *ec2.DisableVpcClassicLinkOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DisableVpcClassicLinkRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DisableVpcClassicLinkOutput)
@@ -11969,13 +10538,11 @@ func (m *MockEC2API) DisableVpcClassicLinkRequest(arg0 *ec2.DisableVpcClassicLin
 
 // DisableVpcClassicLinkRequest indicates an expected call of DisableVpcClassicLinkRequest
 func (mr *MockEC2APIMockRecorder) DisableVpcClassicLinkRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DisableVpcClassicLinkRequest", reflect.TypeOf((*MockEC2API)(nil).DisableVpcClassicLinkRequest), arg0)
 }
 
 // DisableVpcClassicLinkWithContext mocks base method
 func (m *MockEC2API) DisableVpcClassicLinkWithContext(arg0 context.Context, arg1 *ec2.DisableVpcClassicLinkInput, arg2 ...request.Option) (*ec2.DisableVpcClassicLinkOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -11988,14 +10555,12 @@ func (m *MockEC2API) DisableVpcClassicLinkWithContext(arg0 context.Context, arg1
 
 // DisableVpcClassicLinkWithContext indicates an expected call of DisableVpcClassicLinkWithContext
 func (mr *MockEC2APIMockRecorder) DisableVpcClassicLinkWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DisableVpcClassicLinkWithContext", reflect.TypeOf((*MockEC2API)(nil).DisableVpcClassicLinkWithContext), varargs...)
 }
 
 // DisassociateAddress mocks base method
 func (m *MockEC2API) DisassociateAddress(arg0 *ec2.DisassociateAddressInput) (*ec2.DisassociateAddressOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DisassociateAddress", arg0)
 	ret0, _ := ret[0].(*ec2.DisassociateAddressOutput)
 	ret1, _ := ret[1].(error)
@@ -12004,13 +10569,11 @@ func (m *MockEC2API) DisassociateAddress(arg0 *ec2.DisassociateAddressInput) (*e
 
 // DisassociateAddress indicates an expected call of DisassociateAddress
 func (mr *MockEC2APIMockRecorder) DisassociateAddress(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DisassociateAddress", reflect.TypeOf((*MockEC2API)(nil).DisassociateAddress), arg0)
 }
 
 // DisassociateAddressRequest mocks base method
 func (m *MockEC2API) DisassociateAddressRequest(arg0 *ec2.DisassociateAddressInput) (*request.Request, *ec2.DisassociateAddressOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DisassociateAddressRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DisassociateAddressOutput)
@@ -12019,13 +10582,11 @@ func (m *MockEC2API) DisassociateAddressRequest(arg0 *ec2.DisassociateAddressInp
 
 // DisassociateAddressRequest indicates an expected call of DisassociateAddressRequest
 func (mr *MockEC2APIMockRecorder) DisassociateAddressRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DisassociateAddressRequest", reflect.TypeOf((*MockEC2API)(nil).DisassociateAddressRequest), arg0)
 }
 
 // DisassociateAddressWithContext mocks base method
 func (m *MockEC2API) DisassociateAddressWithContext(arg0 context.Context, arg1 *ec2.DisassociateAddressInput, arg2 ...request.Option) (*ec2.DisassociateAddressOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -12038,14 +10599,12 @@ func (m *MockEC2API) DisassociateAddressWithContext(arg0 context.Context, arg1 *
 
 // DisassociateAddressWithContext indicates an expected call of DisassociateAddressWithContext
 func (mr *MockEC2APIMockRecorder) DisassociateAddressWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DisassociateAddressWithContext", reflect.TypeOf((*MockEC2API)(nil).DisassociateAddressWithContext), varargs...)
 }
 
 // DisassociateClientVpnTargetNetwork mocks base method
 func (m *MockEC2API) DisassociateClientVpnTargetNetwork(arg0 *ec2.DisassociateClientVpnTargetNetworkInput) (*ec2.DisassociateClientVpnTargetNetworkOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DisassociateClientVpnTargetNetwork", arg0)
 	ret0, _ := ret[0].(*ec2.DisassociateClientVpnTargetNetworkOutput)
 	ret1, _ := ret[1].(error)
@@ -12054,13 +10613,11 @@ func (m *MockEC2API) DisassociateClientVpnTargetNetwork(arg0 *ec2.DisassociateCl
 
 // DisassociateClientVpnTargetNetwork indicates an expected call of DisassociateClientVpnTargetNetwork
 func (mr *MockEC2APIMockRecorder) DisassociateClientVpnTargetNetwork(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DisassociateClientVpnTargetNetwork", reflect.TypeOf((*MockEC2API)(nil).DisassociateClientVpnTargetNetwork), arg0)
 }
 
 // DisassociateClientVpnTargetNetworkRequest mocks base method
 func (m *MockEC2API) DisassociateClientVpnTargetNetworkRequest(arg0 *ec2.DisassociateClientVpnTargetNetworkInput) (*request.Request, *ec2.DisassociateClientVpnTargetNetworkOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DisassociateClientVpnTargetNetworkRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DisassociateClientVpnTargetNetworkOutput)
@@ -12069,13 +10626,11 @@ func (m *MockEC2API) DisassociateClientVpnTargetNetworkRequest(arg0 *ec2.Disasso
 
 // DisassociateClientVpnTargetNetworkRequest indicates an expected call of DisassociateClientVpnTargetNetworkRequest
 func (mr *MockEC2APIMockRecorder) DisassociateClientVpnTargetNetworkRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DisassociateClientVpnTargetNetworkRequest", reflect.TypeOf((*MockEC2API)(nil).DisassociateClientVpnTargetNetworkRequest), arg0)
 }
 
 // DisassociateClientVpnTargetNetworkWithContext mocks base method
 func (m *MockEC2API) DisassociateClientVpnTargetNetworkWithContext(arg0 context.Context, arg1 *ec2.DisassociateClientVpnTargetNetworkInput, arg2 ...request.Option) (*ec2.DisassociateClientVpnTargetNetworkOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -12088,14 +10643,12 @@ func (m *MockEC2API) DisassociateClientVpnTargetNetworkWithContext(arg0 context.
 
 // DisassociateClientVpnTargetNetworkWithContext indicates an expected call of DisassociateClientVpnTargetNetworkWithContext
 func (mr *MockEC2APIMockRecorder) DisassociateClientVpnTargetNetworkWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DisassociateClientVpnTargetNetworkWithContext", reflect.TypeOf((*MockEC2API)(nil).DisassociateClientVpnTargetNetworkWithContext), varargs...)
 }
 
 // DisassociateIamInstanceProfile mocks base method
 func (m *MockEC2API) DisassociateIamInstanceProfile(arg0 *ec2.DisassociateIamInstanceProfileInput) (*ec2.DisassociateIamInstanceProfileOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DisassociateIamInstanceProfile", arg0)
 	ret0, _ := ret[0].(*ec2.DisassociateIamInstanceProfileOutput)
 	ret1, _ := ret[1].(error)
@@ -12104,13 +10657,11 @@ func (m *MockEC2API) DisassociateIamInstanceProfile(arg0 *ec2.DisassociateIamIns
 
 // DisassociateIamInstanceProfile indicates an expected call of DisassociateIamInstanceProfile
 func (mr *MockEC2APIMockRecorder) DisassociateIamInstanceProfile(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DisassociateIamInstanceProfile", reflect.TypeOf((*MockEC2API)(nil).DisassociateIamInstanceProfile), arg0)
 }
 
 // DisassociateIamInstanceProfileRequest mocks base method
 func (m *MockEC2API) DisassociateIamInstanceProfileRequest(arg0 *ec2.DisassociateIamInstanceProfileInput) (*request.Request, *ec2.DisassociateIamInstanceProfileOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DisassociateIamInstanceProfileRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DisassociateIamInstanceProfileOutput)
@@ -12119,13 +10670,11 @@ func (m *MockEC2API) DisassociateIamInstanceProfileRequest(arg0 *ec2.Disassociat
 
 // DisassociateIamInstanceProfileRequest indicates an expected call of DisassociateIamInstanceProfileRequest
 func (mr *MockEC2APIMockRecorder) DisassociateIamInstanceProfileRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DisassociateIamInstanceProfileRequest", reflect.TypeOf((*MockEC2API)(nil).DisassociateIamInstanceProfileRequest), arg0)
 }
 
 // DisassociateIamInstanceProfileWithContext mocks base method
 func (m *MockEC2API) DisassociateIamInstanceProfileWithContext(arg0 context.Context, arg1 *ec2.DisassociateIamInstanceProfileInput, arg2 ...request.Option) (*ec2.DisassociateIamInstanceProfileOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -12138,14 +10687,12 @@ func (m *MockEC2API) DisassociateIamInstanceProfileWithContext(arg0 context.Cont
 
 // DisassociateIamInstanceProfileWithContext indicates an expected call of DisassociateIamInstanceProfileWithContext
 func (mr *MockEC2APIMockRecorder) DisassociateIamInstanceProfileWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DisassociateIamInstanceProfileWithContext", reflect.TypeOf((*MockEC2API)(nil).DisassociateIamInstanceProfileWithContext), varargs...)
 }
 
 // DisassociateRouteTable mocks base method
 func (m *MockEC2API) DisassociateRouteTable(arg0 *ec2.DisassociateRouteTableInput) (*ec2.DisassociateRouteTableOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DisassociateRouteTable", arg0)
 	ret0, _ := ret[0].(*ec2.DisassociateRouteTableOutput)
 	ret1, _ := ret[1].(error)
@@ -12154,13 +10701,11 @@ func (m *MockEC2API) DisassociateRouteTable(arg0 *ec2.DisassociateRouteTableInpu
 
 // DisassociateRouteTable indicates an expected call of DisassociateRouteTable
 func (mr *MockEC2APIMockRecorder) DisassociateRouteTable(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DisassociateRouteTable", reflect.TypeOf((*MockEC2API)(nil).DisassociateRouteTable), arg0)
 }
 
 // DisassociateRouteTableRequest mocks base method
 func (m *MockEC2API) DisassociateRouteTableRequest(arg0 *ec2.DisassociateRouteTableInput) (*request.Request, *ec2.DisassociateRouteTableOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DisassociateRouteTableRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DisassociateRouteTableOutput)
@@ -12169,13 +10714,11 @@ func (m *MockEC2API) DisassociateRouteTableRequest(arg0 *ec2.DisassociateRouteTa
 
 // DisassociateRouteTableRequest indicates an expected call of DisassociateRouteTableRequest
 func (mr *MockEC2APIMockRecorder) DisassociateRouteTableRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DisassociateRouteTableRequest", reflect.TypeOf((*MockEC2API)(nil).DisassociateRouteTableRequest), arg0)
 }
 
 // DisassociateRouteTableWithContext mocks base method
 func (m *MockEC2API) DisassociateRouteTableWithContext(arg0 context.Context, arg1 *ec2.DisassociateRouteTableInput, arg2 ...request.Option) (*ec2.DisassociateRouteTableOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -12188,14 +10731,12 @@ func (m *MockEC2API) DisassociateRouteTableWithContext(arg0 context.Context, arg
 
 // DisassociateRouteTableWithContext indicates an expected call of DisassociateRouteTableWithContext
 func (mr *MockEC2APIMockRecorder) DisassociateRouteTableWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DisassociateRouteTableWithContext", reflect.TypeOf((*MockEC2API)(nil).DisassociateRouteTableWithContext), varargs...)
 }
 
 // DisassociateSubnetCidrBlock mocks base method
 func (m *MockEC2API) DisassociateSubnetCidrBlock(arg0 *ec2.DisassociateSubnetCidrBlockInput) (*ec2.DisassociateSubnetCidrBlockOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DisassociateSubnetCidrBlock", arg0)
 	ret0, _ := ret[0].(*ec2.DisassociateSubnetCidrBlockOutput)
 	ret1, _ := ret[1].(error)
@@ -12204,13 +10745,11 @@ func (m *MockEC2API) DisassociateSubnetCidrBlock(arg0 *ec2.DisassociateSubnetCid
 
 // DisassociateSubnetCidrBlock indicates an expected call of DisassociateSubnetCidrBlock
 func (mr *MockEC2APIMockRecorder) DisassociateSubnetCidrBlock(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DisassociateSubnetCidrBlock", reflect.TypeOf((*MockEC2API)(nil).DisassociateSubnetCidrBlock), arg0)
 }
 
 // DisassociateSubnetCidrBlockRequest mocks base method
 func (m *MockEC2API) DisassociateSubnetCidrBlockRequest(arg0 *ec2.DisassociateSubnetCidrBlockInput) (*request.Request, *ec2.DisassociateSubnetCidrBlockOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DisassociateSubnetCidrBlockRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DisassociateSubnetCidrBlockOutput)
@@ -12219,13 +10758,11 @@ func (m *MockEC2API) DisassociateSubnetCidrBlockRequest(arg0 *ec2.DisassociateSu
 
 // DisassociateSubnetCidrBlockRequest indicates an expected call of DisassociateSubnetCidrBlockRequest
 func (mr *MockEC2APIMockRecorder) DisassociateSubnetCidrBlockRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DisassociateSubnetCidrBlockRequest", reflect.TypeOf((*MockEC2API)(nil).DisassociateSubnetCidrBlockRequest), arg0)
 }
 
 // DisassociateSubnetCidrBlockWithContext mocks base method
 func (m *MockEC2API) DisassociateSubnetCidrBlockWithContext(arg0 context.Context, arg1 *ec2.DisassociateSubnetCidrBlockInput, arg2 ...request.Option) (*ec2.DisassociateSubnetCidrBlockOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -12238,14 +10775,12 @@ func (m *MockEC2API) DisassociateSubnetCidrBlockWithContext(arg0 context.Context
 
 // DisassociateSubnetCidrBlockWithContext indicates an expected call of DisassociateSubnetCidrBlockWithContext
 func (mr *MockEC2APIMockRecorder) DisassociateSubnetCidrBlockWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DisassociateSubnetCidrBlockWithContext", reflect.TypeOf((*MockEC2API)(nil).DisassociateSubnetCidrBlockWithContext), varargs...)
 }
 
 // DisassociateTransitGatewayRouteTable mocks base method
 func (m *MockEC2API) DisassociateTransitGatewayRouteTable(arg0 *ec2.DisassociateTransitGatewayRouteTableInput) (*ec2.DisassociateTransitGatewayRouteTableOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DisassociateTransitGatewayRouteTable", arg0)
 	ret0, _ := ret[0].(*ec2.DisassociateTransitGatewayRouteTableOutput)
 	ret1, _ := ret[1].(error)
@@ -12254,13 +10789,11 @@ func (m *MockEC2API) DisassociateTransitGatewayRouteTable(arg0 *ec2.Disassociate
 
 // DisassociateTransitGatewayRouteTable indicates an expected call of DisassociateTransitGatewayRouteTable
 func (mr *MockEC2APIMockRecorder) DisassociateTransitGatewayRouteTable(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DisassociateTransitGatewayRouteTable", reflect.TypeOf((*MockEC2API)(nil).DisassociateTransitGatewayRouteTable), arg0)
 }
 
 // DisassociateTransitGatewayRouteTableRequest mocks base method
 func (m *MockEC2API) DisassociateTransitGatewayRouteTableRequest(arg0 *ec2.DisassociateTransitGatewayRouteTableInput) (*request.Request, *ec2.DisassociateTransitGatewayRouteTableOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DisassociateTransitGatewayRouteTableRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DisassociateTransitGatewayRouteTableOutput)
@@ -12269,13 +10802,11 @@ func (m *MockEC2API) DisassociateTransitGatewayRouteTableRequest(arg0 *ec2.Disas
 
 // DisassociateTransitGatewayRouteTableRequest indicates an expected call of DisassociateTransitGatewayRouteTableRequest
 func (mr *MockEC2APIMockRecorder) DisassociateTransitGatewayRouteTableRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DisassociateTransitGatewayRouteTableRequest", reflect.TypeOf((*MockEC2API)(nil).DisassociateTransitGatewayRouteTableRequest), arg0)
 }
 
 // DisassociateTransitGatewayRouteTableWithContext mocks base method
 func (m *MockEC2API) DisassociateTransitGatewayRouteTableWithContext(arg0 context.Context, arg1 *ec2.DisassociateTransitGatewayRouteTableInput, arg2 ...request.Option) (*ec2.DisassociateTransitGatewayRouteTableOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -12288,14 +10819,12 @@ func (m *MockEC2API) DisassociateTransitGatewayRouteTableWithContext(arg0 contex
 
 // DisassociateTransitGatewayRouteTableWithContext indicates an expected call of DisassociateTransitGatewayRouteTableWithContext
 func (mr *MockEC2APIMockRecorder) DisassociateTransitGatewayRouteTableWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DisassociateTransitGatewayRouteTableWithContext", reflect.TypeOf((*MockEC2API)(nil).DisassociateTransitGatewayRouteTableWithContext), varargs...)
 }
 
 // DisassociateVpcCidrBlock mocks base method
 func (m *MockEC2API) DisassociateVpcCidrBlock(arg0 *ec2.DisassociateVpcCidrBlockInput) (*ec2.DisassociateVpcCidrBlockOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DisassociateVpcCidrBlock", arg0)
 	ret0, _ := ret[0].(*ec2.DisassociateVpcCidrBlockOutput)
 	ret1, _ := ret[1].(error)
@@ -12304,13 +10833,11 @@ func (m *MockEC2API) DisassociateVpcCidrBlock(arg0 *ec2.DisassociateVpcCidrBlock
 
 // DisassociateVpcCidrBlock indicates an expected call of DisassociateVpcCidrBlock
 func (mr *MockEC2APIMockRecorder) DisassociateVpcCidrBlock(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DisassociateVpcCidrBlock", reflect.TypeOf((*MockEC2API)(nil).DisassociateVpcCidrBlock), arg0)
 }
 
 // DisassociateVpcCidrBlockRequest mocks base method
 func (m *MockEC2API) DisassociateVpcCidrBlockRequest(arg0 *ec2.DisassociateVpcCidrBlockInput) (*request.Request, *ec2.DisassociateVpcCidrBlockOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DisassociateVpcCidrBlockRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.DisassociateVpcCidrBlockOutput)
@@ -12319,13 +10846,11 @@ func (m *MockEC2API) DisassociateVpcCidrBlockRequest(arg0 *ec2.DisassociateVpcCi
 
 // DisassociateVpcCidrBlockRequest indicates an expected call of DisassociateVpcCidrBlockRequest
 func (mr *MockEC2APIMockRecorder) DisassociateVpcCidrBlockRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DisassociateVpcCidrBlockRequest", reflect.TypeOf((*MockEC2API)(nil).DisassociateVpcCidrBlockRequest), arg0)
 }
 
 // DisassociateVpcCidrBlockWithContext mocks base method
 func (m *MockEC2API) DisassociateVpcCidrBlockWithContext(arg0 context.Context, arg1 *ec2.DisassociateVpcCidrBlockInput, arg2 ...request.Option) (*ec2.DisassociateVpcCidrBlockOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -12338,14 +10863,12 @@ func (m *MockEC2API) DisassociateVpcCidrBlockWithContext(arg0 context.Context, a
 
 // DisassociateVpcCidrBlockWithContext indicates an expected call of DisassociateVpcCidrBlockWithContext
 func (mr *MockEC2APIMockRecorder) DisassociateVpcCidrBlockWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DisassociateVpcCidrBlockWithContext", reflect.TypeOf((*MockEC2API)(nil).DisassociateVpcCidrBlockWithContext), varargs...)
 }
 
 // EnableTransitGatewayRouteTablePropagation mocks base method
 func (m *MockEC2API) EnableTransitGatewayRouteTablePropagation(arg0 *ec2.EnableTransitGatewayRouteTablePropagationInput) (*ec2.EnableTransitGatewayRouteTablePropagationOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "EnableTransitGatewayRouteTablePropagation", arg0)
 	ret0, _ := ret[0].(*ec2.EnableTransitGatewayRouteTablePropagationOutput)
 	ret1, _ := ret[1].(error)
@@ -12354,13 +10877,11 @@ func (m *MockEC2API) EnableTransitGatewayRouteTablePropagation(arg0 *ec2.EnableT
 
 // EnableTransitGatewayRouteTablePropagation indicates an expected call of EnableTransitGatewayRouteTablePropagation
 func (mr *MockEC2APIMockRecorder) EnableTransitGatewayRouteTablePropagation(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnableTransitGatewayRouteTablePropagation", reflect.TypeOf((*MockEC2API)(nil).EnableTransitGatewayRouteTablePropagation), arg0)
 }
 
 // EnableTransitGatewayRouteTablePropagationRequest mocks base method
 func (m *MockEC2API) EnableTransitGatewayRouteTablePropagationRequest(arg0 *ec2.EnableTransitGatewayRouteTablePropagationInput) (*request.Request, *ec2.EnableTransitGatewayRouteTablePropagationOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "EnableTransitGatewayRouteTablePropagationRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.EnableTransitGatewayRouteTablePropagationOutput)
@@ -12369,13 +10890,11 @@ func (m *MockEC2API) EnableTransitGatewayRouteTablePropagationRequest(arg0 *ec2.
 
 // EnableTransitGatewayRouteTablePropagationRequest indicates an expected call of EnableTransitGatewayRouteTablePropagationRequest
 func (mr *MockEC2APIMockRecorder) EnableTransitGatewayRouteTablePropagationRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnableTransitGatewayRouteTablePropagationRequest", reflect.TypeOf((*MockEC2API)(nil).EnableTransitGatewayRouteTablePropagationRequest), arg0)
 }
 
 // EnableTransitGatewayRouteTablePropagationWithContext mocks base method
 func (m *MockEC2API) EnableTransitGatewayRouteTablePropagationWithContext(arg0 context.Context, arg1 *ec2.EnableTransitGatewayRouteTablePropagationInput, arg2 ...request.Option) (*ec2.EnableTransitGatewayRouteTablePropagationOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -12388,14 +10907,12 @@ func (m *MockEC2API) EnableTransitGatewayRouteTablePropagationWithContext(arg0 c
 
 // EnableTransitGatewayRouteTablePropagationWithContext indicates an expected call of EnableTransitGatewayRouteTablePropagationWithContext
 func (mr *MockEC2APIMockRecorder) EnableTransitGatewayRouteTablePropagationWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnableTransitGatewayRouteTablePropagationWithContext", reflect.TypeOf((*MockEC2API)(nil).EnableTransitGatewayRouteTablePropagationWithContext), varargs...)
 }
 
 // EnableVgwRoutePropagation mocks base method
 func (m *MockEC2API) EnableVgwRoutePropagation(arg0 *ec2.EnableVgwRoutePropagationInput) (*ec2.EnableVgwRoutePropagationOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "EnableVgwRoutePropagation", arg0)
 	ret0, _ := ret[0].(*ec2.EnableVgwRoutePropagationOutput)
 	ret1, _ := ret[1].(error)
@@ -12404,13 +10921,11 @@ func (m *MockEC2API) EnableVgwRoutePropagation(arg0 *ec2.EnableVgwRoutePropagati
 
 // EnableVgwRoutePropagation indicates an expected call of EnableVgwRoutePropagation
 func (mr *MockEC2APIMockRecorder) EnableVgwRoutePropagation(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnableVgwRoutePropagation", reflect.TypeOf((*MockEC2API)(nil).EnableVgwRoutePropagation), arg0)
 }
 
 // EnableVgwRoutePropagationRequest mocks base method
 func (m *MockEC2API) EnableVgwRoutePropagationRequest(arg0 *ec2.EnableVgwRoutePropagationInput) (*request.Request, *ec2.EnableVgwRoutePropagationOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "EnableVgwRoutePropagationRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.EnableVgwRoutePropagationOutput)
@@ -12419,13 +10934,11 @@ func (m *MockEC2API) EnableVgwRoutePropagationRequest(arg0 *ec2.EnableVgwRoutePr
 
 // EnableVgwRoutePropagationRequest indicates an expected call of EnableVgwRoutePropagationRequest
 func (mr *MockEC2APIMockRecorder) EnableVgwRoutePropagationRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnableVgwRoutePropagationRequest", reflect.TypeOf((*MockEC2API)(nil).EnableVgwRoutePropagationRequest), arg0)
 }
 
 // EnableVgwRoutePropagationWithContext mocks base method
 func (m *MockEC2API) EnableVgwRoutePropagationWithContext(arg0 context.Context, arg1 *ec2.EnableVgwRoutePropagationInput, arg2 ...request.Option) (*ec2.EnableVgwRoutePropagationOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -12438,14 +10951,12 @@ func (m *MockEC2API) EnableVgwRoutePropagationWithContext(arg0 context.Context, 
 
 // EnableVgwRoutePropagationWithContext indicates an expected call of EnableVgwRoutePropagationWithContext
 func (mr *MockEC2APIMockRecorder) EnableVgwRoutePropagationWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnableVgwRoutePropagationWithContext", reflect.TypeOf((*MockEC2API)(nil).EnableVgwRoutePropagationWithContext), varargs...)
 }
 
 // EnableVolumeIO mocks base method
 func (m *MockEC2API) EnableVolumeIO(arg0 *ec2.EnableVolumeIOInput) (*ec2.EnableVolumeIOOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "EnableVolumeIO", arg0)
 	ret0, _ := ret[0].(*ec2.EnableVolumeIOOutput)
 	ret1, _ := ret[1].(error)
@@ -12454,13 +10965,11 @@ func (m *MockEC2API) EnableVolumeIO(arg0 *ec2.EnableVolumeIOInput) (*ec2.EnableV
 
 // EnableVolumeIO indicates an expected call of EnableVolumeIO
 func (mr *MockEC2APIMockRecorder) EnableVolumeIO(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnableVolumeIO", reflect.TypeOf((*MockEC2API)(nil).EnableVolumeIO), arg0)
 }
 
 // EnableVolumeIORequest mocks base method
 func (m *MockEC2API) EnableVolumeIORequest(arg0 *ec2.EnableVolumeIOInput) (*request.Request, *ec2.EnableVolumeIOOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "EnableVolumeIORequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.EnableVolumeIOOutput)
@@ -12469,13 +10978,11 @@ func (m *MockEC2API) EnableVolumeIORequest(arg0 *ec2.EnableVolumeIOInput) (*requ
 
 // EnableVolumeIORequest indicates an expected call of EnableVolumeIORequest
 func (mr *MockEC2APIMockRecorder) EnableVolumeIORequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnableVolumeIORequest", reflect.TypeOf((*MockEC2API)(nil).EnableVolumeIORequest), arg0)
 }
 
 // EnableVolumeIOWithContext mocks base method
 func (m *MockEC2API) EnableVolumeIOWithContext(arg0 context.Context, arg1 *ec2.EnableVolumeIOInput, arg2 ...request.Option) (*ec2.EnableVolumeIOOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -12488,14 +10995,12 @@ func (m *MockEC2API) EnableVolumeIOWithContext(arg0 context.Context, arg1 *ec2.E
 
 // EnableVolumeIOWithContext indicates an expected call of EnableVolumeIOWithContext
 func (mr *MockEC2APIMockRecorder) EnableVolumeIOWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnableVolumeIOWithContext", reflect.TypeOf((*MockEC2API)(nil).EnableVolumeIOWithContext), varargs...)
 }
 
 // EnableVpcClassicLink mocks base method
 func (m *MockEC2API) EnableVpcClassicLink(arg0 *ec2.EnableVpcClassicLinkInput) (*ec2.EnableVpcClassicLinkOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "EnableVpcClassicLink", arg0)
 	ret0, _ := ret[0].(*ec2.EnableVpcClassicLinkOutput)
 	ret1, _ := ret[1].(error)
@@ -12504,13 +11009,11 @@ func (m *MockEC2API) EnableVpcClassicLink(arg0 *ec2.EnableVpcClassicLinkInput) (
 
 // EnableVpcClassicLink indicates an expected call of EnableVpcClassicLink
 func (mr *MockEC2APIMockRecorder) EnableVpcClassicLink(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnableVpcClassicLink", reflect.TypeOf((*MockEC2API)(nil).EnableVpcClassicLink), arg0)
 }
 
 // EnableVpcClassicLinkDnsSupport mocks base method
 func (m *MockEC2API) EnableVpcClassicLinkDnsSupport(arg0 *ec2.EnableVpcClassicLinkDnsSupportInput) (*ec2.EnableVpcClassicLinkDnsSupportOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "EnableVpcClassicLinkDnsSupport", arg0)
 	ret0, _ := ret[0].(*ec2.EnableVpcClassicLinkDnsSupportOutput)
 	ret1, _ := ret[1].(error)
@@ -12519,13 +11022,11 @@ func (m *MockEC2API) EnableVpcClassicLinkDnsSupport(arg0 *ec2.EnableVpcClassicLi
 
 // EnableVpcClassicLinkDnsSupport indicates an expected call of EnableVpcClassicLinkDnsSupport
 func (mr *MockEC2APIMockRecorder) EnableVpcClassicLinkDnsSupport(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnableVpcClassicLinkDnsSupport", reflect.TypeOf((*MockEC2API)(nil).EnableVpcClassicLinkDnsSupport), arg0)
 }
 
 // EnableVpcClassicLinkDnsSupportRequest mocks base method
 func (m *MockEC2API) EnableVpcClassicLinkDnsSupportRequest(arg0 *ec2.EnableVpcClassicLinkDnsSupportInput) (*request.Request, *ec2.EnableVpcClassicLinkDnsSupportOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "EnableVpcClassicLinkDnsSupportRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.EnableVpcClassicLinkDnsSupportOutput)
@@ -12534,13 +11035,11 @@ func (m *MockEC2API) EnableVpcClassicLinkDnsSupportRequest(arg0 *ec2.EnableVpcCl
 
 // EnableVpcClassicLinkDnsSupportRequest indicates an expected call of EnableVpcClassicLinkDnsSupportRequest
 func (mr *MockEC2APIMockRecorder) EnableVpcClassicLinkDnsSupportRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnableVpcClassicLinkDnsSupportRequest", reflect.TypeOf((*MockEC2API)(nil).EnableVpcClassicLinkDnsSupportRequest), arg0)
 }
 
 // EnableVpcClassicLinkDnsSupportWithContext mocks base method
 func (m *MockEC2API) EnableVpcClassicLinkDnsSupportWithContext(arg0 context.Context, arg1 *ec2.EnableVpcClassicLinkDnsSupportInput, arg2 ...request.Option) (*ec2.EnableVpcClassicLinkDnsSupportOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -12553,14 +11052,12 @@ func (m *MockEC2API) EnableVpcClassicLinkDnsSupportWithContext(arg0 context.Cont
 
 // EnableVpcClassicLinkDnsSupportWithContext indicates an expected call of EnableVpcClassicLinkDnsSupportWithContext
 func (mr *MockEC2APIMockRecorder) EnableVpcClassicLinkDnsSupportWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnableVpcClassicLinkDnsSupportWithContext", reflect.TypeOf((*MockEC2API)(nil).EnableVpcClassicLinkDnsSupportWithContext), varargs...)
 }
 
 // EnableVpcClassicLinkRequest mocks base method
 func (m *MockEC2API) EnableVpcClassicLinkRequest(arg0 *ec2.EnableVpcClassicLinkInput) (*request.Request, *ec2.EnableVpcClassicLinkOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "EnableVpcClassicLinkRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.EnableVpcClassicLinkOutput)
@@ -12569,13 +11066,11 @@ func (m *MockEC2API) EnableVpcClassicLinkRequest(arg0 *ec2.EnableVpcClassicLinkI
 
 // EnableVpcClassicLinkRequest indicates an expected call of EnableVpcClassicLinkRequest
 func (mr *MockEC2APIMockRecorder) EnableVpcClassicLinkRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnableVpcClassicLinkRequest", reflect.TypeOf((*MockEC2API)(nil).EnableVpcClassicLinkRequest), arg0)
 }
 
 // EnableVpcClassicLinkWithContext mocks base method
 func (m *MockEC2API) EnableVpcClassicLinkWithContext(arg0 context.Context, arg1 *ec2.EnableVpcClassicLinkInput, arg2 ...request.Option) (*ec2.EnableVpcClassicLinkOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -12588,14 +11083,12 @@ func (m *MockEC2API) EnableVpcClassicLinkWithContext(arg0 context.Context, arg1 
 
 // EnableVpcClassicLinkWithContext indicates an expected call of EnableVpcClassicLinkWithContext
 func (mr *MockEC2APIMockRecorder) EnableVpcClassicLinkWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnableVpcClassicLinkWithContext", reflect.TypeOf((*MockEC2API)(nil).EnableVpcClassicLinkWithContext), varargs...)
 }
 
 // ExportClientVpnClientCertificateRevocationList mocks base method
 func (m *MockEC2API) ExportClientVpnClientCertificateRevocationList(arg0 *ec2.ExportClientVpnClientCertificateRevocationListInput) (*ec2.ExportClientVpnClientCertificateRevocationListOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ExportClientVpnClientCertificateRevocationList", arg0)
 	ret0, _ := ret[0].(*ec2.ExportClientVpnClientCertificateRevocationListOutput)
 	ret1, _ := ret[1].(error)
@@ -12604,13 +11097,11 @@ func (m *MockEC2API) ExportClientVpnClientCertificateRevocationList(arg0 *ec2.Ex
 
 // ExportClientVpnClientCertificateRevocationList indicates an expected call of ExportClientVpnClientCertificateRevocationList
 func (mr *MockEC2APIMockRecorder) ExportClientVpnClientCertificateRevocationList(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExportClientVpnClientCertificateRevocationList", reflect.TypeOf((*MockEC2API)(nil).ExportClientVpnClientCertificateRevocationList), arg0)
 }
 
 // ExportClientVpnClientCertificateRevocationListRequest mocks base method
 func (m *MockEC2API) ExportClientVpnClientCertificateRevocationListRequest(arg0 *ec2.ExportClientVpnClientCertificateRevocationListInput) (*request.Request, *ec2.ExportClientVpnClientCertificateRevocationListOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ExportClientVpnClientCertificateRevocationListRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.ExportClientVpnClientCertificateRevocationListOutput)
@@ -12619,13 +11110,11 @@ func (m *MockEC2API) ExportClientVpnClientCertificateRevocationListRequest(arg0 
 
 // ExportClientVpnClientCertificateRevocationListRequest indicates an expected call of ExportClientVpnClientCertificateRevocationListRequest
 func (mr *MockEC2APIMockRecorder) ExportClientVpnClientCertificateRevocationListRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExportClientVpnClientCertificateRevocationListRequest", reflect.TypeOf((*MockEC2API)(nil).ExportClientVpnClientCertificateRevocationListRequest), arg0)
 }
 
 // ExportClientVpnClientCertificateRevocationListWithContext mocks base method
 func (m *MockEC2API) ExportClientVpnClientCertificateRevocationListWithContext(arg0 context.Context, arg1 *ec2.ExportClientVpnClientCertificateRevocationListInput, arg2 ...request.Option) (*ec2.ExportClientVpnClientCertificateRevocationListOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -12638,14 +11127,12 @@ func (m *MockEC2API) ExportClientVpnClientCertificateRevocationListWithContext(a
 
 // ExportClientVpnClientCertificateRevocationListWithContext indicates an expected call of ExportClientVpnClientCertificateRevocationListWithContext
 func (mr *MockEC2APIMockRecorder) ExportClientVpnClientCertificateRevocationListWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExportClientVpnClientCertificateRevocationListWithContext", reflect.TypeOf((*MockEC2API)(nil).ExportClientVpnClientCertificateRevocationListWithContext), varargs...)
 }
 
 // ExportClientVpnClientConfiguration mocks base method
 func (m *MockEC2API) ExportClientVpnClientConfiguration(arg0 *ec2.ExportClientVpnClientConfigurationInput) (*ec2.ExportClientVpnClientConfigurationOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ExportClientVpnClientConfiguration", arg0)
 	ret0, _ := ret[0].(*ec2.ExportClientVpnClientConfigurationOutput)
 	ret1, _ := ret[1].(error)
@@ -12654,13 +11141,11 @@ func (m *MockEC2API) ExportClientVpnClientConfiguration(arg0 *ec2.ExportClientVp
 
 // ExportClientVpnClientConfiguration indicates an expected call of ExportClientVpnClientConfiguration
 func (mr *MockEC2APIMockRecorder) ExportClientVpnClientConfiguration(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExportClientVpnClientConfiguration", reflect.TypeOf((*MockEC2API)(nil).ExportClientVpnClientConfiguration), arg0)
 }
 
 // ExportClientVpnClientConfigurationRequest mocks base method
 func (m *MockEC2API) ExportClientVpnClientConfigurationRequest(arg0 *ec2.ExportClientVpnClientConfigurationInput) (*request.Request, *ec2.ExportClientVpnClientConfigurationOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ExportClientVpnClientConfigurationRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.ExportClientVpnClientConfigurationOutput)
@@ -12669,13 +11154,11 @@ func (m *MockEC2API) ExportClientVpnClientConfigurationRequest(arg0 *ec2.ExportC
 
 // ExportClientVpnClientConfigurationRequest indicates an expected call of ExportClientVpnClientConfigurationRequest
 func (mr *MockEC2APIMockRecorder) ExportClientVpnClientConfigurationRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExportClientVpnClientConfigurationRequest", reflect.TypeOf((*MockEC2API)(nil).ExportClientVpnClientConfigurationRequest), arg0)
 }
 
 // ExportClientVpnClientConfigurationWithContext mocks base method
 func (m *MockEC2API) ExportClientVpnClientConfigurationWithContext(arg0 context.Context, arg1 *ec2.ExportClientVpnClientConfigurationInput, arg2 ...request.Option) (*ec2.ExportClientVpnClientConfigurationOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -12688,14 +11171,12 @@ func (m *MockEC2API) ExportClientVpnClientConfigurationWithContext(arg0 context.
 
 // ExportClientVpnClientConfigurationWithContext indicates an expected call of ExportClientVpnClientConfigurationWithContext
 func (mr *MockEC2APIMockRecorder) ExportClientVpnClientConfigurationWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExportClientVpnClientConfigurationWithContext", reflect.TypeOf((*MockEC2API)(nil).ExportClientVpnClientConfigurationWithContext), varargs...)
 }
 
 // ExportTransitGatewayRoutes mocks base method
 func (m *MockEC2API) ExportTransitGatewayRoutes(arg0 *ec2.ExportTransitGatewayRoutesInput) (*ec2.ExportTransitGatewayRoutesOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ExportTransitGatewayRoutes", arg0)
 	ret0, _ := ret[0].(*ec2.ExportTransitGatewayRoutesOutput)
 	ret1, _ := ret[1].(error)
@@ -12704,13 +11185,11 @@ func (m *MockEC2API) ExportTransitGatewayRoutes(arg0 *ec2.ExportTransitGatewayRo
 
 // ExportTransitGatewayRoutes indicates an expected call of ExportTransitGatewayRoutes
 func (mr *MockEC2APIMockRecorder) ExportTransitGatewayRoutes(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExportTransitGatewayRoutes", reflect.TypeOf((*MockEC2API)(nil).ExportTransitGatewayRoutes), arg0)
 }
 
 // ExportTransitGatewayRoutesRequest mocks base method
 func (m *MockEC2API) ExportTransitGatewayRoutesRequest(arg0 *ec2.ExportTransitGatewayRoutesInput) (*request.Request, *ec2.ExportTransitGatewayRoutesOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ExportTransitGatewayRoutesRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.ExportTransitGatewayRoutesOutput)
@@ -12719,13 +11198,11 @@ func (m *MockEC2API) ExportTransitGatewayRoutesRequest(arg0 *ec2.ExportTransitGa
 
 // ExportTransitGatewayRoutesRequest indicates an expected call of ExportTransitGatewayRoutesRequest
 func (mr *MockEC2APIMockRecorder) ExportTransitGatewayRoutesRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExportTransitGatewayRoutesRequest", reflect.TypeOf((*MockEC2API)(nil).ExportTransitGatewayRoutesRequest), arg0)
 }
 
 // ExportTransitGatewayRoutesWithContext mocks base method
 func (m *MockEC2API) ExportTransitGatewayRoutesWithContext(arg0 context.Context, arg1 *ec2.ExportTransitGatewayRoutesInput, arg2 ...request.Option) (*ec2.ExportTransitGatewayRoutesOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -12738,14 +11215,12 @@ func (m *MockEC2API) ExportTransitGatewayRoutesWithContext(arg0 context.Context,
 
 // ExportTransitGatewayRoutesWithContext indicates an expected call of ExportTransitGatewayRoutesWithContext
 func (mr *MockEC2APIMockRecorder) ExportTransitGatewayRoutesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExportTransitGatewayRoutesWithContext", reflect.TypeOf((*MockEC2API)(nil).ExportTransitGatewayRoutesWithContext), varargs...)
 }
 
 // GetConsoleOutput mocks base method
 func (m *MockEC2API) GetConsoleOutput(arg0 *ec2.GetConsoleOutputInput) (*ec2.GetConsoleOutputOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetConsoleOutput", arg0)
 	ret0, _ := ret[0].(*ec2.GetConsoleOutputOutput)
 	ret1, _ := ret[1].(error)
@@ -12754,13 +11229,11 @@ func (m *MockEC2API) GetConsoleOutput(arg0 *ec2.GetConsoleOutputInput) (*ec2.Get
 
 // GetConsoleOutput indicates an expected call of GetConsoleOutput
 func (mr *MockEC2APIMockRecorder) GetConsoleOutput(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetConsoleOutput", reflect.TypeOf((*MockEC2API)(nil).GetConsoleOutput), arg0)
 }
 
 // GetConsoleOutputRequest mocks base method
 func (m *MockEC2API) GetConsoleOutputRequest(arg0 *ec2.GetConsoleOutputInput) (*request.Request, *ec2.GetConsoleOutputOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetConsoleOutputRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.GetConsoleOutputOutput)
@@ -12769,13 +11242,11 @@ func (m *MockEC2API) GetConsoleOutputRequest(arg0 *ec2.GetConsoleOutputInput) (*
 
 // GetConsoleOutputRequest indicates an expected call of GetConsoleOutputRequest
 func (mr *MockEC2APIMockRecorder) GetConsoleOutputRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetConsoleOutputRequest", reflect.TypeOf((*MockEC2API)(nil).GetConsoleOutputRequest), arg0)
 }
 
 // GetConsoleOutputWithContext mocks base method
 func (m *MockEC2API) GetConsoleOutputWithContext(arg0 context.Context, arg1 *ec2.GetConsoleOutputInput, arg2 ...request.Option) (*ec2.GetConsoleOutputOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -12788,14 +11259,12 @@ func (m *MockEC2API) GetConsoleOutputWithContext(arg0 context.Context, arg1 *ec2
 
 // GetConsoleOutputWithContext indicates an expected call of GetConsoleOutputWithContext
 func (mr *MockEC2APIMockRecorder) GetConsoleOutputWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetConsoleOutputWithContext", reflect.TypeOf((*MockEC2API)(nil).GetConsoleOutputWithContext), varargs...)
 }
 
 // GetConsoleScreenshot mocks base method
 func (m *MockEC2API) GetConsoleScreenshot(arg0 *ec2.GetConsoleScreenshotInput) (*ec2.GetConsoleScreenshotOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetConsoleScreenshot", arg0)
 	ret0, _ := ret[0].(*ec2.GetConsoleScreenshotOutput)
 	ret1, _ := ret[1].(error)
@@ -12804,13 +11273,11 @@ func (m *MockEC2API) GetConsoleScreenshot(arg0 *ec2.GetConsoleScreenshotInput) (
 
 // GetConsoleScreenshot indicates an expected call of GetConsoleScreenshot
 func (mr *MockEC2APIMockRecorder) GetConsoleScreenshot(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetConsoleScreenshot", reflect.TypeOf((*MockEC2API)(nil).GetConsoleScreenshot), arg0)
 }
 
 // GetConsoleScreenshotRequest mocks base method
 func (m *MockEC2API) GetConsoleScreenshotRequest(arg0 *ec2.GetConsoleScreenshotInput) (*request.Request, *ec2.GetConsoleScreenshotOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetConsoleScreenshotRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.GetConsoleScreenshotOutput)
@@ -12819,13 +11286,11 @@ func (m *MockEC2API) GetConsoleScreenshotRequest(arg0 *ec2.GetConsoleScreenshotI
 
 // GetConsoleScreenshotRequest indicates an expected call of GetConsoleScreenshotRequest
 func (mr *MockEC2APIMockRecorder) GetConsoleScreenshotRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetConsoleScreenshotRequest", reflect.TypeOf((*MockEC2API)(nil).GetConsoleScreenshotRequest), arg0)
 }
 
 // GetConsoleScreenshotWithContext mocks base method
 func (m *MockEC2API) GetConsoleScreenshotWithContext(arg0 context.Context, arg1 *ec2.GetConsoleScreenshotInput, arg2 ...request.Option) (*ec2.GetConsoleScreenshotOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -12838,14 +11303,12 @@ func (m *MockEC2API) GetConsoleScreenshotWithContext(arg0 context.Context, arg1 
 
 // GetConsoleScreenshotWithContext indicates an expected call of GetConsoleScreenshotWithContext
 func (mr *MockEC2APIMockRecorder) GetConsoleScreenshotWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetConsoleScreenshotWithContext", reflect.TypeOf((*MockEC2API)(nil).GetConsoleScreenshotWithContext), varargs...)
 }
 
 // GetHostReservationPurchasePreview mocks base method
 func (m *MockEC2API) GetHostReservationPurchasePreview(arg0 *ec2.GetHostReservationPurchasePreviewInput) (*ec2.GetHostReservationPurchasePreviewOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetHostReservationPurchasePreview", arg0)
 	ret0, _ := ret[0].(*ec2.GetHostReservationPurchasePreviewOutput)
 	ret1, _ := ret[1].(error)
@@ -12854,13 +11317,11 @@ func (m *MockEC2API) GetHostReservationPurchasePreview(arg0 *ec2.GetHostReservat
 
 // GetHostReservationPurchasePreview indicates an expected call of GetHostReservationPurchasePreview
 func (mr *MockEC2APIMockRecorder) GetHostReservationPurchasePreview(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHostReservationPurchasePreview", reflect.TypeOf((*MockEC2API)(nil).GetHostReservationPurchasePreview), arg0)
 }
 
 // GetHostReservationPurchasePreviewRequest mocks base method
 func (m *MockEC2API) GetHostReservationPurchasePreviewRequest(arg0 *ec2.GetHostReservationPurchasePreviewInput) (*request.Request, *ec2.GetHostReservationPurchasePreviewOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetHostReservationPurchasePreviewRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.GetHostReservationPurchasePreviewOutput)
@@ -12869,13 +11330,11 @@ func (m *MockEC2API) GetHostReservationPurchasePreviewRequest(arg0 *ec2.GetHostR
 
 // GetHostReservationPurchasePreviewRequest indicates an expected call of GetHostReservationPurchasePreviewRequest
 func (mr *MockEC2APIMockRecorder) GetHostReservationPurchasePreviewRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHostReservationPurchasePreviewRequest", reflect.TypeOf((*MockEC2API)(nil).GetHostReservationPurchasePreviewRequest), arg0)
 }
 
 // GetHostReservationPurchasePreviewWithContext mocks base method
 func (m *MockEC2API) GetHostReservationPurchasePreviewWithContext(arg0 context.Context, arg1 *ec2.GetHostReservationPurchasePreviewInput, arg2 ...request.Option) (*ec2.GetHostReservationPurchasePreviewOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -12888,14 +11347,12 @@ func (m *MockEC2API) GetHostReservationPurchasePreviewWithContext(arg0 context.C
 
 // GetHostReservationPurchasePreviewWithContext indicates an expected call of GetHostReservationPurchasePreviewWithContext
 func (mr *MockEC2APIMockRecorder) GetHostReservationPurchasePreviewWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHostReservationPurchasePreviewWithContext", reflect.TypeOf((*MockEC2API)(nil).GetHostReservationPurchasePreviewWithContext), varargs...)
 }
 
 // GetLaunchTemplateData mocks base method
 func (m *MockEC2API) GetLaunchTemplateData(arg0 *ec2.GetLaunchTemplateDataInput) (*ec2.GetLaunchTemplateDataOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetLaunchTemplateData", arg0)
 	ret0, _ := ret[0].(*ec2.GetLaunchTemplateDataOutput)
 	ret1, _ := ret[1].(error)
@@ -12904,13 +11361,11 @@ func (m *MockEC2API) GetLaunchTemplateData(arg0 *ec2.GetLaunchTemplateDataInput)
 
 // GetLaunchTemplateData indicates an expected call of GetLaunchTemplateData
 func (mr *MockEC2APIMockRecorder) GetLaunchTemplateData(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLaunchTemplateData", reflect.TypeOf((*MockEC2API)(nil).GetLaunchTemplateData), arg0)
 }
 
 // GetLaunchTemplateDataRequest mocks base method
 func (m *MockEC2API) GetLaunchTemplateDataRequest(arg0 *ec2.GetLaunchTemplateDataInput) (*request.Request, *ec2.GetLaunchTemplateDataOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetLaunchTemplateDataRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.GetLaunchTemplateDataOutput)
@@ -12919,13 +11374,11 @@ func (m *MockEC2API) GetLaunchTemplateDataRequest(arg0 *ec2.GetLaunchTemplateDat
 
 // GetLaunchTemplateDataRequest indicates an expected call of GetLaunchTemplateDataRequest
 func (mr *MockEC2APIMockRecorder) GetLaunchTemplateDataRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLaunchTemplateDataRequest", reflect.TypeOf((*MockEC2API)(nil).GetLaunchTemplateDataRequest), arg0)
 }
 
 // GetLaunchTemplateDataWithContext mocks base method
 func (m *MockEC2API) GetLaunchTemplateDataWithContext(arg0 context.Context, arg1 *ec2.GetLaunchTemplateDataInput, arg2 ...request.Option) (*ec2.GetLaunchTemplateDataOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -12938,14 +11391,12 @@ func (m *MockEC2API) GetLaunchTemplateDataWithContext(arg0 context.Context, arg1
 
 // GetLaunchTemplateDataWithContext indicates an expected call of GetLaunchTemplateDataWithContext
 func (mr *MockEC2APIMockRecorder) GetLaunchTemplateDataWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLaunchTemplateDataWithContext", reflect.TypeOf((*MockEC2API)(nil).GetLaunchTemplateDataWithContext), varargs...)
 }
 
 // GetPasswordData mocks base method
 func (m *MockEC2API) GetPasswordData(arg0 *ec2.GetPasswordDataInput) (*ec2.GetPasswordDataOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetPasswordData", arg0)
 	ret0, _ := ret[0].(*ec2.GetPasswordDataOutput)
 	ret1, _ := ret[1].(error)
@@ -12954,13 +11405,11 @@ func (m *MockEC2API) GetPasswordData(arg0 *ec2.GetPasswordDataInput) (*ec2.GetPa
 
 // GetPasswordData indicates an expected call of GetPasswordData
 func (mr *MockEC2APIMockRecorder) GetPasswordData(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPasswordData", reflect.TypeOf((*MockEC2API)(nil).GetPasswordData), arg0)
 }
 
 // GetPasswordDataRequest mocks base method
 func (m *MockEC2API) GetPasswordDataRequest(arg0 *ec2.GetPasswordDataInput) (*request.Request, *ec2.GetPasswordDataOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetPasswordDataRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.GetPasswordDataOutput)
@@ -12969,13 +11418,11 @@ func (m *MockEC2API) GetPasswordDataRequest(arg0 *ec2.GetPasswordDataInput) (*re
 
 // GetPasswordDataRequest indicates an expected call of GetPasswordDataRequest
 func (mr *MockEC2APIMockRecorder) GetPasswordDataRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPasswordDataRequest", reflect.TypeOf((*MockEC2API)(nil).GetPasswordDataRequest), arg0)
 }
 
 // GetPasswordDataWithContext mocks base method
 func (m *MockEC2API) GetPasswordDataWithContext(arg0 context.Context, arg1 *ec2.GetPasswordDataInput, arg2 ...request.Option) (*ec2.GetPasswordDataOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -12988,14 +11435,12 @@ func (m *MockEC2API) GetPasswordDataWithContext(arg0 context.Context, arg1 *ec2.
 
 // GetPasswordDataWithContext indicates an expected call of GetPasswordDataWithContext
 func (mr *MockEC2APIMockRecorder) GetPasswordDataWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPasswordDataWithContext", reflect.TypeOf((*MockEC2API)(nil).GetPasswordDataWithContext), varargs...)
 }
 
 // GetReservedInstancesExchangeQuote mocks base method
 func (m *MockEC2API) GetReservedInstancesExchangeQuote(arg0 *ec2.GetReservedInstancesExchangeQuoteInput) (*ec2.GetReservedInstancesExchangeQuoteOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetReservedInstancesExchangeQuote", arg0)
 	ret0, _ := ret[0].(*ec2.GetReservedInstancesExchangeQuoteOutput)
 	ret1, _ := ret[1].(error)
@@ -13004,13 +11449,11 @@ func (m *MockEC2API) GetReservedInstancesExchangeQuote(arg0 *ec2.GetReservedInst
 
 // GetReservedInstancesExchangeQuote indicates an expected call of GetReservedInstancesExchangeQuote
 func (mr *MockEC2APIMockRecorder) GetReservedInstancesExchangeQuote(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetReservedInstancesExchangeQuote", reflect.TypeOf((*MockEC2API)(nil).GetReservedInstancesExchangeQuote), arg0)
 }
 
 // GetReservedInstancesExchangeQuoteRequest mocks base method
 func (m *MockEC2API) GetReservedInstancesExchangeQuoteRequest(arg0 *ec2.GetReservedInstancesExchangeQuoteInput) (*request.Request, *ec2.GetReservedInstancesExchangeQuoteOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetReservedInstancesExchangeQuoteRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.GetReservedInstancesExchangeQuoteOutput)
@@ -13019,13 +11462,11 @@ func (m *MockEC2API) GetReservedInstancesExchangeQuoteRequest(arg0 *ec2.GetReser
 
 // GetReservedInstancesExchangeQuoteRequest indicates an expected call of GetReservedInstancesExchangeQuoteRequest
 func (mr *MockEC2APIMockRecorder) GetReservedInstancesExchangeQuoteRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetReservedInstancesExchangeQuoteRequest", reflect.TypeOf((*MockEC2API)(nil).GetReservedInstancesExchangeQuoteRequest), arg0)
 }
 
 // GetReservedInstancesExchangeQuoteWithContext mocks base method
 func (m *MockEC2API) GetReservedInstancesExchangeQuoteWithContext(arg0 context.Context, arg1 *ec2.GetReservedInstancesExchangeQuoteInput, arg2 ...request.Option) (*ec2.GetReservedInstancesExchangeQuoteOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -13038,14 +11479,12 @@ func (m *MockEC2API) GetReservedInstancesExchangeQuoteWithContext(arg0 context.C
 
 // GetReservedInstancesExchangeQuoteWithContext indicates an expected call of GetReservedInstancesExchangeQuoteWithContext
 func (mr *MockEC2APIMockRecorder) GetReservedInstancesExchangeQuoteWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetReservedInstancesExchangeQuoteWithContext", reflect.TypeOf((*MockEC2API)(nil).GetReservedInstancesExchangeQuoteWithContext), varargs...)
 }
 
 // GetTransitGatewayAttachmentPropagations mocks base method
 func (m *MockEC2API) GetTransitGatewayAttachmentPropagations(arg0 *ec2.GetTransitGatewayAttachmentPropagationsInput) (*ec2.GetTransitGatewayAttachmentPropagationsOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetTransitGatewayAttachmentPropagations", arg0)
 	ret0, _ := ret[0].(*ec2.GetTransitGatewayAttachmentPropagationsOutput)
 	ret1, _ := ret[1].(error)
@@ -13054,13 +11493,11 @@ func (m *MockEC2API) GetTransitGatewayAttachmentPropagations(arg0 *ec2.GetTransi
 
 // GetTransitGatewayAttachmentPropagations indicates an expected call of GetTransitGatewayAttachmentPropagations
 func (mr *MockEC2APIMockRecorder) GetTransitGatewayAttachmentPropagations(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTransitGatewayAttachmentPropagations", reflect.TypeOf((*MockEC2API)(nil).GetTransitGatewayAttachmentPropagations), arg0)
 }
 
 // GetTransitGatewayAttachmentPropagationsRequest mocks base method
 func (m *MockEC2API) GetTransitGatewayAttachmentPropagationsRequest(arg0 *ec2.GetTransitGatewayAttachmentPropagationsInput) (*request.Request, *ec2.GetTransitGatewayAttachmentPropagationsOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetTransitGatewayAttachmentPropagationsRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.GetTransitGatewayAttachmentPropagationsOutput)
@@ -13069,13 +11506,11 @@ func (m *MockEC2API) GetTransitGatewayAttachmentPropagationsRequest(arg0 *ec2.Ge
 
 // GetTransitGatewayAttachmentPropagationsRequest indicates an expected call of GetTransitGatewayAttachmentPropagationsRequest
 func (mr *MockEC2APIMockRecorder) GetTransitGatewayAttachmentPropagationsRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTransitGatewayAttachmentPropagationsRequest", reflect.TypeOf((*MockEC2API)(nil).GetTransitGatewayAttachmentPropagationsRequest), arg0)
 }
 
 // GetTransitGatewayAttachmentPropagationsWithContext mocks base method
 func (m *MockEC2API) GetTransitGatewayAttachmentPropagationsWithContext(arg0 context.Context, arg1 *ec2.GetTransitGatewayAttachmentPropagationsInput, arg2 ...request.Option) (*ec2.GetTransitGatewayAttachmentPropagationsOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -13088,14 +11523,12 @@ func (m *MockEC2API) GetTransitGatewayAttachmentPropagationsWithContext(arg0 con
 
 // GetTransitGatewayAttachmentPropagationsWithContext indicates an expected call of GetTransitGatewayAttachmentPropagationsWithContext
 func (mr *MockEC2APIMockRecorder) GetTransitGatewayAttachmentPropagationsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTransitGatewayAttachmentPropagationsWithContext", reflect.TypeOf((*MockEC2API)(nil).GetTransitGatewayAttachmentPropagationsWithContext), varargs...)
 }
 
 // GetTransitGatewayRouteTableAssociations mocks base method
 func (m *MockEC2API) GetTransitGatewayRouteTableAssociations(arg0 *ec2.GetTransitGatewayRouteTableAssociationsInput) (*ec2.GetTransitGatewayRouteTableAssociationsOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetTransitGatewayRouteTableAssociations", arg0)
 	ret0, _ := ret[0].(*ec2.GetTransitGatewayRouteTableAssociationsOutput)
 	ret1, _ := ret[1].(error)
@@ -13104,13 +11537,11 @@ func (m *MockEC2API) GetTransitGatewayRouteTableAssociations(arg0 *ec2.GetTransi
 
 // GetTransitGatewayRouteTableAssociations indicates an expected call of GetTransitGatewayRouteTableAssociations
 func (mr *MockEC2APIMockRecorder) GetTransitGatewayRouteTableAssociations(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTransitGatewayRouteTableAssociations", reflect.TypeOf((*MockEC2API)(nil).GetTransitGatewayRouteTableAssociations), arg0)
 }
 
 // GetTransitGatewayRouteTableAssociationsRequest mocks base method
 func (m *MockEC2API) GetTransitGatewayRouteTableAssociationsRequest(arg0 *ec2.GetTransitGatewayRouteTableAssociationsInput) (*request.Request, *ec2.GetTransitGatewayRouteTableAssociationsOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetTransitGatewayRouteTableAssociationsRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.GetTransitGatewayRouteTableAssociationsOutput)
@@ -13119,13 +11550,11 @@ func (m *MockEC2API) GetTransitGatewayRouteTableAssociationsRequest(arg0 *ec2.Ge
 
 // GetTransitGatewayRouteTableAssociationsRequest indicates an expected call of GetTransitGatewayRouteTableAssociationsRequest
 func (mr *MockEC2APIMockRecorder) GetTransitGatewayRouteTableAssociationsRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTransitGatewayRouteTableAssociationsRequest", reflect.TypeOf((*MockEC2API)(nil).GetTransitGatewayRouteTableAssociationsRequest), arg0)
 }
 
 // GetTransitGatewayRouteTableAssociationsWithContext mocks base method
 func (m *MockEC2API) GetTransitGatewayRouteTableAssociationsWithContext(arg0 context.Context, arg1 *ec2.GetTransitGatewayRouteTableAssociationsInput, arg2 ...request.Option) (*ec2.GetTransitGatewayRouteTableAssociationsOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -13138,14 +11567,12 @@ func (m *MockEC2API) GetTransitGatewayRouteTableAssociationsWithContext(arg0 con
 
 // GetTransitGatewayRouteTableAssociationsWithContext indicates an expected call of GetTransitGatewayRouteTableAssociationsWithContext
 func (mr *MockEC2APIMockRecorder) GetTransitGatewayRouteTableAssociationsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTransitGatewayRouteTableAssociationsWithContext", reflect.TypeOf((*MockEC2API)(nil).GetTransitGatewayRouteTableAssociationsWithContext), varargs...)
 }
 
 // GetTransitGatewayRouteTablePropagations mocks base method
 func (m *MockEC2API) GetTransitGatewayRouteTablePropagations(arg0 *ec2.GetTransitGatewayRouteTablePropagationsInput) (*ec2.GetTransitGatewayRouteTablePropagationsOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetTransitGatewayRouteTablePropagations", arg0)
 	ret0, _ := ret[0].(*ec2.GetTransitGatewayRouteTablePropagationsOutput)
 	ret1, _ := ret[1].(error)
@@ -13154,13 +11581,11 @@ func (m *MockEC2API) GetTransitGatewayRouteTablePropagations(arg0 *ec2.GetTransi
 
 // GetTransitGatewayRouteTablePropagations indicates an expected call of GetTransitGatewayRouteTablePropagations
 func (mr *MockEC2APIMockRecorder) GetTransitGatewayRouteTablePropagations(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTransitGatewayRouteTablePropagations", reflect.TypeOf((*MockEC2API)(nil).GetTransitGatewayRouteTablePropagations), arg0)
 }
 
 // GetTransitGatewayRouteTablePropagationsRequest mocks base method
 func (m *MockEC2API) GetTransitGatewayRouteTablePropagationsRequest(arg0 *ec2.GetTransitGatewayRouteTablePropagationsInput) (*request.Request, *ec2.GetTransitGatewayRouteTablePropagationsOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetTransitGatewayRouteTablePropagationsRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.GetTransitGatewayRouteTablePropagationsOutput)
@@ -13169,13 +11594,11 @@ func (m *MockEC2API) GetTransitGatewayRouteTablePropagationsRequest(arg0 *ec2.Ge
 
 // GetTransitGatewayRouteTablePropagationsRequest indicates an expected call of GetTransitGatewayRouteTablePropagationsRequest
 func (mr *MockEC2APIMockRecorder) GetTransitGatewayRouteTablePropagationsRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTransitGatewayRouteTablePropagationsRequest", reflect.TypeOf((*MockEC2API)(nil).GetTransitGatewayRouteTablePropagationsRequest), arg0)
 }
 
 // GetTransitGatewayRouteTablePropagationsWithContext mocks base method
 func (m *MockEC2API) GetTransitGatewayRouteTablePropagationsWithContext(arg0 context.Context, arg1 *ec2.GetTransitGatewayRouteTablePropagationsInput, arg2 ...request.Option) (*ec2.GetTransitGatewayRouteTablePropagationsOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -13188,14 +11611,12 @@ func (m *MockEC2API) GetTransitGatewayRouteTablePropagationsWithContext(arg0 con
 
 // GetTransitGatewayRouteTablePropagationsWithContext indicates an expected call of GetTransitGatewayRouteTablePropagationsWithContext
 func (mr *MockEC2APIMockRecorder) GetTransitGatewayRouteTablePropagationsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTransitGatewayRouteTablePropagationsWithContext", reflect.TypeOf((*MockEC2API)(nil).GetTransitGatewayRouteTablePropagationsWithContext), varargs...)
 }
 
 // ImportClientVpnClientCertificateRevocationList mocks base method
 func (m *MockEC2API) ImportClientVpnClientCertificateRevocationList(arg0 *ec2.ImportClientVpnClientCertificateRevocationListInput) (*ec2.ImportClientVpnClientCertificateRevocationListOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ImportClientVpnClientCertificateRevocationList", arg0)
 	ret0, _ := ret[0].(*ec2.ImportClientVpnClientCertificateRevocationListOutput)
 	ret1, _ := ret[1].(error)
@@ -13204,13 +11625,11 @@ func (m *MockEC2API) ImportClientVpnClientCertificateRevocationList(arg0 *ec2.Im
 
 // ImportClientVpnClientCertificateRevocationList indicates an expected call of ImportClientVpnClientCertificateRevocationList
 func (mr *MockEC2APIMockRecorder) ImportClientVpnClientCertificateRevocationList(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ImportClientVpnClientCertificateRevocationList", reflect.TypeOf((*MockEC2API)(nil).ImportClientVpnClientCertificateRevocationList), arg0)
 }
 
 // ImportClientVpnClientCertificateRevocationListRequest mocks base method
 func (m *MockEC2API) ImportClientVpnClientCertificateRevocationListRequest(arg0 *ec2.ImportClientVpnClientCertificateRevocationListInput) (*request.Request, *ec2.ImportClientVpnClientCertificateRevocationListOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ImportClientVpnClientCertificateRevocationListRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.ImportClientVpnClientCertificateRevocationListOutput)
@@ -13219,13 +11638,11 @@ func (m *MockEC2API) ImportClientVpnClientCertificateRevocationListRequest(arg0 
 
 // ImportClientVpnClientCertificateRevocationListRequest indicates an expected call of ImportClientVpnClientCertificateRevocationListRequest
 func (mr *MockEC2APIMockRecorder) ImportClientVpnClientCertificateRevocationListRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ImportClientVpnClientCertificateRevocationListRequest", reflect.TypeOf((*MockEC2API)(nil).ImportClientVpnClientCertificateRevocationListRequest), arg0)
 }
 
 // ImportClientVpnClientCertificateRevocationListWithContext mocks base method
 func (m *MockEC2API) ImportClientVpnClientCertificateRevocationListWithContext(arg0 context.Context, arg1 *ec2.ImportClientVpnClientCertificateRevocationListInput, arg2 ...request.Option) (*ec2.ImportClientVpnClientCertificateRevocationListOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -13238,14 +11655,12 @@ func (m *MockEC2API) ImportClientVpnClientCertificateRevocationListWithContext(a
 
 // ImportClientVpnClientCertificateRevocationListWithContext indicates an expected call of ImportClientVpnClientCertificateRevocationListWithContext
 func (mr *MockEC2APIMockRecorder) ImportClientVpnClientCertificateRevocationListWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ImportClientVpnClientCertificateRevocationListWithContext", reflect.TypeOf((*MockEC2API)(nil).ImportClientVpnClientCertificateRevocationListWithContext), varargs...)
 }
 
 // ImportImage mocks base method
 func (m *MockEC2API) ImportImage(arg0 *ec2.ImportImageInput) (*ec2.ImportImageOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ImportImage", arg0)
 	ret0, _ := ret[0].(*ec2.ImportImageOutput)
 	ret1, _ := ret[1].(error)
@@ -13254,13 +11669,11 @@ func (m *MockEC2API) ImportImage(arg0 *ec2.ImportImageInput) (*ec2.ImportImageOu
 
 // ImportImage indicates an expected call of ImportImage
 func (mr *MockEC2APIMockRecorder) ImportImage(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ImportImage", reflect.TypeOf((*MockEC2API)(nil).ImportImage), arg0)
 }
 
 // ImportImageRequest mocks base method
 func (m *MockEC2API) ImportImageRequest(arg0 *ec2.ImportImageInput) (*request.Request, *ec2.ImportImageOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ImportImageRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.ImportImageOutput)
@@ -13269,13 +11682,11 @@ func (m *MockEC2API) ImportImageRequest(arg0 *ec2.ImportImageInput) (*request.Re
 
 // ImportImageRequest indicates an expected call of ImportImageRequest
 func (mr *MockEC2APIMockRecorder) ImportImageRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ImportImageRequest", reflect.TypeOf((*MockEC2API)(nil).ImportImageRequest), arg0)
 }
 
 // ImportImageWithContext mocks base method
 func (m *MockEC2API) ImportImageWithContext(arg0 context.Context, arg1 *ec2.ImportImageInput, arg2 ...request.Option) (*ec2.ImportImageOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -13288,14 +11699,12 @@ func (m *MockEC2API) ImportImageWithContext(arg0 context.Context, arg1 *ec2.Impo
 
 // ImportImageWithContext indicates an expected call of ImportImageWithContext
 func (mr *MockEC2APIMockRecorder) ImportImageWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ImportImageWithContext", reflect.TypeOf((*MockEC2API)(nil).ImportImageWithContext), varargs...)
 }
 
 // ImportInstance mocks base method
 func (m *MockEC2API) ImportInstance(arg0 *ec2.ImportInstanceInput) (*ec2.ImportInstanceOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ImportInstance", arg0)
 	ret0, _ := ret[0].(*ec2.ImportInstanceOutput)
 	ret1, _ := ret[1].(error)
@@ -13304,13 +11713,11 @@ func (m *MockEC2API) ImportInstance(arg0 *ec2.ImportInstanceInput) (*ec2.ImportI
 
 // ImportInstance indicates an expected call of ImportInstance
 func (mr *MockEC2APIMockRecorder) ImportInstance(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ImportInstance", reflect.TypeOf((*MockEC2API)(nil).ImportInstance), arg0)
 }
 
 // ImportInstanceRequest mocks base method
 func (m *MockEC2API) ImportInstanceRequest(arg0 *ec2.ImportInstanceInput) (*request.Request, *ec2.ImportInstanceOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ImportInstanceRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.ImportInstanceOutput)
@@ -13319,13 +11726,11 @@ func (m *MockEC2API) ImportInstanceRequest(arg0 *ec2.ImportInstanceInput) (*requ
 
 // ImportInstanceRequest indicates an expected call of ImportInstanceRequest
 func (mr *MockEC2APIMockRecorder) ImportInstanceRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ImportInstanceRequest", reflect.TypeOf((*MockEC2API)(nil).ImportInstanceRequest), arg0)
 }
 
 // ImportInstanceWithContext mocks base method
 func (m *MockEC2API) ImportInstanceWithContext(arg0 context.Context, arg1 *ec2.ImportInstanceInput, arg2 ...request.Option) (*ec2.ImportInstanceOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -13338,14 +11743,12 @@ func (m *MockEC2API) ImportInstanceWithContext(arg0 context.Context, arg1 *ec2.I
 
 // ImportInstanceWithContext indicates an expected call of ImportInstanceWithContext
 func (mr *MockEC2APIMockRecorder) ImportInstanceWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ImportInstanceWithContext", reflect.TypeOf((*MockEC2API)(nil).ImportInstanceWithContext), varargs...)
 }
 
 // ImportKeyPair mocks base method
 func (m *MockEC2API) ImportKeyPair(arg0 *ec2.ImportKeyPairInput) (*ec2.ImportKeyPairOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ImportKeyPair", arg0)
 	ret0, _ := ret[0].(*ec2.ImportKeyPairOutput)
 	ret1, _ := ret[1].(error)
@@ -13354,13 +11757,11 @@ func (m *MockEC2API) ImportKeyPair(arg0 *ec2.ImportKeyPairInput) (*ec2.ImportKey
 
 // ImportKeyPair indicates an expected call of ImportKeyPair
 func (mr *MockEC2APIMockRecorder) ImportKeyPair(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ImportKeyPair", reflect.TypeOf((*MockEC2API)(nil).ImportKeyPair), arg0)
 }
 
 // ImportKeyPairRequest mocks base method
 func (m *MockEC2API) ImportKeyPairRequest(arg0 *ec2.ImportKeyPairInput) (*request.Request, *ec2.ImportKeyPairOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ImportKeyPairRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.ImportKeyPairOutput)
@@ -13369,13 +11770,11 @@ func (m *MockEC2API) ImportKeyPairRequest(arg0 *ec2.ImportKeyPairInput) (*reques
 
 // ImportKeyPairRequest indicates an expected call of ImportKeyPairRequest
 func (mr *MockEC2APIMockRecorder) ImportKeyPairRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ImportKeyPairRequest", reflect.TypeOf((*MockEC2API)(nil).ImportKeyPairRequest), arg0)
 }
 
 // ImportKeyPairWithContext mocks base method
 func (m *MockEC2API) ImportKeyPairWithContext(arg0 context.Context, arg1 *ec2.ImportKeyPairInput, arg2 ...request.Option) (*ec2.ImportKeyPairOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -13388,14 +11787,12 @@ func (m *MockEC2API) ImportKeyPairWithContext(arg0 context.Context, arg1 *ec2.Im
 
 // ImportKeyPairWithContext indicates an expected call of ImportKeyPairWithContext
 func (mr *MockEC2APIMockRecorder) ImportKeyPairWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ImportKeyPairWithContext", reflect.TypeOf((*MockEC2API)(nil).ImportKeyPairWithContext), varargs...)
 }
 
 // ImportSnapshot mocks base method
 func (m *MockEC2API) ImportSnapshot(arg0 *ec2.ImportSnapshotInput) (*ec2.ImportSnapshotOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ImportSnapshot", arg0)
 	ret0, _ := ret[0].(*ec2.ImportSnapshotOutput)
 	ret1, _ := ret[1].(error)
@@ -13404,13 +11801,11 @@ func (m *MockEC2API) ImportSnapshot(arg0 *ec2.ImportSnapshotInput) (*ec2.ImportS
 
 // ImportSnapshot indicates an expected call of ImportSnapshot
 func (mr *MockEC2APIMockRecorder) ImportSnapshot(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ImportSnapshot", reflect.TypeOf((*MockEC2API)(nil).ImportSnapshot), arg0)
 }
 
 // ImportSnapshotRequest mocks base method
 func (m *MockEC2API) ImportSnapshotRequest(arg0 *ec2.ImportSnapshotInput) (*request.Request, *ec2.ImportSnapshotOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ImportSnapshotRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.ImportSnapshotOutput)
@@ -13419,13 +11814,11 @@ func (m *MockEC2API) ImportSnapshotRequest(arg0 *ec2.ImportSnapshotInput) (*requ
 
 // ImportSnapshotRequest indicates an expected call of ImportSnapshotRequest
 func (mr *MockEC2APIMockRecorder) ImportSnapshotRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ImportSnapshotRequest", reflect.TypeOf((*MockEC2API)(nil).ImportSnapshotRequest), arg0)
 }
 
 // ImportSnapshotWithContext mocks base method
 func (m *MockEC2API) ImportSnapshotWithContext(arg0 context.Context, arg1 *ec2.ImportSnapshotInput, arg2 ...request.Option) (*ec2.ImportSnapshotOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -13438,14 +11831,12 @@ func (m *MockEC2API) ImportSnapshotWithContext(arg0 context.Context, arg1 *ec2.I
 
 // ImportSnapshotWithContext indicates an expected call of ImportSnapshotWithContext
 func (mr *MockEC2APIMockRecorder) ImportSnapshotWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ImportSnapshotWithContext", reflect.TypeOf((*MockEC2API)(nil).ImportSnapshotWithContext), varargs...)
 }
 
 // ImportVolume mocks base method
 func (m *MockEC2API) ImportVolume(arg0 *ec2.ImportVolumeInput) (*ec2.ImportVolumeOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ImportVolume", arg0)
 	ret0, _ := ret[0].(*ec2.ImportVolumeOutput)
 	ret1, _ := ret[1].(error)
@@ -13454,13 +11845,11 @@ func (m *MockEC2API) ImportVolume(arg0 *ec2.ImportVolumeInput) (*ec2.ImportVolum
 
 // ImportVolume indicates an expected call of ImportVolume
 func (mr *MockEC2APIMockRecorder) ImportVolume(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ImportVolume", reflect.TypeOf((*MockEC2API)(nil).ImportVolume), arg0)
 }
 
 // ImportVolumeRequest mocks base method
 func (m *MockEC2API) ImportVolumeRequest(arg0 *ec2.ImportVolumeInput) (*request.Request, *ec2.ImportVolumeOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ImportVolumeRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.ImportVolumeOutput)
@@ -13469,13 +11858,11 @@ func (m *MockEC2API) ImportVolumeRequest(arg0 *ec2.ImportVolumeInput) (*request.
 
 // ImportVolumeRequest indicates an expected call of ImportVolumeRequest
 func (mr *MockEC2APIMockRecorder) ImportVolumeRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ImportVolumeRequest", reflect.TypeOf((*MockEC2API)(nil).ImportVolumeRequest), arg0)
 }
 
 // ImportVolumeWithContext mocks base method
 func (m *MockEC2API) ImportVolumeWithContext(arg0 context.Context, arg1 *ec2.ImportVolumeInput, arg2 ...request.Option) (*ec2.ImportVolumeOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -13488,14 +11875,12 @@ func (m *MockEC2API) ImportVolumeWithContext(arg0 context.Context, arg1 *ec2.Imp
 
 // ImportVolumeWithContext indicates an expected call of ImportVolumeWithContext
 func (mr *MockEC2APIMockRecorder) ImportVolumeWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ImportVolumeWithContext", reflect.TypeOf((*MockEC2API)(nil).ImportVolumeWithContext), varargs...)
 }
 
 // ModifyCapacityReservation mocks base method
 func (m *MockEC2API) ModifyCapacityReservation(arg0 *ec2.ModifyCapacityReservationInput) (*ec2.ModifyCapacityReservationOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ModifyCapacityReservation", arg0)
 	ret0, _ := ret[0].(*ec2.ModifyCapacityReservationOutput)
 	ret1, _ := ret[1].(error)
@@ -13504,13 +11889,11 @@ func (m *MockEC2API) ModifyCapacityReservation(arg0 *ec2.ModifyCapacityReservati
 
 // ModifyCapacityReservation indicates an expected call of ModifyCapacityReservation
 func (mr *MockEC2APIMockRecorder) ModifyCapacityReservation(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyCapacityReservation", reflect.TypeOf((*MockEC2API)(nil).ModifyCapacityReservation), arg0)
 }
 
 // ModifyCapacityReservationRequest mocks base method
 func (m *MockEC2API) ModifyCapacityReservationRequest(arg0 *ec2.ModifyCapacityReservationInput) (*request.Request, *ec2.ModifyCapacityReservationOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ModifyCapacityReservationRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.ModifyCapacityReservationOutput)
@@ -13519,13 +11902,11 @@ func (m *MockEC2API) ModifyCapacityReservationRequest(arg0 *ec2.ModifyCapacityRe
 
 // ModifyCapacityReservationRequest indicates an expected call of ModifyCapacityReservationRequest
 func (mr *MockEC2APIMockRecorder) ModifyCapacityReservationRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyCapacityReservationRequest", reflect.TypeOf((*MockEC2API)(nil).ModifyCapacityReservationRequest), arg0)
 }
 
 // ModifyCapacityReservationWithContext mocks base method
 func (m *MockEC2API) ModifyCapacityReservationWithContext(arg0 context.Context, arg1 *ec2.ModifyCapacityReservationInput, arg2 ...request.Option) (*ec2.ModifyCapacityReservationOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -13538,14 +11919,12 @@ func (m *MockEC2API) ModifyCapacityReservationWithContext(arg0 context.Context, 
 
 // ModifyCapacityReservationWithContext indicates an expected call of ModifyCapacityReservationWithContext
 func (mr *MockEC2APIMockRecorder) ModifyCapacityReservationWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyCapacityReservationWithContext", reflect.TypeOf((*MockEC2API)(nil).ModifyCapacityReservationWithContext), varargs...)
 }
 
 // ModifyClientVpnEndpoint mocks base method
 func (m *MockEC2API) ModifyClientVpnEndpoint(arg0 *ec2.ModifyClientVpnEndpointInput) (*ec2.ModifyClientVpnEndpointOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ModifyClientVpnEndpoint", arg0)
 	ret0, _ := ret[0].(*ec2.ModifyClientVpnEndpointOutput)
 	ret1, _ := ret[1].(error)
@@ -13554,13 +11933,11 @@ func (m *MockEC2API) ModifyClientVpnEndpoint(arg0 *ec2.ModifyClientVpnEndpointIn
 
 // ModifyClientVpnEndpoint indicates an expected call of ModifyClientVpnEndpoint
 func (mr *MockEC2APIMockRecorder) ModifyClientVpnEndpoint(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyClientVpnEndpoint", reflect.TypeOf((*MockEC2API)(nil).ModifyClientVpnEndpoint), arg0)
 }
 
 // ModifyClientVpnEndpointRequest mocks base method
 func (m *MockEC2API) ModifyClientVpnEndpointRequest(arg0 *ec2.ModifyClientVpnEndpointInput) (*request.Request, *ec2.ModifyClientVpnEndpointOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ModifyClientVpnEndpointRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.ModifyClientVpnEndpointOutput)
@@ -13569,13 +11946,11 @@ func (m *MockEC2API) ModifyClientVpnEndpointRequest(arg0 *ec2.ModifyClientVpnEnd
 
 // ModifyClientVpnEndpointRequest indicates an expected call of ModifyClientVpnEndpointRequest
 func (mr *MockEC2APIMockRecorder) ModifyClientVpnEndpointRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyClientVpnEndpointRequest", reflect.TypeOf((*MockEC2API)(nil).ModifyClientVpnEndpointRequest), arg0)
 }
 
 // ModifyClientVpnEndpointWithContext mocks base method
 func (m *MockEC2API) ModifyClientVpnEndpointWithContext(arg0 context.Context, arg1 *ec2.ModifyClientVpnEndpointInput, arg2 ...request.Option) (*ec2.ModifyClientVpnEndpointOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -13588,14 +11963,12 @@ func (m *MockEC2API) ModifyClientVpnEndpointWithContext(arg0 context.Context, ar
 
 // ModifyClientVpnEndpointWithContext indicates an expected call of ModifyClientVpnEndpointWithContext
 func (mr *MockEC2APIMockRecorder) ModifyClientVpnEndpointWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyClientVpnEndpointWithContext", reflect.TypeOf((*MockEC2API)(nil).ModifyClientVpnEndpointWithContext), varargs...)
 }
 
 // ModifyFleet mocks base method
 func (m *MockEC2API) ModifyFleet(arg0 *ec2.ModifyFleetInput) (*ec2.ModifyFleetOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ModifyFleet", arg0)
 	ret0, _ := ret[0].(*ec2.ModifyFleetOutput)
 	ret1, _ := ret[1].(error)
@@ -13604,13 +11977,11 @@ func (m *MockEC2API) ModifyFleet(arg0 *ec2.ModifyFleetInput) (*ec2.ModifyFleetOu
 
 // ModifyFleet indicates an expected call of ModifyFleet
 func (mr *MockEC2APIMockRecorder) ModifyFleet(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyFleet", reflect.TypeOf((*MockEC2API)(nil).ModifyFleet), arg0)
 }
 
 // ModifyFleetRequest mocks base method
 func (m *MockEC2API) ModifyFleetRequest(arg0 *ec2.ModifyFleetInput) (*request.Request, *ec2.ModifyFleetOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ModifyFleetRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.ModifyFleetOutput)
@@ -13619,13 +11990,11 @@ func (m *MockEC2API) ModifyFleetRequest(arg0 *ec2.ModifyFleetInput) (*request.Re
 
 // ModifyFleetRequest indicates an expected call of ModifyFleetRequest
 func (mr *MockEC2APIMockRecorder) ModifyFleetRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyFleetRequest", reflect.TypeOf((*MockEC2API)(nil).ModifyFleetRequest), arg0)
 }
 
 // ModifyFleetWithContext mocks base method
 func (m *MockEC2API) ModifyFleetWithContext(arg0 context.Context, arg1 *ec2.ModifyFleetInput, arg2 ...request.Option) (*ec2.ModifyFleetOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -13638,14 +12007,12 @@ func (m *MockEC2API) ModifyFleetWithContext(arg0 context.Context, arg1 *ec2.Modi
 
 // ModifyFleetWithContext indicates an expected call of ModifyFleetWithContext
 func (mr *MockEC2APIMockRecorder) ModifyFleetWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyFleetWithContext", reflect.TypeOf((*MockEC2API)(nil).ModifyFleetWithContext), varargs...)
 }
 
 // ModifyFpgaImageAttribute mocks base method
 func (m *MockEC2API) ModifyFpgaImageAttribute(arg0 *ec2.ModifyFpgaImageAttributeInput) (*ec2.ModifyFpgaImageAttributeOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ModifyFpgaImageAttribute", arg0)
 	ret0, _ := ret[0].(*ec2.ModifyFpgaImageAttributeOutput)
 	ret1, _ := ret[1].(error)
@@ -13654,13 +12021,11 @@ func (m *MockEC2API) ModifyFpgaImageAttribute(arg0 *ec2.ModifyFpgaImageAttribute
 
 // ModifyFpgaImageAttribute indicates an expected call of ModifyFpgaImageAttribute
 func (mr *MockEC2APIMockRecorder) ModifyFpgaImageAttribute(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyFpgaImageAttribute", reflect.TypeOf((*MockEC2API)(nil).ModifyFpgaImageAttribute), arg0)
 }
 
 // ModifyFpgaImageAttributeRequest mocks base method
 func (m *MockEC2API) ModifyFpgaImageAttributeRequest(arg0 *ec2.ModifyFpgaImageAttributeInput) (*request.Request, *ec2.ModifyFpgaImageAttributeOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ModifyFpgaImageAttributeRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.ModifyFpgaImageAttributeOutput)
@@ -13669,13 +12034,11 @@ func (m *MockEC2API) ModifyFpgaImageAttributeRequest(arg0 *ec2.ModifyFpgaImageAt
 
 // ModifyFpgaImageAttributeRequest indicates an expected call of ModifyFpgaImageAttributeRequest
 func (mr *MockEC2APIMockRecorder) ModifyFpgaImageAttributeRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyFpgaImageAttributeRequest", reflect.TypeOf((*MockEC2API)(nil).ModifyFpgaImageAttributeRequest), arg0)
 }
 
 // ModifyFpgaImageAttributeWithContext mocks base method
 func (m *MockEC2API) ModifyFpgaImageAttributeWithContext(arg0 context.Context, arg1 *ec2.ModifyFpgaImageAttributeInput, arg2 ...request.Option) (*ec2.ModifyFpgaImageAttributeOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -13688,14 +12051,12 @@ func (m *MockEC2API) ModifyFpgaImageAttributeWithContext(arg0 context.Context, a
 
 // ModifyFpgaImageAttributeWithContext indicates an expected call of ModifyFpgaImageAttributeWithContext
 func (mr *MockEC2APIMockRecorder) ModifyFpgaImageAttributeWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyFpgaImageAttributeWithContext", reflect.TypeOf((*MockEC2API)(nil).ModifyFpgaImageAttributeWithContext), varargs...)
 }
 
 // ModifyHosts mocks base method
 func (m *MockEC2API) ModifyHosts(arg0 *ec2.ModifyHostsInput) (*ec2.ModifyHostsOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ModifyHosts", arg0)
 	ret0, _ := ret[0].(*ec2.ModifyHostsOutput)
 	ret1, _ := ret[1].(error)
@@ -13704,13 +12065,11 @@ func (m *MockEC2API) ModifyHosts(arg0 *ec2.ModifyHostsInput) (*ec2.ModifyHostsOu
 
 // ModifyHosts indicates an expected call of ModifyHosts
 func (mr *MockEC2APIMockRecorder) ModifyHosts(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyHosts", reflect.TypeOf((*MockEC2API)(nil).ModifyHosts), arg0)
 }
 
 // ModifyHostsRequest mocks base method
 func (m *MockEC2API) ModifyHostsRequest(arg0 *ec2.ModifyHostsInput) (*request.Request, *ec2.ModifyHostsOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ModifyHostsRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.ModifyHostsOutput)
@@ -13719,13 +12078,11 @@ func (m *MockEC2API) ModifyHostsRequest(arg0 *ec2.ModifyHostsInput) (*request.Re
 
 // ModifyHostsRequest indicates an expected call of ModifyHostsRequest
 func (mr *MockEC2APIMockRecorder) ModifyHostsRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyHostsRequest", reflect.TypeOf((*MockEC2API)(nil).ModifyHostsRequest), arg0)
 }
 
 // ModifyHostsWithContext mocks base method
 func (m *MockEC2API) ModifyHostsWithContext(arg0 context.Context, arg1 *ec2.ModifyHostsInput, arg2 ...request.Option) (*ec2.ModifyHostsOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -13738,14 +12095,12 @@ func (m *MockEC2API) ModifyHostsWithContext(arg0 context.Context, arg1 *ec2.Modi
 
 // ModifyHostsWithContext indicates an expected call of ModifyHostsWithContext
 func (mr *MockEC2APIMockRecorder) ModifyHostsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyHostsWithContext", reflect.TypeOf((*MockEC2API)(nil).ModifyHostsWithContext), varargs...)
 }
 
 // ModifyIdFormat mocks base method
 func (m *MockEC2API) ModifyIdFormat(arg0 *ec2.ModifyIdFormatInput) (*ec2.ModifyIdFormatOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ModifyIdFormat", arg0)
 	ret0, _ := ret[0].(*ec2.ModifyIdFormatOutput)
 	ret1, _ := ret[1].(error)
@@ -13754,13 +12109,11 @@ func (m *MockEC2API) ModifyIdFormat(arg0 *ec2.ModifyIdFormatInput) (*ec2.ModifyI
 
 // ModifyIdFormat indicates an expected call of ModifyIdFormat
 func (mr *MockEC2APIMockRecorder) ModifyIdFormat(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyIdFormat", reflect.TypeOf((*MockEC2API)(nil).ModifyIdFormat), arg0)
 }
 
 // ModifyIdFormatRequest mocks base method
 func (m *MockEC2API) ModifyIdFormatRequest(arg0 *ec2.ModifyIdFormatInput) (*request.Request, *ec2.ModifyIdFormatOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ModifyIdFormatRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.ModifyIdFormatOutput)
@@ -13769,13 +12122,11 @@ func (m *MockEC2API) ModifyIdFormatRequest(arg0 *ec2.ModifyIdFormatInput) (*requ
 
 // ModifyIdFormatRequest indicates an expected call of ModifyIdFormatRequest
 func (mr *MockEC2APIMockRecorder) ModifyIdFormatRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyIdFormatRequest", reflect.TypeOf((*MockEC2API)(nil).ModifyIdFormatRequest), arg0)
 }
 
 // ModifyIdFormatWithContext mocks base method
 func (m *MockEC2API) ModifyIdFormatWithContext(arg0 context.Context, arg1 *ec2.ModifyIdFormatInput, arg2 ...request.Option) (*ec2.ModifyIdFormatOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -13788,14 +12139,12 @@ func (m *MockEC2API) ModifyIdFormatWithContext(arg0 context.Context, arg1 *ec2.M
 
 // ModifyIdFormatWithContext indicates an expected call of ModifyIdFormatWithContext
 func (mr *MockEC2APIMockRecorder) ModifyIdFormatWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyIdFormatWithContext", reflect.TypeOf((*MockEC2API)(nil).ModifyIdFormatWithContext), varargs...)
 }
 
 // ModifyIdentityIdFormat mocks base method
 func (m *MockEC2API) ModifyIdentityIdFormat(arg0 *ec2.ModifyIdentityIdFormatInput) (*ec2.ModifyIdentityIdFormatOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ModifyIdentityIdFormat", arg0)
 	ret0, _ := ret[0].(*ec2.ModifyIdentityIdFormatOutput)
 	ret1, _ := ret[1].(error)
@@ -13804,13 +12153,11 @@ func (m *MockEC2API) ModifyIdentityIdFormat(arg0 *ec2.ModifyIdentityIdFormatInpu
 
 // ModifyIdentityIdFormat indicates an expected call of ModifyIdentityIdFormat
 func (mr *MockEC2APIMockRecorder) ModifyIdentityIdFormat(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyIdentityIdFormat", reflect.TypeOf((*MockEC2API)(nil).ModifyIdentityIdFormat), arg0)
 }
 
 // ModifyIdentityIdFormatRequest mocks base method
 func (m *MockEC2API) ModifyIdentityIdFormatRequest(arg0 *ec2.ModifyIdentityIdFormatInput) (*request.Request, *ec2.ModifyIdentityIdFormatOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ModifyIdentityIdFormatRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.ModifyIdentityIdFormatOutput)
@@ -13819,13 +12166,11 @@ func (m *MockEC2API) ModifyIdentityIdFormatRequest(arg0 *ec2.ModifyIdentityIdFor
 
 // ModifyIdentityIdFormatRequest indicates an expected call of ModifyIdentityIdFormatRequest
 func (mr *MockEC2APIMockRecorder) ModifyIdentityIdFormatRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyIdentityIdFormatRequest", reflect.TypeOf((*MockEC2API)(nil).ModifyIdentityIdFormatRequest), arg0)
 }
 
 // ModifyIdentityIdFormatWithContext mocks base method
 func (m *MockEC2API) ModifyIdentityIdFormatWithContext(arg0 context.Context, arg1 *ec2.ModifyIdentityIdFormatInput, arg2 ...request.Option) (*ec2.ModifyIdentityIdFormatOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -13838,14 +12183,12 @@ func (m *MockEC2API) ModifyIdentityIdFormatWithContext(arg0 context.Context, arg
 
 // ModifyIdentityIdFormatWithContext indicates an expected call of ModifyIdentityIdFormatWithContext
 func (mr *MockEC2APIMockRecorder) ModifyIdentityIdFormatWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyIdentityIdFormatWithContext", reflect.TypeOf((*MockEC2API)(nil).ModifyIdentityIdFormatWithContext), varargs...)
 }
 
 // ModifyImageAttribute mocks base method
 func (m *MockEC2API) ModifyImageAttribute(arg0 *ec2.ModifyImageAttributeInput) (*ec2.ModifyImageAttributeOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ModifyImageAttribute", arg0)
 	ret0, _ := ret[0].(*ec2.ModifyImageAttributeOutput)
 	ret1, _ := ret[1].(error)
@@ -13854,13 +12197,11 @@ func (m *MockEC2API) ModifyImageAttribute(arg0 *ec2.ModifyImageAttributeInput) (
 
 // ModifyImageAttribute indicates an expected call of ModifyImageAttribute
 func (mr *MockEC2APIMockRecorder) ModifyImageAttribute(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyImageAttribute", reflect.TypeOf((*MockEC2API)(nil).ModifyImageAttribute), arg0)
 }
 
 // ModifyImageAttributeRequest mocks base method
 func (m *MockEC2API) ModifyImageAttributeRequest(arg0 *ec2.ModifyImageAttributeInput) (*request.Request, *ec2.ModifyImageAttributeOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ModifyImageAttributeRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.ModifyImageAttributeOutput)
@@ -13869,13 +12210,11 @@ func (m *MockEC2API) ModifyImageAttributeRequest(arg0 *ec2.ModifyImageAttributeI
 
 // ModifyImageAttributeRequest indicates an expected call of ModifyImageAttributeRequest
 func (mr *MockEC2APIMockRecorder) ModifyImageAttributeRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyImageAttributeRequest", reflect.TypeOf((*MockEC2API)(nil).ModifyImageAttributeRequest), arg0)
 }
 
 // ModifyImageAttributeWithContext mocks base method
 func (m *MockEC2API) ModifyImageAttributeWithContext(arg0 context.Context, arg1 *ec2.ModifyImageAttributeInput, arg2 ...request.Option) (*ec2.ModifyImageAttributeOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -13888,14 +12227,12 @@ func (m *MockEC2API) ModifyImageAttributeWithContext(arg0 context.Context, arg1 
 
 // ModifyImageAttributeWithContext indicates an expected call of ModifyImageAttributeWithContext
 func (mr *MockEC2APIMockRecorder) ModifyImageAttributeWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyImageAttributeWithContext", reflect.TypeOf((*MockEC2API)(nil).ModifyImageAttributeWithContext), varargs...)
 }
 
 // ModifyInstanceAttribute mocks base method
 func (m *MockEC2API) ModifyInstanceAttribute(arg0 *ec2.ModifyInstanceAttributeInput) (*ec2.ModifyInstanceAttributeOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ModifyInstanceAttribute", arg0)
 	ret0, _ := ret[0].(*ec2.ModifyInstanceAttributeOutput)
 	ret1, _ := ret[1].(error)
@@ -13904,13 +12241,11 @@ func (m *MockEC2API) ModifyInstanceAttribute(arg0 *ec2.ModifyInstanceAttributeIn
 
 // ModifyInstanceAttribute indicates an expected call of ModifyInstanceAttribute
 func (mr *MockEC2APIMockRecorder) ModifyInstanceAttribute(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyInstanceAttribute", reflect.TypeOf((*MockEC2API)(nil).ModifyInstanceAttribute), arg0)
 }
 
 // ModifyInstanceAttributeRequest mocks base method
 func (m *MockEC2API) ModifyInstanceAttributeRequest(arg0 *ec2.ModifyInstanceAttributeInput) (*request.Request, *ec2.ModifyInstanceAttributeOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ModifyInstanceAttributeRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.ModifyInstanceAttributeOutput)
@@ -13919,13 +12254,11 @@ func (m *MockEC2API) ModifyInstanceAttributeRequest(arg0 *ec2.ModifyInstanceAttr
 
 // ModifyInstanceAttributeRequest indicates an expected call of ModifyInstanceAttributeRequest
 func (mr *MockEC2APIMockRecorder) ModifyInstanceAttributeRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyInstanceAttributeRequest", reflect.TypeOf((*MockEC2API)(nil).ModifyInstanceAttributeRequest), arg0)
 }
 
 // ModifyInstanceAttributeWithContext mocks base method
 func (m *MockEC2API) ModifyInstanceAttributeWithContext(arg0 context.Context, arg1 *ec2.ModifyInstanceAttributeInput, arg2 ...request.Option) (*ec2.ModifyInstanceAttributeOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -13938,14 +12271,12 @@ func (m *MockEC2API) ModifyInstanceAttributeWithContext(arg0 context.Context, ar
 
 // ModifyInstanceAttributeWithContext indicates an expected call of ModifyInstanceAttributeWithContext
 func (mr *MockEC2APIMockRecorder) ModifyInstanceAttributeWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyInstanceAttributeWithContext", reflect.TypeOf((*MockEC2API)(nil).ModifyInstanceAttributeWithContext), varargs...)
 }
 
 // ModifyInstanceCapacityReservationAttributes mocks base method
 func (m *MockEC2API) ModifyInstanceCapacityReservationAttributes(arg0 *ec2.ModifyInstanceCapacityReservationAttributesInput) (*ec2.ModifyInstanceCapacityReservationAttributesOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ModifyInstanceCapacityReservationAttributes", arg0)
 	ret0, _ := ret[0].(*ec2.ModifyInstanceCapacityReservationAttributesOutput)
 	ret1, _ := ret[1].(error)
@@ -13954,13 +12285,11 @@ func (m *MockEC2API) ModifyInstanceCapacityReservationAttributes(arg0 *ec2.Modif
 
 // ModifyInstanceCapacityReservationAttributes indicates an expected call of ModifyInstanceCapacityReservationAttributes
 func (mr *MockEC2APIMockRecorder) ModifyInstanceCapacityReservationAttributes(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyInstanceCapacityReservationAttributes", reflect.TypeOf((*MockEC2API)(nil).ModifyInstanceCapacityReservationAttributes), arg0)
 }
 
 // ModifyInstanceCapacityReservationAttributesRequest mocks base method
 func (m *MockEC2API) ModifyInstanceCapacityReservationAttributesRequest(arg0 *ec2.ModifyInstanceCapacityReservationAttributesInput) (*request.Request, *ec2.ModifyInstanceCapacityReservationAttributesOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ModifyInstanceCapacityReservationAttributesRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.ModifyInstanceCapacityReservationAttributesOutput)
@@ -13969,13 +12298,11 @@ func (m *MockEC2API) ModifyInstanceCapacityReservationAttributesRequest(arg0 *ec
 
 // ModifyInstanceCapacityReservationAttributesRequest indicates an expected call of ModifyInstanceCapacityReservationAttributesRequest
 func (mr *MockEC2APIMockRecorder) ModifyInstanceCapacityReservationAttributesRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyInstanceCapacityReservationAttributesRequest", reflect.TypeOf((*MockEC2API)(nil).ModifyInstanceCapacityReservationAttributesRequest), arg0)
 }
 
 // ModifyInstanceCapacityReservationAttributesWithContext mocks base method
 func (m *MockEC2API) ModifyInstanceCapacityReservationAttributesWithContext(arg0 context.Context, arg1 *ec2.ModifyInstanceCapacityReservationAttributesInput, arg2 ...request.Option) (*ec2.ModifyInstanceCapacityReservationAttributesOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -13988,14 +12315,12 @@ func (m *MockEC2API) ModifyInstanceCapacityReservationAttributesWithContext(arg0
 
 // ModifyInstanceCapacityReservationAttributesWithContext indicates an expected call of ModifyInstanceCapacityReservationAttributesWithContext
 func (mr *MockEC2APIMockRecorder) ModifyInstanceCapacityReservationAttributesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyInstanceCapacityReservationAttributesWithContext", reflect.TypeOf((*MockEC2API)(nil).ModifyInstanceCapacityReservationAttributesWithContext), varargs...)
 }
 
 // ModifyInstanceCreditSpecification mocks base method
 func (m *MockEC2API) ModifyInstanceCreditSpecification(arg0 *ec2.ModifyInstanceCreditSpecificationInput) (*ec2.ModifyInstanceCreditSpecificationOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ModifyInstanceCreditSpecification", arg0)
 	ret0, _ := ret[0].(*ec2.ModifyInstanceCreditSpecificationOutput)
 	ret1, _ := ret[1].(error)
@@ -14004,13 +12329,11 @@ func (m *MockEC2API) ModifyInstanceCreditSpecification(arg0 *ec2.ModifyInstanceC
 
 // ModifyInstanceCreditSpecification indicates an expected call of ModifyInstanceCreditSpecification
 func (mr *MockEC2APIMockRecorder) ModifyInstanceCreditSpecification(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyInstanceCreditSpecification", reflect.TypeOf((*MockEC2API)(nil).ModifyInstanceCreditSpecification), arg0)
 }
 
 // ModifyInstanceCreditSpecificationRequest mocks base method
 func (m *MockEC2API) ModifyInstanceCreditSpecificationRequest(arg0 *ec2.ModifyInstanceCreditSpecificationInput) (*request.Request, *ec2.ModifyInstanceCreditSpecificationOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ModifyInstanceCreditSpecificationRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.ModifyInstanceCreditSpecificationOutput)
@@ -14019,13 +12342,11 @@ func (m *MockEC2API) ModifyInstanceCreditSpecificationRequest(arg0 *ec2.ModifyIn
 
 // ModifyInstanceCreditSpecificationRequest indicates an expected call of ModifyInstanceCreditSpecificationRequest
 func (mr *MockEC2APIMockRecorder) ModifyInstanceCreditSpecificationRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyInstanceCreditSpecificationRequest", reflect.TypeOf((*MockEC2API)(nil).ModifyInstanceCreditSpecificationRequest), arg0)
 }
 
 // ModifyInstanceCreditSpecificationWithContext mocks base method
 func (m *MockEC2API) ModifyInstanceCreditSpecificationWithContext(arg0 context.Context, arg1 *ec2.ModifyInstanceCreditSpecificationInput, arg2 ...request.Option) (*ec2.ModifyInstanceCreditSpecificationOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -14038,14 +12359,12 @@ func (m *MockEC2API) ModifyInstanceCreditSpecificationWithContext(arg0 context.C
 
 // ModifyInstanceCreditSpecificationWithContext indicates an expected call of ModifyInstanceCreditSpecificationWithContext
 func (mr *MockEC2APIMockRecorder) ModifyInstanceCreditSpecificationWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyInstanceCreditSpecificationWithContext", reflect.TypeOf((*MockEC2API)(nil).ModifyInstanceCreditSpecificationWithContext), varargs...)
 }
 
 // ModifyInstanceEventStartTime mocks base method
 func (m *MockEC2API) ModifyInstanceEventStartTime(arg0 *ec2.ModifyInstanceEventStartTimeInput) (*ec2.ModifyInstanceEventStartTimeOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ModifyInstanceEventStartTime", arg0)
 	ret0, _ := ret[0].(*ec2.ModifyInstanceEventStartTimeOutput)
 	ret1, _ := ret[1].(error)
@@ -14054,13 +12373,11 @@ func (m *MockEC2API) ModifyInstanceEventStartTime(arg0 *ec2.ModifyInstanceEventS
 
 // ModifyInstanceEventStartTime indicates an expected call of ModifyInstanceEventStartTime
 func (mr *MockEC2APIMockRecorder) ModifyInstanceEventStartTime(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyInstanceEventStartTime", reflect.TypeOf((*MockEC2API)(nil).ModifyInstanceEventStartTime), arg0)
 }
 
 // ModifyInstanceEventStartTimeRequest mocks base method
 func (m *MockEC2API) ModifyInstanceEventStartTimeRequest(arg0 *ec2.ModifyInstanceEventStartTimeInput) (*request.Request, *ec2.ModifyInstanceEventStartTimeOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ModifyInstanceEventStartTimeRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.ModifyInstanceEventStartTimeOutput)
@@ -14069,13 +12386,11 @@ func (m *MockEC2API) ModifyInstanceEventStartTimeRequest(arg0 *ec2.ModifyInstanc
 
 // ModifyInstanceEventStartTimeRequest indicates an expected call of ModifyInstanceEventStartTimeRequest
 func (mr *MockEC2APIMockRecorder) ModifyInstanceEventStartTimeRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyInstanceEventStartTimeRequest", reflect.TypeOf((*MockEC2API)(nil).ModifyInstanceEventStartTimeRequest), arg0)
 }
 
 // ModifyInstanceEventStartTimeWithContext mocks base method
 func (m *MockEC2API) ModifyInstanceEventStartTimeWithContext(arg0 context.Context, arg1 *ec2.ModifyInstanceEventStartTimeInput, arg2 ...request.Option) (*ec2.ModifyInstanceEventStartTimeOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -14088,14 +12403,12 @@ func (m *MockEC2API) ModifyInstanceEventStartTimeWithContext(arg0 context.Contex
 
 // ModifyInstanceEventStartTimeWithContext indicates an expected call of ModifyInstanceEventStartTimeWithContext
 func (mr *MockEC2APIMockRecorder) ModifyInstanceEventStartTimeWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyInstanceEventStartTimeWithContext", reflect.TypeOf((*MockEC2API)(nil).ModifyInstanceEventStartTimeWithContext), varargs...)
 }
 
 // ModifyInstancePlacement mocks base method
 func (m *MockEC2API) ModifyInstancePlacement(arg0 *ec2.ModifyInstancePlacementInput) (*ec2.ModifyInstancePlacementOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ModifyInstancePlacement", arg0)
 	ret0, _ := ret[0].(*ec2.ModifyInstancePlacementOutput)
 	ret1, _ := ret[1].(error)
@@ -14104,13 +12417,11 @@ func (m *MockEC2API) ModifyInstancePlacement(arg0 *ec2.ModifyInstancePlacementIn
 
 // ModifyInstancePlacement indicates an expected call of ModifyInstancePlacement
 func (mr *MockEC2APIMockRecorder) ModifyInstancePlacement(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyInstancePlacement", reflect.TypeOf((*MockEC2API)(nil).ModifyInstancePlacement), arg0)
 }
 
 // ModifyInstancePlacementRequest mocks base method
 func (m *MockEC2API) ModifyInstancePlacementRequest(arg0 *ec2.ModifyInstancePlacementInput) (*request.Request, *ec2.ModifyInstancePlacementOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ModifyInstancePlacementRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.ModifyInstancePlacementOutput)
@@ -14119,13 +12430,11 @@ func (m *MockEC2API) ModifyInstancePlacementRequest(arg0 *ec2.ModifyInstancePlac
 
 // ModifyInstancePlacementRequest indicates an expected call of ModifyInstancePlacementRequest
 func (mr *MockEC2APIMockRecorder) ModifyInstancePlacementRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyInstancePlacementRequest", reflect.TypeOf((*MockEC2API)(nil).ModifyInstancePlacementRequest), arg0)
 }
 
 // ModifyInstancePlacementWithContext mocks base method
 func (m *MockEC2API) ModifyInstancePlacementWithContext(arg0 context.Context, arg1 *ec2.ModifyInstancePlacementInput, arg2 ...request.Option) (*ec2.ModifyInstancePlacementOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -14138,14 +12447,12 @@ func (m *MockEC2API) ModifyInstancePlacementWithContext(arg0 context.Context, ar
 
 // ModifyInstancePlacementWithContext indicates an expected call of ModifyInstancePlacementWithContext
 func (mr *MockEC2APIMockRecorder) ModifyInstancePlacementWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyInstancePlacementWithContext", reflect.TypeOf((*MockEC2API)(nil).ModifyInstancePlacementWithContext), varargs...)
 }
 
 // ModifyLaunchTemplate mocks base method
 func (m *MockEC2API) ModifyLaunchTemplate(arg0 *ec2.ModifyLaunchTemplateInput) (*ec2.ModifyLaunchTemplateOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ModifyLaunchTemplate", arg0)
 	ret0, _ := ret[0].(*ec2.ModifyLaunchTemplateOutput)
 	ret1, _ := ret[1].(error)
@@ -14154,13 +12461,11 @@ func (m *MockEC2API) ModifyLaunchTemplate(arg0 *ec2.ModifyLaunchTemplateInput) (
 
 // ModifyLaunchTemplate indicates an expected call of ModifyLaunchTemplate
 func (mr *MockEC2APIMockRecorder) ModifyLaunchTemplate(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyLaunchTemplate", reflect.TypeOf((*MockEC2API)(nil).ModifyLaunchTemplate), arg0)
 }
 
 // ModifyLaunchTemplateRequest mocks base method
 func (m *MockEC2API) ModifyLaunchTemplateRequest(arg0 *ec2.ModifyLaunchTemplateInput) (*request.Request, *ec2.ModifyLaunchTemplateOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ModifyLaunchTemplateRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.ModifyLaunchTemplateOutput)
@@ -14169,13 +12474,11 @@ func (m *MockEC2API) ModifyLaunchTemplateRequest(arg0 *ec2.ModifyLaunchTemplateI
 
 // ModifyLaunchTemplateRequest indicates an expected call of ModifyLaunchTemplateRequest
 func (mr *MockEC2APIMockRecorder) ModifyLaunchTemplateRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyLaunchTemplateRequest", reflect.TypeOf((*MockEC2API)(nil).ModifyLaunchTemplateRequest), arg0)
 }
 
 // ModifyLaunchTemplateWithContext mocks base method
 func (m *MockEC2API) ModifyLaunchTemplateWithContext(arg0 context.Context, arg1 *ec2.ModifyLaunchTemplateInput, arg2 ...request.Option) (*ec2.ModifyLaunchTemplateOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -14188,14 +12491,12 @@ func (m *MockEC2API) ModifyLaunchTemplateWithContext(arg0 context.Context, arg1 
 
 // ModifyLaunchTemplateWithContext indicates an expected call of ModifyLaunchTemplateWithContext
 func (mr *MockEC2APIMockRecorder) ModifyLaunchTemplateWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyLaunchTemplateWithContext", reflect.TypeOf((*MockEC2API)(nil).ModifyLaunchTemplateWithContext), varargs...)
 }
 
 // ModifyNetworkInterfaceAttribute mocks base method
 func (m *MockEC2API) ModifyNetworkInterfaceAttribute(arg0 *ec2.ModifyNetworkInterfaceAttributeInput) (*ec2.ModifyNetworkInterfaceAttributeOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ModifyNetworkInterfaceAttribute", arg0)
 	ret0, _ := ret[0].(*ec2.ModifyNetworkInterfaceAttributeOutput)
 	ret1, _ := ret[1].(error)
@@ -14204,13 +12505,11 @@ func (m *MockEC2API) ModifyNetworkInterfaceAttribute(arg0 *ec2.ModifyNetworkInte
 
 // ModifyNetworkInterfaceAttribute indicates an expected call of ModifyNetworkInterfaceAttribute
 func (mr *MockEC2APIMockRecorder) ModifyNetworkInterfaceAttribute(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyNetworkInterfaceAttribute", reflect.TypeOf((*MockEC2API)(nil).ModifyNetworkInterfaceAttribute), arg0)
 }
 
 // ModifyNetworkInterfaceAttributeRequest mocks base method
 func (m *MockEC2API) ModifyNetworkInterfaceAttributeRequest(arg0 *ec2.ModifyNetworkInterfaceAttributeInput) (*request.Request, *ec2.ModifyNetworkInterfaceAttributeOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ModifyNetworkInterfaceAttributeRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.ModifyNetworkInterfaceAttributeOutput)
@@ -14219,13 +12518,11 @@ func (m *MockEC2API) ModifyNetworkInterfaceAttributeRequest(arg0 *ec2.ModifyNetw
 
 // ModifyNetworkInterfaceAttributeRequest indicates an expected call of ModifyNetworkInterfaceAttributeRequest
 func (mr *MockEC2APIMockRecorder) ModifyNetworkInterfaceAttributeRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyNetworkInterfaceAttributeRequest", reflect.TypeOf((*MockEC2API)(nil).ModifyNetworkInterfaceAttributeRequest), arg0)
 }
 
 // ModifyNetworkInterfaceAttributeWithContext mocks base method
 func (m *MockEC2API) ModifyNetworkInterfaceAttributeWithContext(arg0 context.Context, arg1 *ec2.ModifyNetworkInterfaceAttributeInput, arg2 ...request.Option) (*ec2.ModifyNetworkInterfaceAttributeOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -14238,14 +12535,12 @@ func (m *MockEC2API) ModifyNetworkInterfaceAttributeWithContext(arg0 context.Con
 
 // ModifyNetworkInterfaceAttributeWithContext indicates an expected call of ModifyNetworkInterfaceAttributeWithContext
 func (mr *MockEC2APIMockRecorder) ModifyNetworkInterfaceAttributeWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyNetworkInterfaceAttributeWithContext", reflect.TypeOf((*MockEC2API)(nil).ModifyNetworkInterfaceAttributeWithContext), varargs...)
 }
 
 // ModifyReservedInstances mocks base method
 func (m *MockEC2API) ModifyReservedInstances(arg0 *ec2.ModifyReservedInstancesInput) (*ec2.ModifyReservedInstancesOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ModifyReservedInstances", arg0)
 	ret0, _ := ret[0].(*ec2.ModifyReservedInstancesOutput)
 	ret1, _ := ret[1].(error)
@@ -14254,13 +12549,11 @@ func (m *MockEC2API) ModifyReservedInstances(arg0 *ec2.ModifyReservedInstancesIn
 
 // ModifyReservedInstances indicates an expected call of ModifyReservedInstances
 func (mr *MockEC2APIMockRecorder) ModifyReservedInstances(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyReservedInstances", reflect.TypeOf((*MockEC2API)(nil).ModifyReservedInstances), arg0)
 }
 
 // ModifyReservedInstancesRequest mocks base method
 func (m *MockEC2API) ModifyReservedInstancesRequest(arg0 *ec2.ModifyReservedInstancesInput) (*request.Request, *ec2.ModifyReservedInstancesOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ModifyReservedInstancesRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.ModifyReservedInstancesOutput)
@@ -14269,13 +12562,11 @@ func (m *MockEC2API) ModifyReservedInstancesRequest(arg0 *ec2.ModifyReservedInst
 
 // ModifyReservedInstancesRequest indicates an expected call of ModifyReservedInstancesRequest
 func (mr *MockEC2APIMockRecorder) ModifyReservedInstancesRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyReservedInstancesRequest", reflect.TypeOf((*MockEC2API)(nil).ModifyReservedInstancesRequest), arg0)
 }
 
 // ModifyReservedInstancesWithContext mocks base method
 func (m *MockEC2API) ModifyReservedInstancesWithContext(arg0 context.Context, arg1 *ec2.ModifyReservedInstancesInput, arg2 ...request.Option) (*ec2.ModifyReservedInstancesOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -14288,14 +12579,12 @@ func (m *MockEC2API) ModifyReservedInstancesWithContext(arg0 context.Context, ar
 
 // ModifyReservedInstancesWithContext indicates an expected call of ModifyReservedInstancesWithContext
 func (mr *MockEC2APIMockRecorder) ModifyReservedInstancesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyReservedInstancesWithContext", reflect.TypeOf((*MockEC2API)(nil).ModifyReservedInstancesWithContext), varargs...)
 }
 
 // ModifySnapshotAttribute mocks base method
 func (m *MockEC2API) ModifySnapshotAttribute(arg0 *ec2.ModifySnapshotAttributeInput) (*ec2.ModifySnapshotAttributeOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ModifySnapshotAttribute", arg0)
 	ret0, _ := ret[0].(*ec2.ModifySnapshotAttributeOutput)
 	ret1, _ := ret[1].(error)
@@ -14304,13 +12593,11 @@ func (m *MockEC2API) ModifySnapshotAttribute(arg0 *ec2.ModifySnapshotAttributeIn
 
 // ModifySnapshotAttribute indicates an expected call of ModifySnapshotAttribute
 func (mr *MockEC2APIMockRecorder) ModifySnapshotAttribute(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifySnapshotAttribute", reflect.TypeOf((*MockEC2API)(nil).ModifySnapshotAttribute), arg0)
 }
 
 // ModifySnapshotAttributeRequest mocks base method
 func (m *MockEC2API) ModifySnapshotAttributeRequest(arg0 *ec2.ModifySnapshotAttributeInput) (*request.Request, *ec2.ModifySnapshotAttributeOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ModifySnapshotAttributeRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.ModifySnapshotAttributeOutput)
@@ -14319,13 +12606,11 @@ func (m *MockEC2API) ModifySnapshotAttributeRequest(arg0 *ec2.ModifySnapshotAttr
 
 // ModifySnapshotAttributeRequest indicates an expected call of ModifySnapshotAttributeRequest
 func (mr *MockEC2APIMockRecorder) ModifySnapshotAttributeRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifySnapshotAttributeRequest", reflect.TypeOf((*MockEC2API)(nil).ModifySnapshotAttributeRequest), arg0)
 }
 
 // ModifySnapshotAttributeWithContext mocks base method
 func (m *MockEC2API) ModifySnapshotAttributeWithContext(arg0 context.Context, arg1 *ec2.ModifySnapshotAttributeInput, arg2 ...request.Option) (*ec2.ModifySnapshotAttributeOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -14338,14 +12623,12 @@ func (m *MockEC2API) ModifySnapshotAttributeWithContext(arg0 context.Context, ar
 
 // ModifySnapshotAttributeWithContext indicates an expected call of ModifySnapshotAttributeWithContext
 func (mr *MockEC2APIMockRecorder) ModifySnapshotAttributeWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifySnapshotAttributeWithContext", reflect.TypeOf((*MockEC2API)(nil).ModifySnapshotAttributeWithContext), varargs...)
 }
 
 // ModifySpotFleetRequest mocks base method
 func (m *MockEC2API) ModifySpotFleetRequest(arg0 *ec2.ModifySpotFleetRequestInput) (*ec2.ModifySpotFleetRequestOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ModifySpotFleetRequest", arg0)
 	ret0, _ := ret[0].(*ec2.ModifySpotFleetRequestOutput)
 	ret1, _ := ret[1].(error)
@@ -14354,13 +12637,11 @@ func (m *MockEC2API) ModifySpotFleetRequest(arg0 *ec2.ModifySpotFleetRequestInpu
 
 // ModifySpotFleetRequest indicates an expected call of ModifySpotFleetRequest
 func (mr *MockEC2APIMockRecorder) ModifySpotFleetRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifySpotFleetRequest", reflect.TypeOf((*MockEC2API)(nil).ModifySpotFleetRequest), arg0)
 }
 
 // ModifySpotFleetRequestRequest mocks base method
 func (m *MockEC2API) ModifySpotFleetRequestRequest(arg0 *ec2.ModifySpotFleetRequestInput) (*request.Request, *ec2.ModifySpotFleetRequestOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ModifySpotFleetRequestRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.ModifySpotFleetRequestOutput)
@@ -14369,13 +12650,11 @@ func (m *MockEC2API) ModifySpotFleetRequestRequest(arg0 *ec2.ModifySpotFleetRequ
 
 // ModifySpotFleetRequestRequest indicates an expected call of ModifySpotFleetRequestRequest
 func (mr *MockEC2APIMockRecorder) ModifySpotFleetRequestRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifySpotFleetRequestRequest", reflect.TypeOf((*MockEC2API)(nil).ModifySpotFleetRequestRequest), arg0)
 }
 
 // ModifySpotFleetRequestWithContext mocks base method
 func (m *MockEC2API) ModifySpotFleetRequestWithContext(arg0 context.Context, arg1 *ec2.ModifySpotFleetRequestInput, arg2 ...request.Option) (*ec2.ModifySpotFleetRequestOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -14388,14 +12667,12 @@ func (m *MockEC2API) ModifySpotFleetRequestWithContext(arg0 context.Context, arg
 
 // ModifySpotFleetRequestWithContext indicates an expected call of ModifySpotFleetRequestWithContext
 func (mr *MockEC2APIMockRecorder) ModifySpotFleetRequestWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifySpotFleetRequestWithContext", reflect.TypeOf((*MockEC2API)(nil).ModifySpotFleetRequestWithContext), varargs...)
 }
 
 // ModifySubnetAttribute mocks base method
 func (m *MockEC2API) ModifySubnetAttribute(arg0 *ec2.ModifySubnetAttributeInput) (*ec2.ModifySubnetAttributeOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ModifySubnetAttribute", arg0)
 	ret0, _ := ret[0].(*ec2.ModifySubnetAttributeOutput)
 	ret1, _ := ret[1].(error)
@@ -14404,13 +12681,11 @@ func (m *MockEC2API) ModifySubnetAttribute(arg0 *ec2.ModifySubnetAttributeInput)
 
 // ModifySubnetAttribute indicates an expected call of ModifySubnetAttribute
 func (mr *MockEC2APIMockRecorder) ModifySubnetAttribute(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifySubnetAttribute", reflect.TypeOf((*MockEC2API)(nil).ModifySubnetAttribute), arg0)
 }
 
 // ModifySubnetAttributeRequest mocks base method
 func (m *MockEC2API) ModifySubnetAttributeRequest(arg0 *ec2.ModifySubnetAttributeInput) (*request.Request, *ec2.ModifySubnetAttributeOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ModifySubnetAttributeRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.ModifySubnetAttributeOutput)
@@ -14419,13 +12694,11 @@ func (m *MockEC2API) ModifySubnetAttributeRequest(arg0 *ec2.ModifySubnetAttribut
 
 // ModifySubnetAttributeRequest indicates an expected call of ModifySubnetAttributeRequest
 func (mr *MockEC2APIMockRecorder) ModifySubnetAttributeRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifySubnetAttributeRequest", reflect.TypeOf((*MockEC2API)(nil).ModifySubnetAttributeRequest), arg0)
 }
 
 // ModifySubnetAttributeWithContext mocks base method
 func (m *MockEC2API) ModifySubnetAttributeWithContext(arg0 context.Context, arg1 *ec2.ModifySubnetAttributeInput, arg2 ...request.Option) (*ec2.ModifySubnetAttributeOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -14438,14 +12711,12 @@ func (m *MockEC2API) ModifySubnetAttributeWithContext(arg0 context.Context, arg1
 
 // ModifySubnetAttributeWithContext indicates an expected call of ModifySubnetAttributeWithContext
 func (mr *MockEC2APIMockRecorder) ModifySubnetAttributeWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifySubnetAttributeWithContext", reflect.TypeOf((*MockEC2API)(nil).ModifySubnetAttributeWithContext), varargs...)
 }
 
 // ModifyTransitGatewayVpcAttachment mocks base method
 func (m *MockEC2API) ModifyTransitGatewayVpcAttachment(arg0 *ec2.ModifyTransitGatewayVpcAttachmentInput) (*ec2.ModifyTransitGatewayVpcAttachmentOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ModifyTransitGatewayVpcAttachment", arg0)
 	ret0, _ := ret[0].(*ec2.ModifyTransitGatewayVpcAttachmentOutput)
 	ret1, _ := ret[1].(error)
@@ -14454,13 +12725,11 @@ func (m *MockEC2API) ModifyTransitGatewayVpcAttachment(arg0 *ec2.ModifyTransitGa
 
 // ModifyTransitGatewayVpcAttachment indicates an expected call of ModifyTransitGatewayVpcAttachment
 func (mr *MockEC2APIMockRecorder) ModifyTransitGatewayVpcAttachment(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyTransitGatewayVpcAttachment", reflect.TypeOf((*MockEC2API)(nil).ModifyTransitGatewayVpcAttachment), arg0)
 }
 
 // ModifyTransitGatewayVpcAttachmentRequest mocks base method
 func (m *MockEC2API) ModifyTransitGatewayVpcAttachmentRequest(arg0 *ec2.ModifyTransitGatewayVpcAttachmentInput) (*request.Request, *ec2.ModifyTransitGatewayVpcAttachmentOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ModifyTransitGatewayVpcAttachmentRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.ModifyTransitGatewayVpcAttachmentOutput)
@@ -14469,13 +12738,11 @@ func (m *MockEC2API) ModifyTransitGatewayVpcAttachmentRequest(arg0 *ec2.ModifyTr
 
 // ModifyTransitGatewayVpcAttachmentRequest indicates an expected call of ModifyTransitGatewayVpcAttachmentRequest
 func (mr *MockEC2APIMockRecorder) ModifyTransitGatewayVpcAttachmentRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyTransitGatewayVpcAttachmentRequest", reflect.TypeOf((*MockEC2API)(nil).ModifyTransitGatewayVpcAttachmentRequest), arg0)
 }
 
 // ModifyTransitGatewayVpcAttachmentWithContext mocks base method
 func (m *MockEC2API) ModifyTransitGatewayVpcAttachmentWithContext(arg0 context.Context, arg1 *ec2.ModifyTransitGatewayVpcAttachmentInput, arg2 ...request.Option) (*ec2.ModifyTransitGatewayVpcAttachmentOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -14488,14 +12755,12 @@ func (m *MockEC2API) ModifyTransitGatewayVpcAttachmentWithContext(arg0 context.C
 
 // ModifyTransitGatewayVpcAttachmentWithContext indicates an expected call of ModifyTransitGatewayVpcAttachmentWithContext
 func (mr *MockEC2APIMockRecorder) ModifyTransitGatewayVpcAttachmentWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyTransitGatewayVpcAttachmentWithContext", reflect.TypeOf((*MockEC2API)(nil).ModifyTransitGatewayVpcAttachmentWithContext), varargs...)
 }
 
 // ModifyVolume mocks base method
 func (m *MockEC2API) ModifyVolume(arg0 *ec2.ModifyVolumeInput) (*ec2.ModifyVolumeOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ModifyVolume", arg0)
 	ret0, _ := ret[0].(*ec2.ModifyVolumeOutput)
 	ret1, _ := ret[1].(error)
@@ -14504,13 +12769,11 @@ func (m *MockEC2API) ModifyVolume(arg0 *ec2.ModifyVolumeInput) (*ec2.ModifyVolum
 
 // ModifyVolume indicates an expected call of ModifyVolume
 func (mr *MockEC2APIMockRecorder) ModifyVolume(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyVolume", reflect.TypeOf((*MockEC2API)(nil).ModifyVolume), arg0)
 }
 
 // ModifyVolumeAttribute mocks base method
 func (m *MockEC2API) ModifyVolumeAttribute(arg0 *ec2.ModifyVolumeAttributeInput) (*ec2.ModifyVolumeAttributeOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ModifyVolumeAttribute", arg0)
 	ret0, _ := ret[0].(*ec2.ModifyVolumeAttributeOutput)
 	ret1, _ := ret[1].(error)
@@ -14519,13 +12782,11 @@ func (m *MockEC2API) ModifyVolumeAttribute(arg0 *ec2.ModifyVolumeAttributeInput)
 
 // ModifyVolumeAttribute indicates an expected call of ModifyVolumeAttribute
 func (mr *MockEC2APIMockRecorder) ModifyVolumeAttribute(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyVolumeAttribute", reflect.TypeOf((*MockEC2API)(nil).ModifyVolumeAttribute), arg0)
 }
 
 // ModifyVolumeAttributeRequest mocks base method
 func (m *MockEC2API) ModifyVolumeAttributeRequest(arg0 *ec2.ModifyVolumeAttributeInput) (*request.Request, *ec2.ModifyVolumeAttributeOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ModifyVolumeAttributeRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.ModifyVolumeAttributeOutput)
@@ -14534,13 +12795,11 @@ func (m *MockEC2API) ModifyVolumeAttributeRequest(arg0 *ec2.ModifyVolumeAttribut
 
 // ModifyVolumeAttributeRequest indicates an expected call of ModifyVolumeAttributeRequest
 func (mr *MockEC2APIMockRecorder) ModifyVolumeAttributeRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyVolumeAttributeRequest", reflect.TypeOf((*MockEC2API)(nil).ModifyVolumeAttributeRequest), arg0)
 }
 
 // ModifyVolumeAttributeWithContext mocks base method
 func (m *MockEC2API) ModifyVolumeAttributeWithContext(arg0 context.Context, arg1 *ec2.ModifyVolumeAttributeInput, arg2 ...request.Option) (*ec2.ModifyVolumeAttributeOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -14553,14 +12812,12 @@ func (m *MockEC2API) ModifyVolumeAttributeWithContext(arg0 context.Context, arg1
 
 // ModifyVolumeAttributeWithContext indicates an expected call of ModifyVolumeAttributeWithContext
 func (mr *MockEC2APIMockRecorder) ModifyVolumeAttributeWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyVolumeAttributeWithContext", reflect.TypeOf((*MockEC2API)(nil).ModifyVolumeAttributeWithContext), varargs...)
 }
 
 // ModifyVolumeRequest mocks base method
 func (m *MockEC2API) ModifyVolumeRequest(arg0 *ec2.ModifyVolumeInput) (*request.Request, *ec2.ModifyVolumeOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ModifyVolumeRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.ModifyVolumeOutput)
@@ -14569,13 +12826,11 @@ func (m *MockEC2API) ModifyVolumeRequest(arg0 *ec2.ModifyVolumeInput) (*request.
 
 // ModifyVolumeRequest indicates an expected call of ModifyVolumeRequest
 func (mr *MockEC2APIMockRecorder) ModifyVolumeRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyVolumeRequest", reflect.TypeOf((*MockEC2API)(nil).ModifyVolumeRequest), arg0)
 }
 
 // ModifyVolumeWithContext mocks base method
 func (m *MockEC2API) ModifyVolumeWithContext(arg0 context.Context, arg1 *ec2.ModifyVolumeInput, arg2 ...request.Option) (*ec2.ModifyVolumeOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -14588,14 +12843,12 @@ func (m *MockEC2API) ModifyVolumeWithContext(arg0 context.Context, arg1 *ec2.Mod
 
 // ModifyVolumeWithContext indicates an expected call of ModifyVolumeWithContext
 func (mr *MockEC2APIMockRecorder) ModifyVolumeWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyVolumeWithContext", reflect.TypeOf((*MockEC2API)(nil).ModifyVolumeWithContext), varargs...)
 }
 
 // ModifyVpcAttribute mocks base method
 func (m *MockEC2API) ModifyVpcAttribute(arg0 *ec2.ModifyVpcAttributeInput) (*ec2.ModifyVpcAttributeOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ModifyVpcAttribute", arg0)
 	ret0, _ := ret[0].(*ec2.ModifyVpcAttributeOutput)
 	ret1, _ := ret[1].(error)
@@ -14604,13 +12857,11 @@ func (m *MockEC2API) ModifyVpcAttribute(arg0 *ec2.ModifyVpcAttributeInput) (*ec2
 
 // ModifyVpcAttribute indicates an expected call of ModifyVpcAttribute
 func (mr *MockEC2APIMockRecorder) ModifyVpcAttribute(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyVpcAttribute", reflect.TypeOf((*MockEC2API)(nil).ModifyVpcAttribute), arg0)
 }
 
 // ModifyVpcAttributeRequest mocks base method
 func (m *MockEC2API) ModifyVpcAttributeRequest(arg0 *ec2.ModifyVpcAttributeInput) (*request.Request, *ec2.ModifyVpcAttributeOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ModifyVpcAttributeRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.ModifyVpcAttributeOutput)
@@ -14619,13 +12870,11 @@ func (m *MockEC2API) ModifyVpcAttributeRequest(arg0 *ec2.ModifyVpcAttributeInput
 
 // ModifyVpcAttributeRequest indicates an expected call of ModifyVpcAttributeRequest
 func (mr *MockEC2APIMockRecorder) ModifyVpcAttributeRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyVpcAttributeRequest", reflect.TypeOf((*MockEC2API)(nil).ModifyVpcAttributeRequest), arg0)
 }
 
 // ModifyVpcAttributeWithContext mocks base method
 func (m *MockEC2API) ModifyVpcAttributeWithContext(arg0 context.Context, arg1 *ec2.ModifyVpcAttributeInput, arg2 ...request.Option) (*ec2.ModifyVpcAttributeOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -14638,14 +12887,12 @@ func (m *MockEC2API) ModifyVpcAttributeWithContext(arg0 context.Context, arg1 *e
 
 // ModifyVpcAttributeWithContext indicates an expected call of ModifyVpcAttributeWithContext
 func (mr *MockEC2APIMockRecorder) ModifyVpcAttributeWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyVpcAttributeWithContext", reflect.TypeOf((*MockEC2API)(nil).ModifyVpcAttributeWithContext), varargs...)
 }
 
 // ModifyVpcEndpoint mocks base method
 func (m *MockEC2API) ModifyVpcEndpoint(arg0 *ec2.ModifyVpcEndpointInput) (*ec2.ModifyVpcEndpointOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ModifyVpcEndpoint", arg0)
 	ret0, _ := ret[0].(*ec2.ModifyVpcEndpointOutput)
 	ret1, _ := ret[1].(error)
@@ -14654,13 +12901,11 @@ func (m *MockEC2API) ModifyVpcEndpoint(arg0 *ec2.ModifyVpcEndpointInput) (*ec2.M
 
 // ModifyVpcEndpoint indicates an expected call of ModifyVpcEndpoint
 func (mr *MockEC2APIMockRecorder) ModifyVpcEndpoint(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyVpcEndpoint", reflect.TypeOf((*MockEC2API)(nil).ModifyVpcEndpoint), arg0)
 }
 
 // ModifyVpcEndpointConnectionNotification mocks base method
 func (m *MockEC2API) ModifyVpcEndpointConnectionNotification(arg0 *ec2.ModifyVpcEndpointConnectionNotificationInput) (*ec2.ModifyVpcEndpointConnectionNotificationOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ModifyVpcEndpointConnectionNotification", arg0)
 	ret0, _ := ret[0].(*ec2.ModifyVpcEndpointConnectionNotificationOutput)
 	ret1, _ := ret[1].(error)
@@ -14669,13 +12914,11 @@ func (m *MockEC2API) ModifyVpcEndpointConnectionNotification(arg0 *ec2.ModifyVpc
 
 // ModifyVpcEndpointConnectionNotification indicates an expected call of ModifyVpcEndpointConnectionNotification
 func (mr *MockEC2APIMockRecorder) ModifyVpcEndpointConnectionNotification(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyVpcEndpointConnectionNotification", reflect.TypeOf((*MockEC2API)(nil).ModifyVpcEndpointConnectionNotification), arg0)
 }
 
 // ModifyVpcEndpointConnectionNotificationRequest mocks base method
 func (m *MockEC2API) ModifyVpcEndpointConnectionNotificationRequest(arg0 *ec2.ModifyVpcEndpointConnectionNotificationInput) (*request.Request, *ec2.ModifyVpcEndpointConnectionNotificationOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ModifyVpcEndpointConnectionNotificationRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.ModifyVpcEndpointConnectionNotificationOutput)
@@ -14684,13 +12927,11 @@ func (m *MockEC2API) ModifyVpcEndpointConnectionNotificationRequest(arg0 *ec2.Mo
 
 // ModifyVpcEndpointConnectionNotificationRequest indicates an expected call of ModifyVpcEndpointConnectionNotificationRequest
 func (mr *MockEC2APIMockRecorder) ModifyVpcEndpointConnectionNotificationRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyVpcEndpointConnectionNotificationRequest", reflect.TypeOf((*MockEC2API)(nil).ModifyVpcEndpointConnectionNotificationRequest), arg0)
 }
 
 // ModifyVpcEndpointConnectionNotificationWithContext mocks base method
 func (m *MockEC2API) ModifyVpcEndpointConnectionNotificationWithContext(arg0 context.Context, arg1 *ec2.ModifyVpcEndpointConnectionNotificationInput, arg2 ...request.Option) (*ec2.ModifyVpcEndpointConnectionNotificationOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -14703,14 +12944,12 @@ func (m *MockEC2API) ModifyVpcEndpointConnectionNotificationWithContext(arg0 con
 
 // ModifyVpcEndpointConnectionNotificationWithContext indicates an expected call of ModifyVpcEndpointConnectionNotificationWithContext
 func (mr *MockEC2APIMockRecorder) ModifyVpcEndpointConnectionNotificationWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyVpcEndpointConnectionNotificationWithContext", reflect.TypeOf((*MockEC2API)(nil).ModifyVpcEndpointConnectionNotificationWithContext), varargs...)
 }
 
 // ModifyVpcEndpointRequest mocks base method
 func (m *MockEC2API) ModifyVpcEndpointRequest(arg0 *ec2.ModifyVpcEndpointInput) (*request.Request, *ec2.ModifyVpcEndpointOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ModifyVpcEndpointRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.ModifyVpcEndpointOutput)
@@ -14719,13 +12958,11 @@ func (m *MockEC2API) ModifyVpcEndpointRequest(arg0 *ec2.ModifyVpcEndpointInput) 
 
 // ModifyVpcEndpointRequest indicates an expected call of ModifyVpcEndpointRequest
 func (mr *MockEC2APIMockRecorder) ModifyVpcEndpointRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyVpcEndpointRequest", reflect.TypeOf((*MockEC2API)(nil).ModifyVpcEndpointRequest), arg0)
 }
 
 // ModifyVpcEndpointServiceConfiguration mocks base method
 func (m *MockEC2API) ModifyVpcEndpointServiceConfiguration(arg0 *ec2.ModifyVpcEndpointServiceConfigurationInput) (*ec2.ModifyVpcEndpointServiceConfigurationOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ModifyVpcEndpointServiceConfiguration", arg0)
 	ret0, _ := ret[0].(*ec2.ModifyVpcEndpointServiceConfigurationOutput)
 	ret1, _ := ret[1].(error)
@@ -14734,13 +12971,11 @@ func (m *MockEC2API) ModifyVpcEndpointServiceConfiguration(arg0 *ec2.ModifyVpcEn
 
 // ModifyVpcEndpointServiceConfiguration indicates an expected call of ModifyVpcEndpointServiceConfiguration
 func (mr *MockEC2APIMockRecorder) ModifyVpcEndpointServiceConfiguration(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyVpcEndpointServiceConfiguration", reflect.TypeOf((*MockEC2API)(nil).ModifyVpcEndpointServiceConfiguration), arg0)
 }
 
 // ModifyVpcEndpointServiceConfigurationRequest mocks base method
 func (m *MockEC2API) ModifyVpcEndpointServiceConfigurationRequest(arg0 *ec2.ModifyVpcEndpointServiceConfigurationInput) (*request.Request, *ec2.ModifyVpcEndpointServiceConfigurationOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ModifyVpcEndpointServiceConfigurationRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.ModifyVpcEndpointServiceConfigurationOutput)
@@ -14749,13 +12984,11 @@ func (m *MockEC2API) ModifyVpcEndpointServiceConfigurationRequest(arg0 *ec2.Modi
 
 // ModifyVpcEndpointServiceConfigurationRequest indicates an expected call of ModifyVpcEndpointServiceConfigurationRequest
 func (mr *MockEC2APIMockRecorder) ModifyVpcEndpointServiceConfigurationRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyVpcEndpointServiceConfigurationRequest", reflect.TypeOf((*MockEC2API)(nil).ModifyVpcEndpointServiceConfigurationRequest), arg0)
 }
 
 // ModifyVpcEndpointServiceConfigurationWithContext mocks base method
 func (m *MockEC2API) ModifyVpcEndpointServiceConfigurationWithContext(arg0 context.Context, arg1 *ec2.ModifyVpcEndpointServiceConfigurationInput, arg2 ...request.Option) (*ec2.ModifyVpcEndpointServiceConfigurationOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -14768,14 +13001,12 @@ func (m *MockEC2API) ModifyVpcEndpointServiceConfigurationWithContext(arg0 conte
 
 // ModifyVpcEndpointServiceConfigurationWithContext indicates an expected call of ModifyVpcEndpointServiceConfigurationWithContext
 func (mr *MockEC2APIMockRecorder) ModifyVpcEndpointServiceConfigurationWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyVpcEndpointServiceConfigurationWithContext", reflect.TypeOf((*MockEC2API)(nil).ModifyVpcEndpointServiceConfigurationWithContext), varargs...)
 }
 
 // ModifyVpcEndpointServicePermissions mocks base method
 func (m *MockEC2API) ModifyVpcEndpointServicePermissions(arg0 *ec2.ModifyVpcEndpointServicePermissionsInput) (*ec2.ModifyVpcEndpointServicePermissionsOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ModifyVpcEndpointServicePermissions", arg0)
 	ret0, _ := ret[0].(*ec2.ModifyVpcEndpointServicePermissionsOutput)
 	ret1, _ := ret[1].(error)
@@ -14784,13 +13015,11 @@ func (m *MockEC2API) ModifyVpcEndpointServicePermissions(arg0 *ec2.ModifyVpcEndp
 
 // ModifyVpcEndpointServicePermissions indicates an expected call of ModifyVpcEndpointServicePermissions
 func (mr *MockEC2APIMockRecorder) ModifyVpcEndpointServicePermissions(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyVpcEndpointServicePermissions", reflect.TypeOf((*MockEC2API)(nil).ModifyVpcEndpointServicePermissions), arg0)
 }
 
 // ModifyVpcEndpointServicePermissionsRequest mocks base method
 func (m *MockEC2API) ModifyVpcEndpointServicePermissionsRequest(arg0 *ec2.ModifyVpcEndpointServicePermissionsInput) (*request.Request, *ec2.ModifyVpcEndpointServicePermissionsOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ModifyVpcEndpointServicePermissionsRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.ModifyVpcEndpointServicePermissionsOutput)
@@ -14799,13 +13028,11 @@ func (m *MockEC2API) ModifyVpcEndpointServicePermissionsRequest(arg0 *ec2.Modify
 
 // ModifyVpcEndpointServicePermissionsRequest indicates an expected call of ModifyVpcEndpointServicePermissionsRequest
 func (mr *MockEC2APIMockRecorder) ModifyVpcEndpointServicePermissionsRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyVpcEndpointServicePermissionsRequest", reflect.TypeOf((*MockEC2API)(nil).ModifyVpcEndpointServicePermissionsRequest), arg0)
 }
 
 // ModifyVpcEndpointServicePermissionsWithContext mocks base method
 func (m *MockEC2API) ModifyVpcEndpointServicePermissionsWithContext(arg0 context.Context, arg1 *ec2.ModifyVpcEndpointServicePermissionsInput, arg2 ...request.Option) (*ec2.ModifyVpcEndpointServicePermissionsOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -14818,14 +13045,12 @@ func (m *MockEC2API) ModifyVpcEndpointServicePermissionsWithContext(arg0 context
 
 // ModifyVpcEndpointServicePermissionsWithContext indicates an expected call of ModifyVpcEndpointServicePermissionsWithContext
 func (mr *MockEC2APIMockRecorder) ModifyVpcEndpointServicePermissionsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyVpcEndpointServicePermissionsWithContext", reflect.TypeOf((*MockEC2API)(nil).ModifyVpcEndpointServicePermissionsWithContext), varargs...)
 }
 
 // ModifyVpcEndpointWithContext mocks base method
 func (m *MockEC2API) ModifyVpcEndpointWithContext(arg0 context.Context, arg1 *ec2.ModifyVpcEndpointInput, arg2 ...request.Option) (*ec2.ModifyVpcEndpointOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -14838,14 +13063,12 @@ func (m *MockEC2API) ModifyVpcEndpointWithContext(arg0 context.Context, arg1 *ec
 
 // ModifyVpcEndpointWithContext indicates an expected call of ModifyVpcEndpointWithContext
 func (mr *MockEC2APIMockRecorder) ModifyVpcEndpointWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyVpcEndpointWithContext", reflect.TypeOf((*MockEC2API)(nil).ModifyVpcEndpointWithContext), varargs...)
 }
 
 // ModifyVpcPeeringConnectionOptions mocks base method
 func (m *MockEC2API) ModifyVpcPeeringConnectionOptions(arg0 *ec2.ModifyVpcPeeringConnectionOptionsInput) (*ec2.ModifyVpcPeeringConnectionOptionsOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ModifyVpcPeeringConnectionOptions", arg0)
 	ret0, _ := ret[0].(*ec2.ModifyVpcPeeringConnectionOptionsOutput)
 	ret1, _ := ret[1].(error)
@@ -14854,13 +13077,11 @@ func (m *MockEC2API) ModifyVpcPeeringConnectionOptions(arg0 *ec2.ModifyVpcPeerin
 
 // ModifyVpcPeeringConnectionOptions indicates an expected call of ModifyVpcPeeringConnectionOptions
 func (mr *MockEC2APIMockRecorder) ModifyVpcPeeringConnectionOptions(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyVpcPeeringConnectionOptions", reflect.TypeOf((*MockEC2API)(nil).ModifyVpcPeeringConnectionOptions), arg0)
 }
 
 // ModifyVpcPeeringConnectionOptionsRequest mocks base method
 func (m *MockEC2API) ModifyVpcPeeringConnectionOptionsRequest(arg0 *ec2.ModifyVpcPeeringConnectionOptionsInput) (*request.Request, *ec2.ModifyVpcPeeringConnectionOptionsOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ModifyVpcPeeringConnectionOptionsRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.ModifyVpcPeeringConnectionOptionsOutput)
@@ -14869,13 +13090,11 @@ func (m *MockEC2API) ModifyVpcPeeringConnectionOptionsRequest(arg0 *ec2.ModifyVp
 
 // ModifyVpcPeeringConnectionOptionsRequest indicates an expected call of ModifyVpcPeeringConnectionOptionsRequest
 func (mr *MockEC2APIMockRecorder) ModifyVpcPeeringConnectionOptionsRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyVpcPeeringConnectionOptionsRequest", reflect.TypeOf((*MockEC2API)(nil).ModifyVpcPeeringConnectionOptionsRequest), arg0)
 }
 
 // ModifyVpcPeeringConnectionOptionsWithContext mocks base method
 func (m *MockEC2API) ModifyVpcPeeringConnectionOptionsWithContext(arg0 context.Context, arg1 *ec2.ModifyVpcPeeringConnectionOptionsInput, arg2 ...request.Option) (*ec2.ModifyVpcPeeringConnectionOptionsOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -14888,14 +13107,12 @@ func (m *MockEC2API) ModifyVpcPeeringConnectionOptionsWithContext(arg0 context.C
 
 // ModifyVpcPeeringConnectionOptionsWithContext indicates an expected call of ModifyVpcPeeringConnectionOptionsWithContext
 func (mr *MockEC2APIMockRecorder) ModifyVpcPeeringConnectionOptionsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyVpcPeeringConnectionOptionsWithContext", reflect.TypeOf((*MockEC2API)(nil).ModifyVpcPeeringConnectionOptionsWithContext), varargs...)
 }
 
 // ModifyVpcTenancy mocks base method
 func (m *MockEC2API) ModifyVpcTenancy(arg0 *ec2.ModifyVpcTenancyInput) (*ec2.ModifyVpcTenancyOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ModifyVpcTenancy", arg0)
 	ret0, _ := ret[0].(*ec2.ModifyVpcTenancyOutput)
 	ret1, _ := ret[1].(error)
@@ -14904,13 +13121,11 @@ func (m *MockEC2API) ModifyVpcTenancy(arg0 *ec2.ModifyVpcTenancyInput) (*ec2.Mod
 
 // ModifyVpcTenancy indicates an expected call of ModifyVpcTenancy
 func (mr *MockEC2APIMockRecorder) ModifyVpcTenancy(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyVpcTenancy", reflect.TypeOf((*MockEC2API)(nil).ModifyVpcTenancy), arg0)
 }
 
 // ModifyVpcTenancyRequest mocks base method
 func (m *MockEC2API) ModifyVpcTenancyRequest(arg0 *ec2.ModifyVpcTenancyInput) (*request.Request, *ec2.ModifyVpcTenancyOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ModifyVpcTenancyRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.ModifyVpcTenancyOutput)
@@ -14919,13 +13134,11 @@ func (m *MockEC2API) ModifyVpcTenancyRequest(arg0 *ec2.ModifyVpcTenancyInput) (*
 
 // ModifyVpcTenancyRequest indicates an expected call of ModifyVpcTenancyRequest
 func (mr *MockEC2APIMockRecorder) ModifyVpcTenancyRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyVpcTenancyRequest", reflect.TypeOf((*MockEC2API)(nil).ModifyVpcTenancyRequest), arg0)
 }
 
 // ModifyVpcTenancyWithContext mocks base method
 func (m *MockEC2API) ModifyVpcTenancyWithContext(arg0 context.Context, arg1 *ec2.ModifyVpcTenancyInput, arg2 ...request.Option) (*ec2.ModifyVpcTenancyOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -14938,14 +13151,12 @@ func (m *MockEC2API) ModifyVpcTenancyWithContext(arg0 context.Context, arg1 *ec2
 
 // ModifyVpcTenancyWithContext indicates an expected call of ModifyVpcTenancyWithContext
 func (mr *MockEC2APIMockRecorder) ModifyVpcTenancyWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyVpcTenancyWithContext", reflect.TypeOf((*MockEC2API)(nil).ModifyVpcTenancyWithContext), varargs...)
 }
 
 // MonitorInstances mocks base method
 func (m *MockEC2API) MonitorInstances(arg0 *ec2.MonitorInstancesInput) (*ec2.MonitorInstancesOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MonitorInstances", arg0)
 	ret0, _ := ret[0].(*ec2.MonitorInstancesOutput)
 	ret1, _ := ret[1].(error)
@@ -14954,13 +13165,11 @@ func (m *MockEC2API) MonitorInstances(arg0 *ec2.MonitorInstancesInput) (*ec2.Mon
 
 // MonitorInstances indicates an expected call of MonitorInstances
 func (mr *MockEC2APIMockRecorder) MonitorInstances(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MonitorInstances", reflect.TypeOf((*MockEC2API)(nil).MonitorInstances), arg0)
 }
 
 // MonitorInstancesRequest mocks base method
 func (m *MockEC2API) MonitorInstancesRequest(arg0 *ec2.MonitorInstancesInput) (*request.Request, *ec2.MonitorInstancesOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MonitorInstancesRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.MonitorInstancesOutput)
@@ -14969,13 +13178,11 @@ func (m *MockEC2API) MonitorInstancesRequest(arg0 *ec2.MonitorInstancesInput) (*
 
 // MonitorInstancesRequest indicates an expected call of MonitorInstancesRequest
 func (mr *MockEC2APIMockRecorder) MonitorInstancesRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MonitorInstancesRequest", reflect.TypeOf((*MockEC2API)(nil).MonitorInstancesRequest), arg0)
 }
 
 // MonitorInstancesWithContext mocks base method
 func (m *MockEC2API) MonitorInstancesWithContext(arg0 context.Context, arg1 *ec2.MonitorInstancesInput, arg2 ...request.Option) (*ec2.MonitorInstancesOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -14988,14 +13195,12 @@ func (m *MockEC2API) MonitorInstancesWithContext(arg0 context.Context, arg1 *ec2
 
 // MonitorInstancesWithContext indicates an expected call of MonitorInstancesWithContext
 func (mr *MockEC2APIMockRecorder) MonitorInstancesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MonitorInstancesWithContext", reflect.TypeOf((*MockEC2API)(nil).MonitorInstancesWithContext), varargs...)
 }
 
 // MoveAddressToVpc mocks base method
 func (m *MockEC2API) MoveAddressToVpc(arg0 *ec2.MoveAddressToVpcInput) (*ec2.MoveAddressToVpcOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MoveAddressToVpc", arg0)
 	ret0, _ := ret[0].(*ec2.MoveAddressToVpcOutput)
 	ret1, _ := ret[1].(error)
@@ -15004,13 +13209,11 @@ func (m *MockEC2API) MoveAddressToVpc(arg0 *ec2.MoveAddressToVpcInput) (*ec2.Mov
 
 // MoveAddressToVpc indicates an expected call of MoveAddressToVpc
 func (mr *MockEC2APIMockRecorder) MoveAddressToVpc(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MoveAddressToVpc", reflect.TypeOf((*MockEC2API)(nil).MoveAddressToVpc), arg0)
 }
 
 // MoveAddressToVpcRequest mocks base method
 func (m *MockEC2API) MoveAddressToVpcRequest(arg0 *ec2.MoveAddressToVpcInput) (*request.Request, *ec2.MoveAddressToVpcOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MoveAddressToVpcRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.MoveAddressToVpcOutput)
@@ -15019,13 +13222,11 @@ func (m *MockEC2API) MoveAddressToVpcRequest(arg0 *ec2.MoveAddressToVpcInput) (*
 
 // MoveAddressToVpcRequest indicates an expected call of MoveAddressToVpcRequest
 func (mr *MockEC2APIMockRecorder) MoveAddressToVpcRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MoveAddressToVpcRequest", reflect.TypeOf((*MockEC2API)(nil).MoveAddressToVpcRequest), arg0)
 }
 
 // MoveAddressToVpcWithContext mocks base method
 func (m *MockEC2API) MoveAddressToVpcWithContext(arg0 context.Context, arg1 *ec2.MoveAddressToVpcInput, arg2 ...request.Option) (*ec2.MoveAddressToVpcOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -15038,14 +13239,12 @@ func (m *MockEC2API) MoveAddressToVpcWithContext(arg0 context.Context, arg1 *ec2
 
 // MoveAddressToVpcWithContext indicates an expected call of MoveAddressToVpcWithContext
 func (mr *MockEC2APIMockRecorder) MoveAddressToVpcWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MoveAddressToVpcWithContext", reflect.TypeOf((*MockEC2API)(nil).MoveAddressToVpcWithContext), varargs...)
 }
 
 // ProvisionByoipCidr mocks base method
 func (m *MockEC2API) ProvisionByoipCidr(arg0 *ec2.ProvisionByoipCidrInput) (*ec2.ProvisionByoipCidrOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ProvisionByoipCidr", arg0)
 	ret0, _ := ret[0].(*ec2.ProvisionByoipCidrOutput)
 	ret1, _ := ret[1].(error)
@@ -15054,13 +13253,11 @@ func (m *MockEC2API) ProvisionByoipCidr(arg0 *ec2.ProvisionByoipCidrInput) (*ec2
 
 // ProvisionByoipCidr indicates an expected call of ProvisionByoipCidr
 func (mr *MockEC2APIMockRecorder) ProvisionByoipCidr(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProvisionByoipCidr", reflect.TypeOf((*MockEC2API)(nil).ProvisionByoipCidr), arg0)
 }
 
 // ProvisionByoipCidrRequest mocks base method
 func (m *MockEC2API) ProvisionByoipCidrRequest(arg0 *ec2.ProvisionByoipCidrInput) (*request.Request, *ec2.ProvisionByoipCidrOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ProvisionByoipCidrRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.ProvisionByoipCidrOutput)
@@ -15069,13 +13266,11 @@ func (m *MockEC2API) ProvisionByoipCidrRequest(arg0 *ec2.ProvisionByoipCidrInput
 
 // ProvisionByoipCidrRequest indicates an expected call of ProvisionByoipCidrRequest
 func (mr *MockEC2APIMockRecorder) ProvisionByoipCidrRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProvisionByoipCidrRequest", reflect.TypeOf((*MockEC2API)(nil).ProvisionByoipCidrRequest), arg0)
 }
 
 // ProvisionByoipCidrWithContext mocks base method
 func (m *MockEC2API) ProvisionByoipCidrWithContext(arg0 context.Context, arg1 *ec2.ProvisionByoipCidrInput, arg2 ...request.Option) (*ec2.ProvisionByoipCidrOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -15088,14 +13283,12 @@ func (m *MockEC2API) ProvisionByoipCidrWithContext(arg0 context.Context, arg1 *e
 
 // ProvisionByoipCidrWithContext indicates an expected call of ProvisionByoipCidrWithContext
 func (mr *MockEC2APIMockRecorder) ProvisionByoipCidrWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProvisionByoipCidrWithContext", reflect.TypeOf((*MockEC2API)(nil).ProvisionByoipCidrWithContext), varargs...)
 }
 
 // PurchaseHostReservation mocks base method
 func (m *MockEC2API) PurchaseHostReservation(arg0 *ec2.PurchaseHostReservationInput) (*ec2.PurchaseHostReservationOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PurchaseHostReservation", arg0)
 	ret0, _ := ret[0].(*ec2.PurchaseHostReservationOutput)
 	ret1, _ := ret[1].(error)
@@ -15104,13 +13297,11 @@ func (m *MockEC2API) PurchaseHostReservation(arg0 *ec2.PurchaseHostReservationIn
 
 // PurchaseHostReservation indicates an expected call of PurchaseHostReservation
 func (mr *MockEC2APIMockRecorder) PurchaseHostReservation(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PurchaseHostReservation", reflect.TypeOf((*MockEC2API)(nil).PurchaseHostReservation), arg0)
 }
 
 // PurchaseHostReservationRequest mocks base method
 func (m *MockEC2API) PurchaseHostReservationRequest(arg0 *ec2.PurchaseHostReservationInput) (*request.Request, *ec2.PurchaseHostReservationOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PurchaseHostReservationRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.PurchaseHostReservationOutput)
@@ -15119,13 +13310,11 @@ func (m *MockEC2API) PurchaseHostReservationRequest(arg0 *ec2.PurchaseHostReserv
 
 // PurchaseHostReservationRequest indicates an expected call of PurchaseHostReservationRequest
 func (mr *MockEC2APIMockRecorder) PurchaseHostReservationRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PurchaseHostReservationRequest", reflect.TypeOf((*MockEC2API)(nil).PurchaseHostReservationRequest), arg0)
 }
 
 // PurchaseHostReservationWithContext mocks base method
 func (m *MockEC2API) PurchaseHostReservationWithContext(arg0 context.Context, arg1 *ec2.PurchaseHostReservationInput, arg2 ...request.Option) (*ec2.PurchaseHostReservationOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -15138,14 +13327,12 @@ func (m *MockEC2API) PurchaseHostReservationWithContext(arg0 context.Context, ar
 
 // PurchaseHostReservationWithContext indicates an expected call of PurchaseHostReservationWithContext
 func (mr *MockEC2APIMockRecorder) PurchaseHostReservationWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PurchaseHostReservationWithContext", reflect.TypeOf((*MockEC2API)(nil).PurchaseHostReservationWithContext), varargs...)
 }
 
 // PurchaseReservedInstancesOffering mocks base method
 func (m *MockEC2API) PurchaseReservedInstancesOffering(arg0 *ec2.PurchaseReservedInstancesOfferingInput) (*ec2.PurchaseReservedInstancesOfferingOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PurchaseReservedInstancesOffering", arg0)
 	ret0, _ := ret[0].(*ec2.PurchaseReservedInstancesOfferingOutput)
 	ret1, _ := ret[1].(error)
@@ -15154,13 +13341,11 @@ func (m *MockEC2API) PurchaseReservedInstancesOffering(arg0 *ec2.PurchaseReserve
 
 // PurchaseReservedInstancesOffering indicates an expected call of PurchaseReservedInstancesOffering
 func (mr *MockEC2APIMockRecorder) PurchaseReservedInstancesOffering(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PurchaseReservedInstancesOffering", reflect.TypeOf((*MockEC2API)(nil).PurchaseReservedInstancesOffering), arg0)
 }
 
 // PurchaseReservedInstancesOfferingRequest mocks base method
 func (m *MockEC2API) PurchaseReservedInstancesOfferingRequest(arg0 *ec2.PurchaseReservedInstancesOfferingInput) (*request.Request, *ec2.PurchaseReservedInstancesOfferingOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PurchaseReservedInstancesOfferingRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.PurchaseReservedInstancesOfferingOutput)
@@ -15169,13 +13354,11 @@ func (m *MockEC2API) PurchaseReservedInstancesOfferingRequest(arg0 *ec2.Purchase
 
 // PurchaseReservedInstancesOfferingRequest indicates an expected call of PurchaseReservedInstancesOfferingRequest
 func (mr *MockEC2APIMockRecorder) PurchaseReservedInstancesOfferingRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PurchaseReservedInstancesOfferingRequest", reflect.TypeOf((*MockEC2API)(nil).PurchaseReservedInstancesOfferingRequest), arg0)
 }
 
 // PurchaseReservedInstancesOfferingWithContext mocks base method
 func (m *MockEC2API) PurchaseReservedInstancesOfferingWithContext(arg0 context.Context, arg1 *ec2.PurchaseReservedInstancesOfferingInput, arg2 ...request.Option) (*ec2.PurchaseReservedInstancesOfferingOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -15188,14 +13371,12 @@ func (m *MockEC2API) PurchaseReservedInstancesOfferingWithContext(arg0 context.C
 
 // PurchaseReservedInstancesOfferingWithContext indicates an expected call of PurchaseReservedInstancesOfferingWithContext
 func (mr *MockEC2APIMockRecorder) PurchaseReservedInstancesOfferingWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PurchaseReservedInstancesOfferingWithContext", reflect.TypeOf((*MockEC2API)(nil).PurchaseReservedInstancesOfferingWithContext), varargs...)
 }
 
 // PurchaseScheduledInstances mocks base method
 func (m *MockEC2API) PurchaseScheduledInstances(arg0 *ec2.PurchaseScheduledInstancesInput) (*ec2.PurchaseScheduledInstancesOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PurchaseScheduledInstances", arg0)
 	ret0, _ := ret[0].(*ec2.PurchaseScheduledInstancesOutput)
 	ret1, _ := ret[1].(error)
@@ -15204,13 +13385,11 @@ func (m *MockEC2API) PurchaseScheduledInstances(arg0 *ec2.PurchaseScheduledInsta
 
 // PurchaseScheduledInstances indicates an expected call of PurchaseScheduledInstances
 func (mr *MockEC2APIMockRecorder) PurchaseScheduledInstances(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PurchaseScheduledInstances", reflect.TypeOf((*MockEC2API)(nil).PurchaseScheduledInstances), arg0)
 }
 
 // PurchaseScheduledInstancesRequest mocks base method
 func (m *MockEC2API) PurchaseScheduledInstancesRequest(arg0 *ec2.PurchaseScheduledInstancesInput) (*request.Request, *ec2.PurchaseScheduledInstancesOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PurchaseScheduledInstancesRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.PurchaseScheduledInstancesOutput)
@@ -15219,13 +13398,11 @@ func (m *MockEC2API) PurchaseScheduledInstancesRequest(arg0 *ec2.PurchaseSchedul
 
 // PurchaseScheduledInstancesRequest indicates an expected call of PurchaseScheduledInstancesRequest
 func (mr *MockEC2APIMockRecorder) PurchaseScheduledInstancesRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PurchaseScheduledInstancesRequest", reflect.TypeOf((*MockEC2API)(nil).PurchaseScheduledInstancesRequest), arg0)
 }
 
 // PurchaseScheduledInstancesWithContext mocks base method
 func (m *MockEC2API) PurchaseScheduledInstancesWithContext(arg0 context.Context, arg1 *ec2.PurchaseScheduledInstancesInput, arg2 ...request.Option) (*ec2.PurchaseScheduledInstancesOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -15238,14 +13415,12 @@ func (m *MockEC2API) PurchaseScheduledInstancesWithContext(arg0 context.Context,
 
 // PurchaseScheduledInstancesWithContext indicates an expected call of PurchaseScheduledInstancesWithContext
 func (mr *MockEC2APIMockRecorder) PurchaseScheduledInstancesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PurchaseScheduledInstancesWithContext", reflect.TypeOf((*MockEC2API)(nil).PurchaseScheduledInstancesWithContext), varargs...)
 }
 
 // RebootInstances mocks base method
 func (m *MockEC2API) RebootInstances(arg0 *ec2.RebootInstancesInput) (*ec2.RebootInstancesOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RebootInstances", arg0)
 	ret0, _ := ret[0].(*ec2.RebootInstancesOutput)
 	ret1, _ := ret[1].(error)
@@ -15254,13 +13429,11 @@ func (m *MockEC2API) RebootInstances(arg0 *ec2.RebootInstancesInput) (*ec2.Reboo
 
 // RebootInstances indicates an expected call of RebootInstances
 func (mr *MockEC2APIMockRecorder) RebootInstances(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RebootInstances", reflect.TypeOf((*MockEC2API)(nil).RebootInstances), arg0)
 }
 
 // RebootInstancesRequest mocks base method
 func (m *MockEC2API) RebootInstancesRequest(arg0 *ec2.RebootInstancesInput) (*request.Request, *ec2.RebootInstancesOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RebootInstancesRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.RebootInstancesOutput)
@@ -15269,13 +13442,11 @@ func (m *MockEC2API) RebootInstancesRequest(arg0 *ec2.RebootInstancesInput) (*re
 
 // RebootInstancesRequest indicates an expected call of RebootInstancesRequest
 func (mr *MockEC2APIMockRecorder) RebootInstancesRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RebootInstancesRequest", reflect.TypeOf((*MockEC2API)(nil).RebootInstancesRequest), arg0)
 }
 
 // RebootInstancesWithContext mocks base method
 func (m *MockEC2API) RebootInstancesWithContext(arg0 context.Context, arg1 *ec2.RebootInstancesInput, arg2 ...request.Option) (*ec2.RebootInstancesOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -15288,14 +13459,12 @@ func (m *MockEC2API) RebootInstancesWithContext(arg0 context.Context, arg1 *ec2.
 
 // RebootInstancesWithContext indicates an expected call of RebootInstancesWithContext
 func (mr *MockEC2APIMockRecorder) RebootInstancesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RebootInstancesWithContext", reflect.TypeOf((*MockEC2API)(nil).RebootInstancesWithContext), varargs...)
 }
 
 // RegisterImage mocks base method
 func (m *MockEC2API) RegisterImage(arg0 *ec2.RegisterImageInput) (*ec2.RegisterImageOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RegisterImage", arg0)
 	ret0, _ := ret[0].(*ec2.RegisterImageOutput)
 	ret1, _ := ret[1].(error)
@@ -15304,13 +13473,11 @@ func (m *MockEC2API) RegisterImage(arg0 *ec2.RegisterImageInput) (*ec2.RegisterI
 
 // RegisterImage indicates an expected call of RegisterImage
 func (mr *MockEC2APIMockRecorder) RegisterImage(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterImage", reflect.TypeOf((*MockEC2API)(nil).RegisterImage), arg0)
 }
 
 // RegisterImageRequest mocks base method
 func (m *MockEC2API) RegisterImageRequest(arg0 *ec2.RegisterImageInput) (*request.Request, *ec2.RegisterImageOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RegisterImageRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.RegisterImageOutput)
@@ -15319,13 +13486,11 @@ func (m *MockEC2API) RegisterImageRequest(arg0 *ec2.RegisterImageInput) (*reques
 
 // RegisterImageRequest indicates an expected call of RegisterImageRequest
 func (mr *MockEC2APIMockRecorder) RegisterImageRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterImageRequest", reflect.TypeOf((*MockEC2API)(nil).RegisterImageRequest), arg0)
 }
 
 // RegisterImageWithContext mocks base method
 func (m *MockEC2API) RegisterImageWithContext(arg0 context.Context, arg1 *ec2.RegisterImageInput, arg2 ...request.Option) (*ec2.RegisterImageOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -15338,14 +13503,12 @@ func (m *MockEC2API) RegisterImageWithContext(arg0 context.Context, arg1 *ec2.Re
 
 // RegisterImageWithContext indicates an expected call of RegisterImageWithContext
 func (mr *MockEC2APIMockRecorder) RegisterImageWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterImageWithContext", reflect.TypeOf((*MockEC2API)(nil).RegisterImageWithContext), varargs...)
 }
 
 // RejectTransitGatewayVpcAttachment mocks base method
 func (m *MockEC2API) RejectTransitGatewayVpcAttachment(arg0 *ec2.RejectTransitGatewayVpcAttachmentInput) (*ec2.RejectTransitGatewayVpcAttachmentOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RejectTransitGatewayVpcAttachment", arg0)
 	ret0, _ := ret[0].(*ec2.RejectTransitGatewayVpcAttachmentOutput)
 	ret1, _ := ret[1].(error)
@@ -15354,13 +13517,11 @@ func (m *MockEC2API) RejectTransitGatewayVpcAttachment(arg0 *ec2.RejectTransitGa
 
 // RejectTransitGatewayVpcAttachment indicates an expected call of RejectTransitGatewayVpcAttachment
 func (mr *MockEC2APIMockRecorder) RejectTransitGatewayVpcAttachment(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RejectTransitGatewayVpcAttachment", reflect.TypeOf((*MockEC2API)(nil).RejectTransitGatewayVpcAttachment), arg0)
 }
 
 // RejectTransitGatewayVpcAttachmentRequest mocks base method
 func (m *MockEC2API) RejectTransitGatewayVpcAttachmentRequest(arg0 *ec2.RejectTransitGatewayVpcAttachmentInput) (*request.Request, *ec2.RejectTransitGatewayVpcAttachmentOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RejectTransitGatewayVpcAttachmentRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.RejectTransitGatewayVpcAttachmentOutput)
@@ -15369,13 +13530,11 @@ func (m *MockEC2API) RejectTransitGatewayVpcAttachmentRequest(arg0 *ec2.RejectTr
 
 // RejectTransitGatewayVpcAttachmentRequest indicates an expected call of RejectTransitGatewayVpcAttachmentRequest
 func (mr *MockEC2APIMockRecorder) RejectTransitGatewayVpcAttachmentRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RejectTransitGatewayVpcAttachmentRequest", reflect.TypeOf((*MockEC2API)(nil).RejectTransitGatewayVpcAttachmentRequest), arg0)
 }
 
 // RejectTransitGatewayVpcAttachmentWithContext mocks base method
 func (m *MockEC2API) RejectTransitGatewayVpcAttachmentWithContext(arg0 context.Context, arg1 *ec2.RejectTransitGatewayVpcAttachmentInput, arg2 ...request.Option) (*ec2.RejectTransitGatewayVpcAttachmentOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -15388,14 +13547,12 @@ func (m *MockEC2API) RejectTransitGatewayVpcAttachmentWithContext(arg0 context.C
 
 // RejectTransitGatewayVpcAttachmentWithContext indicates an expected call of RejectTransitGatewayVpcAttachmentWithContext
 func (mr *MockEC2APIMockRecorder) RejectTransitGatewayVpcAttachmentWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RejectTransitGatewayVpcAttachmentWithContext", reflect.TypeOf((*MockEC2API)(nil).RejectTransitGatewayVpcAttachmentWithContext), varargs...)
 }
 
 // RejectVpcEndpointConnections mocks base method
 func (m *MockEC2API) RejectVpcEndpointConnections(arg0 *ec2.RejectVpcEndpointConnectionsInput) (*ec2.RejectVpcEndpointConnectionsOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RejectVpcEndpointConnections", arg0)
 	ret0, _ := ret[0].(*ec2.RejectVpcEndpointConnectionsOutput)
 	ret1, _ := ret[1].(error)
@@ -15404,13 +13561,11 @@ func (m *MockEC2API) RejectVpcEndpointConnections(arg0 *ec2.RejectVpcEndpointCon
 
 // RejectVpcEndpointConnections indicates an expected call of RejectVpcEndpointConnections
 func (mr *MockEC2APIMockRecorder) RejectVpcEndpointConnections(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RejectVpcEndpointConnections", reflect.TypeOf((*MockEC2API)(nil).RejectVpcEndpointConnections), arg0)
 }
 
 // RejectVpcEndpointConnectionsRequest mocks base method
 func (m *MockEC2API) RejectVpcEndpointConnectionsRequest(arg0 *ec2.RejectVpcEndpointConnectionsInput) (*request.Request, *ec2.RejectVpcEndpointConnectionsOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RejectVpcEndpointConnectionsRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.RejectVpcEndpointConnectionsOutput)
@@ -15419,13 +13574,11 @@ func (m *MockEC2API) RejectVpcEndpointConnectionsRequest(arg0 *ec2.RejectVpcEndp
 
 // RejectVpcEndpointConnectionsRequest indicates an expected call of RejectVpcEndpointConnectionsRequest
 func (mr *MockEC2APIMockRecorder) RejectVpcEndpointConnectionsRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RejectVpcEndpointConnectionsRequest", reflect.TypeOf((*MockEC2API)(nil).RejectVpcEndpointConnectionsRequest), arg0)
 }
 
 // RejectVpcEndpointConnectionsWithContext mocks base method
 func (m *MockEC2API) RejectVpcEndpointConnectionsWithContext(arg0 context.Context, arg1 *ec2.RejectVpcEndpointConnectionsInput, arg2 ...request.Option) (*ec2.RejectVpcEndpointConnectionsOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -15438,14 +13591,12 @@ func (m *MockEC2API) RejectVpcEndpointConnectionsWithContext(arg0 context.Contex
 
 // RejectVpcEndpointConnectionsWithContext indicates an expected call of RejectVpcEndpointConnectionsWithContext
 func (mr *MockEC2APIMockRecorder) RejectVpcEndpointConnectionsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RejectVpcEndpointConnectionsWithContext", reflect.TypeOf((*MockEC2API)(nil).RejectVpcEndpointConnectionsWithContext), varargs...)
 }
 
 // RejectVpcPeeringConnection mocks base method
 func (m *MockEC2API) RejectVpcPeeringConnection(arg0 *ec2.RejectVpcPeeringConnectionInput) (*ec2.RejectVpcPeeringConnectionOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RejectVpcPeeringConnection", arg0)
 	ret0, _ := ret[0].(*ec2.RejectVpcPeeringConnectionOutput)
 	ret1, _ := ret[1].(error)
@@ -15454,13 +13605,11 @@ func (m *MockEC2API) RejectVpcPeeringConnection(arg0 *ec2.RejectVpcPeeringConnec
 
 // RejectVpcPeeringConnection indicates an expected call of RejectVpcPeeringConnection
 func (mr *MockEC2APIMockRecorder) RejectVpcPeeringConnection(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RejectVpcPeeringConnection", reflect.TypeOf((*MockEC2API)(nil).RejectVpcPeeringConnection), arg0)
 }
 
 // RejectVpcPeeringConnectionRequest mocks base method
 func (m *MockEC2API) RejectVpcPeeringConnectionRequest(arg0 *ec2.RejectVpcPeeringConnectionInput) (*request.Request, *ec2.RejectVpcPeeringConnectionOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RejectVpcPeeringConnectionRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.RejectVpcPeeringConnectionOutput)
@@ -15469,13 +13618,11 @@ func (m *MockEC2API) RejectVpcPeeringConnectionRequest(arg0 *ec2.RejectVpcPeerin
 
 // RejectVpcPeeringConnectionRequest indicates an expected call of RejectVpcPeeringConnectionRequest
 func (mr *MockEC2APIMockRecorder) RejectVpcPeeringConnectionRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RejectVpcPeeringConnectionRequest", reflect.TypeOf((*MockEC2API)(nil).RejectVpcPeeringConnectionRequest), arg0)
 }
 
 // RejectVpcPeeringConnectionWithContext mocks base method
 func (m *MockEC2API) RejectVpcPeeringConnectionWithContext(arg0 context.Context, arg1 *ec2.RejectVpcPeeringConnectionInput, arg2 ...request.Option) (*ec2.RejectVpcPeeringConnectionOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -15488,14 +13635,12 @@ func (m *MockEC2API) RejectVpcPeeringConnectionWithContext(arg0 context.Context,
 
 // RejectVpcPeeringConnectionWithContext indicates an expected call of RejectVpcPeeringConnectionWithContext
 func (mr *MockEC2APIMockRecorder) RejectVpcPeeringConnectionWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RejectVpcPeeringConnectionWithContext", reflect.TypeOf((*MockEC2API)(nil).RejectVpcPeeringConnectionWithContext), varargs...)
 }
 
 // ReleaseAddress mocks base method
 func (m *MockEC2API) ReleaseAddress(arg0 *ec2.ReleaseAddressInput) (*ec2.ReleaseAddressOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ReleaseAddress", arg0)
 	ret0, _ := ret[0].(*ec2.ReleaseAddressOutput)
 	ret1, _ := ret[1].(error)
@@ -15504,13 +13649,11 @@ func (m *MockEC2API) ReleaseAddress(arg0 *ec2.ReleaseAddressInput) (*ec2.Release
 
 // ReleaseAddress indicates an expected call of ReleaseAddress
 func (mr *MockEC2APIMockRecorder) ReleaseAddress(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReleaseAddress", reflect.TypeOf((*MockEC2API)(nil).ReleaseAddress), arg0)
 }
 
 // ReleaseAddressRequest mocks base method
 func (m *MockEC2API) ReleaseAddressRequest(arg0 *ec2.ReleaseAddressInput) (*request.Request, *ec2.ReleaseAddressOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ReleaseAddressRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.ReleaseAddressOutput)
@@ -15519,13 +13662,11 @@ func (m *MockEC2API) ReleaseAddressRequest(arg0 *ec2.ReleaseAddressInput) (*requ
 
 // ReleaseAddressRequest indicates an expected call of ReleaseAddressRequest
 func (mr *MockEC2APIMockRecorder) ReleaseAddressRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReleaseAddressRequest", reflect.TypeOf((*MockEC2API)(nil).ReleaseAddressRequest), arg0)
 }
 
 // ReleaseAddressWithContext mocks base method
 func (m *MockEC2API) ReleaseAddressWithContext(arg0 context.Context, arg1 *ec2.ReleaseAddressInput, arg2 ...request.Option) (*ec2.ReleaseAddressOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -15538,14 +13679,12 @@ func (m *MockEC2API) ReleaseAddressWithContext(arg0 context.Context, arg1 *ec2.R
 
 // ReleaseAddressWithContext indicates an expected call of ReleaseAddressWithContext
 func (mr *MockEC2APIMockRecorder) ReleaseAddressWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReleaseAddressWithContext", reflect.TypeOf((*MockEC2API)(nil).ReleaseAddressWithContext), varargs...)
 }
 
 // ReleaseHosts mocks base method
 func (m *MockEC2API) ReleaseHosts(arg0 *ec2.ReleaseHostsInput) (*ec2.ReleaseHostsOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ReleaseHosts", arg0)
 	ret0, _ := ret[0].(*ec2.ReleaseHostsOutput)
 	ret1, _ := ret[1].(error)
@@ -15554,13 +13693,11 @@ func (m *MockEC2API) ReleaseHosts(arg0 *ec2.ReleaseHostsInput) (*ec2.ReleaseHost
 
 // ReleaseHosts indicates an expected call of ReleaseHosts
 func (mr *MockEC2APIMockRecorder) ReleaseHosts(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReleaseHosts", reflect.TypeOf((*MockEC2API)(nil).ReleaseHosts), arg0)
 }
 
 // ReleaseHostsRequest mocks base method
 func (m *MockEC2API) ReleaseHostsRequest(arg0 *ec2.ReleaseHostsInput) (*request.Request, *ec2.ReleaseHostsOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ReleaseHostsRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.ReleaseHostsOutput)
@@ -15569,13 +13706,11 @@ func (m *MockEC2API) ReleaseHostsRequest(arg0 *ec2.ReleaseHostsInput) (*request.
 
 // ReleaseHostsRequest indicates an expected call of ReleaseHostsRequest
 func (mr *MockEC2APIMockRecorder) ReleaseHostsRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReleaseHostsRequest", reflect.TypeOf((*MockEC2API)(nil).ReleaseHostsRequest), arg0)
 }
 
 // ReleaseHostsWithContext mocks base method
 func (m *MockEC2API) ReleaseHostsWithContext(arg0 context.Context, arg1 *ec2.ReleaseHostsInput, arg2 ...request.Option) (*ec2.ReleaseHostsOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -15588,14 +13723,12 @@ func (m *MockEC2API) ReleaseHostsWithContext(arg0 context.Context, arg1 *ec2.Rel
 
 // ReleaseHostsWithContext indicates an expected call of ReleaseHostsWithContext
 func (mr *MockEC2APIMockRecorder) ReleaseHostsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReleaseHostsWithContext", reflect.TypeOf((*MockEC2API)(nil).ReleaseHostsWithContext), varargs...)
 }
 
 // ReplaceIamInstanceProfileAssociation mocks base method
 func (m *MockEC2API) ReplaceIamInstanceProfileAssociation(arg0 *ec2.ReplaceIamInstanceProfileAssociationInput) (*ec2.ReplaceIamInstanceProfileAssociationOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ReplaceIamInstanceProfileAssociation", arg0)
 	ret0, _ := ret[0].(*ec2.ReplaceIamInstanceProfileAssociationOutput)
 	ret1, _ := ret[1].(error)
@@ -15604,13 +13737,11 @@ func (m *MockEC2API) ReplaceIamInstanceProfileAssociation(arg0 *ec2.ReplaceIamIn
 
 // ReplaceIamInstanceProfileAssociation indicates an expected call of ReplaceIamInstanceProfileAssociation
 func (mr *MockEC2APIMockRecorder) ReplaceIamInstanceProfileAssociation(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReplaceIamInstanceProfileAssociation", reflect.TypeOf((*MockEC2API)(nil).ReplaceIamInstanceProfileAssociation), arg0)
 }
 
 // ReplaceIamInstanceProfileAssociationRequest mocks base method
 func (m *MockEC2API) ReplaceIamInstanceProfileAssociationRequest(arg0 *ec2.ReplaceIamInstanceProfileAssociationInput) (*request.Request, *ec2.ReplaceIamInstanceProfileAssociationOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ReplaceIamInstanceProfileAssociationRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.ReplaceIamInstanceProfileAssociationOutput)
@@ -15619,13 +13750,11 @@ func (m *MockEC2API) ReplaceIamInstanceProfileAssociationRequest(arg0 *ec2.Repla
 
 // ReplaceIamInstanceProfileAssociationRequest indicates an expected call of ReplaceIamInstanceProfileAssociationRequest
 func (mr *MockEC2APIMockRecorder) ReplaceIamInstanceProfileAssociationRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReplaceIamInstanceProfileAssociationRequest", reflect.TypeOf((*MockEC2API)(nil).ReplaceIamInstanceProfileAssociationRequest), arg0)
 }
 
 // ReplaceIamInstanceProfileAssociationWithContext mocks base method
 func (m *MockEC2API) ReplaceIamInstanceProfileAssociationWithContext(arg0 context.Context, arg1 *ec2.ReplaceIamInstanceProfileAssociationInput, arg2 ...request.Option) (*ec2.ReplaceIamInstanceProfileAssociationOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -15638,14 +13767,12 @@ func (m *MockEC2API) ReplaceIamInstanceProfileAssociationWithContext(arg0 contex
 
 // ReplaceIamInstanceProfileAssociationWithContext indicates an expected call of ReplaceIamInstanceProfileAssociationWithContext
 func (mr *MockEC2APIMockRecorder) ReplaceIamInstanceProfileAssociationWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReplaceIamInstanceProfileAssociationWithContext", reflect.TypeOf((*MockEC2API)(nil).ReplaceIamInstanceProfileAssociationWithContext), varargs...)
 }
 
 // ReplaceNetworkAclAssociation mocks base method
 func (m *MockEC2API) ReplaceNetworkAclAssociation(arg0 *ec2.ReplaceNetworkAclAssociationInput) (*ec2.ReplaceNetworkAclAssociationOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ReplaceNetworkAclAssociation", arg0)
 	ret0, _ := ret[0].(*ec2.ReplaceNetworkAclAssociationOutput)
 	ret1, _ := ret[1].(error)
@@ -15654,13 +13781,11 @@ func (m *MockEC2API) ReplaceNetworkAclAssociation(arg0 *ec2.ReplaceNetworkAclAss
 
 // ReplaceNetworkAclAssociation indicates an expected call of ReplaceNetworkAclAssociation
 func (mr *MockEC2APIMockRecorder) ReplaceNetworkAclAssociation(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReplaceNetworkAclAssociation", reflect.TypeOf((*MockEC2API)(nil).ReplaceNetworkAclAssociation), arg0)
 }
 
 // ReplaceNetworkAclAssociationRequest mocks base method
 func (m *MockEC2API) ReplaceNetworkAclAssociationRequest(arg0 *ec2.ReplaceNetworkAclAssociationInput) (*request.Request, *ec2.ReplaceNetworkAclAssociationOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ReplaceNetworkAclAssociationRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.ReplaceNetworkAclAssociationOutput)
@@ -15669,13 +13794,11 @@ func (m *MockEC2API) ReplaceNetworkAclAssociationRequest(arg0 *ec2.ReplaceNetwor
 
 // ReplaceNetworkAclAssociationRequest indicates an expected call of ReplaceNetworkAclAssociationRequest
 func (mr *MockEC2APIMockRecorder) ReplaceNetworkAclAssociationRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReplaceNetworkAclAssociationRequest", reflect.TypeOf((*MockEC2API)(nil).ReplaceNetworkAclAssociationRequest), arg0)
 }
 
 // ReplaceNetworkAclAssociationWithContext mocks base method
 func (m *MockEC2API) ReplaceNetworkAclAssociationWithContext(arg0 context.Context, arg1 *ec2.ReplaceNetworkAclAssociationInput, arg2 ...request.Option) (*ec2.ReplaceNetworkAclAssociationOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -15688,14 +13811,12 @@ func (m *MockEC2API) ReplaceNetworkAclAssociationWithContext(arg0 context.Contex
 
 // ReplaceNetworkAclAssociationWithContext indicates an expected call of ReplaceNetworkAclAssociationWithContext
 func (mr *MockEC2APIMockRecorder) ReplaceNetworkAclAssociationWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReplaceNetworkAclAssociationWithContext", reflect.TypeOf((*MockEC2API)(nil).ReplaceNetworkAclAssociationWithContext), varargs...)
 }
 
 // ReplaceNetworkAclEntry mocks base method
 func (m *MockEC2API) ReplaceNetworkAclEntry(arg0 *ec2.ReplaceNetworkAclEntryInput) (*ec2.ReplaceNetworkAclEntryOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ReplaceNetworkAclEntry", arg0)
 	ret0, _ := ret[0].(*ec2.ReplaceNetworkAclEntryOutput)
 	ret1, _ := ret[1].(error)
@@ -15704,13 +13825,11 @@ func (m *MockEC2API) ReplaceNetworkAclEntry(arg0 *ec2.ReplaceNetworkAclEntryInpu
 
 // ReplaceNetworkAclEntry indicates an expected call of ReplaceNetworkAclEntry
 func (mr *MockEC2APIMockRecorder) ReplaceNetworkAclEntry(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReplaceNetworkAclEntry", reflect.TypeOf((*MockEC2API)(nil).ReplaceNetworkAclEntry), arg0)
 }
 
 // ReplaceNetworkAclEntryRequest mocks base method
 func (m *MockEC2API) ReplaceNetworkAclEntryRequest(arg0 *ec2.ReplaceNetworkAclEntryInput) (*request.Request, *ec2.ReplaceNetworkAclEntryOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ReplaceNetworkAclEntryRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.ReplaceNetworkAclEntryOutput)
@@ -15719,13 +13838,11 @@ func (m *MockEC2API) ReplaceNetworkAclEntryRequest(arg0 *ec2.ReplaceNetworkAclEn
 
 // ReplaceNetworkAclEntryRequest indicates an expected call of ReplaceNetworkAclEntryRequest
 func (mr *MockEC2APIMockRecorder) ReplaceNetworkAclEntryRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReplaceNetworkAclEntryRequest", reflect.TypeOf((*MockEC2API)(nil).ReplaceNetworkAclEntryRequest), arg0)
 }
 
 // ReplaceNetworkAclEntryWithContext mocks base method
 func (m *MockEC2API) ReplaceNetworkAclEntryWithContext(arg0 context.Context, arg1 *ec2.ReplaceNetworkAclEntryInput, arg2 ...request.Option) (*ec2.ReplaceNetworkAclEntryOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -15738,14 +13855,12 @@ func (m *MockEC2API) ReplaceNetworkAclEntryWithContext(arg0 context.Context, arg
 
 // ReplaceNetworkAclEntryWithContext indicates an expected call of ReplaceNetworkAclEntryWithContext
 func (mr *MockEC2APIMockRecorder) ReplaceNetworkAclEntryWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReplaceNetworkAclEntryWithContext", reflect.TypeOf((*MockEC2API)(nil).ReplaceNetworkAclEntryWithContext), varargs...)
 }
 
 // ReplaceRoute mocks base method
 func (m *MockEC2API) ReplaceRoute(arg0 *ec2.ReplaceRouteInput) (*ec2.ReplaceRouteOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ReplaceRoute", arg0)
 	ret0, _ := ret[0].(*ec2.ReplaceRouteOutput)
 	ret1, _ := ret[1].(error)
@@ -15754,13 +13869,11 @@ func (m *MockEC2API) ReplaceRoute(arg0 *ec2.ReplaceRouteInput) (*ec2.ReplaceRout
 
 // ReplaceRoute indicates an expected call of ReplaceRoute
 func (mr *MockEC2APIMockRecorder) ReplaceRoute(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReplaceRoute", reflect.TypeOf((*MockEC2API)(nil).ReplaceRoute), arg0)
 }
 
 // ReplaceRouteRequest mocks base method
 func (m *MockEC2API) ReplaceRouteRequest(arg0 *ec2.ReplaceRouteInput) (*request.Request, *ec2.ReplaceRouteOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ReplaceRouteRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.ReplaceRouteOutput)
@@ -15769,13 +13882,11 @@ func (m *MockEC2API) ReplaceRouteRequest(arg0 *ec2.ReplaceRouteInput) (*request.
 
 // ReplaceRouteRequest indicates an expected call of ReplaceRouteRequest
 func (mr *MockEC2APIMockRecorder) ReplaceRouteRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReplaceRouteRequest", reflect.TypeOf((*MockEC2API)(nil).ReplaceRouteRequest), arg0)
 }
 
 // ReplaceRouteTableAssociation mocks base method
 func (m *MockEC2API) ReplaceRouteTableAssociation(arg0 *ec2.ReplaceRouteTableAssociationInput) (*ec2.ReplaceRouteTableAssociationOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ReplaceRouteTableAssociation", arg0)
 	ret0, _ := ret[0].(*ec2.ReplaceRouteTableAssociationOutput)
 	ret1, _ := ret[1].(error)
@@ -15784,13 +13895,11 @@ func (m *MockEC2API) ReplaceRouteTableAssociation(arg0 *ec2.ReplaceRouteTableAss
 
 // ReplaceRouteTableAssociation indicates an expected call of ReplaceRouteTableAssociation
 func (mr *MockEC2APIMockRecorder) ReplaceRouteTableAssociation(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReplaceRouteTableAssociation", reflect.TypeOf((*MockEC2API)(nil).ReplaceRouteTableAssociation), arg0)
 }
 
 // ReplaceRouteTableAssociationRequest mocks base method
 func (m *MockEC2API) ReplaceRouteTableAssociationRequest(arg0 *ec2.ReplaceRouteTableAssociationInput) (*request.Request, *ec2.ReplaceRouteTableAssociationOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ReplaceRouteTableAssociationRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.ReplaceRouteTableAssociationOutput)
@@ -15799,13 +13908,11 @@ func (m *MockEC2API) ReplaceRouteTableAssociationRequest(arg0 *ec2.ReplaceRouteT
 
 // ReplaceRouteTableAssociationRequest indicates an expected call of ReplaceRouteTableAssociationRequest
 func (mr *MockEC2APIMockRecorder) ReplaceRouteTableAssociationRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReplaceRouteTableAssociationRequest", reflect.TypeOf((*MockEC2API)(nil).ReplaceRouteTableAssociationRequest), arg0)
 }
 
 // ReplaceRouteTableAssociationWithContext mocks base method
 func (m *MockEC2API) ReplaceRouteTableAssociationWithContext(arg0 context.Context, arg1 *ec2.ReplaceRouteTableAssociationInput, arg2 ...request.Option) (*ec2.ReplaceRouteTableAssociationOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -15818,14 +13925,12 @@ func (m *MockEC2API) ReplaceRouteTableAssociationWithContext(arg0 context.Contex
 
 // ReplaceRouteTableAssociationWithContext indicates an expected call of ReplaceRouteTableAssociationWithContext
 func (mr *MockEC2APIMockRecorder) ReplaceRouteTableAssociationWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReplaceRouteTableAssociationWithContext", reflect.TypeOf((*MockEC2API)(nil).ReplaceRouteTableAssociationWithContext), varargs...)
 }
 
 // ReplaceRouteWithContext mocks base method
 func (m *MockEC2API) ReplaceRouteWithContext(arg0 context.Context, arg1 *ec2.ReplaceRouteInput, arg2 ...request.Option) (*ec2.ReplaceRouteOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -15838,14 +13943,12 @@ func (m *MockEC2API) ReplaceRouteWithContext(arg0 context.Context, arg1 *ec2.Rep
 
 // ReplaceRouteWithContext indicates an expected call of ReplaceRouteWithContext
 func (mr *MockEC2APIMockRecorder) ReplaceRouteWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReplaceRouteWithContext", reflect.TypeOf((*MockEC2API)(nil).ReplaceRouteWithContext), varargs...)
 }
 
 // ReplaceTransitGatewayRoute mocks base method
 func (m *MockEC2API) ReplaceTransitGatewayRoute(arg0 *ec2.ReplaceTransitGatewayRouteInput) (*ec2.ReplaceTransitGatewayRouteOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ReplaceTransitGatewayRoute", arg0)
 	ret0, _ := ret[0].(*ec2.ReplaceTransitGatewayRouteOutput)
 	ret1, _ := ret[1].(error)
@@ -15854,13 +13957,11 @@ func (m *MockEC2API) ReplaceTransitGatewayRoute(arg0 *ec2.ReplaceTransitGatewayR
 
 // ReplaceTransitGatewayRoute indicates an expected call of ReplaceTransitGatewayRoute
 func (mr *MockEC2APIMockRecorder) ReplaceTransitGatewayRoute(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReplaceTransitGatewayRoute", reflect.TypeOf((*MockEC2API)(nil).ReplaceTransitGatewayRoute), arg0)
 }
 
 // ReplaceTransitGatewayRouteRequest mocks base method
 func (m *MockEC2API) ReplaceTransitGatewayRouteRequest(arg0 *ec2.ReplaceTransitGatewayRouteInput) (*request.Request, *ec2.ReplaceTransitGatewayRouteOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ReplaceTransitGatewayRouteRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.ReplaceTransitGatewayRouteOutput)
@@ -15869,13 +13970,11 @@ func (m *MockEC2API) ReplaceTransitGatewayRouteRequest(arg0 *ec2.ReplaceTransitG
 
 // ReplaceTransitGatewayRouteRequest indicates an expected call of ReplaceTransitGatewayRouteRequest
 func (mr *MockEC2APIMockRecorder) ReplaceTransitGatewayRouteRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReplaceTransitGatewayRouteRequest", reflect.TypeOf((*MockEC2API)(nil).ReplaceTransitGatewayRouteRequest), arg0)
 }
 
 // ReplaceTransitGatewayRouteWithContext mocks base method
 func (m *MockEC2API) ReplaceTransitGatewayRouteWithContext(arg0 context.Context, arg1 *ec2.ReplaceTransitGatewayRouteInput, arg2 ...request.Option) (*ec2.ReplaceTransitGatewayRouteOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -15888,14 +13987,12 @@ func (m *MockEC2API) ReplaceTransitGatewayRouteWithContext(arg0 context.Context,
 
 // ReplaceTransitGatewayRouteWithContext indicates an expected call of ReplaceTransitGatewayRouteWithContext
 func (mr *MockEC2APIMockRecorder) ReplaceTransitGatewayRouteWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReplaceTransitGatewayRouteWithContext", reflect.TypeOf((*MockEC2API)(nil).ReplaceTransitGatewayRouteWithContext), varargs...)
 }
 
 // ReportInstanceStatus mocks base method
 func (m *MockEC2API) ReportInstanceStatus(arg0 *ec2.ReportInstanceStatusInput) (*ec2.ReportInstanceStatusOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ReportInstanceStatus", arg0)
 	ret0, _ := ret[0].(*ec2.ReportInstanceStatusOutput)
 	ret1, _ := ret[1].(error)
@@ -15904,13 +14001,11 @@ func (m *MockEC2API) ReportInstanceStatus(arg0 *ec2.ReportInstanceStatusInput) (
 
 // ReportInstanceStatus indicates an expected call of ReportInstanceStatus
 func (mr *MockEC2APIMockRecorder) ReportInstanceStatus(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReportInstanceStatus", reflect.TypeOf((*MockEC2API)(nil).ReportInstanceStatus), arg0)
 }
 
 // ReportInstanceStatusRequest mocks base method
 func (m *MockEC2API) ReportInstanceStatusRequest(arg0 *ec2.ReportInstanceStatusInput) (*request.Request, *ec2.ReportInstanceStatusOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ReportInstanceStatusRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.ReportInstanceStatusOutput)
@@ -15919,13 +14014,11 @@ func (m *MockEC2API) ReportInstanceStatusRequest(arg0 *ec2.ReportInstanceStatusI
 
 // ReportInstanceStatusRequest indicates an expected call of ReportInstanceStatusRequest
 func (mr *MockEC2APIMockRecorder) ReportInstanceStatusRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReportInstanceStatusRequest", reflect.TypeOf((*MockEC2API)(nil).ReportInstanceStatusRequest), arg0)
 }
 
 // ReportInstanceStatusWithContext mocks base method
 func (m *MockEC2API) ReportInstanceStatusWithContext(arg0 context.Context, arg1 *ec2.ReportInstanceStatusInput, arg2 ...request.Option) (*ec2.ReportInstanceStatusOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -15938,14 +14031,12 @@ func (m *MockEC2API) ReportInstanceStatusWithContext(arg0 context.Context, arg1 
 
 // ReportInstanceStatusWithContext indicates an expected call of ReportInstanceStatusWithContext
 func (mr *MockEC2APIMockRecorder) ReportInstanceStatusWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReportInstanceStatusWithContext", reflect.TypeOf((*MockEC2API)(nil).ReportInstanceStatusWithContext), varargs...)
 }
 
 // RequestSpotFleet mocks base method
 func (m *MockEC2API) RequestSpotFleet(arg0 *ec2.RequestSpotFleetInput) (*ec2.RequestSpotFleetOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RequestSpotFleet", arg0)
 	ret0, _ := ret[0].(*ec2.RequestSpotFleetOutput)
 	ret1, _ := ret[1].(error)
@@ -15954,13 +14045,11 @@ func (m *MockEC2API) RequestSpotFleet(arg0 *ec2.RequestSpotFleetInput) (*ec2.Req
 
 // RequestSpotFleet indicates an expected call of RequestSpotFleet
 func (mr *MockEC2APIMockRecorder) RequestSpotFleet(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RequestSpotFleet", reflect.TypeOf((*MockEC2API)(nil).RequestSpotFleet), arg0)
 }
 
 // RequestSpotFleetRequest mocks base method
 func (m *MockEC2API) RequestSpotFleetRequest(arg0 *ec2.RequestSpotFleetInput) (*request.Request, *ec2.RequestSpotFleetOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RequestSpotFleetRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.RequestSpotFleetOutput)
@@ -15969,13 +14058,11 @@ func (m *MockEC2API) RequestSpotFleetRequest(arg0 *ec2.RequestSpotFleetInput) (*
 
 // RequestSpotFleetRequest indicates an expected call of RequestSpotFleetRequest
 func (mr *MockEC2APIMockRecorder) RequestSpotFleetRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RequestSpotFleetRequest", reflect.TypeOf((*MockEC2API)(nil).RequestSpotFleetRequest), arg0)
 }
 
 // RequestSpotFleetWithContext mocks base method
 func (m *MockEC2API) RequestSpotFleetWithContext(arg0 context.Context, arg1 *ec2.RequestSpotFleetInput, arg2 ...request.Option) (*ec2.RequestSpotFleetOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -15988,14 +14075,12 @@ func (m *MockEC2API) RequestSpotFleetWithContext(arg0 context.Context, arg1 *ec2
 
 // RequestSpotFleetWithContext indicates an expected call of RequestSpotFleetWithContext
 func (mr *MockEC2APIMockRecorder) RequestSpotFleetWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RequestSpotFleetWithContext", reflect.TypeOf((*MockEC2API)(nil).RequestSpotFleetWithContext), varargs...)
 }
 
 // RequestSpotInstances mocks base method
 func (m *MockEC2API) RequestSpotInstances(arg0 *ec2.RequestSpotInstancesInput) (*ec2.RequestSpotInstancesOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RequestSpotInstances", arg0)
 	ret0, _ := ret[0].(*ec2.RequestSpotInstancesOutput)
 	ret1, _ := ret[1].(error)
@@ -16004,13 +14089,11 @@ func (m *MockEC2API) RequestSpotInstances(arg0 *ec2.RequestSpotInstancesInput) (
 
 // RequestSpotInstances indicates an expected call of RequestSpotInstances
 func (mr *MockEC2APIMockRecorder) RequestSpotInstances(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RequestSpotInstances", reflect.TypeOf((*MockEC2API)(nil).RequestSpotInstances), arg0)
 }
 
 // RequestSpotInstancesRequest mocks base method
 func (m *MockEC2API) RequestSpotInstancesRequest(arg0 *ec2.RequestSpotInstancesInput) (*request.Request, *ec2.RequestSpotInstancesOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RequestSpotInstancesRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.RequestSpotInstancesOutput)
@@ -16019,13 +14102,11 @@ func (m *MockEC2API) RequestSpotInstancesRequest(arg0 *ec2.RequestSpotInstancesI
 
 // RequestSpotInstancesRequest indicates an expected call of RequestSpotInstancesRequest
 func (mr *MockEC2APIMockRecorder) RequestSpotInstancesRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RequestSpotInstancesRequest", reflect.TypeOf((*MockEC2API)(nil).RequestSpotInstancesRequest), arg0)
 }
 
 // RequestSpotInstancesWithContext mocks base method
 func (m *MockEC2API) RequestSpotInstancesWithContext(arg0 context.Context, arg1 *ec2.RequestSpotInstancesInput, arg2 ...request.Option) (*ec2.RequestSpotInstancesOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -16038,14 +14119,12 @@ func (m *MockEC2API) RequestSpotInstancesWithContext(arg0 context.Context, arg1 
 
 // RequestSpotInstancesWithContext indicates an expected call of RequestSpotInstancesWithContext
 func (mr *MockEC2APIMockRecorder) RequestSpotInstancesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RequestSpotInstancesWithContext", reflect.TypeOf((*MockEC2API)(nil).RequestSpotInstancesWithContext), varargs...)
 }
 
 // ResetFpgaImageAttribute mocks base method
 func (m *MockEC2API) ResetFpgaImageAttribute(arg0 *ec2.ResetFpgaImageAttributeInput) (*ec2.ResetFpgaImageAttributeOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ResetFpgaImageAttribute", arg0)
 	ret0, _ := ret[0].(*ec2.ResetFpgaImageAttributeOutput)
 	ret1, _ := ret[1].(error)
@@ -16054,13 +14133,11 @@ func (m *MockEC2API) ResetFpgaImageAttribute(arg0 *ec2.ResetFpgaImageAttributeIn
 
 // ResetFpgaImageAttribute indicates an expected call of ResetFpgaImageAttribute
 func (mr *MockEC2APIMockRecorder) ResetFpgaImageAttribute(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResetFpgaImageAttribute", reflect.TypeOf((*MockEC2API)(nil).ResetFpgaImageAttribute), arg0)
 }
 
 // ResetFpgaImageAttributeRequest mocks base method
 func (m *MockEC2API) ResetFpgaImageAttributeRequest(arg0 *ec2.ResetFpgaImageAttributeInput) (*request.Request, *ec2.ResetFpgaImageAttributeOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ResetFpgaImageAttributeRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.ResetFpgaImageAttributeOutput)
@@ -16069,13 +14146,11 @@ func (m *MockEC2API) ResetFpgaImageAttributeRequest(arg0 *ec2.ResetFpgaImageAttr
 
 // ResetFpgaImageAttributeRequest indicates an expected call of ResetFpgaImageAttributeRequest
 func (mr *MockEC2APIMockRecorder) ResetFpgaImageAttributeRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResetFpgaImageAttributeRequest", reflect.TypeOf((*MockEC2API)(nil).ResetFpgaImageAttributeRequest), arg0)
 }
 
 // ResetFpgaImageAttributeWithContext mocks base method
 func (m *MockEC2API) ResetFpgaImageAttributeWithContext(arg0 context.Context, arg1 *ec2.ResetFpgaImageAttributeInput, arg2 ...request.Option) (*ec2.ResetFpgaImageAttributeOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -16088,14 +14163,12 @@ func (m *MockEC2API) ResetFpgaImageAttributeWithContext(arg0 context.Context, ar
 
 // ResetFpgaImageAttributeWithContext indicates an expected call of ResetFpgaImageAttributeWithContext
 func (mr *MockEC2APIMockRecorder) ResetFpgaImageAttributeWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResetFpgaImageAttributeWithContext", reflect.TypeOf((*MockEC2API)(nil).ResetFpgaImageAttributeWithContext), varargs...)
 }
 
 // ResetImageAttribute mocks base method
 func (m *MockEC2API) ResetImageAttribute(arg0 *ec2.ResetImageAttributeInput) (*ec2.ResetImageAttributeOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ResetImageAttribute", arg0)
 	ret0, _ := ret[0].(*ec2.ResetImageAttributeOutput)
 	ret1, _ := ret[1].(error)
@@ -16104,13 +14177,11 @@ func (m *MockEC2API) ResetImageAttribute(arg0 *ec2.ResetImageAttributeInput) (*e
 
 // ResetImageAttribute indicates an expected call of ResetImageAttribute
 func (mr *MockEC2APIMockRecorder) ResetImageAttribute(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResetImageAttribute", reflect.TypeOf((*MockEC2API)(nil).ResetImageAttribute), arg0)
 }
 
 // ResetImageAttributeRequest mocks base method
 func (m *MockEC2API) ResetImageAttributeRequest(arg0 *ec2.ResetImageAttributeInput) (*request.Request, *ec2.ResetImageAttributeOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ResetImageAttributeRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.ResetImageAttributeOutput)
@@ -16119,13 +14190,11 @@ func (m *MockEC2API) ResetImageAttributeRequest(arg0 *ec2.ResetImageAttributeInp
 
 // ResetImageAttributeRequest indicates an expected call of ResetImageAttributeRequest
 func (mr *MockEC2APIMockRecorder) ResetImageAttributeRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResetImageAttributeRequest", reflect.TypeOf((*MockEC2API)(nil).ResetImageAttributeRequest), arg0)
 }
 
 // ResetImageAttributeWithContext mocks base method
 func (m *MockEC2API) ResetImageAttributeWithContext(arg0 context.Context, arg1 *ec2.ResetImageAttributeInput, arg2 ...request.Option) (*ec2.ResetImageAttributeOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -16138,14 +14207,12 @@ func (m *MockEC2API) ResetImageAttributeWithContext(arg0 context.Context, arg1 *
 
 // ResetImageAttributeWithContext indicates an expected call of ResetImageAttributeWithContext
 func (mr *MockEC2APIMockRecorder) ResetImageAttributeWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResetImageAttributeWithContext", reflect.TypeOf((*MockEC2API)(nil).ResetImageAttributeWithContext), varargs...)
 }
 
 // ResetInstanceAttribute mocks base method
 func (m *MockEC2API) ResetInstanceAttribute(arg0 *ec2.ResetInstanceAttributeInput) (*ec2.ResetInstanceAttributeOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ResetInstanceAttribute", arg0)
 	ret0, _ := ret[0].(*ec2.ResetInstanceAttributeOutput)
 	ret1, _ := ret[1].(error)
@@ -16154,13 +14221,11 @@ func (m *MockEC2API) ResetInstanceAttribute(arg0 *ec2.ResetInstanceAttributeInpu
 
 // ResetInstanceAttribute indicates an expected call of ResetInstanceAttribute
 func (mr *MockEC2APIMockRecorder) ResetInstanceAttribute(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResetInstanceAttribute", reflect.TypeOf((*MockEC2API)(nil).ResetInstanceAttribute), arg0)
 }
 
 // ResetInstanceAttributeRequest mocks base method
 func (m *MockEC2API) ResetInstanceAttributeRequest(arg0 *ec2.ResetInstanceAttributeInput) (*request.Request, *ec2.ResetInstanceAttributeOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ResetInstanceAttributeRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.ResetInstanceAttributeOutput)
@@ -16169,13 +14234,11 @@ func (m *MockEC2API) ResetInstanceAttributeRequest(arg0 *ec2.ResetInstanceAttrib
 
 // ResetInstanceAttributeRequest indicates an expected call of ResetInstanceAttributeRequest
 func (mr *MockEC2APIMockRecorder) ResetInstanceAttributeRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResetInstanceAttributeRequest", reflect.TypeOf((*MockEC2API)(nil).ResetInstanceAttributeRequest), arg0)
 }
 
 // ResetInstanceAttributeWithContext mocks base method
 func (m *MockEC2API) ResetInstanceAttributeWithContext(arg0 context.Context, arg1 *ec2.ResetInstanceAttributeInput, arg2 ...request.Option) (*ec2.ResetInstanceAttributeOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -16188,14 +14251,12 @@ func (m *MockEC2API) ResetInstanceAttributeWithContext(arg0 context.Context, arg
 
 // ResetInstanceAttributeWithContext indicates an expected call of ResetInstanceAttributeWithContext
 func (mr *MockEC2APIMockRecorder) ResetInstanceAttributeWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResetInstanceAttributeWithContext", reflect.TypeOf((*MockEC2API)(nil).ResetInstanceAttributeWithContext), varargs...)
 }
 
 // ResetNetworkInterfaceAttribute mocks base method
 func (m *MockEC2API) ResetNetworkInterfaceAttribute(arg0 *ec2.ResetNetworkInterfaceAttributeInput) (*ec2.ResetNetworkInterfaceAttributeOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ResetNetworkInterfaceAttribute", arg0)
 	ret0, _ := ret[0].(*ec2.ResetNetworkInterfaceAttributeOutput)
 	ret1, _ := ret[1].(error)
@@ -16204,13 +14265,11 @@ func (m *MockEC2API) ResetNetworkInterfaceAttribute(arg0 *ec2.ResetNetworkInterf
 
 // ResetNetworkInterfaceAttribute indicates an expected call of ResetNetworkInterfaceAttribute
 func (mr *MockEC2APIMockRecorder) ResetNetworkInterfaceAttribute(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResetNetworkInterfaceAttribute", reflect.TypeOf((*MockEC2API)(nil).ResetNetworkInterfaceAttribute), arg0)
 }
 
 // ResetNetworkInterfaceAttributeRequest mocks base method
 func (m *MockEC2API) ResetNetworkInterfaceAttributeRequest(arg0 *ec2.ResetNetworkInterfaceAttributeInput) (*request.Request, *ec2.ResetNetworkInterfaceAttributeOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ResetNetworkInterfaceAttributeRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.ResetNetworkInterfaceAttributeOutput)
@@ -16219,13 +14278,11 @@ func (m *MockEC2API) ResetNetworkInterfaceAttributeRequest(arg0 *ec2.ResetNetwor
 
 // ResetNetworkInterfaceAttributeRequest indicates an expected call of ResetNetworkInterfaceAttributeRequest
 func (mr *MockEC2APIMockRecorder) ResetNetworkInterfaceAttributeRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResetNetworkInterfaceAttributeRequest", reflect.TypeOf((*MockEC2API)(nil).ResetNetworkInterfaceAttributeRequest), arg0)
 }
 
 // ResetNetworkInterfaceAttributeWithContext mocks base method
 func (m *MockEC2API) ResetNetworkInterfaceAttributeWithContext(arg0 context.Context, arg1 *ec2.ResetNetworkInterfaceAttributeInput, arg2 ...request.Option) (*ec2.ResetNetworkInterfaceAttributeOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -16238,14 +14295,12 @@ func (m *MockEC2API) ResetNetworkInterfaceAttributeWithContext(arg0 context.Cont
 
 // ResetNetworkInterfaceAttributeWithContext indicates an expected call of ResetNetworkInterfaceAttributeWithContext
 func (mr *MockEC2APIMockRecorder) ResetNetworkInterfaceAttributeWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResetNetworkInterfaceAttributeWithContext", reflect.TypeOf((*MockEC2API)(nil).ResetNetworkInterfaceAttributeWithContext), varargs...)
 }
 
 // ResetSnapshotAttribute mocks base method
 func (m *MockEC2API) ResetSnapshotAttribute(arg0 *ec2.ResetSnapshotAttributeInput) (*ec2.ResetSnapshotAttributeOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ResetSnapshotAttribute", arg0)
 	ret0, _ := ret[0].(*ec2.ResetSnapshotAttributeOutput)
 	ret1, _ := ret[1].(error)
@@ -16254,13 +14309,11 @@ func (m *MockEC2API) ResetSnapshotAttribute(arg0 *ec2.ResetSnapshotAttributeInpu
 
 // ResetSnapshotAttribute indicates an expected call of ResetSnapshotAttribute
 func (mr *MockEC2APIMockRecorder) ResetSnapshotAttribute(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResetSnapshotAttribute", reflect.TypeOf((*MockEC2API)(nil).ResetSnapshotAttribute), arg0)
 }
 
 // ResetSnapshotAttributeRequest mocks base method
 func (m *MockEC2API) ResetSnapshotAttributeRequest(arg0 *ec2.ResetSnapshotAttributeInput) (*request.Request, *ec2.ResetSnapshotAttributeOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ResetSnapshotAttributeRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.ResetSnapshotAttributeOutput)
@@ -16269,13 +14322,11 @@ func (m *MockEC2API) ResetSnapshotAttributeRequest(arg0 *ec2.ResetSnapshotAttrib
 
 // ResetSnapshotAttributeRequest indicates an expected call of ResetSnapshotAttributeRequest
 func (mr *MockEC2APIMockRecorder) ResetSnapshotAttributeRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResetSnapshotAttributeRequest", reflect.TypeOf((*MockEC2API)(nil).ResetSnapshotAttributeRequest), arg0)
 }
 
 // ResetSnapshotAttributeWithContext mocks base method
 func (m *MockEC2API) ResetSnapshotAttributeWithContext(arg0 context.Context, arg1 *ec2.ResetSnapshotAttributeInput, arg2 ...request.Option) (*ec2.ResetSnapshotAttributeOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -16288,14 +14339,12 @@ func (m *MockEC2API) ResetSnapshotAttributeWithContext(arg0 context.Context, arg
 
 // ResetSnapshotAttributeWithContext indicates an expected call of ResetSnapshotAttributeWithContext
 func (mr *MockEC2APIMockRecorder) ResetSnapshotAttributeWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResetSnapshotAttributeWithContext", reflect.TypeOf((*MockEC2API)(nil).ResetSnapshotAttributeWithContext), varargs...)
 }
 
 // RestoreAddressToClassic mocks base method
 func (m *MockEC2API) RestoreAddressToClassic(arg0 *ec2.RestoreAddressToClassicInput) (*ec2.RestoreAddressToClassicOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RestoreAddressToClassic", arg0)
 	ret0, _ := ret[0].(*ec2.RestoreAddressToClassicOutput)
 	ret1, _ := ret[1].(error)
@@ -16304,13 +14353,11 @@ func (m *MockEC2API) RestoreAddressToClassic(arg0 *ec2.RestoreAddressToClassicIn
 
 // RestoreAddressToClassic indicates an expected call of RestoreAddressToClassic
 func (mr *MockEC2APIMockRecorder) RestoreAddressToClassic(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RestoreAddressToClassic", reflect.TypeOf((*MockEC2API)(nil).RestoreAddressToClassic), arg0)
 }
 
 // RestoreAddressToClassicRequest mocks base method
 func (m *MockEC2API) RestoreAddressToClassicRequest(arg0 *ec2.RestoreAddressToClassicInput) (*request.Request, *ec2.RestoreAddressToClassicOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RestoreAddressToClassicRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.RestoreAddressToClassicOutput)
@@ -16319,13 +14366,11 @@ func (m *MockEC2API) RestoreAddressToClassicRequest(arg0 *ec2.RestoreAddressToCl
 
 // RestoreAddressToClassicRequest indicates an expected call of RestoreAddressToClassicRequest
 func (mr *MockEC2APIMockRecorder) RestoreAddressToClassicRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RestoreAddressToClassicRequest", reflect.TypeOf((*MockEC2API)(nil).RestoreAddressToClassicRequest), arg0)
 }
 
 // RestoreAddressToClassicWithContext mocks base method
 func (m *MockEC2API) RestoreAddressToClassicWithContext(arg0 context.Context, arg1 *ec2.RestoreAddressToClassicInput, arg2 ...request.Option) (*ec2.RestoreAddressToClassicOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -16338,14 +14383,12 @@ func (m *MockEC2API) RestoreAddressToClassicWithContext(arg0 context.Context, ar
 
 // RestoreAddressToClassicWithContext indicates an expected call of RestoreAddressToClassicWithContext
 func (mr *MockEC2APIMockRecorder) RestoreAddressToClassicWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RestoreAddressToClassicWithContext", reflect.TypeOf((*MockEC2API)(nil).RestoreAddressToClassicWithContext), varargs...)
 }
 
 // RevokeClientVpnIngress mocks base method
 func (m *MockEC2API) RevokeClientVpnIngress(arg0 *ec2.RevokeClientVpnIngressInput) (*ec2.RevokeClientVpnIngressOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RevokeClientVpnIngress", arg0)
 	ret0, _ := ret[0].(*ec2.RevokeClientVpnIngressOutput)
 	ret1, _ := ret[1].(error)
@@ -16354,13 +14397,11 @@ func (m *MockEC2API) RevokeClientVpnIngress(arg0 *ec2.RevokeClientVpnIngressInpu
 
 // RevokeClientVpnIngress indicates an expected call of RevokeClientVpnIngress
 func (mr *MockEC2APIMockRecorder) RevokeClientVpnIngress(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RevokeClientVpnIngress", reflect.TypeOf((*MockEC2API)(nil).RevokeClientVpnIngress), arg0)
 }
 
 // RevokeClientVpnIngressRequest mocks base method
 func (m *MockEC2API) RevokeClientVpnIngressRequest(arg0 *ec2.RevokeClientVpnIngressInput) (*request.Request, *ec2.RevokeClientVpnIngressOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RevokeClientVpnIngressRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.RevokeClientVpnIngressOutput)
@@ -16369,13 +14410,11 @@ func (m *MockEC2API) RevokeClientVpnIngressRequest(arg0 *ec2.RevokeClientVpnIngr
 
 // RevokeClientVpnIngressRequest indicates an expected call of RevokeClientVpnIngressRequest
 func (mr *MockEC2APIMockRecorder) RevokeClientVpnIngressRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RevokeClientVpnIngressRequest", reflect.TypeOf((*MockEC2API)(nil).RevokeClientVpnIngressRequest), arg0)
 }
 
 // RevokeClientVpnIngressWithContext mocks base method
 func (m *MockEC2API) RevokeClientVpnIngressWithContext(arg0 context.Context, arg1 *ec2.RevokeClientVpnIngressInput, arg2 ...request.Option) (*ec2.RevokeClientVpnIngressOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -16388,14 +14427,12 @@ func (m *MockEC2API) RevokeClientVpnIngressWithContext(arg0 context.Context, arg
 
 // RevokeClientVpnIngressWithContext indicates an expected call of RevokeClientVpnIngressWithContext
 func (mr *MockEC2APIMockRecorder) RevokeClientVpnIngressWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RevokeClientVpnIngressWithContext", reflect.TypeOf((*MockEC2API)(nil).RevokeClientVpnIngressWithContext), varargs...)
 }
 
 // RevokeSecurityGroupEgress mocks base method
 func (m *MockEC2API) RevokeSecurityGroupEgress(arg0 *ec2.RevokeSecurityGroupEgressInput) (*ec2.RevokeSecurityGroupEgressOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RevokeSecurityGroupEgress", arg0)
 	ret0, _ := ret[0].(*ec2.RevokeSecurityGroupEgressOutput)
 	ret1, _ := ret[1].(error)
@@ -16404,13 +14441,11 @@ func (m *MockEC2API) RevokeSecurityGroupEgress(arg0 *ec2.RevokeSecurityGroupEgre
 
 // RevokeSecurityGroupEgress indicates an expected call of RevokeSecurityGroupEgress
 func (mr *MockEC2APIMockRecorder) RevokeSecurityGroupEgress(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RevokeSecurityGroupEgress", reflect.TypeOf((*MockEC2API)(nil).RevokeSecurityGroupEgress), arg0)
 }
 
 // RevokeSecurityGroupEgressRequest mocks base method
 func (m *MockEC2API) RevokeSecurityGroupEgressRequest(arg0 *ec2.RevokeSecurityGroupEgressInput) (*request.Request, *ec2.RevokeSecurityGroupEgressOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RevokeSecurityGroupEgressRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.RevokeSecurityGroupEgressOutput)
@@ -16419,13 +14454,11 @@ func (m *MockEC2API) RevokeSecurityGroupEgressRequest(arg0 *ec2.RevokeSecurityGr
 
 // RevokeSecurityGroupEgressRequest indicates an expected call of RevokeSecurityGroupEgressRequest
 func (mr *MockEC2APIMockRecorder) RevokeSecurityGroupEgressRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RevokeSecurityGroupEgressRequest", reflect.TypeOf((*MockEC2API)(nil).RevokeSecurityGroupEgressRequest), arg0)
 }
 
 // RevokeSecurityGroupEgressWithContext mocks base method
 func (m *MockEC2API) RevokeSecurityGroupEgressWithContext(arg0 context.Context, arg1 *ec2.RevokeSecurityGroupEgressInput, arg2 ...request.Option) (*ec2.RevokeSecurityGroupEgressOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -16438,14 +14471,12 @@ func (m *MockEC2API) RevokeSecurityGroupEgressWithContext(arg0 context.Context, 
 
 // RevokeSecurityGroupEgressWithContext indicates an expected call of RevokeSecurityGroupEgressWithContext
 func (mr *MockEC2APIMockRecorder) RevokeSecurityGroupEgressWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RevokeSecurityGroupEgressWithContext", reflect.TypeOf((*MockEC2API)(nil).RevokeSecurityGroupEgressWithContext), varargs...)
 }
 
 // RevokeSecurityGroupIngress mocks base method
 func (m *MockEC2API) RevokeSecurityGroupIngress(arg0 *ec2.RevokeSecurityGroupIngressInput) (*ec2.RevokeSecurityGroupIngressOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RevokeSecurityGroupIngress", arg0)
 	ret0, _ := ret[0].(*ec2.RevokeSecurityGroupIngressOutput)
 	ret1, _ := ret[1].(error)
@@ -16454,13 +14485,11 @@ func (m *MockEC2API) RevokeSecurityGroupIngress(arg0 *ec2.RevokeSecurityGroupIng
 
 // RevokeSecurityGroupIngress indicates an expected call of RevokeSecurityGroupIngress
 func (mr *MockEC2APIMockRecorder) RevokeSecurityGroupIngress(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RevokeSecurityGroupIngress", reflect.TypeOf((*MockEC2API)(nil).RevokeSecurityGroupIngress), arg0)
 }
 
 // RevokeSecurityGroupIngressRequest mocks base method
 func (m *MockEC2API) RevokeSecurityGroupIngressRequest(arg0 *ec2.RevokeSecurityGroupIngressInput) (*request.Request, *ec2.RevokeSecurityGroupIngressOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RevokeSecurityGroupIngressRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.RevokeSecurityGroupIngressOutput)
@@ -16469,13 +14498,11 @@ func (m *MockEC2API) RevokeSecurityGroupIngressRequest(arg0 *ec2.RevokeSecurityG
 
 // RevokeSecurityGroupIngressRequest indicates an expected call of RevokeSecurityGroupIngressRequest
 func (mr *MockEC2APIMockRecorder) RevokeSecurityGroupIngressRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RevokeSecurityGroupIngressRequest", reflect.TypeOf((*MockEC2API)(nil).RevokeSecurityGroupIngressRequest), arg0)
 }
 
 // RevokeSecurityGroupIngressWithContext mocks base method
 func (m *MockEC2API) RevokeSecurityGroupIngressWithContext(arg0 context.Context, arg1 *ec2.RevokeSecurityGroupIngressInput, arg2 ...request.Option) (*ec2.RevokeSecurityGroupIngressOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -16488,14 +14515,12 @@ func (m *MockEC2API) RevokeSecurityGroupIngressWithContext(arg0 context.Context,
 
 // RevokeSecurityGroupIngressWithContext indicates an expected call of RevokeSecurityGroupIngressWithContext
 func (mr *MockEC2APIMockRecorder) RevokeSecurityGroupIngressWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RevokeSecurityGroupIngressWithContext", reflect.TypeOf((*MockEC2API)(nil).RevokeSecurityGroupIngressWithContext), varargs...)
 }
 
 // RunInstances mocks base method
 func (m *MockEC2API) RunInstances(arg0 *ec2.RunInstancesInput) (*ec2.Reservation, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RunInstances", arg0)
 	ret0, _ := ret[0].(*ec2.Reservation)
 	ret1, _ := ret[1].(error)
@@ -16504,13 +14529,11 @@ func (m *MockEC2API) RunInstances(arg0 *ec2.RunInstancesInput) (*ec2.Reservation
 
 // RunInstances indicates an expected call of RunInstances
 func (mr *MockEC2APIMockRecorder) RunInstances(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunInstances", reflect.TypeOf((*MockEC2API)(nil).RunInstances), arg0)
 }
 
 // RunInstancesRequest mocks base method
 func (m *MockEC2API) RunInstancesRequest(arg0 *ec2.RunInstancesInput) (*request.Request, *ec2.Reservation) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RunInstancesRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.Reservation)
@@ -16519,13 +14542,11 @@ func (m *MockEC2API) RunInstancesRequest(arg0 *ec2.RunInstancesInput) (*request.
 
 // RunInstancesRequest indicates an expected call of RunInstancesRequest
 func (mr *MockEC2APIMockRecorder) RunInstancesRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunInstancesRequest", reflect.TypeOf((*MockEC2API)(nil).RunInstancesRequest), arg0)
 }
 
 // RunInstancesWithContext mocks base method
 func (m *MockEC2API) RunInstancesWithContext(arg0 context.Context, arg1 *ec2.RunInstancesInput, arg2 ...request.Option) (*ec2.Reservation, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -16538,14 +14559,12 @@ func (m *MockEC2API) RunInstancesWithContext(arg0 context.Context, arg1 *ec2.Run
 
 // RunInstancesWithContext indicates an expected call of RunInstancesWithContext
 func (mr *MockEC2APIMockRecorder) RunInstancesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunInstancesWithContext", reflect.TypeOf((*MockEC2API)(nil).RunInstancesWithContext), varargs...)
 }
 
 // RunScheduledInstances mocks base method
 func (m *MockEC2API) RunScheduledInstances(arg0 *ec2.RunScheduledInstancesInput) (*ec2.RunScheduledInstancesOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RunScheduledInstances", arg0)
 	ret0, _ := ret[0].(*ec2.RunScheduledInstancesOutput)
 	ret1, _ := ret[1].(error)
@@ -16554,13 +14573,11 @@ func (m *MockEC2API) RunScheduledInstances(arg0 *ec2.RunScheduledInstancesInput)
 
 // RunScheduledInstances indicates an expected call of RunScheduledInstances
 func (mr *MockEC2APIMockRecorder) RunScheduledInstances(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunScheduledInstances", reflect.TypeOf((*MockEC2API)(nil).RunScheduledInstances), arg0)
 }
 
 // RunScheduledInstancesRequest mocks base method
 func (m *MockEC2API) RunScheduledInstancesRequest(arg0 *ec2.RunScheduledInstancesInput) (*request.Request, *ec2.RunScheduledInstancesOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RunScheduledInstancesRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.RunScheduledInstancesOutput)
@@ -16569,13 +14586,11 @@ func (m *MockEC2API) RunScheduledInstancesRequest(arg0 *ec2.RunScheduledInstance
 
 // RunScheduledInstancesRequest indicates an expected call of RunScheduledInstancesRequest
 func (mr *MockEC2APIMockRecorder) RunScheduledInstancesRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunScheduledInstancesRequest", reflect.TypeOf((*MockEC2API)(nil).RunScheduledInstancesRequest), arg0)
 }
 
 // RunScheduledInstancesWithContext mocks base method
 func (m *MockEC2API) RunScheduledInstancesWithContext(arg0 context.Context, arg1 *ec2.RunScheduledInstancesInput, arg2 ...request.Option) (*ec2.RunScheduledInstancesOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -16588,14 +14603,12 @@ func (m *MockEC2API) RunScheduledInstancesWithContext(arg0 context.Context, arg1
 
 // RunScheduledInstancesWithContext indicates an expected call of RunScheduledInstancesWithContext
 func (mr *MockEC2APIMockRecorder) RunScheduledInstancesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunScheduledInstancesWithContext", reflect.TypeOf((*MockEC2API)(nil).RunScheduledInstancesWithContext), varargs...)
 }
 
 // SearchTransitGatewayRoutes mocks base method
 func (m *MockEC2API) SearchTransitGatewayRoutes(arg0 *ec2.SearchTransitGatewayRoutesInput) (*ec2.SearchTransitGatewayRoutesOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SearchTransitGatewayRoutes", arg0)
 	ret0, _ := ret[0].(*ec2.SearchTransitGatewayRoutesOutput)
 	ret1, _ := ret[1].(error)
@@ -16604,13 +14617,11 @@ func (m *MockEC2API) SearchTransitGatewayRoutes(arg0 *ec2.SearchTransitGatewayRo
 
 // SearchTransitGatewayRoutes indicates an expected call of SearchTransitGatewayRoutes
 func (mr *MockEC2APIMockRecorder) SearchTransitGatewayRoutes(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SearchTransitGatewayRoutes", reflect.TypeOf((*MockEC2API)(nil).SearchTransitGatewayRoutes), arg0)
 }
 
 // SearchTransitGatewayRoutesRequest mocks base method
 func (m *MockEC2API) SearchTransitGatewayRoutesRequest(arg0 *ec2.SearchTransitGatewayRoutesInput) (*request.Request, *ec2.SearchTransitGatewayRoutesOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SearchTransitGatewayRoutesRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.SearchTransitGatewayRoutesOutput)
@@ -16619,13 +14630,11 @@ func (m *MockEC2API) SearchTransitGatewayRoutesRequest(arg0 *ec2.SearchTransitGa
 
 // SearchTransitGatewayRoutesRequest indicates an expected call of SearchTransitGatewayRoutesRequest
 func (mr *MockEC2APIMockRecorder) SearchTransitGatewayRoutesRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SearchTransitGatewayRoutesRequest", reflect.TypeOf((*MockEC2API)(nil).SearchTransitGatewayRoutesRequest), arg0)
 }
 
 // SearchTransitGatewayRoutesWithContext mocks base method
 func (m *MockEC2API) SearchTransitGatewayRoutesWithContext(arg0 context.Context, arg1 *ec2.SearchTransitGatewayRoutesInput, arg2 ...request.Option) (*ec2.SearchTransitGatewayRoutesOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -16638,14 +14647,12 @@ func (m *MockEC2API) SearchTransitGatewayRoutesWithContext(arg0 context.Context,
 
 // SearchTransitGatewayRoutesWithContext indicates an expected call of SearchTransitGatewayRoutesWithContext
 func (mr *MockEC2APIMockRecorder) SearchTransitGatewayRoutesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SearchTransitGatewayRoutesWithContext", reflect.TypeOf((*MockEC2API)(nil).SearchTransitGatewayRoutesWithContext), varargs...)
 }
 
 // StartInstances mocks base method
 func (m *MockEC2API) StartInstances(arg0 *ec2.StartInstancesInput) (*ec2.StartInstancesOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StartInstances", arg0)
 	ret0, _ := ret[0].(*ec2.StartInstancesOutput)
 	ret1, _ := ret[1].(error)
@@ -16654,13 +14661,11 @@ func (m *MockEC2API) StartInstances(arg0 *ec2.StartInstancesInput) (*ec2.StartIn
 
 // StartInstances indicates an expected call of StartInstances
 func (mr *MockEC2APIMockRecorder) StartInstances(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartInstances", reflect.TypeOf((*MockEC2API)(nil).StartInstances), arg0)
 }
 
 // StartInstancesRequest mocks base method
 func (m *MockEC2API) StartInstancesRequest(arg0 *ec2.StartInstancesInput) (*request.Request, *ec2.StartInstancesOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StartInstancesRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.StartInstancesOutput)
@@ -16669,13 +14674,11 @@ func (m *MockEC2API) StartInstancesRequest(arg0 *ec2.StartInstancesInput) (*requ
 
 // StartInstancesRequest indicates an expected call of StartInstancesRequest
 func (mr *MockEC2APIMockRecorder) StartInstancesRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartInstancesRequest", reflect.TypeOf((*MockEC2API)(nil).StartInstancesRequest), arg0)
 }
 
 // StartInstancesWithContext mocks base method
 func (m *MockEC2API) StartInstancesWithContext(arg0 context.Context, arg1 *ec2.StartInstancesInput, arg2 ...request.Option) (*ec2.StartInstancesOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -16688,14 +14691,12 @@ func (m *MockEC2API) StartInstancesWithContext(arg0 context.Context, arg1 *ec2.S
 
 // StartInstancesWithContext indicates an expected call of StartInstancesWithContext
 func (mr *MockEC2APIMockRecorder) StartInstancesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartInstancesWithContext", reflect.TypeOf((*MockEC2API)(nil).StartInstancesWithContext), varargs...)
 }
 
 // StopInstances mocks base method
 func (m *MockEC2API) StopInstances(arg0 *ec2.StopInstancesInput) (*ec2.StopInstancesOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StopInstances", arg0)
 	ret0, _ := ret[0].(*ec2.StopInstancesOutput)
 	ret1, _ := ret[1].(error)
@@ -16704,13 +14705,11 @@ func (m *MockEC2API) StopInstances(arg0 *ec2.StopInstancesInput) (*ec2.StopInsta
 
 // StopInstances indicates an expected call of StopInstances
 func (mr *MockEC2APIMockRecorder) StopInstances(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StopInstances", reflect.TypeOf((*MockEC2API)(nil).StopInstances), arg0)
 }
 
 // StopInstancesRequest mocks base method
 func (m *MockEC2API) StopInstancesRequest(arg0 *ec2.StopInstancesInput) (*request.Request, *ec2.StopInstancesOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StopInstancesRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.StopInstancesOutput)
@@ -16719,13 +14718,11 @@ func (m *MockEC2API) StopInstancesRequest(arg0 *ec2.StopInstancesInput) (*reques
 
 // StopInstancesRequest indicates an expected call of StopInstancesRequest
 func (mr *MockEC2APIMockRecorder) StopInstancesRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StopInstancesRequest", reflect.TypeOf((*MockEC2API)(nil).StopInstancesRequest), arg0)
 }
 
 // StopInstancesWithContext mocks base method
 func (m *MockEC2API) StopInstancesWithContext(arg0 context.Context, arg1 *ec2.StopInstancesInput, arg2 ...request.Option) (*ec2.StopInstancesOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -16738,14 +14735,12 @@ func (m *MockEC2API) StopInstancesWithContext(arg0 context.Context, arg1 *ec2.St
 
 // StopInstancesWithContext indicates an expected call of StopInstancesWithContext
 func (mr *MockEC2APIMockRecorder) StopInstancesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StopInstancesWithContext", reflect.TypeOf((*MockEC2API)(nil).StopInstancesWithContext), varargs...)
 }
 
 // TerminateClientVpnConnections mocks base method
 func (m *MockEC2API) TerminateClientVpnConnections(arg0 *ec2.TerminateClientVpnConnectionsInput) (*ec2.TerminateClientVpnConnectionsOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "TerminateClientVpnConnections", arg0)
 	ret0, _ := ret[0].(*ec2.TerminateClientVpnConnectionsOutput)
 	ret1, _ := ret[1].(error)
@@ -16754,13 +14749,11 @@ func (m *MockEC2API) TerminateClientVpnConnections(arg0 *ec2.TerminateClientVpnC
 
 // TerminateClientVpnConnections indicates an expected call of TerminateClientVpnConnections
 func (mr *MockEC2APIMockRecorder) TerminateClientVpnConnections(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TerminateClientVpnConnections", reflect.TypeOf((*MockEC2API)(nil).TerminateClientVpnConnections), arg0)
 }
 
 // TerminateClientVpnConnectionsRequest mocks base method
 func (m *MockEC2API) TerminateClientVpnConnectionsRequest(arg0 *ec2.TerminateClientVpnConnectionsInput) (*request.Request, *ec2.TerminateClientVpnConnectionsOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "TerminateClientVpnConnectionsRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.TerminateClientVpnConnectionsOutput)
@@ -16769,13 +14762,11 @@ func (m *MockEC2API) TerminateClientVpnConnectionsRequest(arg0 *ec2.TerminateCli
 
 // TerminateClientVpnConnectionsRequest indicates an expected call of TerminateClientVpnConnectionsRequest
 func (mr *MockEC2APIMockRecorder) TerminateClientVpnConnectionsRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TerminateClientVpnConnectionsRequest", reflect.TypeOf((*MockEC2API)(nil).TerminateClientVpnConnectionsRequest), arg0)
 }
 
 // TerminateClientVpnConnectionsWithContext mocks base method
 func (m *MockEC2API) TerminateClientVpnConnectionsWithContext(arg0 context.Context, arg1 *ec2.TerminateClientVpnConnectionsInput, arg2 ...request.Option) (*ec2.TerminateClientVpnConnectionsOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -16788,14 +14779,12 @@ func (m *MockEC2API) TerminateClientVpnConnectionsWithContext(arg0 context.Conte
 
 // TerminateClientVpnConnectionsWithContext indicates an expected call of TerminateClientVpnConnectionsWithContext
 func (mr *MockEC2APIMockRecorder) TerminateClientVpnConnectionsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TerminateClientVpnConnectionsWithContext", reflect.TypeOf((*MockEC2API)(nil).TerminateClientVpnConnectionsWithContext), varargs...)
 }
 
 // TerminateInstances mocks base method
 func (m *MockEC2API) TerminateInstances(arg0 *ec2.TerminateInstancesInput) (*ec2.TerminateInstancesOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "TerminateInstances", arg0)
 	ret0, _ := ret[0].(*ec2.TerminateInstancesOutput)
 	ret1, _ := ret[1].(error)
@@ -16804,13 +14793,11 @@ func (m *MockEC2API) TerminateInstances(arg0 *ec2.TerminateInstancesInput) (*ec2
 
 // TerminateInstances indicates an expected call of TerminateInstances
 func (mr *MockEC2APIMockRecorder) TerminateInstances(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TerminateInstances", reflect.TypeOf((*MockEC2API)(nil).TerminateInstances), arg0)
 }
 
 // TerminateInstancesRequest mocks base method
 func (m *MockEC2API) TerminateInstancesRequest(arg0 *ec2.TerminateInstancesInput) (*request.Request, *ec2.TerminateInstancesOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "TerminateInstancesRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.TerminateInstancesOutput)
@@ -16819,13 +14806,11 @@ func (m *MockEC2API) TerminateInstancesRequest(arg0 *ec2.TerminateInstancesInput
 
 // TerminateInstancesRequest indicates an expected call of TerminateInstancesRequest
 func (mr *MockEC2APIMockRecorder) TerminateInstancesRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TerminateInstancesRequest", reflect.TypeOf((*MockEC2API)(nil).TerminateInstancesRequest), arg0)
 }
 
 // TerminateInstancesWithContext mocks base method
 func (m *MockEC2API) TerminateInstancesWithContext(arg0 context.Context, arg1 *ec2.TerminateInstancesInput, arg2 ...request.Option) (*ec2.TerminateInstancesOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -16838,14 +14823,12 @@ func (m *MockEC2API) TerminateInstancesWithContext(arg0 context.Context, arg1 *e
 
 // TerminateInstancesWithContext indicates an expected call of TerminateInstancesWithContext
 func (mr *MockEC2APIMockRecorder) TerminateInstancesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TerminateInstancesWithContext", reflect.TypeOf((*MockEC2API)(nil).TerminateInstancesWithContext), varargs...)
 }
 
 // UnassignIpv6Addresses mocks base method
 func (m *MockEC2API) UnassignIpv6Addresses(arg0 *ec2.UnassignIpv6AddressesInput) (*ec2.UnassignIpv6AddressesOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UnassignIpv6Addresses", arg0)
 	ret0, _ := ret[0].(*ec2.UnassignIpv6AddressesOutput)
 	ret1, _ := ret[1].(error)
@@ -16854,13 +14837,11 @@ func (m *MockEC2API) UnassignIpv6Addresses(arg0 *ec2.UnassignIpv6AddressesInput)
 
 // UnassignIpv6Addresses indicates an expected call of UnassignIpv6Addresses
 func (mr *MockEC2APIMockRecorder) UnassignIpv6Addresses(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnassignIpv6Addresses", reflect.TypeOf((*MockEC2API)(nil).UnassignIpv6Addresses), arg0)
 }
 
 // UnassignIpv6AddressesRequest mocks base method
 func (m *MockEC2API) UnassignIpv6AddressesRequest(arg0 *ec2.UnassignIpv6AddressesInput) (*request.Request, *ec2.UnassignIpv6AddressesOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UnassignIpv6AddressesRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.UnassignIpv6AddressesOutput)
@@ -16869,13 +14850,11 @@ func (m *MockEC2API) UnassignIpv6AddressesRequest(arg0 *ec2.UnassignIpv6Addresse
 
 // UnassignIpv6AddressesRequest indicates an expected call of UnassignIpv6AddressesRequest
 func (mr *MockEC2APIMockRecorder) UnassignIpv6AddressesRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnassignIpv6AddressesRequest", reflect.TypeOf((*MockEC2API)(nil).UnassignIpv6AddressesRequest), arg0)
 }
 
 // UnassignIpv6AddressesWithContext mocks base method
 func (m *MockEC2API) UnassignIpv6AddressesWithContext(arg0 context.Context, arg1 *ec2.UnassignIpv6AddressesInput, arg2 ...request.Option) (*ec2.UnassignIpv6AddressesOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -16888,14 +14867,12 @@ func (m *MockEC2API) UnassignIpv6AddressesWithContext(arg0 context.Context, arg1
 
 // UnassignIpv6AddressesWithContext indicates an expected call of UnassignIpv6AddressesWithContext
 func (mr *MockEC2APIMockRecorder) UnassignIpv6AddressesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnassignIpv6AddressesWithContext", reflect.TypeOf((*MockEC2API)(nil).UnassignIpv6AddressesWithContext), varargs...)
 }
 
 // UnassignPrivateIpAddresses mocks base method
 func (m *MockEC2API) UnassignPrivateIpAddresses(arg0 *ec2.UnassignPrivateIpAddressesInput) (*ec2.UnassignPrivateIpAddressesOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UnassignPrivateIpAddresses", arg0)
 	ret0, _ := ret[0].(*ec2.UnassignPrivateIpAddressesOutput)
 	ret1, _ := ret[1].(error)
@@ -16904,13 +14881,11 @@ func (m *MockEC2API) UnassignPrivateIpAddresses(arg0 *ec2.UnassignPrivateIpAddre
 
 // UnassignPrivateIpAddresses indicates an expected call of UnassignPrivateIpAddresses
 func (mr *MockEC2APIMockRecorder) UnassignPrivateIpAddresses(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnassignPrivateIpAddresses", reflect.TypeOf((*MockEC2API)(nil).UnassignPrivateIpAddresses), arg0)
 }
 
 // UnassignPrivateIpAddressesRequest mocks base method
 func (m *MockEC2API) UnassignPrivateIpAddressesRequest(arg0 *ec2.UnassignPrivateIpAddressesInput) (*request.Request, *ec2.UnassignPrivateIpAddressesOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UnassignPrivateIpAddressesRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.UnassignPrivateIpAddressesOutput)
@@ -16919,13 +14894,11 @@ func (m *MockEC2API) UnassignPrivateIpAddressesRequest(arg0 *ec2.UnassignPrivate
 
 // UnassignPrivateIpAddressesRequest indicates an expected call of UnassignPrivateIpAddressesRequest
 func (mr *MockEC2APIMockRecorder) UnassignPrivateIpAddressesRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnassignPrivateIpAddressesRequest", reflect.TypeOf((*MockEC2API)(nil).UnassignPrivateIpAddressesRequest), arg0)
 }
 
 // UnassignPrivateIpAddressesWithContext mocks base method
 func (m *MockEC2API) UnassignPrivateIpAddressesWithContext(arg0 context.Context, arg1 *ec2.UnassignPrivateIpAddressesInput, arg2 ...request.Option) (*ec2.UnassignPrivateIpAddressesOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -16938,14 +14911,12 @@ func (m *MockEC2API) UnassignPrivateIpAddressesWithContext(arg0 context.Context,
 
 // UnassignPrivateIpAddressesWithContext indicates an expected call of UnassignPrivateIpAddressesWithContext
 func (mr *MockEC2APIMockRecorder) UnassignPrivateIpAddressesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnassignPrivateIpAddressesWithContext", reflect.TypeOf((*MockEC2API)(nil).UnassignPrivateIpAddressesWithContext), varargs...)
 }
 
 // UnmonitorInstances mocks base method
 func (m *MockEC2API) UnmonitorInstances(arg0 *ec2.UnmonitorInstancesInput) (*ec2.UnmonitorInstancesOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UnmonitorInstances", arg0)
 	ret0, _ := ret[0].(*ec2.UnmonitorInstancesOutput)
 	ret1, _ := ret[1].(error)
@@ -16954,13 +14925,11 @@ func (m *MockEC2API) UnmonitorInstances(arg0 *ec2.UnmonitorInstancesInput) (*ec2
 
 // UnmonitorInstances indicates an expected call of UnmonitorInstances
 func (mr *MockEC2APIMockRecorder) UnmonitorInstances(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnmonitorInstances", reflect.TypeOf((*MockEC2API)(nil).UnmonitorInstances), arg0)
 }
 
 // UnmonitorInstancesRequest mocks base method
 func (m *MockEC2API) UnmonitorInstancesRequest(arg0 *ec2.UnmonitorInstancesInput) (*request.Request, *ec2.UnmonitorInstancesOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UnmonitorInstancesRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.UnmonitorInstancesOutput)
@@ -16969,13 +14938,11 @@ func (m *MockEC2API) UnmonitorInstancesRequest(arg0 *ec2.UnmonitorInstancesInput
 
 // UnmonitorInstancesRequest indicates an expected call of UnmonitorInstancesRequest
 func (mr *MockEC2APIMockRecorder) UnmonitorInstancesRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnmonitorInstancesRequest", reflect.TypeOf((*MockEC2API)(nil).UnmonitorInstancesRequest), arg0)
 }
 
 // UnmonitorInstancesWithContext mocks base method
 func (m *MockEC2API) UnmonitorInstancesWithContext(arg0 context.Context, arg1 *ec2.UnmonitorInstancesInput, arg2 ...request.Option) (*ec2.UnmonitorInstancesOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -16988,14 +14955,12 @@ func (m *MockEC2API) UnmonitorInstancesWithContext(arg0 context.Context, arg1 *e
 
 // UnmonitorInstancesWithContext indicates an expected call of UnmonitorInstancesWithContext
 func (mr *MockEC2APIMockRecorder) UnmonitorInstancesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnmonitorInstancesWithContext", reflect.TypeOf((*MockEC2API)(nil).UnmonitorInstancesWithContext), varargs...)
 }
 
 // UpdateSecurityGroupRuleDescriptionsEgress mocks base method
 func (m *MockEC2API) UpdateSecurityGroupRuleDescriptionsEgress(arg0 *ec2.UpdateSecurityGroupRuleDescriptionsEgressInput) (*ec2.UpdateSecurityGroupRuleDescriptionsEgressOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateSecurityGroupRuleDescriptionsEgress", arg0)
 	ret0, _ := ret[0].(*ec2.UpdateSecurityGroupRuleDescriptionsEgressOutput)
 	ret1, _ := ret[1].(error)
@@ -17004,13 +14969,11 @@ func (m *MockEC2API) UpdateSecurityGroupRuleDescriptionsEgress(arg0 *ec2.UpdateS
 
 // UpdateSecurityGroupRuleDescriptionsEgress indicates an expected call of UpdateSecurityGroupRuleDescriptionsEgress
 func (mr *MockEC2APIMockRecorder) UpdateSecurityGroupRuleDescriptionsEgress(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateSecurityGroupRuleDescriptionsEgress", reflect.TypeOf((*MockEC2API)(nil).UpdateSecurityGroupRuleDescriptionsEgress), arg0)
 }
 
 // UpdateSecurityGroupRuleDescriptionsEgressRequest mocks base method
 func (m *MockEC2API) UpdateSecurityGroupRuleDescriptionsEgressRequest(arg0 *ec2.UpdateSecurityGroupRuleDescriptionsEgressInput) (*request.Request, *ec2.UpdateSecurityGroupRuleDescriptionsEgressOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateSecurityGroupRuleDescriptionsEgressRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.UpdateSecurityGroupRuleDescriptionsEgressOutput)
@@ -17019,13 +14982,11 @@ func (m *MockEC2API) UpdateSecurityGroupRuleDescriptionsEgressRequest(arg0 *ec2.
 
 // UpdateSecurityGroupRuleDescriptionsEgressRequest indicates an expected call of UpdateSecurityGroupRuleDescriptionsEgressRequest
 func (mr *MockEC2APIMockRecorder) UpdateSecurityGroupRuleDescriptionsEgressRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateSecurityGroupRuleDescriptionsEgressRequest", reflect.TypeOf((*MockEC2API)(nil).UpdateSecurityGroupRuleDescriptionsEgressRequest), arg0)
 }
 
 // UpdateSecurityGroupRuleDescriptionsEgressWithContext mocks base method
 func (m *MockEC2API) UpdateSecurityGroupRuleDescriptionsEgressWithContext(arg0 context.Context, arg1 *ec2.UpdateSecurityGroupRuleDescriptionsEgressInput, arg2 ...request.Option) (*ec2.UpdateSecurityGroupRuleDescriptionsEgressOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -17038,14 +14999,12 @@ func (m *MockEC2API) UpdateSecurityGroupRuleDescriptionsEgressWithContext(arg0 c
 
 // UpdateSecurityGroupRuleDescriptionsEgressWithContext indicates an expected call of UpdateSecurityGroupRuleDescriptionsEgressWithContext
 func (mr *MockEC2APIMockRecorder) UpdateSecurityGroupRuleDescriptionsEgressWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateSecurityGroupRuleDescriptionsEgressWithContext", reflect.TypeOf((*MockEC2API)(nil).UpdateSecurityGroupRuleDescriptionsEgressWithContext), varargs...)
 }
 
 // UpdateSecurityGroupRuleDescriptionsIngress mocks base method
 func (m *MockEC2API) UpdateSecurityGroupRuleDescriptionsIngress(arg0 *ec2.UpdateSecurityGroupRuleDescriptionsIngressInput) (*ec2.UpdateSecurityGroupRuleDescriptionsIngressOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateSecurityGroupRuleDescriptionsIngress", arg0)
 	ret0, _ := ret[0].(*ec2.UpdateSecurityGroupRuleDescriptionsIngressOutput)
 	ret1, _ := ret[1].(error)
@@ -17054,13 +15013,11 @@ func (m *MockEC2API) UpdateSecurityGroupRuleDescriptionsIngress(arg0 *ec2.Update
 
 // UpdateSecurityGroupRuleDescriptionsIngress indicates an expected call of UpdateSecurityGroupRuleDescriptionsIngress
 func (mr *MockEC2APIMockRecorder) UpdateSecurityGroupRuleDescriptionsIngress(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateSecurityGroupRuleDescriptionsIngress", reflect.TypeOf((*MockEC2API)(nil).UpdateSecurityGroupRuleDescriptionsIngress), arg0)
 }
 
 // UpdateSecurityGroupRuleDescriptionsIngressRequest mocks base method
 func (m *MockEC2API) UpdateSecurityGroupRuleDescriptionsIngressRequest(arg0 *ec2.UpdateSecurityGroupRuleDescriptionsIngressInput) (*request.Request, *ec2.UpdateSecurityGroupRuleDescriptionsIngressOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateSecurityGroupRuleDescriptionsIngressRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.UpdateSecurityGroupRuleDescriptionsIngressOutput)
@@ -17069,13 +15026,11 @@ func (m *MockEC2API) UpdateSecurityGroupRuleDescriptionsIngressRequest(arg0 *ec2
 
 // UpdateSecurityGroupRuleDescriptionsIngressRequest indicates an expected call of UpdateSecurityGroupRuleDescriptionsIngressRequest
 func (mr *MockEC2APIMockRecorder) UpdateSecurityGroupRuleDescriptionsIngressRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateSecurityGroupRuleDescriptionsIngressRequest", reflect.TypeOf((*MockEC2API)(nil).UpdateSecurityGroupRuleDescriptionsIngressRequest), arg0)
 }
 
 // UpdateSecurityGroupRuleDescriptionsIngressWithContext mocks base method
 func (m *MockEC2API) UpdateSecurityGroupRuleDescriptionsIngressWithContext(arg0 context.Context, arg1 *ec2.UpdateSecurityGroupRuleDescriptionsIngressInput, arg2 ...request.Option) (*ec2.UpdateSecurityGroupRuleDescriptionsIngressOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -17088,14 +15043,12 @@ func (m *MockEC2API) UpdateSecurityGroupRuleDescriptionsIngressWithContext(arg0 
 
 // UpdateSecurityGroupRuleDescriptionsIngressWithContext indicates an expected call of UpdateSecurityGroupRuleDescriptionsIngressWithContext
 func (mr *MockEC2APIMockRecorder) UpdateSecurityGroupRuleDescriptionsIngressWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateSecurityGroupRuleDescriptionsIngressWithContext", reflect.TypeOf((*MockEC2API)(nil).UpdateSecurityGroupRuleDescriptionsIngressWithContext), varargs...)
 }
 
 // WaitUntilBundleTaskComplete mocks base method
 func (m *MockEC2API) WaitUntilBundleTaskComplete(arg0 *ec2.DescribeBundleTasksInput) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WaitUntilBundleTaskComplete", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -17103,13 +15056,11 @@ func (m *MockEC2API) WaitUntilBundleTaskComplete(arg0 *ec2.DescribeBundleTasksIn
 
 // WaitUntilBundleTaskComplete indicates an expected call of WaitUntilBundleTaskComplete
 func (mr *MockEC2APIMockRecorder) WaitUntilBundleTaskComplete(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitUntilBundleTaskComplete", reflect.TypeOf((*MockEC2API)(nil).WaitUntilBundleTaskComplete), arg0)
 }
 
 // WaitUntilBundleTaskCompleteWithContext mocks base method
 func (m *MockEC2API) WaitUntilBundleTaskCompleteWithContext(arg0 context.Context, arg1 *ec2.DescribeBundleTasksInput, arg2 ...request.WaiterOption) error {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -17121,14 +15072,12 @@ func (m *MockEC2API) WaitUntilBundleTaskCompleteWithContext(arg0 context.Context
 
 // WaitUntilBundleTaskCompleteWithContext indicates an expected call of WaitUntilBundleTaskCompleteWithContext
 func (mr *MockEC2APIMockRecorder) WaitUntilBundleTaskCompleteWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitUntilBundleTaskCompleteWithContext", reflect.TypeOf((*MockEC2API)(nil).WaitUntilBundleTaskCompleteWithContext), varargs...)
 }
 
 // WaitUntilConversionTaskCancelled mocks base method
 func (m *MockEC2API) WaitUntilConversionTaskCancelled(arg0 *ec2.DescribeConversionTasksInput) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WaitUntilConversionTaskCancelled", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -17136,13 +15085,11 @@ func (m *MockEC2API) WaitUntilConversionTaskCancelled(arg0 *ec2.DescribeConversi
 
 // WaitUntilConversionTaskCancelled indicates an expected call of WaitUntilConversionTaskCancelled
 func (mr *MockEC2APIMockRecorder) WaitUntilConversionTaskCancelled(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitUntilConversionTaskCancelled", reflect.TypeOf((*MockEC2API)(nil).WaitUntilConversionTaskCancelled), arg0)
 }
 
 // WaitUntilConversionTaskCancelledWithContext mocks base method
 func (m *MockEC2API) WaitUntilConversionTaskCancelledWithContext(arg0 context.Context, arg1 *ec2.DescribeConversionTasksInput, arg2 ...request.WaiterOption) error {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -17154,14 +15101,12 @@ func (m *MockEC2API) WaitUntilConversionTaskCancelledWithContext(arg0 context.Co
 
 // WaitUntilConversionTaskCancelledWithContext indicates an expected call of WaitUntilConversionTaskCancelledWithContext
 func (mr *MockEC2APIMockRecorder) WaitUntilConversionTaskCancelledWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitUntilConversionTaskCancelledWithContext", reflect.TypeOf((*MockEC2API)(nil).WaitUntilConversionTaskCancelledWithContext), varargs...)
 }
 
 // WaitUntilConversionTaskCompleted mocks base method
 func (m *MockEC2API) WaitUntilConversionTaskCompleted(arg0 *ec2.DescribeConversionTasksInput) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WaitUntilConversionTaskCompleted", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -17169,13 +15114,11 @@ func (m *MockEC2API) WaitUntilConversionTaskCompleted(arg0 *ec2.DescribeConversi
 
 // WaitUntilConversionTaskCompleted indicates an expected call of WaitUntilConversionTaskCompleted
 func (mr *MockEC2APIMockRecorder) WaitUntilConversionTaskCompleted(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitUntilConversionTaskCompleted", reflect.TypeOf((*MockEC2API)(nil).WaitUntilConversionTaskCompleted), arg0)
 }
 
 // WaitUntilConversionTaskCompletedWithContext mocks base method
 func (m *MockEC2API) WaitUntilConversionTaskCompletedWithContext(arg0 context.Context, arg1 *ec2.DescribeConversionTasksInput, arg2 ...request.WaiterOption) error {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -17187,14 +15130,12 @@ func (m *MockEC2API) WaitUntilConversionTaskCompletedWithContext(arg0 context.Co
 
 // WaitUntilConversionTaskCompletedWithContext indicates an expected call of WaitUntilConversionTaskCompletedWithContext
 func (mr *MockEC2APIMockRecorder) WaitUntilConversionTaskCompletedWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitUntilConversionTaskCompletedWithContext", reflect.TypeOf((*MockEC2API)(nil).WaitUntilConversionTaskCompletedWithContext), varargs...)
 }
 
 // WaitUntilConversionTaskDeleted mocks base method
 func (m *MockEC2API) WaitUntilConversionTaskDeleted(arg0 *ec2.DescribeConversionTasksInput) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WaitUntilConversionTaskDeleted", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -17202,13 +15143,11 @@ func (m *MockEC2API) WaitUntilConversionTaskDeleted(arg0 *ec2.DescribeConversion
 
 // WaitUntilConversionTaskDeleted indicates an expected call of WaitUntilConversionTaskDeleted
 func (mr *MockEC2APIMockRecorder) WaitUntilConversionTaskDeleted(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitUntilConversionTaskDeleted", reflect.TypeOf((*MockEC2API)(nil).WaitUntilConversionTaskDeleted), arg0)
 }
 
 // WaitUntilConversionTaskDeletedWithContext mocks base method
 func (m *MockEC2API) WaitUntilConversionTaskDeletedWithContext(arg0 context.Context, arg1 *ec2.DescribeConversionTasksInput, arg2 ...request.WaiterOption) error {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -17220,14 +15159,12 @@ func (m *MockEC2API) WaitUntilConversionTaskDeletedWithContext(arg0 context.Cont
 
 // WaitUntilConversionTaskDeletedWithContext indicates an expected call of WaitUntilConversionTaskDeletedWithContext
 func (mr *MockEC2APIMockRecorder) WaitUntilConversionTaskDeletedWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitUntilConversionTaskDeletedWithContext", reflect.TypeOf((*MockEC2API)(nil).WaitUntilConversionTaskDeletedWithContext), varargs...)
 }
 
 // WaitUntilCustomerGatewayAvailable mocks base method
 func (m *MockEC2API) WaitUntilCustomerGatewayAvailable(arg0 *ec2.DescribeCustomerGatewaysInput) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WaitUntilCustomerGatewayAvailable", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -17235,13 +15172,11 @@ func (m *MockEC2API) WaitUntilCustomerGatewayAvailable(arg0 *ec2.DescribeCustome
 
 // WaitUntilCustomerGatewayAvailable indicates an expected call of WaitUntilCustomerGatewayAvailable
 func (mr *MockEC2APIMockRecorder) WaitUntilCustomerGatewayAvailable(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitUntilCustomerGatewayAvailable", reflect.TypeOf((*MockEC2API)(nil).WaitUntilCustomerGatewayAvailable), arg0)
 }
 
 // WaitUntilCustomerGatewayAvailableWithContext mocks base method
 func (m *MockEC2API) WaitUntilCustomerGatewayAvailableWithContext(arg0 context.Context, arg1 *ec2.DescribeCustomerGatewaysInput, arg2 ...request.WaiterOption) error {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -17253,14 +15188,12 @@ func (m *MockEC2API) WaitUntilCustomerGatewayAvailableWithContext(arg0 context.C
 
 // WaitUntilCustomerGatewayAvailableWithContext indicates an expected call of WaitUntilCustomerGatewayAvailableWithContext
 func (mr *MockEC2APIMockRecorder) WaitUntilCustomerGatewayAvailableWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitUntilCustomerGatewayAvailableWithContext", reflect.TypeOf((*MockEC2API)(nil).WaitUntilCustomerGatewayAvailableWithContext), varargs...)
 }
 
 // WaitUntilExportTaskCancelled mocks base method
 func (m *MockEC2API) WaitUntilExportTaskCancelled(arg0 *ec2.DescribeExportTasksInput) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WaitUntilExportTaskCancelled", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -17268,13 +15201,11 @@ func (m *MockEC2API) WaitUntilExportTaskCancelled(arg0 *ec2.DescribeExportTasksI
 
 // WaitUntilExportTaskCancelled indicates an expected call of WaitUntilExportTaskCancelled
 func (mr *MockEC2APIMockRecorder) WaitUntilExportTaskCancelled(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitUntilExportTaskCancelled", reflect.TypeOf((*MockEC2API)(nil).WaitUntilExportTaskCancelled), arg0)
 }
 
 // WaitUntilExportTaskCancelledWithContext mocks base method
 func (m *MockEC2API) WaitUntilExportTaskCancelledWithContext(arg0 context.Context, arg1 *ec2.DescribeExportTasksInput, arg2 ...request.WaiterOption) error {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -17286,14 +15217,12 @@ func (m *MockEC2API) WaitUntilExportTaskCancelledWithContext(arg0 context.Contex
 
 // WaitUntilExportTaskCancelledWithContext indicates an expected call of WaitUntilExportTaskCancelledWithContext
 func (mr *MockEC2APIMockRecorder) WaitUntilExportTaskCancelledWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitUntilExportTaskCancelledWithContext", reflect.TypeOf((*MockEC2API)(nil).WaitUntilExportTaskCancelledWithContext), varargs...)
 }
 
 // WaitUntilExportTaskCompleted mocks base method
 func (m *MockEC2API) WaitUntilExportTaskCompleted(arg0 *ec2.DescribeExportTasksInput) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WaitUntilExportTaskCompleted", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -17301,13 +15230,11 @@ func (m *MockEC2API) WaitUntilExportTaskCompleted(arg0 *ec2.DescribeExportTasksI
 
 // WaitUntilExportTaskCompleted indicates an expected call of WaitUntilExportTaskCompleted
 func (mr *MockEC2APIMockRecorder) WaitUntilExportTaskCompleted(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitUntilExportTaskCompleted", reflect.TypeOf((*MockEC2API)(nil).WaitUntilExportTaskCompleted), arg0)
 }
 
 // WaitUntilExportTaskCompletedWithContext mocks base method
 func (m *MockEC2API) WaitUntilExportTaskCompletedWithContext(arg0 context.Context, arg1 *ec2.DescribeExportTasksInput, arg2 ...request.WaiterOption) error {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -17319,14 +15246,12 @@ func (m *MockEC2API) WaitUntilExportTaskCompletedWithContext(arg0 context.Contex
 
 // WaitUntilExportTaskCompletedWithContext indicates an expected call of WaitUntilExportTaskCompletedWithContext
 func (mr *MockEC2APIMockRecorder) WaitUntilExportTaskCompletedWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitUntilExportTaskCompletedWithContext", reflect.TypeOf((*MockEC2API)(nil).WaitUntilExportTaskCompletedWithContext), varargs...)
 }
 
 // WaitUntilImageAvailable mocks base method
 func (m *MockEC2API) WaitUntilImageAvailable(arg0 *ec2.DescribeImagesInput) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WaitUntilImageAvailable", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -17334,13 +15259,11 @@ func (m *MockEC2API) WaitUntilImageAvailable(arg0 *ec2.DescribeImagesInput) erro
 
 // WaitUntilImageAvailable indicates an expected call of WaitUntilImageAvailable
 func (mr *MockEC2APIMockRecorder) WaitUntilImageAvailable(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitUntilImageAvailable", reflect.TypeOf((*MockEC2API)(nil).WaitUntilImageAvailable), arg0)
 }
 
 // WaitUntilImageAvailableWithContext mocks base method
 func (m *MockEC2API) WaitUntilImageAvailableWithContext(arg0 context.Context, arg1 *ec2.DescribeImagesInput, arg2 ...request.WaiterOption) error {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -17352,14 +15275,12 @@ func (m *MockEC2API) WaitUntilImageAvailableWithContext(arg0 context.Context, ar
 
 // WaitUntilImageAvailableWithContext indicates an expected call of WaitUntilImageAvailableWithContext
 func (mr *MockEC2APIMockRecorder) WaitUntilImageAvailableWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitUntilImageAvailableWithContext", reflect.TypeOf((*MockEC2API)(nil).WaitUntilImageAvailableWithContext), varargs...)
 }
 
 // WaitUntilImageExists mocks base method
 func (m *MockEC2API) WaitUntilImageExists(arg0 *ec2.DescribeImagesInput) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WaitUntilImageExists", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -17367,13 +15288,11 @@ func (m *MockEC2API) WaitUntilImageExists(arg0 *ec2.DescribeImagesInput) error {
 
 // WaitUntilImageExists indicates an expected call of WaitUntilImageExists
 func (mr *MockEC2APIMockRecorder) WaitUntilImageExists(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitUntilImageExists", reflect.TypeOf((*MockEC2API)(nil).WaitUntilImageExists), arg0)
 }
 
 // WaitUntilImageExistsWithContext mocks base method
 func (m *MockEC2API) WaitUntilImageExistsWithContext(arg0 context.Context, arg1 *ec2.DescribeImagesInput, arg2 ...request.WaiterOption) error {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -17385,14 +15304,12 @@ func (m *MockEC2API) WaitUntilImageExistsWithContext(arg0 context.Context, arg1 
 
 // WaitUntilImageExistsWithContext indicates an expected call of WaitUntilImageExistsWithContext
 func (mr *MockEC2APIMockRecorder) WaitUntilImageExistsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitUntilImageExistsWithContext", reflect.TypeOf((*MockEC2API)(nil).WaitUntilImageExistsWithContext), varargs...)
 }
 
 // WaitUntilInstanceExists mocks base method
 func (m *MockEC2API) WaitUntilInstanceExists(arg0 *ec2.DescribeInstancesInput) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WaitUntilInstanceExists", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -17400,13 +15317,11 @@ func (m *MockEC2API) WaitUntilInstanceExists(arg0 *ec2.DescribeInstancesInput) e
 
 // WaitUntilInstanceExists indicates an expected call of WaitUntilInstanceExists
 func (mr *MockEC2APIMockRecorder) WaitUntilInstanceExists(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitUntilInstanceExists", reflect.TypeOf((*MockEC2API)(nil).WaitUntilInstanceExists), arg0)
 }
 
 // WaitUntilInstanceExistsWithContext mocks base method
 func (m *MockEC2API) WaitUntilInstanceExistsWithContext(arg0 context.Context, arg1 *ec2.DescribeInstancesInput, arg2 ...request.WaiterOption) error {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -17418,14 +15333,12 @@ func (m *MockEC2API) WaitUntilInstanceExistsWithContext(arg0 context.Context, ar
 
 // WaitUntilInstanceExistsWithContext indicates an expected call of WaitUntilInstanceExistsWithContext
 func (mr *MockEC2APIMockRecorder) WaitUntilInstanceExistsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitUntilInstanceExistsWithContext", reflect.TypeOf((*MockEC2API)(nil).WaitUntilInstanceExistsWithContext), varargs...)
 }
 
 // WaitUntilInstanceRunning mocks base method
 func (m *MockEC2API) WaitUntilInstanceRunning(arg0 *ec2.DescribeInstancesInput) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WaitUntilInstanceRunning", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -17433,13 +15346,11 @@ func (m *MockEC2API) WaitUntilInstanceRunning(arg0 *ec2.DescribeInstancesInput) 
 
 // WaitUntilInstanceRunning indicates an expected call of WaitUntilInstanceRunning
 func (mr *MockEC2APIMockRecorder) WaitUntilInstanceRunning(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitUntilInstanceRunning", reflect.TypeOf((*MockEC2API)(nil).WaitUntilInstanceRunning), arg0)
 }
 
 // WaitUntilInstanceRunningWithContext mocks base method
 func (m *MockEC2API) WaitUntilInstanceRunningWithContext(arg0 context.Context, arg1 *ec2.DescribeInstancesInput, arg2 ...request.WaiterOption) error {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -17451,14 +15362,12 @@ func (m *MockEC2API) WaitUntilInstanceRunningWithContext(arg0 context.Context, a
 
 // WaitUntilInstanceRunningWithContext indicates an expected call of WaitUntilInstanceRunningWithContext
 func (mr *MockEC2APIMockRecorder) WaitUntilInstanceRunningWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitUntilInstanceRunningWithContext", reflect.TypeOf((*MockEC2API)(nil).WaitUntilInstanceRunningWithContext), varargs...)
 }
 
 // WaitUntilInstanceStatusOk mocks base method
 func (m *MockEC2API) WaitUntilInstanceStatusOk(arg0 *ec2.DescribeInstanceStatusInput) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WaitUntilInstanceStatusOk", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -17466,13 +15375,11 @@ func (m *MockEC2API) WaitUntilInstanceStatusOk(arg0 *ec2.DescribeInstanceStatusI
 
 // WaitUntilInstanceStatusOk indicates an expected call of WaitUntilInstanceStatusOk
 func (mr *MockEC2APIMockRecorder) WaitUntilInstanceStatusOk(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitUntilInstanceStatusOk", reflect.TypeOf((*MockEC2API)(nil).WaitUntilInstanceStatusOk), arg0)
 }
 
 // WaitUntilInstanceStatusOkWithContext mocks base method
 func (m *MockEC2API) WaitUntilInstanceStatusOkWithContext(arg0 context.Context, arg1 *ec2.DescribeInstanceStatusInput, arg2 ...request.WaiterOption) error {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -17484,14 +15391,12 @@ func (m *MockEC2API) WaitUntilInstanceStatusOkWithContext(arg0 context.Context, 
 
 // WaitUntilInstanceStatusOkWithContext indicates an expected call of WaitUntilInstanceStatusOkWithContext
 func (mr *MockEC2APIMockRecorder) WaitUntilInstanceStatusOkWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitUntilInstanceStatusOkWithContext", reflect.TypeOf((*MockEC2API)(nil).WaitUntilInstanceStatusOkWithContext), varargs...)
 }
 
 // WaitUntilInstanceStopped mocks base method
 func (m *MockEC2API) WaitUntilInstanceStopped(arg0 *ec2.DescribeInstancesInput) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WaitUntilInstanceStopped", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -17499,13 +15404,11 @@ func (m *MockEC2API) WaitUntilInstanceStopped(arg0 *ec2.DescribeInstancesInput) 
 
 // WaitUntilInstanceStopped indicates an expected call of WaitUntilInstanceStopped
 func (mr *MockEC2APIMockRecorder) WaitUntilInstanceStopped(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitUntilInstanceStopped", reflect.TypeOf((*MockEC2API)(nil).WaitUntilInstanceStopped), arg0)
 }
 
 // WaitUntilInstanceStoppedWithContext mocks base method
 func (m *MockEC2API) WaitUntilInstanceStoppedWithContext(arg0 context.Context, arg1 *ec2.DescribeInstancesInput, arg2 ...request.WaiterOption) error {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -17517,14 +15420,12 @@ func (m *MockEC2API) WaitUntilInstanceStoppedWithContext(arg0 context.Context, a
 
 // WaitUntilInstanceStoppedWithContext indicates an expected call of WaitUntilInstanceStoppedWithContext
 func (mr *MockEC2APIMockRecorder) WaitUntilInstanceStoppedWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitUntilInstanceStoppedWithContext", reflect.TypeOf((*MockEC2API)(nil).WaitUntilInstanceStoppedWithContext), varargs...)
 }
 
 // WaitUntilInstanceTerminated mocks base method
 func (m *MockEC2API) WaitUntilInstanceTerminated(arg0 *ec2.DescribeInstancesInput) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WaitUntilInstanceTerminated", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -17532,13 +15433,11 @@ func (m *MockEC2API) WaitUntilInstanceTerminated(arg0 *ec2.DescribeInstancesInpu
 
 // WaitUntilInstanceTerminated indicates an expected call of WaitUntilInstanceTerminated
 func (mr *MockEC2APIMockRecorder) WaitUntilInstanceTerminated(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitUntilInstanceTerminated", reflect.TypeOf((*MockEC2API)(nil).WaitUntilInstanceTerminated), arg0)
 }
 
 // WaitUntilInstanceTerminatedWithContext mocks base method
 func (m *MockEC2API) WaitUntilInstanceTerminatedWithContext(arg0 context.Context, arg1 *ec2.DescribeInstancesInput, arg2 ...request.WaiterOption) error {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -17550,14 +15449,12 @@ func (m *MockEC2API) WaitUntilInstanceTerminatedWithContext(arg0 context.Context
 
 // WaitUntilInstanceTerminatedWithContext indicates an expected call of WaitUntilInstanceTerminatedWithContext
 func (mr *MockEC2APIMockRecorder) WaitUntilInstanceTerminatedWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitUntilInstanceTerminatedWithContext", reflect.TypeOf((*MockEC2API)(nil).WaitUntilInstanceTerminatedWithContext), varargs...)
 }
 
 // WaitUntilKeyPairExists mocks base method
 func (m *MockEC2API) WaitUntilKeyPairExists(arg0 *ec2.DescribeKeyPairsInput) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WaitUntilKeyPairExists", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -17565,13 +15462,11 @@ func (m *MockEC2API) WaitUntilKeyPairExists(arg0 *ec2.DescribeKeyPairsInput) err
 
 // WaitUntilKeyPairExists indicates an expected call of WaitUntilKeyPairExists
 func (mr *MockEC2APIMockRecorder) WaitUntilKeyPairExists(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitUntilKeyPairExists", reflect.TypeOf((*MockEC2API)(nil).WaitUntilKeyPairExists), arg0)
 }
 
 // WaitUntilKeyPairExistsWithContext mocks base method
 func (m *MockEC2API) WaitUntilKeyPairExistsWithContext(arg0 context.Context, arg1 *ec2.DescribeKeyPairsInput, arg2 ...request.WaiterOption) error {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -17583,14 +15478,12 @@ func (m *MockEC2API) WaitUntilKeyPairExistsWithContext(arg0 context.Context, arg
 
 // WaitUntilKeyPairExistsWithContext indicates an expected call of WaitUntilKeyPairExistsWithContext
 func (mr *MockEC2APIMockRecorder) WaitUntilKeyPairExistsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitUntilKeyPairExistsWithContext", reflect.TypeOf((*MockEC2API)(nil).WaitUntilKeyPairExistsWithContext), varargs...)
 }
 
 // WaitUntilNatGatewayAvailable mocks base method
 func (m *MockEC2API) WaitUntilNatGatewayAvailable(arg0 *ec2.DescribeNatGatewaysInput) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WaitUntilNatGatewayAvailable", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -17598,13 +15491,11 @@ func (m *MockEC2API) WaitUntilNatGatewayAvailable(arg0 *ec2.DescribeNatGatewaysI
 
 // WaitUntilNatGatewayAvailable indicates an expected call of WaitUntilNatGatewayAvailable
 func (mr *MockEC2APIMockRecorder) WaitUntilNatGatewayAvailable(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitUntilNatGatewayAvailable", reflect.TypeOf((*MockEC2API)(nil).WaitUntilNatGatewayAvailable), arg0)
 }
 
 // WaitUntilNatGatewayAvailableWithContext mocks base method
 func (m *MockEC2API) WaitUntilNatGatewayAvailableWithContext(arg0 context.Context, arg1 *ec2.DescribeNatGatewaysInput, arg2 ...request.WaiterOption) error {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -17616,14 +15507,12 @@ func (m *MockEC2API) WaitUntilNatGatewayAvailableWithContext(arg0 context.Contex
 
 // WaitUntilNatGatewayAvailableWithContext indicates an expected call of WaitUntilNatGatewayAvailableWithContext
 func (mr *MockEC2APIMockRecorder) WaitUntilNatGatewayAvailableWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitUntilNatGatewayAvailableWithContext", reflect.TypeOf((*MockEC2API)(nil).WaitUntilNatGatewayAvailableWithContext), varargs...)
 }
 
 // WaitUntilNetworkInterfaceAvailable mocks base method
 func (m *MockEC2API) WaitUntilNetworkInterfaceAvailable(arg0 *ec2.DescribeNetworkInterfacesInput) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WaitUntilNetworkInterfaceAvailable", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -17631,13 +15520,11 @@ func (m *MockEC2API) WaitUntilNetworkInterfaceAvailable(arg0 *ec2.DescribeNetwor
 
 // WaitUntilNetworkInterfaceAvailable indicates an expected call of WaitUntilNetworkInterfaceAvailable
 func (mr *MockEC2APIMockRecorder) WaitUntilNetworkInterfaceAvailable(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitUntilNetworkInterfaceAvailable", reflect.TypeOf((*MockEC2API)(nil).WaitUntilNetworkInterfaceAvailable), arg0)
 }
 
 // WaitUntilNetworkInterfaceAvailableWithContext mocks base method
 func (m *MockEC2API) WaitUntilNetworkInterfaceAvailableWithContext(arg0 context.Context, arg1 *ec2.DescribeNetworkInterfacesInput, arg2 ...request.WaiterOption) error {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -17649,14 +15536,12 @@ func (m *MockEC2API) WaitUntilNetworkInterfaceAvailableWithContext(arg0 context.
 
 // WaitUntilNetworkInterfaceAvailableWithContext indicates an expected call of WaitUntilNetworkInterfaceAvailableWithContext
 func (mr *MockEC2APIMockRecorder) WaitUntilNetworkInterfaceAvailableWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitUntilNetworkInterfaceAvailableWithContext", reflect.TypeOf((*MockEC2API)(nil).WaitUntilNetworkInterfaceAvailableWithContext), varargs...)
 }
 
 // WaitUntilPasswordDataAvailable mocks base method
 func (m *MockEC2API) WaitUntilPasswordDataAvailable(arg0 *ec2.GetPasswordDataInput) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WaitUntilPasswordDataAvailable", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -17664,13 +15549,11 @@ func (m *MockEC2API) WaitUntilPasswordDataAvailable(arg0 *ec2.GetPasswordDataInp
 
 // WaitUntilPasswordDataAvailable indicates an expected call of WaitUntilPasswordDataAvailable
 func (mr *MockEC2APIMockRecorder) WaitUntilPasswordDataAvailable(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitUntilPasswordDataAvailable", reflect.TypeOf((*MockEC2API)(nil).WaitUntilPasswordDataAvailable), arg0)
 }
 
 // WaitUntilPasswordDataAvailableWithContext mocks base method
 func (m *MockEC2API) WaitUntilPasswordDataAvailableWithContext(arg0 context.Context, arg1 *ec2.GetPasswordDataInput, arg2 ...request.WaiterOption) error {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -17682,14 +15565,12 @@ func (m *MockEC2API) WaitUntilPasswordDataAvailableWithContext(arg0 context.Cont
 
 // WaitUntilPasswordDataAvailableWithContext indicates an expected call of WaitUntilPasswordDataAvailableWithContext
 func (mr *MockEC2APIMockRecorder) WaitUntilPasswordDataAvailableWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitUntilPasswordDataAvailableWithContext", reflect.TypeOf((*MockEC2API)(nil).WaitUntilPasswordDataAvailableWithContext), varargs...)
 }
 
 // WaitUntilSnapshotCompleted mocks base method
 func (m *MockEC2API) WaitUntilSnapshotCompleted(arg0 *ec2.DescribeSnapshotsInput) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WaitUntilSnapshotCompleted", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -17697,13 +15578,11 @@ func (m *MockEC2API) WaitUntilSnapshotCompleted(arg0 *ec2.DescribeSnapshotsInput
 
 // WaitUntilSnapshotCompleted indicates an expected call of WaitUntilSnapshotCompleted
 func (mr *MockEC2APIMockRecorder) WaitUntilSnapshotCompleted(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitUntilSnapshotCompleted", reflect.TypeOf((*MockEC2API)(nil).WaitUntilSnapshotCompleted), arg0)
 }
 
 // WaitUntilSnapshotCompletedWithContext mocks base method
 func (m *MockEC2API) WaitUntilSnapshotCompletedWithContext(arg0 context.Context, arg1 *ec2.DescribeSnapshotsInput, arg2 ...request.WaiterOption) error {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -17715,14 +15594,12 @@ func (m *MockEC2API) WaitUntilSnapshotCompletedWithContext(arg0 context.Context,
 
 // WaitUntilSnapshotCompletedWithContext indicates an expected call of WaitUntilSnapshotCompletedWithContext
 func (mr *MockEC2APIMockRecorder) WaitUntilSnapshotCompletedWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitUntilSnapshotCompletedWithContext", reflect.TypeOf((*MockEC2API)(nil).WaitUntilSnapshotCompletedWithContext), varargs...)
 }
 
 // WaitUntilSpotInstanceRequestFulfilled mocks base method
 func (m *MockEC2API) WaitUntilSpotInstanceRequestFulfilled(arg0 *ec2.DescribeSpotInstanceRequestsInput) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WaitUntilSpotInstanceRequestFulfilled", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -17730,13 +15607,11 @@ func (m *MockEC2API) WaitUntilSpotInstanceRequestFulfilled(arg0 *ec2.DescribeSpo
 
 // WaitUntilSpotInstanceRequestFulfilled indicates an expected call of WaitUntilSpotInstanceRequestFulfilled
 func (mr *MockEC2APIMockRecorder) WaitUntilSpotInstanceRequestFulfilled(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitUntilSpotInstanceRequestFulfilled", reflect.TypeOf((*MockEC2API)(nil).WaitUntilSpotInstanceRequestFulfilled), arg0)
 }
 
 // WaitUntilSpotInstanceRequestFulfilledWithContext mocks base method
 func (m *MockEC2API) WaitUntilSpotInstanceRequestFulfilledWithContext(arg0 context.Context, arg1 *ec2.DescribeSpotInstanceRequestsInput, arg2 ...request.WaiterOption) error {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -17748,14 +15623,12 @@ func (m *MockEC2API) WaitUntilSpotInstanceRequestFulfilledWithContext(arg0 conte
 
 // WaitUntilSpotInstanceRequestFulfilledWithContext indicates an expected call of WaitUntilSpotInstanceRequestFulfilledWithContext
 func (mr *MockEC2APIMockRecorder) WaitUntilSpotInstanceRequestFulfilledWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitUntilSpotInstanceRequestFulfilledWithContext", reflect.TypeOf((*MockEC2API)(nil).WaitUntilSpotInstanceRequestFulfilledWithContext), varargs...)
 }
 
 // WaitUntilSubnetAvailable mocks base method
 func (m *MockEC2API) WaitUntilSubnetAvailable(arg0 *ec2.DescribeSubnetsInput) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WaitUntilSubnetAvailable", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -17763,13 +15636,11 @@ func (m *MockEC2API) WaitUntilSubnetAvailable(arg0 *ec2.DescribeSubnetsInput) er
 
 // WaitUntilSubnetAvailable indicates an expected call of WaitUntilSubnetAvailable
 func (mr *MockEC2APIMockRecorder) WaitUntilSubnetAvailable(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitUntilSubnetAvailable", reflect.TypeOf((*MockEC2API)(nil).WaitUntilSubnetAvailable), arg0)
 }
 
 // WaitUntilSubnetAvailableWithContext mocks base method
 func (m *MockEC2API) WaitUntilSubnetAvailableWithContext(arg0 context.Context, arg1 *ec2.DescribeSubnetsInput, arg2 ...request.WaiterOption) error {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -17781,14 +15652,12 @@ func (m *MockEC2API) WaitUntilSubnetAvailableWithContext(arg0 context.Context, a
 
 // WaitUntilSubnetAvailableWithContext indicates an expected call of WaitUntilSubnetAvailableWithContext
 func (mr *MockEC2APIMockRecorder) WaitUntilSubnetAvailableWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitUntilSubnetAvailableWithContext", reflect.TypeOf((*MockEC2API)(nil).WaitUntilSubnetAvailableWithContext), varargs...)
 }
 
 // WaitUntilSystemStatusOk mocks base method
 func (m *MockEC2API) WaitUntilSystemStatusOk(arg0 *ec2.DescribeInstanceStatusInput) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WaitUntilSystemStatusOk", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -17796,13 +15665,11 @@ func (m *MockEC2API) WaitUntilSystemStatusOk(arg0 *ec2.DescribeInstanceStatusInp
 
 // WaitUntilSystemStatusOk indicates an expected call of WaitUntilSystemStatusOk
 func (mr *MockEC2APIMockRecorder) WaitUntilSystemStatusOk(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitUntilSystemStatusOk", reflect.TypeOf((*MockEC2API)(nil).WaitUntilSystemStatusOk), arg0)
 }
 
 // WaitUntilSystemStatusOkWithContext mocks base method
 func (m *MockEC2API) WaitUntilSystemStatusOkWithContext(arg0 context.Context, arg1 *ec2.DescribeInstanceStatusInput, arg2 ...request.WaiterOption) error {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -17814,14 +15681,12 @@ func (m *MockEC2API) WaitUntilSystemStatusOkWithContext(arg0 context.Context, ar
 
 // WaitUntilSystemStatusOkWithContext indicates an expected call of WaitUntilSystemStatusOkWithContext
 func (mr *MockEC2APIMockRecorder) WaitUntilSystemStatusOkWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitUntilSystemStatusOkWithContext", reflect.TypeOf((*MockEC2API)(nil).WaitUntilSystemStatusOkWithContext), varargs...)
 }
 
 // WaitUntilVolumeAvailable mocks base method
 func (m *MockEC2API) WaitUntilVolumeAvailable(arg0 *ec2.DescribeVolumesInput) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WaitUntilVolumeAvailable", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -17829,13 +15694,11 @@ func (m *MockEC2API) WaitUntilVolumeAvailable(arg0 *ec2.DescribeVolumesInput) er
 
 // WaitUntilVolumeAvailable indicates an expected call of WaitUntilVolumeAvailable
 func (mr *MockEC2APIMockRecorder) WaitUntilVolumeAvailable(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitUntilVolumeAvailable", reflect.TypeOf((*MockEC2API)(nil).WaitUntilVolumeAvailable), arg0)
 }
 
 // WaitUntilVolumeAvailableWithContext mocks base method
 func (m *MockEC2API) WaitUntilVolumeAvailableWithContext(arg0 context.Context, arg1 *ec2.DescribeVolumesInput, arg2 ...request.WaiterOption) error {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -17847,14 +15710,12 @@ func (m *MockEC2API) WaitUntilVolumeAvailableWithContext(arg0 context.Context, a
 
 // WaitUntilVolumeAvailableWithContext indicates an expected call of WaitUntilVolumeAvailableWithContext
 func (mr *MockEC2APIMockRecorder) WaitUntilVolumeAvailableWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitUntilVolumeAvailableWithContext", reflect.TypeOf((*MockEC2API)(nil).WaitUntilVolumeAvailableWithContext), varargs...)
 }
 
 // WaitUntilVolumeDeleted mocks base method
 func (m *MockEC2API) WaitUntilVolumeDeleted(arg0 *ec2.DescribeVolumesInput) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WaitUntilVolumeDeleted", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -17862,13 +15723,11 @@ func (m *MockEC2API) WaitUntilVolumeDeleted(arg0 *ec2.DescribeVolumesInput) erro
 
 // WaitUntilVolumeDeleted indicates an expected call of WaitUntilVolumeDeleted
 func (mr *MockEC2APIMockRecorder) WaitUntilVolumeDeleted(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitUntilVolumeDeleted", reflect.TypeOf((*MockEC2API)(nil).WaitUntilVolumeDeleted), arg0)
 }
 
 // WaitUntilVolumeDeletedWithContext mocks base method
 func (m *MockEC2API) WaitUntilVolumeDeletedWithContext(arg0 context.Context, arg1 *ec2.DescribeVolumesInput, arg2 ...request.WaiterOption) error {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -17880,14 +15739,12 @@ func (m *MockEC2API) WaitUntilVolumeDeletedWithContext(arg0 context.Context, arg
 
 // WaitUntilVolumeDeletedWithContext indicates an expected call of WaitUntilVolumeDeletedWithContext
 func (mr *MockEC2APIMockRecorder) WaitUntilVolumeDeletedWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitUntilVolumeDeletedWithContext", reflect.TypeOf((*MockEC2API)(nil).WaitUntilVolumeDeletedWithContext), varargs...)
 }
 
 // WaitUntilVolumeInUse mocks base method
 func (m *MockEC2API) WaitUntilVolumeInUse(arg0 *ec2.DescribeVolumesInput) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WaitUntilVolumeInUse", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -17895,13 +15752,11 @@ func (m *MockEC2API) WaitUntilVolumeInUse(arg0 *ec2.DescribeVolumesInput) error 
 
 // WaitUntilVolumeInUse indicates an expected call of WaitUntilVolumeInUse
 func (mr *MockEC2APIMockRecorder) WaitUntilVolumeInUse(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitUntilVolumeInUse", reflect.TypeOf((*MockEC2API)(nil).WaitUntilVolumeInUse), arg0)
 }
 
 // WaitUntilVolumeInUseWithContext mocks base method
 func (m *MockEC2API) WaitUntilVolumeInUseWithContext(arg0 context.Context, arg1 *ec2.DescribeVolumesInput, arg2 ...request.WaiterOption) error {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -17913,14 +15768,12 @@ func (m *MockEC2API) WaitUntilVolumeInUseWithContext(arg0 context.Context, arg1 
 
 // WaitUntilVolumeInUseWithContext indicates an expected call of WaitUntilVolumeInUseWithContext
 func (mr *MockEC2APIMockRecorder) WaitUntilVolumeInUseWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitUntilVolumeInUseWithContext", reflect.TypeOf((*MockEC2API)(nil).WaitUntilVolumeInUseWithContext), varargs...)
 }
 
 // WaitUntilVpcAvailable mocks base method
 func (m *MockEC2API) WaitUntilVpcAvailable(arg0 *ec2.DescribeVpcsInput) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WaitUntilVpcAvailable", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -17928,13 +15781,11 @@ func (m *MockEC2API) WaitUntilVpcAvailable(arg0 *ec2.DescribeVpcsInput) error {
 
 // WaitUntilVpcAvailable indicates an expected call of WaitUntilVpcAvailable
 func (mr *MockEC2APIMockRecorder) WaitUntilVpcAvailable(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitUntilVpcAvailable", reflect.TypeOf((*MockEC2API)(nil).WaitUntilVpcAvailable), arg0)
 }
 
 // WaitUntilVpcAvailableWithContext mocks base method
 func (m *MockEC2API) WaitUntilVpcAvailableWithContext(arg0 context.Context, arg1 *ec2.DescribeVpcsInput, arg2 ...request.WaiterOption) error {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -17946,14 +15797,12 @@ func (m *MockEC2API) WaitUntilVpcAvailableWithContext(arg0 context.Context, arg1
 
 // WaitUntilVpcAvailableWithContext indicates an expected call of WaitUntilVpcAvailableWithContext
 func (mr *MockEC2APIMockRecorder) WaitUntilVpcAvailableWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitUntilVpcAvailableWithContext", reflect.TypeOf((*MockEC2API)(nil).WaitUntilVpcAvailableWithContext), varargs...)
 }
 
 // WaitUntilVpcExists mocks base method
 func (m *MockEC2API) WaitUntilVpcExists(arg0 *ec2.DescribeVpcsInput) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WaitUntilVpcExists", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -17961,13 +15810,11 @@ func (m *MockEC2API) WaitUntilVpcExists(arg0 *ec2.DescribeVpcsInput) error {
 
 // WaitUntilVpcExists indicates an expected call of WaitUntilVpcExists
 func (mr *MockEC2APIMockRecorder) WaitUntilVpcExists(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitUntilVpcExists", reflect.TypeOf((*MockEC2API)(nil).WaitUntilVpcExists), arg0)
 }
 
 // WaitUntilVpcExistsWithContext mocks base method
 func (m *MockEC2API) WaitUntilVpcExistsWithContext(arg0 context.Context, arg1 *ec2.DescribeVpcsInput, arg2 ...request.WaiterOption) error {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -17979,14 +15826,12 @@ func (m *MockEC2API) WaitUntilVpcExistsWithContext(arg0 context.Context, arg1 *e
 
 // WaitUntilVpcExistsWithContext indicates an expected call of WaitUntilVpcExistsWithContext
 func (mr *MockEC2APIMockRecorder) WaitUntilVpcExistsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitUntilVpcExistsWithContext", reflect.TypeOf((*MockEC2API)(nil).WaitUntilVpcExistsWithContext), varargs...)
 }
 
 // WaitUntilVpcPeeringConnectionDeleted mocks base method
 func (m *MockEC2API) WaitUntilVpcPeeringConnectionDeleted(arg0 *ec2.DescribeVpcPeeringConnectionsInput) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WaitUntilVpcPeeringConnectionDeleted", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -17994,13 +15839,11 @@ func (m *MockEC2API) WaitUntilVpcPeeringConnectionDeleted(arg0 *ec2.DescribeVpcP
 
 // WaitUntilVpcPeeringConnectionDeleted indicates an expected call of WaitUntilVpcPeeringConnectionDeleted
 func (mr *MockEC2APIMockRecorder) WaitUntilVpcPeeringConnectionDeleted(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitUntilVpcPeeringConnectionDeleted", reflect.TypeOf((*MockEC2API)(nil).WaitUntilVpcPeeringConnectionDeleted), arg0)
 }
 
 // WaitUntilVpcPeeringConnectionDeletedWithContext mocks base method
 func (m *MockEC2API) WaitUntilVpcPeeringConnectionDeletedWithContext(arg0 context.Context, arg1 *ec2.DescribeVpcPeeringConnectionsInput, arg2 ...request.WaiterOption) error {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -18012,14 +15855,12 @@ func (m *MockEC2API) WaitUntilVpcPeeringConnectionDeletedWithContext(arg0 contex
 
 // WaitUntilVpcPeeringConnectionDeletedWithContext indicates an expected call of WaitUntilVpcPeeringConnectionDeletedWithContext
 func (mr *MockEC2APIMockRecorder) WaitUntilVpcPeeringConnectionDeletedWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitUntilVpcPeeringConnectionDeletedWithContext", reflect.TypeOf((*MockEC2API)(nil).WaitUntilVpcPeeringConnectionDeletedWithContext), varargs...)
 }
 
 // WaitUntilVpcPeeringConnectionExists mocks base method
 func (m *MockEC2API) WaitUntilVpcPeeringConnectionExists(arg0 *ec2.DescribeVpcPeeringConnectionsInput) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WaitUntilVpcPeeringConnectionExists", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -18027,13 +15868,11 @@ func (m *MockEC2API) WaitUntilVpcPeeringConnectionExists(arg0 *ec2.DescribeVpcPe
 
 // WaitUntilVpcPeeringConnectionExists indicates an expected call of WaitUntilVpcPeeringConnectionExists
 func (mr *MockEC2APIMockRecorder) WaitUntilVpcPeeringConnectionExists(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitUntilVpcPeeringConnectionExists", reflect.TypeOf((*MockEC2API)(nil).WaitUntilVpcPeeringConnectionExists), arg0)
 }
 
 // WaitUntilVpcPeeringConnectionExistsWithContext mocks base method
 func (m *MockEC2API) WaitUntilVpcPeeringConnectionExistsWithContext(arg0 context.Context, arg1 *ec2.DescribeVpcPeeringConnectionsInput, arg2 ...request.WaiterOption) error {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -18045,14 +15884,12 @@ func (m *MockEC2API) WaitUntilVpcPeeringConnectionExistsWithContext(arg0 context
 
 // WaitUntilVpcPeeringConnectionExistsWithContext indicates an expected call of WaitUntilVpcPeeringConnectionExistsWithContext
 func (mr *MockEC2APIMockRecorder) WaitUntilVpcPeeringConnectionExistsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitUntilVpcPeeringConnectionExistsWithContext", reflect.TypeOf((*MockEC2API)(nil).WaitUntilVpcPeeringConnectionExistsWithContext), varargs...)
 }
 
 // WaitUntilVpnConnectionAvailable mocks base method
 func (m *MockEC2API) WaitUntilVpnConnectionAvailable(arg0 *ec2.DescribeVpnConnectionsInput) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WaitUntilVpnConnectionAvailable", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -18060,13 +15897,11 @@ func (m *MockEC2API) WaitUntilVpnConnectionAvailable(arg0 *ec2.DescribeVpnConnec
 
 // WaitUntilVpnConnectionAvailable indicates an expected call of WaitUntilVpnConnectionAvailable
 func (mr *MockEC2APIMockRecorder) WaitUntilVpnConnectionAvailable(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitUntilVpnConnectionAvailable", reflect.TypeOf((*MockEC2API)(nil).WaitUntilVpnConnectionAvailable), arg0)
 }
 
 // WaitUntilVpnConnectionAvailableWithContext mocks base method
 func (m *MockEC2API) WaitUntilVpnConnectionAvailableWithContext(arg0 context.Context, arg1 *ec2.DescribeVpnConnectionsInput, arg2 ...request.WaiterOption) error {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -18078,14 +15913,12 @@ func (m *MockEC2API) WaitUntilVpnConnectionAvailableWithContext(arg0 context.Con
 
 // WaitUntilVpnConnectionAvailableWithContext indicates an expected call of WaitUntilVpnConnectionAvailableWithContext
 func (mr *MockEC2APIMockRecorder) WaitUntilVpnConnectionAvailableWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitUntilVpnConnectionAvailableWithContext", reflect.TypeOf((*MockEC2API)(nil).WaitUntilVpnConnectionAvailableWithContext), varargs...)
 }
 
 // WaitUntilVpnConnectionDeleted mocks base method
 func (m *MockEC2API) WaitUntilVpnConnectionDeleted(arg0 *ec2.DescribeVpnConnectionsInput) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WaitUntilVpnConnectionDeleted", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -18093,13 +15926,11 @@ func (m *MockEC2API) WaitUntilVpnConnectionDeleted(arg0 *ec2.DescribeVpnConnecti
 
 // WaitUntilVpnConnectionDeleted indicates an expected call of WaitUntilVpnConnectionDeleted
 func (mr *MockEC2APIMockRecorder) WaitUntilVpnConnectionDeleted(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitUntilVpnConnectionDeleted", reflect.TypeOf((*MockEC2API)(nil).WaitUntilVpnConnectionDeleted), arg0)
 }
 
 // WaitUntilVpnConnectionDeletedWithContext mocks base method
 func (m *MockEC2API) WaitUntilVpnConnectionDeletedWithContext(arg0 context.Context, arg1 *ec2.DescribeVpnConnectionsInput, arg2 ...request.WaiterOption) error {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -18111,14 +15942,12 @@ func (m *MockEC2API) WaitUntilVpnConnectionDeletedWithContext(arg0 context.Conte
 
 // WaitUntilVpnConnectionDeletedWithContext indicates an expected call of WaitUntilVpnConnectionDeletedWithContext
 func (mr *MockEC2APIMockRecorder) WaitUntilVpnConnectionDeletedWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitUntilVpnConnectionDeletedWithContext", reflect.TypeOf((*MockEC2API)(nil).WaitUntilVpnConnectionDeletedWithContext), varargs...)
 }
 
 // WithdrawByoipCidr mocks base method
 func (m *MockEC2API) WithdrawByoipCidr(arg0 *ec2.WithdrawByoipCidrInput) (*ec2.WithdrawByoipCidrOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WithdrawByoipCidr", arg0)
 	ret0, _ := ret[0].(*ec2.WithdrawByoipCidrOutput)
 	ret1, _ := ret[1].(error)
@@ -18127,13 +15956,11 @@ func (m *MockEC2API) WithdrawByoipCidr(arg0 *ec2.WithdrawByoipCidrInput) (*ec2.W
 
 // WithdrawByoipCidr indicates an expected call of WithdrawByoipCidr
 func (mr *MockEC2APIMockRecorder) WithdrawByoipCidr(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WithdrawByoipCidr", reflect.TypeOf((*MockEC2API)(nil).WithdrawByoipCidr), arg0)
 }
 
 // WithdrawByoipCidrRequest mocks base method
 func (m *MockEC2API) WithdrawByoipCidrRequest(arg0 *ec2.WithdrawByoipCidrInput) (*request.Request, *ec2.WithdrawByoipCidrOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WithdrawByoipCidrRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ec2.WithdrawByoipCidrOutput)
@@ -18142,13 +15969,11 @@ func (m *MockEC2API) WithdrawByoipCidrRequest(arg0 *ec2.WithdrawByoipCidrInput) 
 
 // WithdrawByoipCidrRequest indicates an expected call of WithdrawByoipCidrRequest
 func (mr *MockEC2APIMockRecorder) WithdrawByoipCidrRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WithdrawByoipCidrRequest", reflect.TypeOf((*MockEC2API)(nil).WithdrawByoipCidrRequest), arg0)
 }
 
 // WithdrawByoipCidrWithContext mocks base method
 func (m *MockEC2API) WithdrawByoipCidrWithContext(arg0 context.Context, arg1 *ec2.WithdrawByoipCidrInput, arg2 ...request.Option) (*ec2.WithdrawByoipCidrOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -18161,7 +15986,6 @@ func (m *MockEC2API) WithdrawByoipCidrWithContext(arg0 context.Context, arg1 *ec
 
 // WithdrawByoipCidrWithContext indicates an expected call of WithdrawByoipCidrWithContext
 func (mr *MockEC2APIMockRecorder) WithdrawByoipCidrWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WithdrawByoipCidrWithContext", reflect.TypeOf((*MockEC2API)(nil).WithdrawByoipCidrWithContext), varargs...)
 }

--- a/ecs-cli/modules/clients/aws/ecr/mock/client.go
+++ b/ecs-cli/modules/clients/aws/ecr/mock/client.go
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2015-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the
@@ -49,7 +49,6 @@ func (m *MockClient) EXPECT() *MockClientMockRecorder {
 
 // CreateRepository mocks base method
 func (m *MockClient) CreateRepository(arg0 string) (string, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateRepository", arg0)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
@@ -58,13 +57,11 @@ func (m *MockClient) CreateRepository(arg0 string) (string, error) {
 
 // CreateRepository indicates an expected call of CreateRepository
 func (mr *MockClientMockRecorder) CreateRepository(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateRepository", reflect.TypeOf((*MockClient)(nil).CreateRepository), arg0)
 }
 
 // GetAuthorizationToken mocks base method
 func (m *MockClient) GetAuthorizationToken(arg0 string) (*ecr.Auth, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetAuthorizationToken", arg0)
 	ret0, _ := ret[0].(*ecr.Auth)
 	ret1, _ := ret[1].(error)
@@ -73,13 +70,11 @@ func (m *MockClient) GetAuthorizationToken(arg0 string) (*ecr.Auth, error) {
 
 // GetAuthorizationToken indicates an expected call of GetAuthorizationToken
 func (mr *MockClientMockRecorder) GetAuthorizationToken(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAuthorizationToken", reflect.TypeOf((*MockClient)(nil).GetAuthorizationToken), arg0)
 }
 
 // GetAuthorizationTokenByID mocks base method
 func (m *MockClient) GetAuthorizationTokenByID(arg0 string) (*ecr.Auth, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetAuthorizationTokenByID", arg0)
 	ret0, _ := ret[0].(*ecr.Auth)
 	ret1, _ := ret[1].(error)
@@ -88,13 +83,11 @@ func (m *MockClient) GetAuthorizationTokenByID(arg0 string) (*ecr.Auth, error) {
 
 // GetAuthorizationTokenByID indicates an expected call of GetAuthorizationTokenByID
 func (mr *MockClientMockRecorder) GetAuthorizationTokenByID(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAuthorizationTokenByID", reflect.TypeOf((*MockClient)(nil).GetAuthorizationTokenByID), arg0)
 }
 
 // GetImages mocks base method
 func (m *MockClient) GetImages(arg0 []*string, arg1, arg2 string, arg3 ecr.ProcessImageDetails) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetImages", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -102,13 +95,11 @@ func (m *MockClient) GetImages(arg0 []*string, arg1, arg2 string, arg3 ecr.Proce
 
 // GetImages indicates an expected call of GetImages
 func (mr *MockClientMockRecorder) GetImages(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetImages", reflect.TypeOf((*MockClient)(nil).GetImages), arg0, arg1, arg2, arg3)
 }
 
 // RepositoryExists mocks base method
 func (m *MockClient) RepositoryExists(arg0 string) bool {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RepositoryExists", arg0)
 	ret0, _ := ret[0].(bool)
 	return ret0
@@ -116,6 +107,5 @@ func (m *MockClient) RepositoryExists(arg0 string) bool {
 
 // RepositoryExists indicates an expected call of RepositoryExists
 func (mr *MockClientMockRecorder) RepositoryExists(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RepositoryExists", reflect.TypeOf((*MockClient)(nil).RepositoryExists), arg0)
 }

--- a/ecs-cli/modules/clients/aws/ecr/mock/credential-helper/login_mock.go
+++ b/ecs-cli/modules/clients/aws/ecr/mock/credential-helper/login_mock.go
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2015-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the
@@ -49,7 +49,6 @@ func (m *MockClient) EXPECT() *MockClientMockRecorder {
 
 // GetCredentials mocks base method
 func (m *MockClient) GetCredentials(arg0 string) (*api.Auth, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetCredentials", arg0)
 	ret0, _ := ret[0].(*api.Auth)
 	ret1, _ := ret[1].(error)
@@ -58,13 +57,11 @@ func (m *MockClient) GetCredentials(arg0 string) (*api.Auth, error) {
 
 // GetCredentials indicates an expected call of GetCredentials
 func (mr *MockClientMockRecorder) GetCredentials(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCredentials", reflect.TypeOf((*MockClient)(nil).GetCredentials), arg0)
 }
 
 // GetCredentialsByRegistryID mocks base method
 func (m *MockClient) GetCredentialsByRegistryID(arg0 string) (*api.Auth, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetCredentialsByRegistryID", arg0)
 	ret0, _ := ret[0].(*api.Auth)
 	ret1, _ := ret[1].(error)
@@ -73,13 +70,11 @@ func (m *MockClient) GetCredentialsByRegistryID(arg0 string) (*api.Auth, error) 
 
 // GetCredentialsByRegistryID indicates an expected call of GetCredentialsByRegistryID
 func (mr *MockClientMockRecorder) GetCredentialsByRegistryID(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCredentialsByRegistryID", reflect.TypeOf((*MockClient)(nil).GetCredentialsByRegistryID), arg0)
 }
 
 // ListCredentials mocks base method
 func (m *MockClient) ListCredentials() ([]*api.Auth, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListCredentials")
 	ret0, _ := ret[0].([]*api.Auth)
 	ret1, _ := ret[1].(error)
@@ -88,6 +83,5 @@ func (m *MockClient) ListCredentials() ([]*api.Auth, error) {
 
 // ListCredentials indicates an expected call of ListCredentials
 func (mr *MockClientMockRecorder) ListCredentials() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListCredentials", reflect.TypeOf((*MockClient)(nil).ListCredentials))
 }

--- a/ecs-cli/modules/clients/aws/ecr/mock/sdk/ecriface_mock.go
+++ b/ecs-cli/modules/clients/aws/ecr/mock/sdk/ecriface_mock.go
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2015-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the
@@ -51,7 +51,6 @@ func (m *MockECRAPI) EXPECT() *MockECRAPIMockRecorder {
 
 // BatchCheckLayerAvailability mocks base method
 func (m *MockECRAPI) BatchCheckLayerAvailability(arg0 *ecr.BatchCheckLayerAvailabilityInput) (*ecr.BatchCheckLayerAvailabilityOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "BatchCheckLayerAvailability", arg0)
 	ret0, _ := ret[0].(*ecr.BatchCheckLayerAvailabilityOutput)
 	ret1, _ := ret[1].(error)
@@ -60,13 +59,11 @@ func (m *MockECRAPI) BatchCheckLayerAvailability(arg0 *ecr.BatchCheckLayerAvaila
 
 // BatchCheckLayerAvailability indicates an expected call of BatchCheckLayerAvailability
 func (mr *MockECRAPIMockRecorder) BatchCheckLayerAvailability(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BatchCheckLayerAvailability", reflect.TypeOf((*MockECRAPI)(nil).BatchCheckLayerAvailability), arg0)
 }
 
 // BatchCheckLayerAvailabilityRequest mocks base method
 func (m *MockECRAPI) BatchCheckLayerAvailabilityRequest(arg0 *ecr.BatchCheckLayerAvailabilityInput) (*request.Request, *ecr.BatchCheckLayerAvailabilityOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "BatchCheckLayerAvailabilityRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ecr.BatchCheckLayerAvailabilityOutput)
@@ -75,13 +72,11 @@ func (m *MockECRAPI) BatchCheckLayerAvailabilityRequest(arg0 *ecr.BatchCheckLaye
 
 // BatchCheckLayerAvailabilityRequest indicates an expected call of BatchCheckLayerAvailabilityRequest
 func (mr *MockECRAPIMockRecorder) BatchCheckLayerAvailabilityRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BatchCheckLayerAvailabilityRequest", reflect.TypeOf((*MockECRAPI)(nil).BatchCheckLayerAvailabilityRequest), arg0)
 }
 
 // BatchCheckLayerAvailabilityWithContext mocks base method
 func (m *MockECRAPI) BatchCheckLayerAvailabilityWithContext(arg0 context.Context, arg1 *ecr.BatchCheckLayerAvailabilityInput, arg2 ...request.Option) (*ecr.BatchCheckLayerAvailabilityOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -94,14 +89,12 @@ func (m *MockECRAPI) BatchCheckLayerAvailabilityWithContext(arg0 context.Context
 
 // BatchCheckLayerAvailabilityWithContext indicates an expected call of BatchCheckLayerAvailabilityWithContext
 func (mr *MockECRAPIMockRecorder) BatchCheckLayerAvailabilityWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BatchCheckLayerAvailabilityWithContext", reflect.TypeOf((*MockECRAPI)(nil).BatchCheckLayerAvailabilityWithContext), varargs...)
 }
 
 // BatchDeleteImage mocks base method
 func (m *MockECRAPI) BatchDeleteImage(arg0 *ecr.BatchDeleteImageInput) (*ecr.BatchDeleteImageOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "BatchDeleteImage", arg0)
 	ret0, _ := ret[0].(*ecr.BatchDeleteImageOutput)
 	ret1, _ := ret[1].(error)
@@ -110,13 +103,11 @@ func (m *MockECRAPI) BatchDeleteImage(arg0 *ecr.BatchDeleteImageInput) (*ecr.Bat
 
 // BatchDeleteImage indicates an expected call of BatchDeleteImage
 func (mr *MockECRAPIMockRecorder) BatchDeleteImage(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BatchDeleteImage", reflect.TypeOf((*MockECRAPI)(nil).BatchDeleteImage), arg0)
 }
 
 // BatchDeleteImageRequest mocks base method
 func (m *MockECRAPI) BatchDeleteImageRequest(arg0 *ecr.BatchDeleteImageInput) (*request.Request, *ecr.BatchDeleteImageOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "BatchDeleteImageRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ecr.BatchDeleteImageOutput)
@@ -125,13 +116,11 @@ func (m *MockECRAPI) BatchDeleteImageRequest(arg0 *ecr.BatchDeleteImageInput) (*
 
 // BatchDeleteImageRequest indicates an expected call of BatchDeleteImageRequest
 func (mr *MockECRAPIMockRecorder) BatchDeleteImageRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BatchDeleteImageRequest", reflect.TypeOf((*MockECRAPI)(nil).BatchDeleteImageRequest), arg0)
 }
 
 // BatchDeleteImageWithContext mocks base method
 func (m *MockECRAPI) BatchDeleteImageWithContext(arg0 context.Context, arg1 *ecr.BatchDeleteImageInput, arg2 ...request.Option) (*ecr.BatchDeleteImageOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -144,14 +133,12 @@ func (m *MockECRAPI) BatchDeleteImageWithContext(arg0 context.Context, arg1 *ecr
 
 // BatchDeleteImageWithContext indicates an expected call of BatchDeleteImageWithContext
 func (mr *MockECRAPIMockRecorder) BatchDeleteImageWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BatchDeleteImageWithContext", reflect.TypeOf((*MockECRAPI)(nil).BatchDeleteImageWithContext), varargs...)
 }
 
 // BatchGetImage mocks base method
 func (m *MockECRAPI) BatchGetImage(arg0 *ecr.BatchGetImageInput) (*ecr.BatchGetImageOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "BatchGetImage", arg0)
 	ret0, _ := ret[0].(*ecr.BatchGetImageOutput)
 	ret1, _ := ret[1].(error)
@@ -160,13 +147,11 @@ func (m *MockECRAPI) BatchGetImage(arg0 *ecr.BatchGetImageInput) (*ecr.BatchGetI
 
 // BatchGetImage indicates an expected call of BatchGetImage
 func (mr *MockECRAPIMockRecorder) BatchGetImage(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BatchGetImage", reflect.TypeOf((*MockECRAPI)(nil).BatchGetImage), arg0)
 }
 
 // BatchGetImageRequest mocks base method
 func (m *MockECRAPI) BatchGetImageRequest(arg0 *ecr.BatchGetImageInput) (*request.Request, *ecr.BatchGetImageOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "BatchGetImageRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ecr.BatchGetImageOutput)
@@ -175,13 +160,11 @@ func (m *MockECRAPI) BatchGetImageRequest(arg0 *ecr.BatchGetImageInput) (*reques
 
 // BatchGetImageRequest indicates an expected call of BatchGetImageRequest
 func (mr *MockECRAPIMockRecorder) BatchGetImageRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BatchGetImageRequest", reflect.TypeOf((*MockECRAPI)(nil).BatchGetImageRequest), arg0)
 }
 
 // BatchGetImageWithContext mocks base method
 func (m *MockECRAPI) BatchGetImageWithContext(arg0 context.Context, arg1 *ecr.BatchGetImageInput, arg2 ...request.Option) (*ecr.BatchGetImageOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -194,14 +177,12 @@ func (m *MockECRAPI) BatchGetImageWithContext(arg0 context.Context, arg1 *ecr.Ba
 
 // BatchGetImageWithContext indicates an expected call of BatchGetImageWithContext
 func (mr *MockECRAPIMockRecorder) BatchGetImageWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BatchGetImageWithContext", reflect.TypeOf((*MockECRAPI)(nil).BatchGetImageWithContext), varargs...)
 }
 
 // CompleteLayerUpload mocks base method
 func (m *MockECRAPI) CompleteLayerUpload(arg0 *ecr.CompleteLayerUploadInput) (*ecr.CompleteLayerUploadOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CompleteLayerUpload", arg0)
 	ret0, _ := ret[0].(*ecr.CompleteLayerUploadOutput)
 	ret1, _ := ret[1].(error)
@@ -210,13 +191,11 @@ func (m *MockECRAPI) CompleteLayerUpload(arg0 *ecr.CompleteLayerUploadInput) (*e
 
 // CompleteLayerUpload indicates an expected call of CompleteLayerUpload
 func (mr *MockECRAPIMockRecorder) CompleteLayerUpload(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CompleteLayerUpload", reflect.TypeOf((*MockECRAPI)(nil).CompleteLayerUpload), arg0)
 }
 
 // CompleteLayerUploadRequest mocks base method
 func (m *MockECRAPI) CompleteLayerUploadRequest(arg0 *ecr.CompleteLayerUploadInput) (*request.Request, *ecr.CompleteLayerUploadOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CompleteLayerUploadRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ecr.CompleteLayerUploadOutput)
@@ -225,13 +204,11 @@ func (m *MockECRAPI) CompleteLayerUploadRequest(arg0 *ecr.CompleteLayerUploadInp
 
 // CompleteLayerUploadRequest indicates an expected call of CompleteLayerUploadRequest
 func (mr *MockECRAPIMockRecorder) CompleteLayerUploadRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CompleteLayerUploadRequest", reflect.TypeOf((*MockECRAPI)(nil).CompleteLayerUploadRequest), arg0)
 }
 
 // CompleteLayerUploadWithContext mocks base method
 func (m *MockECRAPI) CompleteLayerUploadWithContext(arg0 context.Context, arg1 *ecr.CompleteLayerUploadInput, arg2 ...request.Option) (*ecr.CompleteLayerUploadOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -244,14 +221,12 @@ func (m *MockECRAPI) CompleteLayerUploadWithContext(arg0 context.Context, arg1 *
 
 // CompleteLayerUploadWithContext indicates an expected call of CompleteLayerUploadWithContext
 func (mr *MockECRAPIMockRecorder) CompleteLayerUploadWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CompleteLayerUploadWithContext", reflect.TypeOf((*MockECRAPI)(nil).CompleteLayerUploadWithContext), varargs...)
 }
 
 // CreateRepository mocks base method
 func (m *MockECRAPI) CreateRepository(arg0 *ecr.CreateRepositoryInput) (*ecr.CreateRepositoryOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateRepository", arg0)
 	ret0, _ := ret[0].(*ecr.CreateRepositoryOutput)
 	ret1, _ := ret[1].(error)
@@ -260,13 +235,11 @@ func (m *MockECRAPI) CreateRepository(arg0 *ecr.CreateRepositoryInput) (*ecr.Cre
 
 // CreateRepository indicates an expected call of CreateRepository
 func (mr *MockECRAPIMockRecorder) CreateRepository(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateRepository", reflect.TypeOf((*MockECRAPI)(nil).CreateRepository), arg0)
 }
 
 // CreateRepositoryRequest mocks base method
 func (m *MockECRAPI) CreateRepositoryRequest(arg0 *ecr.CreateRepositoryInput) (*request.Request, *ecr.CreateRepositoryOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateRepositoryRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ecr.CreateRepositoryOutput)
@@ -275,13 +248,11 @@ func (m *MockECRAPI) CreateRepositoryRequest(arg0 *ecr.CreateRepositoryInput) (*
 
 // CreateRepositoryRequest indicates an expected call of CreateRepositoryRequest
 func (mr *MockECRAPIMockRecorder) CreateRepositoryRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateRepositoryRequest", reflect.TypeOf((*MockECRAPI)(nil).CreateRepositoryRequest), arg0)
 }
 
 // CreateRepositoryWithContext mocks base method
 func (m *MockECRAPI) CreateRepositoryWithContext(arg0 context.Context, arg1 *ecr.CreateRepositoryInput, arg2 ...request.Option) (*ecr.CreateRepositoryOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -294,14 +265,12 @@ func (m *MockECRAPI) CreateRepositoryWithContext(arg0 context.Context, arg1 *ecr
 
 // CreateRepositoryWithContext indicates an expected call of CreateRepositoryWithContext
 func (mr *MockECRAPIMockRecorder) CreateRepositoryWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateRepositoryWithContext", reflect.TypeOf((*MockECRAPI)(nil).CreateRepositoryWithContext), varargs...)
 }
 
 // DeleteLifecyclePolicy mocks base method
 func (m *MockECRAPI) DeleteLifecyclePolicy(arg0 *ecr.DeleteLifecyclePolicyInput) (*ecr.DeleteLifecyclePolicyOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteLifecyclePolicy", arg0)
 	ret0, _ := ret[0].(*ecr.DeleteLifecyclePolicyOutput)
 	ret1, _ := ret[1].(error)
@@ -310,13 +279,11 @@ func (m *MockECRAPI) DeleteLifecyclePolicy(arg0 *ecr.DeleteLifecyclePolicyInput)
 
 // DeleteLifecyclePolicy indicates an expected call of DeleteLifecyclePolicy
 func (mr *MockECRAPIMockRecorder) DeleteLifecyclePolicy(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteLifecyclePolicy", reflect.TypeOf((*MockECRAPI)(nil).DeleteLifecyclePolicy), arg0)
 }
 
 // DeleteLifecyclePolicyRequest mocks base method
 func (m *MockECRAPI) DeleteLifecyclePolicyRequest(arg0 *ecr.DeleteLifecyclePolicyInput) (*request.Request, *ecr.DeleteLifecyclePolicyOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteLifecyclePolicyRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ecr.DeleteLifecyclePolicyOutput)
@@ -325,13 +292,11 @@ func (m *MockECRAPI) DeleteLifecyclePolicyRequest(arg0 *ecr.DeleteLifecyclePolic
 
 // DeleteLifecyclePolicyRequest indicates an expected call of DeleteLifecyclePolicyRequest
 func (mr *MockECRAPIMockRecorder) DeleteLifecyclePolicyRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteLifecyclePolicyRequest", reflect.TypeOf((*MockECRAPI)(nil).DeleteLifecyclePolicyRequest), arg0)
 }
 
 // DeleteLifecyclePolicyWithContext mocks base method
 func (m *MockECRAPI) DeleteLifecyclePolicyWithContext(arg0 context.Context, arg1 *ecr.DeleteLifecyclePolicyInput, arg2 ...request.Option) (*ecr.DeleteLifecyclePolicyOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -344,14 +309,12 @@ func (m *MockECRAPI) DeleteLifecyclePolicyWithContext(arg0 context.Context, arg1
 
 // DeleteLifecyclePolicyWithContext indicates an expected call of DeleteLifecyclePolicyWithContext
 func (mr *MockECRAPIMockRecorder) DeleteLifecyclePolicyWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteLifecyclePolicyWithContext", reflect.TypeOf((*MockECRAPI)(nil).DeleteLifecyclePolicyWithContext), varargs...)
 }
 
 // DeleteRepository mocks base method
 func (m *MockECRAPI) DeleteRepository(arg0 *ecr.DeleteRepositoryInput) (*ecr.DeleteRepositoryOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteRepository", arg0)
 	ret0, _ := ret[0].(*ecr.DeleteRepositoryOutput)
 	ret1, _ := ret[1].(error)
@@ -360,13 +323,11 @@ func (m *MockECRAPI) DeleteRepository(arg0 *ecr.DeleteRepositoryInput) (*ecr.Del
 
 // DeleteRepository indicates an expected call of DeleteRepository
 func (mr *MockECRAPIMockRecorder) DeleteRepository(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteRepository", reflect.TypeOf((*MockECRAPI)(nil).DeleteRepository), arg0)
 }
 
 // DeleteRepositoryPolicy mocks base method
 func (m *MockECRAPI) DeleteRepositoryPolicy(arg0 *ecr.DeleteRepositoryPolicyInput) (*ecr.DeleteRepositoryPolicyOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteRepositoryPolicy", arg0)
 	ret0, _ := ret[0].(*ecr.DeleteRepositoryPolicyOutput)
 	ret1, _ := ret[1].(error)
@@ -375,13 +336,11 @@ func (m *MockECRAPI) DeleteRepositoryPolicy(arg0 *ecr.DeleteRepositoryPolicyInpu
 
 // DeleteRepositoryPolicy indicates an expected call of DeleteRepositoryPolicy
 func (mr *MockECRAPIMockRecorder) DeleteRepositoryPolicy(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteRepositoryPolicy", reflect.TypeOf((*MockECRAPI)(nil).DeleteRepositoryPolicy), arg0)
 }
 
 // DeleteRepositoryPolicyRequest mocks base method
 func (m *MockECRAPI) DeleteRepositoryPolicyRequest(arg0 *ecr.DeleteRepositoryPolicyInput) (*request.Request, *ecr.DeleteRepositoryPolicyOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteRepositoryPolicyRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ecr.DeleteRepositoryPolicyOutput)
@@ -390,13 +349,11 @@ func (m *MockECRAPI) DeleteRepositoryPolicyRequest(arg0 *ecr.DeleteRepositoryPol
 
 // DeleteRepositoryPolicyRequest indicates an expected call of DeleteRepositoryPolicyRequest
 func (mr *MockECRAPIMockRecorder) DeleteRepositoryPolicyRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteRepositoryPolicyRequest", reflect.TypeOf((*MockECRAPI)(nil).DeleteRepositoryPolicyRequest), arg0)
 }
 
 // DeleteRepositoryPolicyWithContext mocks base method
 func (m *MockECRAPI) DeleteRepositoryPolicyWithContext(arg0 context.Context, arg1 *ecr.DeleteRepositoryPolicyInput, arg2 ...request.Option) (*ecr.DeleteRepositoryPolicyOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -409,14 +366,12 @@ func (m *MockECRAPI) DeleteRepositoryPolicyWithContext(arg0 context.Context, arg
 
 // DeleteRepositoryPolicyWithContext indicates an expected call of DeleteRepositoryPolicyWithContext
 func (mr *MockECRAPIMockRecorder) DeleteRepositoryPolicyWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteRepositoryPolicyWithContext", reflect.TypeOf((*MockECRAPI)(nil).DeleteRepositoryPolicyWithContext), varargs...)
 }
 
 // DeleteRepositoryRequest mocks base method
 func (m *MockECRAPI) DeleteRepositoryRequest(arg0 *ecr.DeleteRepositoryInput) (*request.Request, *ecr.DeleteRepositoryOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteRepositoryRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ecr.DeleteRepositoryOutput)
@@ -425,13 +380,11 @@ func (m *MockECRAPI) DeleteRepositoryRequest(arg0 *ecr.DeleteRepositoryInput) (*
 
 // DeleteRepositoryRequest indicates an expected call of DeleteRepositoryRequest
 func (mr *MockECRAPIMockRecorder) DeleteRepositoryRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteRepositoryRequest", reflect.TypeOf((*MockECRAPI)(nil).DeleteRepositoryRequest), arg0)
 }
 
 // DeleteRepositoryWithContext mocks base method
 func (m *MockECRAPI) DeleteRepositoryWithContext(arg0 context.Context, arg1 *ecr.DeleteRepositoryInput, arg2 ...request.Option) (*ecr.DeleteRepositoryOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -444,14 +397,12 @@ func (m *MockECRAPI) DeleteRepositoryWithContext(arg0 context.Context, arg1 *ecr
 
 // DeleteRepositoryWithContext indicates an expected call of DeleteRepositoryWithContext
 func (mr *MockECRAPIMockRecorder) DeleteRepositoryWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteRepositoryWithContext", reflect.TypeOf((*MockECRAPI)(nil).DeleteRepositoryWithContext), varargs...)
 }
 
 // DescribeImages mocks base method
 func (m *MockECRAPI) DescribeImages(arg0 *ecr.DescribeImagesInput) (*ecr.DescribeImagesOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeImages", arg0)
 	ret0, _ := ret[0].(*ecr.DescribeImagesOutput)
 	ret1, _ := ret[1].(error)
@@ -460,13 +411,11 @@ func (m *MockECRAPI) DescribeImages(arg0 *ecr.DescribeImagesInput) (*ecr.Describ
 
 // DescribeImages indicates an expected call of DescribeImages
 func (mr *MockECRAPIMockRecorder) DescribeImages(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeImages", reflect.TypeOf((*MockECRAPI)(nil).DescribeImages), arg0)
 }
 
 // DescribeImagesPages mocks base method
 func (m *MockECRAPI) DescribeImagesPages(arg0 *ecr.DescribeImagesInput, arg1 func(*ecr.DescribeImagesOutput, bool) bool) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeImagesPages", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -474,13 +423,11 @@ func (m *MockECRAPI) DescribeImagesPages(arg0 *ecr.DescribeImagesInput, arg1 fun
 
 // DescribeImagesPages indicates an expected call of DescribeImagesPages
 func (mr *MockECRAPIMockRecorder) DescribeImagesPages(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeImagesPages", reflect.TypeOf((*MockECRAPI)(nil).DescribeImagesPages), arg0, arg1)
 }
 
 // DescribeImagesPagesWithContext mocks base method
 func (m *MockECRAPI) DescribeImagesPagesWithContext(arg0 context.Context, arg1 *ecr.DescribeImagesInput, arg2 func(*ecr.DescribeImagesOutput, bool) bool, arg3 ...request.Option) error {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1, arg2}
 	for _, a := range arg3 {
 		varargs = append(varargs, a)
@@ -492,14 +439,12 @@ func (m *MockECRAPI) DescribeImagesPagesWithContext(arg0 context.Context, arg1 *
 
 // DescribeImagesPagesWithContext indicates an expected call of DescribeImagesPagesWithContext
 func (mr *MockECRAPIMockRecorder) DescribeImagesPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeImagesPagesWithContext", reflect.TypeOf((*MockECRAPI)(nil).DescribeImagesPagesWithContext), varargs...)
 }
 
 // DescribeImagesRequest mocks base method
 func (m *MockECRAPI) DescribeImagesRequest(arg0 *ecr.DescribeImagesInput) (*request.Request, *ecr.DescribeImagesOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeImagesRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ecr.DescribeImagesOutput)
@@ -508,13 +453,11 @@ func (m *MockECRAPI) DescribeImagesRequest(arg0 *ecr.DescribeImagesInput) (*requ
 
 // DescribeImagesRequest indicates an expected call of DescribeImagesRequest
 func (mr *MockECRAPIMockRecorder) DescribeImagesRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeImagesRequest", reflect.TypeOf((*MockECRAPI)(nil).DescribeImagesRequest), arg0)
 }
 
 // DescribeImagesWithContext mocks base method
 func (m *MockECRAPI) DescribeImagesWithContext(arg0 context.Context, arg1 *ecr.DescribeImagesInput, arg2 ...request.Option) (*ecr.DescribeImagesOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -527,14 +470,12 @@ func (m *MockECRAPI) DescribeImagesWithContext(arg0 context.Context, arg1 *ecr.D
 
 // DescribeImagesWithContext indicates an expected call of DescribeImagesWithContext
 func (mr *MockECRAPIMockRecorder) DescribeImagesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeImagesWithContext", reflect.TypeOf((*MockECRAPI)(nil).DescribeImagesWithContext), varargs...)
 }
 
 // DescribeRepositories mocks base method
 func (m *MockECRAPI) DescribeRepositories(arg0 *ecr.DescribeRepositoriesInput) (*ecr.DescribeRepositoriesOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeRepositories", arg0)
 	ret0, _ := ret[0].(*ecr.DescribeRepositoriesOutput)
 	ret1, _ := ret[1].(error)
@@ -543,13 +484,11 @@ func (m *MockECRAPI) DescribeRepositories(arg0 *ecr.DescribeRepositoriesInput) (
 
 // DescribeRepositories indicates an expected call of DescribeRepositories
 func (mr *MockECRAPIMockRecorder) DescribeRepositories(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeRepositories", reflect.TypeOf((*MockECRAPI)(nil).DescribeRepositories), arg0)
 }
 
 // DescribeRepositoriesPages mocks base method
 func (m *MockECRAPI) DescribeRepositoriesPages(arg0 *ecr.DescribeRepositoriesInput, arg1 func(*ecr.DescribeRepositoriesOutput, bool) bool) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeRepositoriesPages", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -557,13 +496,11 @@ func (m *MockECRAPI) DescribeRepositoriesPages(arg0 *ecr.DescribeRepositoriesInp
 
 // DescribeRepositoriesPages indicates an expected call of DescribeRepositoriesPages
 func (mr *MockECRAPIMockRecorder) DescribeRepositoriesPages(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeRepositoriesPages", reflect.TypeOf((*MockECRAPI)(nil).DescribeRepositoriesPages), arg0, arg1)
 }
 
 // DescribeRepositoriesPagesWithContext mocks base method
 func (m *MockECRAPI) DescribeRepositoriesPagesWithContext(arg0 context.Context, arg1 *ecr.DescribeRepositoriesInput, arg2 func(*ecr.DescribeRepositoriesOutput, bool) bool, arg3 ...request.Option) error {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1, arg2}
 	for _, a := range arg3 {
 		varargs = append(varargs, a)
@@ -575,14 +512,12 @@ func (m *MockECRAPI) DescribeRepositoriesPagesWithContext(arg0 context.Context, 
 
 // DescribeRepositoriesPagesWithContext indicates an expected call of DescribeRepositoriesPagesWithContext
 func (mr *MockECRAPIMockRecorder) DescribeRepositoriesPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeRepositoriesPagesWithContext", reflect.TypeOf((*MockECRAPI)(nil).DescribeRepositoriesPagesWithContext), varargs...)
 }
 
 // DescribeRepositoriesRequest mocks base method
 func (m *MockECRAPI) DescribeRepositoriesRequest(arg0 *ecr.DescribeRepositoriesInput) (*request.Request, *ecr.DescribeRepositoriesOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeRepositoriesRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ecr.DescribeRepositoriesOutput)
@@ -591,13 +526,11 @@ func (m *MockECRAPI) DescribeRepositoriesRequest(arg0 *ecr.DescribeRepositoriesI
 
 // DescribeRepositoriesRequest indicates an expected call of DescribeRepositoriesRequest
 func (mr *MockECRAPIMockRecorder) DescribeRepositoriesRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeRepositoriesRequest", reflect.TypeOf((*MockECRAPI)(nil).DescribeRepositoriesRequest), arg0)
 }
 
 // DescribeRepositoriesWithContext mocks base method
 func (m *MockECRAPI) DescribeRepositoriesWithContext(arg0 context.Context, arg1 *ecr.DescribeRepositoriesInput, arg2 ...request.Option) (*ecr.DescribeRepositoriesOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -610,14 +543,12 @@ func (m *MockECRAPI) DescribeRepositoriesWithContext(arg0 context.Context, arg1 
 
 // DescribeRepositoriesWithContext indicates an expected call of DescribeRepositoriesWithContext
 func (mr *MockECRAPIMockRecorder) DescribeRepositoriesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeRepositoriesWithContext", reflect.TypeOf((*MockECRAPI)(nil).DescribeRepositoriesWithContext), varargs...)
 }
 
 // GetAuthorizationToken mocks base method
 func (m *MockECRAPI) GetAuthorizationToken(arg0 *ecr.GetAuthorizationTokenInput) (*ecr.GetAuthorizationTokenOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetAuthorizationToken", arg0)
 	ret0, _ := ret[0].(*ecr.GetAuthorizationTokenOutput)
 	ret1, _ := ret[1].(error)
@@ -626,13 +557,11 @@ func (m *MockECRAPI) GetAuthorizationToken(arg0 *ecr.GetAuthorizationTokenInput)
 
 // GetAuthorizationToken indicates an expected call of GetAuthorizationToken
 func (mr *MockECRAPIMockRecorder) GetAuthorizationToken(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAuthorizationToken", reflect.TypeOf((*MockECRAPI)(nil).GetAuthorizationToken), arg0)
 }
 
 // GetAuthorizationTokenRequest mocks base method
 func (m *MockECRAPI) GetAuthorizationTokenRequest(arg0 *ecr.GetAuthorizationTokenInput) (*request.Request, *ecr.GetAuthorizationTokenOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetAuthorizationTokenRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ecr.GetAuthorizationTokenOutput)
@@ -641,13 +570,11 @@ func (m *MockECRAPI) GetAuthorizationTokenRequest(arg0 *ecr.GetAuthorizationToke
 
 // GetAuthorizationTokenRequest indicates an expected call of GetAuthorizationTokenRequest
 func (mr *MockECRAPIMockRecorder) GetAuthorizationTokenRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAuthorizationTokenRequest", reflect.TypeOf((*MockECRAPI)(nil).GetAuthorizationTokenRequest), arg0)
 }
 
 // GetAuthorizationTokenWithContext mocks base method
 func (m *MockECRAPI) GetAuthorizationTokenWithContext(arg0 context.Context, arg1 *ecr.GetAuthorizationTokenInput, arg2 ...request.Option) (*ecr.GetAuthorizationTokenOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -660,14 +587,12 @@ func (m *MockECRAPI) GetAuthorizationTokenWithContext(arg0 context.Context, arg1
 
 // GetAuthorizationTokenWithContext indicates an expected call of GetAuthorizationTokenWithContext
 func (mr *MockECRAPIMockRecorder) GetAuthorizationTokenWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAuthorizationTokenWithContext", reflect.TypeOf((*MockECRAPI)(nil).GetAuthorizationTokenWithContext), varargs...)
 }
 
 // GetDownloadUrlForLayer mocks base method
 func (m *MockECRAPI) GetDownloadUrlForLayer(arg0 *ecr.GetDownloadUrlForLayerInput) (*ecr.GetDownloadUrlForLayerOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetDownloadUrlForLayer", arg0)
 	ret0, _ := ret[0].(*ecr.GetDownloadUrlForLayerOutput)
 	ret1, _ := ret[1].(error)
@@ -676,13 +601,11 @@ func (m *MockECRAPI) GetDownloadUrlForLayer(arg0 *ecr.GetDownloadUrlForLayerInpu
 
 // GetDownloadUrlForLayer indicates an expected call of GetDownloadUrlForLayer
 func (mr *MockECRAPIMockRecorder) GetDownloadUrlForLayer(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDownloadUrlForLayer", reflect.TypeOf((*MockECRAPI)(nil).GetDownloadUrlForLayer), arg0)
 }
 
 // GetDownloadUrlForLayerRequest mocks base method
 func (m *MockECRAPI) GetDownloadUrlForLayerRequest(arg0 *ecr.GetDownloadUrlForLayerInput) (*request.Request, *ecr.GetDownloadUrlForLayerOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetDownloadUrlForLayerRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ecr.GetDownloadUrlForLayerOutput)
@@ -691,13 +614,11 @@ func (m *MockECRAPI) GetDownloadUrlForLayerRequest(arg0 *ecr.GetDownloadUrlForLa
 
 // GetDownloadUrlForLayerRequest indicates an expected call of GetDownloadUrlForLayerRequest
 func (mr *MockECRAPIMockRecorder) GetDownloadUrlForLayerRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDownloadUrlForLayerRequest", reflect.TypeOf((*MockECRAPI)(nil).GetDownloadUrlForLayerRequest), arg0)
 }
 
 // GetDownloadUrlForLayerWithContext mocks base method
 func (m *MockECRAPI) GetDownloadUrlForLayerWithContext(arg0 context.Context, arg1 *ecr.GetDownloadUrlForLayerInput, arg2 ...request.Option) (*ecr.GetDownloadUrlForLayerOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -710,14 +631,12 @@ func (m *MockECRAPI) GetDownloadUrlForLayerWithContext(arg0 context.Context, arg
 
 // GetDownloadUrlForLayerWithContext indicates an expected call of GetDownloadUrlForLayerWithContext
 func (mr *MockECRAPIMockRecorder) GetDownloadUrlForLayerWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDownloadUrlForLayerWithContext", reflect.TypeOf((*MockECRAPI)(nil).GetDownloadUrlForLayerWithContext), varargs...)
 }
 
 // GetLifecyclePolicy mocks base method
 func (m *MockECRAPI) GetLifecyclePolicy(arg0 *ecr.GetLifecyclePolicyInput) (*ecr.GetLifecyclePolicyOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetLifecyclePolicy", arg0)
 	ret0, _ := ret[0].(*ecr.GetLifecyclePolicyOutput)
 	ret1, _ := ret[1].(error)
@@ -726,13 +645,11 @@ func (m *MockECRAPI) GetLifecyclePolicy(arg0 *ecr.GetLifecyclePolicyInput) (*ecr
 
 // GetLifecyclePolicy indicates an expected call of GetLifecyclePolicy
 func (mr *MockECRAPIMockRecorder) GetLifecyclePolicy(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLifecyclePolicy", reflect.TypeOf((*MockECRAPI)(nil).GetLifecyclePolicy), arg0)
 }
 
 // GetLifecyclePolicyPreview mocks base method
 func (m *MockECRAPI) GetLifecyclePolicyPreview(arg0 *ecr.GetLifecyclePolicyPreviewInput) (*ecr.GetLifecyclePolicyPreviewOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetLifecyclePolicyPreview", arg0)
 	ret0, _ := ret[0].(*ecr.GetLifecyclePolicyPreviewOutput)
 	ret1, _ := ret[1].(error)
@@ -741,13 +658,11 @@ func (m *MockECRAPI) GetLifecyclePolicyPreview(arg0 *ecr.GetLifecyclePolicyPrevi
 
 // GetLifecyclePolicyPreview indicates an expected call of GetLifecyclePolicyPreview
 func (mr *MockECRAPIMockRecorder) GetLifecyclePolicyPreview(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLifecyclePolicyPreview", reflect.TypeOf((*MockECRAPI)(nil).GetLifecyclePolicyPreview), arg0)
 }
 
 // GetLifecyclePolicyPreviewRequest mocks base method
 func (m *MockECRAPI) GetLifecyclePolicyPreviewRequest(arg0 *ecr.GetLifecyclePolicyPreviewInput) (*request.Request, *ecr.GetLifecyclePolicyPreviewOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetLifecyclePolicyPreviewRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ecr.GetLifecyclePolicyPreviewOutput)
@@ -756,13 +671,11 @@ func (m *MockECRAPI) GetLifecyclePolicyPreviewRequest(arg0 *ecr.GetLifecyclePoli
 
 // GetLifecyclePolicyPreviewRequest indicates an expected call of GetLifecyclePolicyPreviewRequest
 func (mr *MockECRAPIMockRecorder) GetLifecyclePolicyPreviewRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLifecyclePolicyPreviewRequest", reflect.TypeOf((*MockECRAPI)(nil).GetLifecyclePolicyPreviewRequest), arg0)
 }
 
 // GetLifecyclePolicyPreviewWithContext mocks base method
 func (m *MockECRAPI) GetLifecyclePolicyPreviewWithContext(arg0 context.Context, arg1 *ecr.GetLifecyclePolicyPreviewInput, arg2 ...request.Option) (*ecr.GetLifecyclePolicyPreviewOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -775,14 +688,12 @@ func (m *MockECRAPI) GetLifecyclePolicyPreviewWithContext(arg0 context.Context, 
 
 // GetLifecyclePolicyPreviewWithContext indicates an expected call of GetLifecyclePolicyPreviewWithContext
 func (mr *MockECRAPIMockRecorder) GetLifecyclePolicyPreviewWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLifecyclePolicyPreviewWithContext", reflect.TypeOf((*MockECRAPI)(nil).GetLifecyclePolicyPreviewWithContext), varargs...)
 }
 
 // GetLifecyclePolicyRequest mocks base method
 func (m *MockECRAPI) GetLifecyclePolicyRequest(arg0 *ecr.GetLifecyclePolicyInput) (*request.Request, *ecr.GetLifecyclePolicyOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetLifecyclePolicyRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ecr.GetLifecyclePolicyOutput)
@@ -791,13 +702,11 @@ func (m *MockECRAPI) GetLifecyclePolicyRequest(arg0 *ecr.GetLifecyclePolicyInput
 
 // GetLifecyclePolicyRequest indicates an expected call of GetLifecyclePolicyRequest
 func (mr *MockECRAPIMockRecorder) GetLifecyclePolicyRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLifecyclePolicyRequest", reflect.TypeOf((*MockECRAPI)(nil).GetLifecyclePolicyRequest), arg0)
 }
 
 // GetLifecyclePolicyWithContext mocks base method
 func (m *MockECRAPI) GetLifecyclePolicyWithContext(arg0 context.Context, arg1 *ecr.GetLifecyclePolicyInput, arg2 ...request.Option) (*ecr.GetLifecyclePolicyOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -810,14 +719,12 @@ func (m *MockECRAPI) GetLifecyclePolicyWithContext(arg0 context.Context, arg1 *e
 
 // GetLifecyclePolicyWithContext indicates an expected call of GetLifecyclePolicyWithContext
 func (mr *MockECRAPIMockRecorder) GetLifecyclePolicyWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLifecyclePolicyWithContext", reflect.TypeOf((*MockECRAPI)(nil).GetLifecyclePolicyWithContext), varargs...)
 }
 
 // GetRepositoryPolicy mocks base method
 func (m *MockECRAPI) GetRepositoryPolicy(arg0 *ecr.GetRepositoryPolicyInput) (*ecr.GetRepositoryPolicyOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetRepositoryPolicy", arg0)
 	ret0, _ := ret[0].(*ecr.GetRepositoryPolicyOutput)
 	ret1, _ := ret[1].(error)
@@ -826,13 +733,11 @@ func (m *MockECRAPI) GetRepositoryPolicy(arg0 *ecr.GetRepositoryPolicyInput) (*e
 
 // GetRepositoryPolicy indicates an expected call of GetRepositoryPolicy
 func (mr *MockECRAPIMockRecorder) GetRepositoryPolicy(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRepositoryPolicy", reflect.TypeOf((*MockECRAPI)(nil).GetRepositoryPolicy), arg0)
 }
 
 // GetRepositoryPolicyRequest mocks base method
 func (m *MockECRAPI) GetRepositoryPolicyRequest(arg0 *ecr.GetRepositoryPolicyInput) (*request.Request, *ecr.GetRepositoryPolicyOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetRepositoryPolicyRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ecr.GetRepositoryPolicyOutput)
@@ -841,13 +746,11 @@ func (m *MockECRAPI) GetRepositoryPolicyRequest(arg0 *ecr.GetRepositoryPolicyInp
 
 // GetRepositoryPolicyRequest indicates an expected call of GetRepositoryPolicyRequest
 func (mr *MockECRAPIMockRecorder) GetRepositoryPolicyRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRepositoryPolicyRequest", reflect.TypeOf((*MockECRAPI)(nil).GetRepositoryPolicyRequest), arg0)
 }
 
 // GetRepositoryPolicyWithContext mocks base method
 func (m *MockECRAPI) GetRepositoryPolicyWithContext(arg0 context.Context, arg1 *ecr.GetRepositoryPolicyInput, arg2 ...request.Option) (*ecr.GetRepositoryPolicyOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -860,14 +763,12 @@ func (m *MockECRAPI) GetRepositoryPolicyWithContext(arg0 context.Context, arg1 *
 
 // GetRepositoryPolicyWithContext indicates an expected call of GetRepositoryPolicyWithContext
 func (mr *MockECRAPIMockRecorder) GetRepositoryPolicyWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRepositoryPolicyWithContext", reflect.TypeOf((*MockECRAPI)(nil).GetRepositoryPolicyWithContext), varargs...)
 }
 
 // InitiateLayerUpload mocks base method
 func (m *MockECRAPI) InitiateLayerUpload(arg0 *ecr.InitiateLayerUploadInput) (*ecr.InitiateLayerUploadOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "InitiateLayerUpload", arg0)
 	ret0, _ := ret[0].(*ecr.InitiateLayerUploadOutput)
 	ret1, _ := ret[1].(error)
@@ -876,13 +777,11 @@ func (m *MockECRAPI) InitiateLayerUpload(arg0 *ecr.InitiateLayerUploadInput) (*e
 
 // InitiateLayerUpload indicates an expected call of InitiateLayerUpload
 func (mr *MockECRAPIMockRecorder) InitiateLayerUpload(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InitiateLayerUpload", reflect.TypeOf((*MockECRAPI)(nil).InitiateLayerUpload), arg0)
 }
 
 // InitiateLayerUploadRequest mocks base method
 func (m *MockECRAPI) InitiateLayerUploadRequest(arg0 *ecr.InitiateLayerUploadInput) (*request.Request, *ecr.InitiateLayerUploadOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "InitiateLayerUploadRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ecr.InitiateLayerUploadOutput)
@@ -891,13 +790,11 @@ func (m *MockECRAPI) InitiateLayerUploadRequest(arg0 *ecr.InitiateLayerUploadInp
 
 // InitiateLayerUploadRequest indicates an expected call of InitiateLayerUploadRequest
 func (mr *MockECRAPIMockRecorder) InitiateLayerUploadRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InitiateLayerUploadRequest", reflect.TypeOf((*MockECRAPI)(nil).InitiateLayerUploadRequest), arg0)
 }
 
 // InitiateLayerUploadWithContext mocks base method
 func (m *MockECRAPI) InitiateLayerUploadWithContext(arg0 context.Context, arg1 *ecr.InitiateLayerUploadInput, arg2 ...request.Option) (*ecr.InitiateLayerUploadOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -910,14 +807,12 @@ func (m *MockECRAPI) InitiateLayerUploadWithContext(arg0 context.Context, arg1 *
 
 // InitiateLayerUploadWithContext indicates an expected call of InitiateLayerUploadWithContext
 func (mr *MockECRAPIMockRecorder) InitiateLayerUploadWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InitiateLayerUploadWithContext", reflect.TypeOf((*MockECRAPI)(nil).InitiateLayerUploadWithContext), varargs...)
 }
 
 // ListImages mocks base method
 func (m *MockECRAPI) ListImages(arg0 *ecr.ListImagesInput) (*ecr.ListImagesOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListImages", arg0)
 	ret0, _ := ret[0].(*ecr.ListImagesOutput)
 	ret1, _ := ret[1].(error)
@@ -926,13 +821,11 @@ func (m *MockECRAPI) ListImages(arg0 *ecr.ListImagesInput) (*ecr.ListImagesOutpu
 
 // ListImages indicates an expected call of ListImages
 func (mr *MockECRAPIMockRecorder) ListImages(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListImages", reflect.TypeOf((*MockECRAPI)(nil).ListImages), arg0)
 }
 
 // ListImagesPages mocks base method
 func (m *MockECRAPI) ListImagesPages(arg0 *ecr.ListImagesInput, arg1 func(*ecr.ListImagesOutput, bool) bool) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListImagesPages", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -940,13 +833,11 @@ func (m *MockECRAPI) ListImagesPages(arg0 *ecr.ListImagesInput, arg1 func(*ecr.L
 
 // ListImagesPages indicates an expected call of ListImagesPages
 func (mr *MockECRAPIMockRecorder) ListImagesPages(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListImagesPages", reflect.TypeOf((*MockECRAPI)(nil).ListImagesPages), arg0, arg1)
 }
 
 // ListImagesPagesWithContext mocks base method
 func (m *MockECRAPI) ListImagesPagesWithContext(arg0 context.Context, arg1 *ecr.ListImagesInput, arg2 func(*ecr.ListImagesOutput, bool) bool, arg3 ...request.Option) error {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1, arg2}
 	for _, a := range arg3 {
 		varargs = append(varargs, a)
@@ -958,14 +849,12 @@ func (m *MockECRAPI) ListImagesPagesWithContext(arg0 context.Context, arg1 *ecr.
 
 // ListImagesPagesWithContext indicates an expected call of ListImagesPagesWithContext
 func (mr *MockECRAPIMockRecorder) ListImagesPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListImagesPagesWithContext", reflect.TypeOf((*MockECRAPI)(nil).ListImagesPagesWithContext), varargs...)
 }
 
 // ListImagesRequest mocks base method
 func (m *MockECRAPI) ListImagesRequest(arg0 *ecr.ListImagesInput) (*request.Request, *ecr.ListImagesOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListImagesRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ecr.ListImagesOutput)
@@ -974,13 +863,11 @@ func (m *MockECRAPI) ListImagesRequest(arg0 *ecr.ListImagesInput) (*request.Requ
 
 // ListImagesRequest indicates an expected call of ListImagesRequest
 func (mr *MockECRAPIMockRecorder) ListImagesRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListImagesRequest", reflect.TypeOf((*MockECRAPI)(nil).ListImagesRequest), arg0)
 }
 
 // ListImagesWithContext mocks base method
 func (m *MockECRAPI) ListImagesWithContext(arg0 context.Context, arg1 *ecr.ListImagesInput, arg2 ...request.Option) (*ecr.ListImagesOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -993,14 +880,12 @@ func (m *MockECRAPI) ListImagesWithContext(arg0 context.Context, arg1 *ecr.ListI
 
 // ListImagesWithContext indicates an expected call of ListImagesWithContext
 func (mr *MockECRAPIMockRecorder) ListImagesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListImagesWithContext", reflect.TypeOf((*MockECRAPI)(nil).ListImagesWithContext), varargs...)
 }
 
 // ListTagsForResource mocks base method
 func (m *MockECRAPI) ListTagsForResource(arg0 *ecr.ListTagsForResourceInput) (*ecr.ListTagsForResourceOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListTagsForResource", arg0)
 	ret0, _ := ret[0].(*ecr.ListTagsForResourceOutput)
 	ret1, _ := ret[1].(error)
@@ -1009,13 +894,11 @@ func (m *MockECRAPI) ListTagsForResource(arg0 *ecr.ListTagsForResourceInput) (*e
 
 // ListTagsForResource indicates an expected call of ListTagsForResource
 func (mr *MockECRAPIMockRecorder) ListTagsForResource(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListTagsForResource", reflect.TypeOf((*MockECRAPI)(nil).ListTagsForResource), arg0)
 }
 
 // ListTagsForResourceRequest mocks base method
 func (m *MockECRAPI) ListTagsForResourceRequest(arg0 *ecr.ListTagsForResourceInput) (*request.Request, *ecr.ListTagsForResourceOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListTagsForResourceRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ecr.ListTagsForResourceOutput)
@@ -1024,13 +907,11 @@ func (m *MockECRAPI) ListTagsForResourceRequest(arg0 *ecr.ListTagsForResourceInp
 
 // ListTagsForResourceRequest indicates an expected call of ListTagsForResourceRequest
 func (mr *MockECRAPIMockRecorder) ListTagsForResourceRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListTagsForResourceRequest", reflect.TypeOf((*MockECRAPI)(nil).ListTagsForResourceRequest), arg0)
 }
 
 // ListTagsForResourceWithContext mocks base method
 func (m *MockECRAPI) ListTagsForResourceWithContext(arg0 context.Context, arg1 *ecr.ListTagsForResourceInput, arg2 ...request.Option) (*ecr.ListTagsForResourceOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -1043,14 +924,12 @@ func (m *MockECRAPI) ListTagsForResourceWithContext(arg0 context.Context, arg1 *
 
 // ListTagsForResourceWithContext indicates an expected call of ListTagsForResourceWithContext
 func (mr *MockECRAPIMockRecorder) ListTagsForResourceWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListTagsForResourceWithContext", reflect.TypeOf((*MockECRAPI)(nil).ListTagsForResourceWithContext), varargs...)
 }
 
 // PutImage mocks base method
 func (m *MockECRAPI) PutImage(arg0 *ecr.PutImageInput) (*ecr.PutImageOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PutImage", arg0)
 	ret0, _ := ret[0].(*ecr.PutImageOutput)
 	ret1, _ := ret[1].(error)
@@ -1059,13 +938,11 @@ func (m *MockECRAPI) PutImage(arg0 *ecr.PutImageInput) (*ecr.PutImageOutput, err
 
 // PutImage indicates an expected call of PutImage
 func (mr *MockECRAPIMockRecorder) PutImage(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutImage", reflect.TypeOf((*MockECRAPI)(nil).PutImage), arg0)
 }
 
 // PutImageRequest mocks base method
 func (m *MockECRAPI) PutImageRequest(arg0 *ecr.PutImageInput) (*request.Request, *ecr.PutImageOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PutImageRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ecr.PutImageOutput)
@@ -1074,13 +951,11 @@ func (m *MockECRAPI) PutImageRequest(arg0 *ecr.PutImageInput) (*request.Request,
 
 // PutImageRequest indicates an expected call of PutImageRequest
 func (mr *MockECRAPIMockRecorder) PutImageRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutImageRequest", reflect.TypeOf((*MockECRAPI)(nil).PutImageRequest), arg0)
 }
 
 // PutImageWithContext mocks base method
 func (m *MockECRAPI) PutImageWithContext(arg0 context.Context, arg1 *ecr.PutImageInput, arg2 ...request.Option) (*ecr.PutImageOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -1093,14 +968,12 @@ func (m *MockECRAPI) PutImageWithContext(arg0 context.Context, arg1 *ecr.PutImag
 
 // PutImageWithContext indicates an expected call of PutImageWithContext
 func (mr *MockECRAPIMockRecorder) PutImageWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutImageWithContext", reflect.TypeOf((*MockECRAPI)(nil).PutImageWithContext), varargs...)
 }
 
 // PutLifecyclePolicy mocks base method
 func (m *MockECRAPI) PutLifecyclePolicy(arg0 *ecr.PutLifecyclePolicyInput) (*ecr.PutLifecyclePolicyOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PutLifecyclePolicy", arg0)
 	ret0, _ := ret[0].(*ecr.PutLifecyclePolicyOutput)
 	ret1, _ := ret[1].(error)
@@ -1109,13 +982,11 @@ func (m *MockECRAPI) PutLifecyclePolicy(arg0 *ecr.PutLifecyclePolicyInput) (*ecr
 
 // PutLifecyclePolicy indicates an expected call of PutLifecyclePolicy
 func (mr *MockECRAPIMockRecorder) PutLifecyclePolicy(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutLifecyclePolicy", reflect.TypeOf((*MockECRAPI)(nil).PutLifecyclePolicy), arg0)
 }
 
 // PutLifecyclePolicyRequest mocks base method
 func (m *MockECRAPI) PutLifecyclePolicyRequest(arg0 *ecr.PutLifecyclePolicyInput) (*request.Request, *ecr.PutLifecyclePolicyOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PutLifecyclePolicyRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ecr.PutLifecyclePolicyOutput)
@@ -1124,13 +995,11 @@ func (m *MockECRAPI) PutLifecyclePolicyRequest(arg0 *ecr.PutLifecyclePolicyInput
 
 // PutLifecyclePolicyRequest indicates an expected call of PutLifecyclePolicyRequest
 func (mr *MockECRAPIMockRecorder) PutLifecyclePolicyRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutLifecyclePolicyRequest", reflect.TypeOf((*MockECRAPI)(nil).PutLifecyclePolicyRequest), arg0)
 }
 
 // PutLifecyclePolicyWithContext mocks base method
 func (m *MockECRAPI) PutLifecyclePolicyWithContext(arg0 context.Context, arg1 *ecr.PutLifecyclePolicyInput, arg2 ...request.Option) (*ecr.PutLifecyclePolicyOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -1143,14 +1012,12 @@ func (m *MockECRAPI) PutLifecyclePolicyWithContext(arg0 context.Context, arg1 *e
 
 // PutLifecyclePolicyWithContext indicates an expected call of PutLifecyclePolicyWithContext
 func (mr *MockECRAPIMockRecorder) PutLifecyclePolicyWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutLifecyclePolicyWithContext", reflect.TypeOf((*MockECRAPI)(nil).PutLifecyclePolicyWithContext), varargs...)
 }
 
 // SetRepositoryPolicy mocks base method
 func (m *MockECRAPI) SetRepositoryPolicy(arg0 *ecr.SetRepositoryPolicyInput) (*ecr.SetRepositoryPolicyOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetRepositoryPolicy", arg0)
 	ret0, _ := ret[0].(*ecr.SetRepositoryPolicyOutput)
 	ret1, _ := ret[1].(error)
@@ -1159,13 +1026,11 @@ func (m *MockECRAPI) SetRepositoryPolicy(arg0 *ecr.SetRepositoryPolicyInput) (*e
 
 // SetRepositoryPolicy indicates an expected call of SetRepositoryPolicy
 func (mr *MockECRAPIMockRecorder) SetRepositoryPolicy(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetRepositoryPolicy", reflect.TypeOf((*MockECRAPI)(nil).SetRepositoryPolicy), arg0)
 }
 
 // SetRepositoryPolicyRequest mocks base method
 func (m *MockECRAPI) SetRepositoryPolicyRequest(arg0 *ecr.SetRepositoryPolicyInput) (*request.Request, *ecr.SetRepositoryPolicyOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetRepositoryPolicyRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ecr.SetRepositoryPolicyOutput)
@@ -1174,13 +1039,11 @@ func (m *MockECRAPI) SetRepositoryPolicyRequest(arg0 *ecr.SetRepositoryPolicyInp
 
 // SetRepositoryPolicyRequest indicates an expected call of SetRepositoryPolicyRequest
 func (mr *MockECRAPIMockRecorder) SetRepositoryPolicyRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetRepositoryPolicyRequest", reflect.TypeOf((*MockECRAPI)(nil).SetRepositoryPolicyRequest), arg0)
 }
 
 // SetRepositoryPolicyWithContext mocks base method
 func (m *MockECRAPI) SetRepositoryPolicyWithContext(arg0 context.Context, arg1 *ecr.SetRepositoryPolicyInput, arg2 ...request.Option) (*ecr.SetRepositoryPolicyOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -1193,14 +1056,12 @@ func (m *MockECRAPI) SetRepositoryPolicyWithContext(arg0 context.Context, arg1 *
 
 // SetRepositoryPolicyWithContext indicates an expected call of SetRepositoryPolicyWithContext
 func (mr *MockECRAPIMockRecorder) SetRepositoryPolicyWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetRepositoryPolicyWithContext", reflect.TypeOf((*MockECRAPI)(nil).SetRepositoryPolicyWithContext), varargs...)
 }
 
 // StartLifecyclePolicyPreview mocks base method
 func (m *MockECRAPI) StartLifecyclePolicyPreview(arg0 *ecr.StartLifecyclePolicyPreviewInput) (*ecr.StartLifecyclePolicyPreviewOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StartLifecyclePolicyPreview", arg0)
 	ret0, _ := ret[0].(*ecr.StartLifecyclePolicyPreviewOutput)
 	ret1, _ := ret[1].(error)
@@ -1209,13 +1070,11 @@ func (m *MockECRAPI) StartLifecyclePolicyPreview(arg0 *ecr.StartLifecyclePolicyP
 
 // StartLifecyclePolicyPreview indicates an expected call of StartLifecyclePolicyPreview
 func (mr *MockECRAPIMockRecorder) StartLifecyclePolicyPreview(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartLifecyclePolicyPreview", reflect.TypeOf((*MockECRAPI)(nil).StartLifecyclePolicyPreview), arg0)
 }
 
 // StartLifecyclePolicyPreviewRequest mocks base method
 func (m *MockECRAPI) StartLifecyclePolicyPreviewRequest(arg0 *ecr.StartLifecyclePolicyPreviewInput) (*request.Request, *ecr.StartLifecyclePolicyPreviewOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StartLifecyclePolicyPreviewRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ecr.StartLifecyclePolicyPreviewOutput)
@@ -1224,13 +1083,11 @@ func (m *MockECRAPI) StartLifecyclePolicyPreviewRequest(arg0 *ecr.StartLifecycle
 
 // StartLifecyclePolicyPreviewRequest indicates an expected call of StartLifecyclePolicyPreviewRequest
 func (mr *MockECRAPIMockRecorder) StartLifecyclePolicyPreviewRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartLifecyclePolicyPreviewRequest", reflect.TypeOf((*MockECRAPI)(nil).StartLifecyclePolicyPreviewRequest), arg0)
 }
 
 // StartLifecyclePolicyPreviewWithContext mocks base method
 func (m *MockECRAPI) StartLifecyclePolicyPreviewWithContext(arg0 context.Context, arg1 *ecr.StartLifecyclePolicyPreviewInput, arg2 ...request.Option) (*ecr.StartLifecyclePolicyPreviewOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -1243,14 +1100,12 @@ func (m *MockECRAPI) StartLifecyclePolicyPreviewWithContext(arg0 context.Context
 
 // StartLifecyclePolicyPreviewWithContext indicates an expected call of StartLifecyclePolicyPreviewWithContext
 func (mr *MockECRAPIMockRecorder) StartLifecyclePolicyPreviewWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartLifecyclePolicyPreviewWithContext", reflect.TypeOf((*MockECRAPI)(nil).StartLifecyclePolicyPreviewWithContext), varargs...)
 }
 
 // TagResource mocks base method
 func (m *MockECRAPI) TagResource(arg0 *ecr.TagResourceInput) (*ecr.TagResourceOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "TagResource", arg0)
 	ret0, _ := ret[0].(*ecr.TagResourceOutput)
 	ret1, _ := ret[1].(error)
@@ -1259,13 +1114,11 @@ func (m *MockECRAPI) TagResource(arg0 *ecr.TagResourceInput) (*ecr.TagResourceOu
 
 // TagResource indicates an expected call of TagResource
 func (mr *MockECRAPIMockRecorder) TagResource(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TagResource", reflect.TypeOf((*MockECRAPI)(nil).TagResource), arg0)
 }
 
 // TagResourceRequest mocks base method
 func (m *MockECRAPI) TagResourceRequest(arg0 *ecr.TagResourceInput) (*request.Request, *ecr.TagResourceOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "TagResourceRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ecr.TagResourceOutput)
@@ -1274,13 +1127,11 @@ func (m *MockECRAPI) TagResourceRequest(arg0 *ecr.TagResourceInput) (*request.Re
 
 // TagResourceRequest indicates an expected call of TagResourceRequest
 func (mr *MockECRAPIMockRecorder) TagResourceRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TagResourceRequest", reflect.TypeOf((*MockECRAPI)(nil).TagResourceRequest), arg0)
 }
 
 // TagResourceWithContext mocks base method
 func (m *MockECRAPI) TagResourceWithContext(arg0 context.Context, arg1 *ecr.TagResourceInput, arg2 ...request.Option) (*ecr.TagResourceOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -1293,14 +1144,12 @@ func (m *MockECRAPI) TagResourceWithContext(arg0 context.Context, arg1 *ecr.TagR
 
 // TagResourceWithContext indicates an expected call of TagResourceWithContext
 func (mr *MockECRAPIMockRecorder) TagResourceWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TagResourceWithContext", reflect.TypeOf((*MockECRAPI)(nil).TagResourceWithContext), varargs...)
 }
 
 // UntagResource mocks base method
 func (m *MockECRAPI) UntagResource(arg0 *ecr.UntagResourceInput) (*ecr.UntagResourceOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UntagResource", arg0)
 	ret0, _ := ret[0].(*ecr.UntagResourceOutput)
 	ret1, _ := ret[1].(error)
@@ -1309,13 +1158,11 @@ func (m *MockECRAPI) UntagResource(arg0 *ecr.UntagResourceInput) (*ecr.UntagReso
 
 // UntagResource indicates an expected call of UntagResource
 func (mr *MockECRAPIMockRecorder) UntagResource(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UntagResource", reflect.TypeOf((*MockECRAPI)(nil).UntagResource), arg0)
 }
 
 // UntagResourceRequest mocks base method
 func (m *MockECRAPI) UntagResourceRequest(arg0 *ecr.UntagResourceInput) (*request.Request, *ecr.UntagResourceOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UntagResourceRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ecr.UntagResourceOutput)
@@ -1324,13 +1171,11 @@ func (m *MockECRAPI) UntagResourceRequest(arg0 *ecr.UntagResourceInput) (*reques
 
 // UntagResourceRequest indicates an expected call of UntagResourceRequest
 func (mr *MockECRAPIMockRecorder) UntagResourceRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UntagResourceRequest", reflect.TypeOf((*MockECRAPI)(nil).UntagResourceRequest), arg0)
 }
 
 // UntagResourceWithContext mocks base method
 func (m *MockECRAPI) UntagResourceWithContext(arg0 context.Context, arg1 *ecr.UntagResourceInput, arg2 ...request.Option) (*ecr.UntagResourceOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -1343,14 +1188,12 @@ func (m *MockECRAPI) UntagResourceWithContext(arg0 context.Context, arg1 *ecr.Un
 
 // UntagResourceWithContext indicates an expected call of UntagResourceWithContext
 func (mr *MockECRAPIMockRecorder) UntagResourceWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UntagResourceWithContext", reflect.TypeOf((*MockECRAPI)(nil).UntagResourceWithContext), varargs...)
 }
 
 // UploadLayerPart mocks base method
 func (m *MockECRAPI) UploadLayerPart(arg0 *ecr.UploadLayerPartInput) (*ecr.UploadLayerPartOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UploadLayerPart", arg0)
 	ret0, _ := ret[0].(*ecr.UploadLayerPartOutput)
 	ret1, _ := ret[1].(error)
@@ -1359,13 +1202,11 @@ func (m *MockECRAPI) UploadLayerPart(arg0 *ecr.UploadLayerPartInput) (*ecr.Uploa
 
 // UploadLayerPart indicates an expected call of UploadLayerPart
 func (mr *MockECRAPIMockRecorder) UploadLayerPart(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UploadLayerPart", reflect.TypeOf((*MockECRAPI)(nil).UploadLayerPart), arg0)
 }
 
 // UploadLayerPartRequest mocks base method
 func (m *MockECRAPI) UploadLayerPartRequest(arg0 *ecr.UploadLayerPartInput) (*request.Request, *ecr.UploadLayerPartOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UploadLayerPartRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ecr.UploadLayerPartOutput)
@@ -1374,13 +1215,11 @@ func (m *MockECRAPI) UploadLayerPartRequest(arg0 *ecr.UploadLayerPartInput) (*re
 
 // UploadLayerPartRequest indicates an expected call of UploadLayerPartRequest
 func (mr *MockECRAPIMockRecorder) UploadLayerPartRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UploadLayerPartRequest", reflect.TypeOf((*MockECRAPI)(nil).UploadLayerPartRequest), arg0)
 }
 
 // UploadLayerPartWithContext mocks base method
 func (m *MockECRAPI) UploadLayerPartWithContext(arg0 context.Context, arg1 *ecr.UploadLayerPartInput, arg2 ...request.Option) (*ecr.UploadLayerPartOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -1393,7 +1232,6 @@ func (m *MockECRAPI) UploadLayerPartWithContext(arg0 context.Context, arg1 *ecr.
 
 // UploadLayerPartWithContext indicates an expected call of UploadLayerPartWithContext
 func (mr *MockECRAPIMockRecorder) UploadLayerPartWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UploadLayerPartWithContext", reflect.TypeOf((*MockECRAPI)(nil).UploadLayerPartWithContext), varargs...)
 }

--- a/ecs-cli/modules/clients/aws/ecs/mock/client.go
+++ b/ecs-cli/modules/clients/aws/ecs/mock/client.go
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2015-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the
@@ -51,7 +51,6 @@ func (m *MockECSClient) EXPECT() *MockECSClientMockRecorder {
 
 // CreateCluster mocks base method
 func (m *MockECSClient) CreateCluster(arg0 string, arg1 []*ecs0.Tag) (string, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateCluster", arg0, arg1)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
@@ -60,13 +59,11 @@ func (m *MockECSClient) CreateCluster(arg0 string, arg1 []*ecs0.Tag) (string, er
 
 // CreateCluster indicates an expected call of CreateCluster
 func (mr *MockECSClientMockRecorder) CreateCluster(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateCluster", reflect.TypeOf((*MockECSClient)(nil).CreateCluster), arg0, arg1)
 }
 
 // CreateService mocks base method
 func (m *MockECSClient) CreateService(arg0 *ecs0.CreateServiceInput) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateService", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -74,13 +71,11 @@ func (m *MockECSClient) CreateService(arg0 *ecs0.CreateServiceInput) error {
 
 // CreateService indicates an expected call of CreateService
 func (mr *MockECSClientMockRecorder) CreateService(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateService", reflect.TypeOf((*MockECSClient)(nil).CreateService), arg0)
 }
 
 // DeleteCluster mocks base method
 func (m *MockECSClient) DeleteCluster(arg0 string) (string, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteCluster", arg0)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
@@ -89,13 +84,11 @@ func (m *MockECSClient) DeleteCluster(arg0 string) (string, error) {
 
 // DeleteCluster indicates an expected call of DeleteCluster
 func (mr *MockECSClientMockRecorder) DeleteCluster(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteCluster", reflect.TypeOf((*MockECSClient)(nil).DeleteCluster), arg0)
 }
 
 // DeleteService mocks base method
 func (m *MockECSClient) DeleteService(arg0 string) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteService", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -103,13 +96,11 @@ func (m *MockECSClient) DeleteService(arg0 string) error {
 
 // DeleteService indicates an expected call of DeleteService
 func (mr *MockECSClientMockRecorder) DeleteService(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteService", reflect.TypeOf((*MockECSClient)(nil).DeleteService), arg0)
 }
 
 // DescribeService mocks base method
 func (m *MockECSClient) DescribeService(arg0 string) (*ecs0.DescribeServicesOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeService", arg0)
 	ret0, _ := ret[0].(*ecs0.DescribeServicesOutput)
 	ret1, _ := ret[1].(error)
@@ -118,13 +109,11 @@ func (m *MockECSClient) DescribeService(arg0 string) (*ecs0.DescribeServicesOutp
 
 // DescribeService indicates an expected call of DescribeService
 func (mr *MockECSClientMockRecorder) DescribeService(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeService", reflect.TypeOf((*MockECSClient)(nil).DescribeService), arg0)
 }
 
 // DescribeTaskDefinition mocks base method
 func (m *MockECSClient) DescribeTaskDefinition(arg0 string) (*ecs0.TaskDefinition, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeTaskDefinition", arg0)
 	ret0, _ := ret[0].(*ecs0.TaskDefinition)
 	ret1, _ := ret[1].(error)
@@ -133,13 +122,11 @@ func (m *MockECSClient) DescribeTaskDefinition(arg0 string) (*ecs0.TaskDefinitio
 
 // DescribeTaskDefinition indicates an expected call of DescribeTaskDefinition
 func (mr *MockECSClientMockRecorder) DescribeTaskDefinition(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeTaskDefinition", reflect.TypeOf((*MockECSClient)(nil).DescribeTaskDefinition), arg0)
 }
 
 // DescribeTasks mocks base method
 func (m *MockECSClient) DescribeTasks(arg0 []*string) ([]*ecs0.Task, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeTasks", arg0)
 	ret0, _ := ret[0].([]*ecs0.Task)
 	ret1, _ := ret[1].(error)
@@ -148,13 +135,11 @@ func (m *MockECSClient) DescribeTasks(arg0 []*string) ([]*ecs0.Task, error) {
 
 // DescribeTasks indicates an expected call of DescribeTasks
 func (mr *MockECSClientMockRecorder) DescribeTasks(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeTasks", reflect.TypeOf((*MockECSClient)(nil).DescribeTasks), arg0)
 }
 
 // GetAttributesFromDescribeContainerInstances mocks base method
 func (m *MockECSClient) GetAttributesFromDescribeContainerInstances(arg0 []*string) (map[string][]*string, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetAttributesFromDescribeContainerInstances", arg0)
 	ret0, _ := ret[0].(map[string][]*string)
 	ret1, _ := ret[1].(error)
@@ -163,13 +148,11 @@ func (m *MockECSClient) GetAttributesFromDescribeContainerInstances(arg0 []*stri
 
 // GetAttributesFromDescribeContainerInstances indicates an expected call of GetAttributesFromDescribeContainerInstances
 func (mr *MockECSClientMockRecorder) GetAttributesFromDescribeContainerInstances(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAttributesFromDescribeContainerInstances", reflect.TypeOf((*MockECSClient)(nil).GetAttributesFromDescribeContainerInstances), arg0)
 }
 
 // GetEC2InstanceIDs mocks base method
 func (m *MockECSClient) GetEC2InstanceIDs(arg0 []*string) (map[string]string, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetEC2InstanceIDs", arg0)
 	ret0, _ := ret[0].(map[string]string)
 	ret1, _ := ret[1].(error)
@@ -178,13 +161,11 @@ func (m *MockECSClient) GetEC2InstanceIDs(arg0 []*string) (map[string]string, er
 
 // GetEC2InstanceIDs indicates an expected call of GetEC2InstanceIDs
 func (mr *MockECSClientMockRecorder) GetEC2InstanceIDs(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEC2InstanceIDs", reflect.TypeOf((*MockECSClient)(nil).GetEC2InstanceIDs), arg0)
 }
 
 // GetTasksPages mocks base method
 func (m *MockECSClient) GetTasksPages(arg0 *ecs0.ListTasksInput, arg1 ecs.ProcessTasksAction) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetTasksPages", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -192,13 +173,11 @@ func (m *MockECSClient) GetTasksPages(arg0 *ecs0.ListTasksInput, arg1 ecs.Proces
 
 // GetTasksPages indicates an expected call of GetTasksPages
 func (mr *MockECSClientMockRecorder) GetTasksPages(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTasksPages", reflect.TypeOf((*MockECSClient)(nil).GetTasksPages), arg0, arg1)
 }
 
 // IsActiveCluster mocks base method
 func (m *MockECSClient) IsActiveCluster(arg0 string) (bool, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsActiveCluster", arg0)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
@@ -207,13 +186,11 @@ func (m *MockECSClient) IsActiveCluster(arg0 string) (bool, error) {
 
 // IsActiveCluster indicates an expected call of IsActiveCluster
 func (mr *MockECSClientMockRecorder) IsActiveCluster(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsActiveCluster", reflect.TypeOf((*MockECSClient)(nil).IsActiveCluster), arg0)
 }
 
 // ListAccountSettings mocks base method
 func (m *MockECSClient) ListAccountSettings(arg0 *ecs0.ListAccountSettingsInput) (*ecs0.ListAccountSettingsOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListAccountSettings", arg0)
 	ret0, _ := ret[0].(*ecs0.ListAccountSettingsOutput)
 	ret1, _ := ret[1].(error)
@@ -222,13 +199,11 @@ func (m *MockECSClient) ListAccountSettings(arg0 *ecs0.ListAccountSettingsInput)
 
 // ListAccountSettings indicates an expected call of ListAccountSettings
 func (mr *MockECSClientMockRecorder) ListAccountSettings(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAccountSettings", reflect.TypeOf((*MockECSClient)(nil).ListAccountSettings), arg0)
 }
 
 // RegisterTaskDefinitionIfNeeded mocks base method
 func (m *MockECSClient) RegisterTaskDefinitionIfNeeded(arg0 *ecs0.RegisterTaskDefinitionInput, arg1 cache.Cache) (*ecs0.TaskDefinition, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RegisterTaskDefinitionIfNeeded", arg0, arg1)
 	ret0, _ := ret[0].(*ecs0.TaskDefinition)
 	ret1, _ := ret[1].(error)
@@ -237,13 +212,11 @@ func (m *MockECSClient) RegisterTaskDefinitionIfNeeded(arg0 *ecs0.RegisterTaskDe
 
 // RegisterTaskDefinitionIfNeeded indicates an expected call of RegisterTaskDefinitionIfNeeded
 func (mr *MockECSClientMockRecorder) RegisterTaskDefinitionIfNeeded(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterTaskDefinitionIfNeeded", reflect.TypeOf((*MockECSClient)(nil).RegisterTaskDefinitionIfNeeded), arg0, arg1)
 }
 
 // RunTask mocks base method
 func (m *MockECSClient) RunTask(arg0 *ecs0.RunTaskInput) (*ecs0.RunTaskOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RunTask", arg0)
 	ret0, _ := ret[0].(*ecs0.RunTaskOutput)
 	ret1, _ := ret[1].(error)
@@ -252,13 +225,11 @@ func (m *MockECSClient) RunTask(arg0 *ecs0.RunTaskInput) (*ecs0.RunTaskOutput, e
 
 // RunTask indicates an expected call of RunTask
 func (mr *MockECSClientMockRecorder) RunTask(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunTask", reflect.TypeOf((*MockECSClient)(nil).RunTask), arg0)
 }
 
 // StopTask mocks base method
 func (m *MockECSClient) StopTask(arg0 string) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StopTask", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -266,13 +237,11 @@ func (m *MockECSClient) StopTask(arg0 string) error {
 
 // StopTask indicates an expected call of StopTask
 func (mr *MockECSClientMockRecorder) StopTask(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StopTask", reflect.TypeOf((*MockECSClient)(nil).StopTask), arg0)
 }
 
 // UpdateService mocks base method
 func (m *MockECSClient) UpdateService(arg0 *ecs0.UpdateServiceInput) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateService", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -280,6 +249,5 @@ func (m *MockECSClient) UpdateService(arg0 *ecs0.UpdateServiceInput) error {
 
 // UpdateService indicates an expected call of UpdateService
 func (mr *MockECSClientMockRecorder) UpdateService(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateService", reflect.TypeOf((*MockECSClient)(nil).UpdateService), arg0)
 }

--- a/ecs-cli/modules/clients/aws/ecs/mock/sdk/ecsiface_mock.go
+++ b/ecs-cli/modules/clients/aws/ecs/mock/sdk/ecsiface_mock.go
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2015-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the
@@ -51,7 +51,6 @@ func (m *MockECSAPI) EXPECT() *MockECSAPIMockRecorder {
 
 // CreateCluster mocks base method
 func (m *MockECSAPI) CreateCluster(arg0 *ecs.CreateClusterInput) (*ecs.CreateClusterOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateCluster", arg0)
 	ret0, _ := ret[0].(*ecs.CreateClusterOutput)
 	ret1, _ := ret[1].(error)
@@ -60,13 +59,11 @@ func (m *MockECSAPI) CreateCluster(arg0 *ecs.CreateClusterInput) (*ecs.CreateClu
 
 // CreateCluster indicates an expected call of CreateCluster
 func (mr *MockECSAPIMockRecorder) CreateCluster(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateCluster", reflect.TypeOf((*MockECSAPI)(nil).CreateCluster), arg0)
 }
 
 // CreateClusterRequest mocks base method
 func (m *MockECSAPI) CreateClusterRequest(arg0 *ecs.CreateClusterInput) (*request.Request, *ecs.CreateClusterOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateClusterRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ecs.CreateClusterOutput)
@@ -75,13 +72,11 @@ func (m *MockECSAPI) CreateClusterRequest(arg0 *ecs.CreateClusterInput) (*reques
 
 // CreateClusterRequest indicates an expected call of CreateClusterRequest
 func (mr *MockECSAPIMockRecorder) CreateClusterRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateClusterRequest", reflect.TypeOf((*MockECSAPI)(nil).CreateClusterRequest), arg0)
 }
 
 // CreateClusterWithContext mocks base method
 func (m *MockECSAPI) CreateClusterWithContext(arg0 context.Context, arg1 *ecs.CreateClusterInput, arg2 ...request.Option) (*ecs.CreateClusterOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -94,14 +89,12 @@ func (m *MockECSAPI) CreateClusterWithContext(arg0 context.Context, arg1 *ecs.Cr
 
 // CreateClusterWithContext indicates an expected call of CreateClusterWithContext
 func (mr *MockECSAPIMockRecorder) CreateClusterWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateClusterWithContext", reflect.TypeOf((*MockECSAPI)(nil).CreateClusterWithContext), varargs...)
 }
 
 // CreateService mocks base method
 func (m *MockECSAPI) CreateService(arg0 *ecs.CreateServiceInput) (*ecs.CreateServiceOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateService", arg0)
 	ret0, _ := ret[0].(*ecs.CreateServiceOutput)
 	ret1, _ := ret[1].(error)
@@ -110,13 +103,11 @@ func (m *MockECSAPI) CreateService(arg0 *ecs.CreateServiceInput) (*ecs.CreateSer
 
 // CreateService indicates an expected call of CreateService
 func (mr *MockECSAPIMockRecorder) CreateService(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateService", reflect.TypeOf((*MockECSAPI)(nil).CreateService), arg0)
 }
 
 // CreateServiceRequest mocks base method
 func (m *MockECSAPI) CreateServiceRequest(arg0 *ecs.CreateServiceInput) (*request.Request, *ecs.CreateServiceOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateServiceRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ecs.CreateServiceOutput)
@@ -125,13 +116,11 @@ func (m *MockECSAPI) CreateServiceRequest(arg0 *ecs.CreateServiceInput) (*reques
 
 // CreateServiceRequest indicates an expected call of CreateServiceRequest
 func (mr *MockECSAPIMockRecorder) CreateServiceRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateServiceRequest", reflect.TypeOf((*MockECSAPI)(nil).CreateServiceRequest), arg0)
 }
 
 // CreateServiceWithContext mocks base method
 func (m *MockECSAPI) CreateServiceWithContext(arg0 context.Context, arg1 *ecs.CreateServiceInput, arg2 ...request.Option) (*ecs.CreateServiceOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -144,14 +133,12 @@ func (m *MockECSAPI) CreateServiceWithContext(arg0 context.Context, arg1 *ecs.Cr
 
 // CreateServiceWithContext indicates an expected call of CreateServiceWithContext
 func (mr *MockECSAPIMockRecorder) CreateServiceWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateServiceWithContext", reflect.TypeOf((*MockECSAPI)(nil).CreateServiceWithContext), varargs...)
 }
 
 // DeleteAccountSetting mocks base method
 func (m *MockECSAPI) DeleteAccountSetting(arg0 *ecs.DeleteAccountSettingInput) (*ecs.DeleteAccountSettingOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteAccountSetting", arg0)
 	ret0, _ := ret[0].(*ecs.DeleteAccountSettingOutput)
 	ret1, _ := ret[1].(error)
@@ -160,13 +147,11 @@ func (m *MockECSAPI) DeleteAccountSetting(arg0 *ecs.DeleteAccountSettingInput) (
 
 // DeleteAccountSetting indicates an expected call of DeleteAccountSetting
 func (mr *MockECSAPIMockRecorder) DeleteAccountSetting(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteAccountSetting", reflect.TypeOf((*MockECSAPI)(nil).DeleteAccountSetting), arg0)
 }
 
 // DeleteAccountSettingRequest mocks base method
 func (m *MockECSAPI) DeleteAccountSettingRequest(arg0 *ecs.DeleteAccountSettingInput) (*request.Request, *ecs.DeleteAccountSettingOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteAccountSettingRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ecs.DeleteAccountSettingOutput)
@@ -175,13 +160,11 @@ func (m *MockECSAPI) DeleteAccountSettingRequest(arg0 *ecs.DeleteAccountSettingI
 
 // DeleteAccountSettingRequest indicates an expected call of DeleteAccountSettingRequest
 func (mr *MockECSAPIMockRecorder) DeleteAccountSettingRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteAccountSettingRequest", reflect.TypeOf((*MockECSAPI)(nil).DeleteAccountSettingRequest), arg0)
 }
 
 // DeleteAccountSettingWithContext mocks base method
 func (m *MockECSAPI) DeleteAccountSettingWithContext(arg0 context.Context, arg1 *ecs.DeleteAccountSettingInput, arg2 ...request.Option) (*ecs.DeleteAccountSettingOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -194,14 +177,12 @@ func (m *MockECSAPI) DeleteAccountSettingWithContext(arg0 context.Context, arg1 
 
 // DeleteAccountSettingWithContext indicates an expected call of DeleteAccountSettingWithContext
 func (mr *MockECSAPIMockRecorder) DeleteAccountSettingWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteAccountSettingWithContext", reflect.TypeOf((*MockECSAPI)(nil).DeleteAccountSettingWithContext), varargs...)
 }
 
 // DeleteAttributes mocks base method
 func (m *MockECSAPI) DeleteAttributes(arg0 *ecs.DeleteAttributesInput) (*ecs.DeleteAttributesOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteAttributes", arg0)
 	ret0, _ := ret[0].(*ecs.DeleteAttributesOutput)
 	ret1, _ := ret[1].(error)
@@ -210,13 +191,11 @@ func (m *MockECSAPI) DeleteAttributes(arg0 *ecs.DeleteAttributesInput) (*ecs.Del
 
 // DeleteAttributes indicates an expected call of DeleteAttributes
 func (mr *MockECSAPIMockRecorder) DeleteAttributes(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteAttributes", reflect.TypeOf((*MockECSAPI)(nil).DeleteAttributes), arg0)
 }
 
 // DeleteAttributesRequest mocks base method
 func (m *MockECSAPI) DeleteAttributesRequest(arg0 *ecs.DeleteAttributesInput) (*request.Request, *ecs.DeleteAttributesOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteAttributesRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ecs.DeleteAttributesOutput)
@@ -225,13 +204,11 @@ func (m *MockECSAPI) DeleteAttributesRequest(arg0 *ecs.DeleteAttributesInput) (*
 
 // DeleteAttributesRequest indicates an expected call of DeleteAttributesRequest
 func (mr *MockECSAPIMockRecorder) DeleteAttributesRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteAttributesRequest", reflect.TypeOf((*MockECSAPI)(nil).DeleteAttributesRequest), arg0)
 }
 
 // DeleteAttributesWithContext mocks base method
 func (m *MockECSAPI) DeleteAttributesWithContext(arg0 context.Context, arg1 *ecs.DeleteAttributesInput, arg2 ...request.Option) (*ecs.DeleteAttributesOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -244,14 +221,12 @@ func (m *MockECSAPI) DeleteAttributesWithContext(arg0 context.Context, arg1 *ecs
 
 // DeleteAttributesWithContext indicates an expected call of DeleteAttributesWithContext
 func (mr *MockECSAPIMockRecorder) DeleteAttributesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteAttributesWithContext", reflect.TypeOf((*MockECSAPI)(nil).DeleteAttributesWithContext), varargs...)
 }
 
 // DeleteCluster mocks base method
 func (m *MockECSAPI) DeleteCluster(arg0 *ecs.DeleteClusterInput) (*ecs.DeleteClusterOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteCluster", arg0)
 	ret0, _ := ret[0].(*ecs.DeleteClusterOutput)
 	ret1, _ := ret[1].(error)
@@ -260,13 +235,11 @@ func (m *MockECSAPI) DeleteCluster(arg0 *ecs.DeleteClusterInput) (*ecs.DeleteClu
 
 // DeleteCluster indicates an expected call of DeleteCluster
 func (mr *MockECSAPIMockRecorder) DeleteCluster(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteCluster", reflect.TypeOf((*MockECSAPI)(nil).DeleteCluster), arg0)
 }
 
 // DeleteClusterRequest mocks base method
 func (m *MockECSAPI) DeleteClusterRequest(arg0 *ecs.DeleteClusterInput) (*request.Request, *ecs.DeleteClusterOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteClusterRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ecs.DeleteClusterOutput)
@@ -275,13 +248,11 @@ func (m *MockECSAPI) DeleteClusterRequest(arg0 *ecs.DeleteClusterInput) (*reques
 
 // DeleteClusterRequest indicates an expected call of DeleteClusterRequest
 func (mr *MockECSAPIMockRecorder) DeleteClusterRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteClusterRequest", reflect.TypeOf((*MockECSAPI)(nil).DeleteClusterRequest), arg0)
 }
 
 // DeleteClusterWithContext mocks base method
 func (m *MockECSAPI) DeleteClusterWithContext(arg0 context.Context, arg1 *ecs.DeleteClusterInput, arg2 ...request.Option) (*ecs.DeleteClusterOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -294,14 +265,12 @@ func (m *MockECSAPI) DeleteClusterWithContext(arg0 context.Context, arg1 *ecs.De
 
 // DeleteClusterWithContext indicates an expected call of DeleteClusterWithContext
 func (mr *MockECSAPIMockRecorder) DeleteClusterWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteClusterWithContext", reflect.TypeOf((*MockECSAPI)(nil).DeleteClusterWithContext), varargs...)
 }
 
 // DeleteService mocks base method
 func (m *MockECSAPI) DeleteService(arg0 *ecs.DeleteServiceInput) (*ecs.DeleteServiceOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteService", arg0)
 	ret0, _ := ret[0].(*ecs.DeleteServiceOutput)
 	ret1, _ := ret[1].(error)
@@ -310,13 +279,11 @@ func (m *MockECSAPI) DeleteService(arg0 *ecs.DeleteServiceInput) (*ecs.DeleteSer
 
 // DeleteService indicates an expected call of DeleteService
 func (mr *MockECSAPIMockRecorder) DeleteService(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteService", reflect.TypeOf((*MockECSAPI)(nil).DeleteService), arg0)
 }
 
 // DeleteServiceRequest mocks base method
 func (m *MockECSAPI) DeleteServiceRequest(arg0 *ecs.DeleteServiceInput) (*request.Request, *ecs.DeleteServiceOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteServiceRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ecs.DeleteServiceOutput)
@@ -325,13 +292,11 @@ func (m *MockECSAPI) DeleteServiceRequest(arg0 *ecs.DeleteServiceInput) (*reques
 
 // DeleteServiceRequest indicates an expected call of DeleteServiceRequest
 func (mr *MockECSAPIMockRecorder) DeleteServiceRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteServiceRequest", reflect.TypeOf((*MockECSAPI)(nil).DeleteServiceRequest), arg0)
 }
 
 // DeleteServiceWithContext mocks base method
 func (m *MockECSAPI) DeleteServiceWithContext(arg0 context.Context, arg1 *ecs.DeleteServiceInput, arg2 ...request.Option) (*ecs.DeleteServiceOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -344,14 +309,12 @@ func (m *MockECSAPI) DeleteServiceWithContext(arg0 context.Context, arg1 *ecs.De
 
 // DeleteServiceWithContext indicates an expected call of DeleteServiceWithContext
 func (mr *MockECSAPIMockRecorder) DeleteServiceWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteServiceWithContext", reflect.TypeOf((*MockECSAPI)(nil).DeleteServiceWithContext), varargs...)
 }
 
 // DeregisterContainerInstance mocks base method
 func (m *MockECSAPI) DeregisterContainerInstance(arg0 *ecs.DeregisterContainerInstanceInput) (*ecs.DeregisterContainerInstanceOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeregisterContainerInstance", arg0)
 	ret0, _ := ret[0].(*ecs.DeregisterContainerInstanceOutput)
 	ret1, _ := ret[1].(error)
@@ -360,13 +323,11 @@ func (m *MockECSAPI) DeregisterContainerInstance(arg0 *ecs.DeregisterContainerIn
 
 // DeregisterContainerInstance indicates an expected call of DeregisterContainerInstance
 func (mr *MockECSAPIMockRecorder) DeregisterContainerInstance(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeregisterContainerInstance", reflect.TypeOf((*MockECSAPI)(nil).DeregisterContainerInstance), arg0)
 }
 
 // DeregisterContainerInstanceRequest mocks base method
 func (m *MockECSAPI) DeregisterContainerInstanceRequest(arg0 *ecs.DeregisterContainerInstanceInput) (*request.Request, *ecs.DeregisterContainerInstanceOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeregisterContainerInstanceRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ecs.DeregisterContainerInstanceOutput)
@@ -375,13 +336,11 @@ func (m *MockECSAPI) DeregisterContainerInstanceRequest(arg0 *ecs.DeregisterCont
 
 // DeregisterContainerInstanceRequest indicates an expected call of DeregisterContainerInstanceRequest
 func (mr *MockECSAPIMockRecorder) DeregisterContainerInstanceRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeregisterContainerInstanceRequest", reflect.TypeOf((*MockECSAPI)(nil).DeregisterContainerInstanceRequest), arg0)
 }
 
 // DeregisterContainerInstanceWithContext mocks base method
 func (m *MockECSAPI) DeregisterContainerInstanceWithContext(arg0 context.Context, arg1 *ecs.DeregisterContainerInstanceInput, arg2 ...request.Option) (*ecs.DeregisterContainerInstanceOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -394,14 +353,12 @@ func (m *MockECSAPI) DeregisterContainerInstanceWithContext(arg0 context.Context
 
 // DeregisterContainerInstanceWithContext indicates an expected call of DeregisterContainerInstanceWithContext
 func (mr *MockECSAPIMockRecorder) DeregisterContainerInstanceWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeregisterContainerInstanceWithContext", reflect.TypeOf((*MockECSAPI)(nil).DeregisterContainerInstanceWithContext), varargs...)
 }
 
 // DeregisterTaskDefinition mocks base method
 func (m *MockECSAPI) DeregisterTaskDefinition(arg0 *ecs.DeregisterTaskDefinitionInput) (*ecs.DeregisterTaskDefinitionOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeregisterTaskDefinition", arg0)
 	ret0, _ := ret[0].(*ecs.DeregisterTaskDefinitionOutput)
 	ret1, _ := ret[1].(error)
@@ -410,13 +367,11 @@ func (m *MockECSAPI) DeregisterTaskDefinition(arg0 *ecs.DeregisterTaskDefinition
 
 // DeregisterTaskDefinition indicates an expected call of DeregisterTaskDefinition
 func (mr *MockECSAPIMockRecorder) DeregisterTaskDefinition(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeregisterTaskDefinition", reflect.TypeOf((*MockECSAPI)(nil).DeregisterTaskDefinition), arg0)
 }
 
 // DeregisterTaskDefinitionRequest mocks base method
 func (m *MockECSAPI) DeregisterTaskDefinitionRequest(arg0 *ecs.DeregisterTaskDefinitionInput) (*request.Request, *ecs.DeregisterTaskDefinitionOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeregisterTaskDefinitionRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ecs.DeregisterTaskDefinitionOutput)
@@ -425,13 +380,11 @@ func (m *MockECSAPI) DeregisterTaskDefinitionRequest(arg0 *ecs.DeregisterTaskDef
 
 // DeregisterTaskDefinitionRequest indicates an expected call of DeregisterTaskDefinitionRequest
 func (mr *MockECSAPIMockRecorder) DeregisterTaskDefinitionRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeregisterTaskDefinitionRequest", reflect.TypeOf((*MockECSAPI)(nil).DeregisterTaskDefinitionRequest), arg0)
 }
 
 // DeregisterTaskDefinitionWithContext mocks base method
 func (m *MockECSAPI) DeregisterTaskDefinitionWithContext(arg0 context.Context, arg1 *ecs.DeregisterTaskDefinitionInput, arg2 ...request.Option) (*ecs.DeregisterTaskDefinitionOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -444,14 +397,12 @@ func (m *MockECSAPI) DeregisterTaskDefinitionWithContext(arg0 context.Context, a
 
 // DeregisterTaskDefinitionWithContext indicates an expected call of DeregisterTaskDefinitionWithContext
 func (mr *MockECSAPIMockRecorder) DeregisterTaskDefinitionWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeregisterTaskDefinitionWithContext", reflect.TypeOf((*MockECSAPI)(nil).DeregisterTaskDefinitionWithContext), varargs...)
 }
 
 // DescribeClusters mocks base method
 func (m *MockECSAPI) DescribeClusters(arg0 *ecs.DescribeClustersInput) (*ecs.DescribeClustersOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeClusters", arg0)
 	ret0, _ := ret[0].(*ecs.DescribeClustersOutput)
 	ret1, _ := ret[1].(error)
@@ -460,13 +411,11 @@ func (m *MockECSAPI) DescribeClusters(arg0 *ecs.DescribeClustersInput) (*ecs.Des
 
 // DescribeClusters indicates an expected call of DescribeClusters
 func (mr *MockECSAPIMockRecorder) DescribeClusters(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeClusters", reflect.TypeOf((*MockECSAPI)(nil).DescribeClusters), arg0)
 }
 
 // DescribeClustersRequest mocks base method
 func (m *MockECSAPI) DescribeClustersRequest(arg0 *ecs.DescribeClustersInput) (*request.Request, *ecs.DescribeClustersOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeClustersRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ecs.DescribeClustersOutput)
@@ -475,13 +424,11 @@ func (m *MockECSAPI) DescribeClustersRequest(arg0 *ecs.DescribeClustersInput) (*
 
 // DescribeClustersRequest indicates an expected call of DescribeClustersRequest
 func (mr *MockECSAPIMockRecorder) DescribeClustersRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeClustersRequest", reflect.TypeOf((*MockECSAPI)(nil).DescribeClustersRequest), arg0)
 }
 
 // DescribeClustersWithContext mocks base method
 func (m *MockECSAPI) DescribeClustersWithContext(arg0 context.Context, arg1 *ecs.DescribeClustersInput, arg2 ...request.Option) (*ecs.DescribeClustersOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -494,14 +441,12 @@ func (m *MockECSAPI) DescribeClustersWithContext(arg0 context.Context, arg1 *ecs
 
 // DescribeClustersWithContext indicates an expected call of DescribeClustersWithContext
 func (mr *MockECSAPIMockRecorder) DescribeClustersWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeClustersWithContext", reflect.TypeOf((*MockECSAPI)(nil).DescribeClustersWithContext), varargs...)
 }
 
 // DescribeContainerInstances mocks base method
 func (m *MockECSAPI) DescribeContainerInstances(arg0 *ecs.DescribeContainerInstancesInput) (*ecs.DescribeContainerInstancesOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeContainerInstances", arg0)
 	ret0, _ := ret[0].(*ecs.DescribeContainerInstancesOutput)
 	ret1, _ := ret[1].(error)
@@ -510,13 +455,11 @@ func (m *MockECSAPI) DescribeContainerInstances(arg0 *ecs.DescribeContainerInsta
 
 // DescribeContainerInstances indicates an expected call of DescribeContainerInstances
 func (mr *MockECSAPIMockRecorder) DescribeContainerInstances(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeContainerInstances", reflect.TypeOf((*MockECSAPI)(nil).DescribeContainerInstances), arg0)
 }
 
 // DescribeContainerInstancesRequest mocks base method
 func (m *MockECSAPI) DescribeContainerInstancesRequest(arg0 *ecs.DescribeContainerInstancesInput) (*request.Request, *ecs.DescribeContainerInstancesOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeContainerInstancesRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ecs.DescribeContainerInstancesOutput)
@@ -525,13 +468,11 @@ func (m *MockECSAPI) DescribeContainerInstancesRequest(arg0 *ecs.DescribeContain
 
 // DescribeContainerInstancesRequest indicates an expected call of DescribeContainerInstancesRequest
 func (mr *MockECSAPIMockRecorder) DescribeContainerInstancesRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeContainerInstancesRequest", reflect.TypeOf((*MockECSAPI)(nil).DescribeContainerInstancesRequest), arg0)
 }
 
 // DescribeContainerInstancesWithContext mocks base method
 func (m *MockECSAPI) DescribeContainerInstancesWithContext(arg0 context.Context, arg1 *ecs.DescribeContainerInstancesInput, arg2 ...request.Option) (*ecs.DescribeContainerInstancesOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -544,14 +485,12 @@ func (m *MockECSAPI) DescribeContainerInstancesWithContext(arg0 context.Context,
 
 // DescribeContainerInstancesWithContext indicates an expected call of DescribeContainerInstancesWithContext
 func (mr *MockECSAPIMockRecorder) DescribeContainerInstancesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeContainerInstancesWithContext", reflect.TypeOf((*MockECSAPI)(nil).DescribeContainerInstancesWithContext), varargs...)
 }
 
 // DescribeServices mocks base method
 func (m *MockECSAPI) DescribeServices(arg0 *ecs.DescribeServicesInput) (*ecs.DescribeServicesOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeServices", arg0)
 	ret0, _ := ret[0].(*ecs.DescribeServicesOutput)
 	ret1, _ := ret[1].(error)
@@ -560,13 +499,11 @@ func (m *MockECSAPI) DescribeServices(arg0 *ecs.DescribeServicesInput) (*ecs.Des
 
 // DescribeServices indicates an expected call of DescribeServices
 func (mr *MockECSAPIMockRecorder) DescribeServices(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeServices", reflect.TypeOf((*MockECSAPI)(nil).DescribeServices), arg0)
 }
 
 // DescribeServicesRequest mocks base method
 func (m *MockECSAPI) DescribeServicesRequest(arg0 *ecs.DescribeServicesInput) (*request.Request, *ecs.DescribeServicesOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeServicesRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ecs.DescribeServicesOutput)
@@ -575,13 +512,11 @@ func (m *MockECSAPI) DescribeServicesRequest(arg0 *ecs.DescribeServicesInput) (*
 
 // DescribeServicesRequest indicates an expected call of DescribeServicesRequest
 func (mr *MockECSAPIMockRecorder) DescribeServicesRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeServicesRequest", reflect.TypeOf((*MockECSAPI)(nil).DescribeServicesRequest), arg0)
 }
 
 // DescribeServicesWithContext mocks base method
 func (m *MockECSAPI) DescribeServicesWithContext(arg0 context.Context, arg1 *ecs.DescribeServicesInput, arg2 ...request.Option) (*ecs.DescribeServicesOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -594,14 +529,12 @@ func (m *MockECSAPI) DescribeServicesWithContext(arg0 context.Context, arg1 *ecs
 
 // DescribeServicesWithContext indicates an expected call of DescribeServicesWithContext
 func (mr *MockECSAPIMockRecorder) DescribeServicesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeServicesWithContext", reflect.TypeOf((*MockECSAPI)(nil).DescribeServicesWithContext), varargs...)
 }
 
 // DescribeTaskDefinition mocks base method
 func (m *MockECSAPI) DescribeTaskDefinition(arg0 *ecs.DescribeTaskDefinitionInput) (*ecs.DescribeTaskDefinitionOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeTaskDefinition", arg0)
 	ret0, _ := ret[0].(*ecs.DescribeTaskDefinitionOutput)
 	ret1, _ := ret[1].(error)
@@ -610,13 +543,11 @@ func (m *MockECSAPI) DescribeTaskDefinition(arg0 *ecs.DescribeTaskDefinitionInpu
 
 // DescribeTaskDefinition indicates an expected call of DescribeTaskDefinition
 func (mr *MockECSAPIMockRecorder) DescribeTaskDefinition(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeTaskDefinition", reflect.TypeOf((*MockECSAPI)(nil).DescribeTaskDefinition), arg0)
 }
 
 // DescribeTaskDefinitionRequest mocks base method
 func (m *MockECSAPI) DescribeTaskDefinitionRequest(arg0 *ecs.DescribeTaskDefinitionInput) (*request.Request, *ecs.DescribeTaskDefinitionOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeTaskDefinitionRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ecs.DescribeTaskDefinitionOutput)
@@ -625,13 +556,11 @@ func (m *MockECSAPI) DescribeTaskDefinitionRequest(arg0 *ecs.DescribeTaskDefinit
 
 // DescribeTaskDefinitionRequest indicates an expected call of DescribeTaskDefinitionRequest
 func (mr *MockECSAPIMockRecorder) DescribeTaskDefinitionRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeTaskDefinitionRequest", reflect.TypeOf((*MockECSAPI)(nil).DescribeTaskDefinitionRequest), arg0)
 }
 
 // DescribeTaskDefinitionWithContext mocks base method
 func (m *MockECSAPI) DescribeTaskDefinitionWithContext(arg0 context.Context, arg1 *ecs.DescribeTaskDefinitionInput, arg2 ...request.Option) (*ecs.DescribeTaskDefinitionOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -644,14 +573,12 @@ func (m *MockECSAPI) DescribeTaskDefinitionWithContext(arg0 context.Context, arg
 
 // DescribeTaskDefinitionWithContext indicates an expected call of DescribeTaskDefinitionWithContext
 func (mr *MockECSAPIMockRecorder) DescribeTaskDefinitionWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeTaskDefinitionWithContext", reflect.TypeOf((*MockECSAPI)(nil).DescribeTaskDefinitionWithContext), varargs...)
 }
 
 // DescribeTasks mocks base method
 func (m *MockECSAPI) DescribeTasks(arg0 *ecs.DescribeTasksInput) (*ecs.DescribeTasksOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeTasks", arg0)
 	ret0, _ := ret[0].(*ecs.DescribeTasksOutput)
 	ret1, _ := ret[1].(error)
@@ -660,13 +587,11 @@ func (m *MockECSAPI) DescribeTasks(arg0 *ecs.DescribeTasksInput) (*ecs.DescribeT
 
 // DescribeTasks indicates an expected call of DescribeTasks
 func (mr *MockECSAPIMockRecorder) DescribeTasks(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeTasks", reflect.TypeOf((*MockECSAPI)(nil).DescribeTasks), arg0)
 }
 
 // DescribeTasksRequest mocks base method
 func (m *MockECSAPI) DescribeTasksRequest(arg0 *ecs.DescribeTasksInput) (*request.Request, *ecs.DescribeTasksOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeTasksRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ecs.DescribeTasksOutput)
@@ -675,13 +600,11 @@ func (m *MockECSAPI) DescribeTasksRequest(arg0 *ecs.DescribeTasksInput) (*reques
 
 // DescribeTasksRequest indicates an expected call of DescribeTasksRequest
 func (mr *MockECSAPIMockRecorder) DescribeTasksRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeTasksRequest", reflect.TypeOf((*MockECSAPI)(nil).DescribeTasksRequest), arg0)
 }
 
 // DescribeTasksWithContext mocks base method
 func (m *MockECSAPI) DescribeTasksWithContext(arg0 context.Context, arg1 *ecs.DescribeTasksInput, arg2 ...request.Option) (*ecs.DescribeTasksOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -694,14 +617,12 @@ func (m *MockECSAPI) DescribeTasksWithContext(arg0 context.Context, arg1 *ecs.De
 
 // DescribeTasksWithContext indicates an expected call of DescribeTasksWithContext
 func (mr *MockECSAPIMockRecorder) DescribeTasksWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeTasksWithContext", reflect.TypeOf((*MockECSAPI)(nil).DescribeTasksWithContext), varargs...)
 }
 
 // DiscoverPollEndpoint mocks base method
 func (m *MockECSAPI) DiscoverPollEndpoint(arg0 *ecs.DiscoverPollEndpointInput) (*ecs.DiscoverPollEndpointOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DiscoverPollEndpoint", arg0)
 	ret0, _ := ret[0].(*ecs.DiscoverPollEndpointOutput)
 	ret1, _ := ret[1].(error)
@@ -710,13 +631,11 @@ func (m *MockECSAPI) DiscoverPollEndpoint(arg0 *ecs.DiscoverPollEndpointInput) (
 
 // DiscoverPollEndpoint indicates an expected call of DiscoverPollEndpoint
 func (mr *MockECSAPIMockRecorder) DiscoverPollEndpoint(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DiscoverPollEndpoint", reflect.TypeOf((*MockECSAPI)(nil).DiscoverPollEndpoint), arg0)
 }
 
 // DiscoverPollEndpointRequest mocks base method
 func (m *MockECSAPI) DiscoverPollEndpointRequest(arg0 *ecs.DiscoverPollEndpointInput) (*request.Request, *ecs.DiscoverPollEndpointOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DiscoverPollEndpointRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ecs.DiscoverPollEndpointOutput)
@@ -725,13 +644,11 @@ func (m *MockECSAPI) DiscoverPollEndpointRequest(arg0 *ecs.DiscoverPollEndpointI
 
 // DiscoverPollEndpointRequest indicates an expected call of DiscoverPollEndpointRequest
 func (mr *MockECSAPIMockRecorder) DiscoverPollEndpointRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DiscoverPollEndpointRequest", reflect.TypeOf((*MockECSAPI)(nil).DiscoverPollEndpointRequest), arg0)
 }
 
 // DiscoverPollEndpointWithContext mocks base method
 func (m *MockECSAPI) DiscoverPollEndpointWithContext(arg0 context.Context, arg1 *ecs.DiscoverPollEndpointInput, arg2 ...request.Option) (*ecs.DiscoverPollEndpointOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -744,14 +661,12 @@ func (m *MockECSAPI) DiscoverPollEndpointWithContext(arg0 context.Context, arg1 
 
 // DiscoverPollEndpointWithContext indicates an expected call of DiscoverPollEndpointWithContext
 func (mr *MockECSAPIMockRecorder) DiscoverPollEndpointWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DiscoverPollEndpointWithContext", reflect.TypeOf((*MockECSAPI)(nil).DiscoverPollEndpointWithContext), varargs...)
 }
 
 // ListAccountSettings mocks base method
 func (m *MockECSAPI) ListAccountSettings(arg0 *ecs.ListAccountSettingsInput) (*ecs.ListAccountSettingsOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListAccountSettings", arg0)
 	ret0, _ := ret[0].(*ecs.ListAccountSettingsOutput)
 	ret1, _ := ret[1].(error)
@@ -760,13 +675,11 @@ func (m *MockECSAPI) ListAccountSettings(arg0 *ecs.ListAccountSettingsInput) (*e
 
 // ListAccountSettings indicates an expected call of ListAccountSettings
 func (mr *MockECSAPIMockRecorder) ListAccountSettings(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAccountSettings", reflect.TypeOf((*MockECSAPI)(nil).ListAccountSettings), arg0)
 }
 
 // ListAccountSettingsRequest mocks base method
 func (m *MockECSAPI) ListAccountSettingsRequest(arg0 *ecs.ListAccountSettingsInput) (*request.Request, *ecs.ListAccountSettingsOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListAccountSettingsRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ecs.ListAccountSettingsOutput)
@@ -775,13 +688,11 @@ func (m *MockECSAPI) ListAccountSettingsRequest(arg0 *ecs.ListAccountSettingsInp
 
 // ListAccountSettingsRequest indicates an expected call of ListAccountSettingsRequest
 func (mr *MockECSAPIMockRecorder) ListAccountSettingsRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAccountSettingsRequest", reflect.TypeOf((*MockECSAPI)(nil).ListAccountSettingsRequest), arg0)
 }
 
 // ListAccountSettingsWithContext mocks base method
 func (m *MockECSAPI) ListAccountSettingsWithContext(arg0 context.Context, arg1 *ecs.ListAccountSettingsInput, arg2 ...request.Option) (*ecs.ListAccountSettingsOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -794,14 +705,12 @@ func (m *MockECSAPI) ListAccountSettingsWithContext(arg0 context.Context, arg1 *
 
 // ListAccountSettingsWithContext indicates an expected call of ListAccountSettingsWithContext
 func (mr *MockECSAPIMockRecorder) ListAccountSettingsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAccountSettingsWithContext", reflect.TypeOf((*MockECSAPI)(nil).ListAccountSettingsWithContext), varargs...)
 }
 
 // ListAttributes mocks base method
 func (m *MockECSAPI) ListAttributes(arg0 *ecs.ListAttributesInput) (*ecs.ListAttributesOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListAttributes", arg0)
 	ret0, _ := ret[0].(*ecs.ListAttributesOutput)
 	ret1, _ := ret[1].(error)
@@ -810,13 +719,11 @@ func (m *MockECSAPI) ListAttributes(arg0 *ecs.ListAttributesInput) (*ecs.ListAtt
 
 // ListAttributes indicates an expected call of ListAttributes
 func (mr *MockECSAPIMockRecorder) ListAttributes(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAttributes", reflect.TypeOf((*MockECSAPI)(nil).ListAttributes), arg0)
 }
 
 // ListAttributesRequest mocks base method
 func (m *MockECSAPI) ListAttributesRequest(arg0 *ecs.ListAttributesInput) (*request.Request, *ecs.ListAttributesOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListAttributesRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ecs.ListAttributesOutput)
@@ -825,13 +732,11 @@ func (m *MockECSAPI) ListAttributesRequest(arg0 *ecs.ListAttributesInput) (*requ
 
 // ListAttributesRequest indicates an expected call of ListAttributesRequest
 func (mr *MockECSAPIMockRecorder) ListAttributesRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAttributesRequest", reflect.TypeOf((*MockECSAPI)(nil).ListAttributesRequest), arg0)
 }
 
 // ListAttributesWithContext mocks base method
 func (m *MockECSAPI) ListAttributesWithContext(arg0 context.Context, arg1 *ecs.ListAttributesInput, arg2 ...request.Option) (*ecs.ListAttributesOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -844,14 +749,12 @@ func (m *MockECSAPI) ListAttributesWithContext(arg0 context.Context, arg1 *ecs.L
 
 // ListAttributesWithContext indicates an expected call of ListAttributesWithContext
 func (mr *MockECSAPIMockRecorder) ListAttributesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAttributesWithContext", reflect.TypeOf((*MockECSAPI)(nil).ListAttributesWithContext), varargs...)
 }
 
 // ListClusters mocks base method
 func (m *MockECSAPI) ListClusters(arg0 *ecs.ListClustersInput) (*ecs.ListClustersOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListClusters", arg0)
 	ret0, _ := ret[0].(*ecs.ListClustersOutput)
 	ret1, _ := ret[1].(error)
@@ -860,13 +763,11 @@ func (m *MockECSAPI) ListClusters(arg0 *ecs.ListClustersInput) (*ecs.ListCluster
 
 // ListClusters indicates an expected call of ListClusters
 func (mr *MockECSAPIMockRecorder) ListClusters(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListClusters", reflect.TypeOf((*MockECSAPI)(nil).ListClusters), arg0)
 }
 
 // ListClustersPages mocks base method
 func (m *MockECSAPI) ListClustersPages(arg0 *ecs.ListClustersInput, arg1 func(*ecs.ListClustersOutput, bool) bool) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListClustersPages", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -874,13 +775,11 @@ func (m *MockECSAPI) ListClustersPages(arg0 *ecs.ListClustersInput, arg1 func(*e
 
 // ListClustersPages indicates an expected call of ListClustersPages
 func (mr *MockECSAPIMockRecorder) ListClustersPages(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListClustersPages", reflect.TypeOf((*MockECSAPI)(nil).ListClustersPages), arg0, arg1)
 }
 
 // ListClustersPagesWithContext mocks base method
 func (m *MockECSAPI) ListClustersPagesWithContext(arg0 context.Context, arg1 *ecs.ListClustersInput, arg2 func(*ecs.ListClustersOutput, bool) bool, arg3 ...request.Option) error {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1, arg2}
 	for _, a := range arg3 {
 		varargs = append(varargs, a)
@@ -892,14 +791,12 @@ func (m *MockECSAPI) ListClustersPagesWithContext(arg0 context.Context, arg1 *ec
 
 // ListClustersPagesWithContext indicates an expected call of ListClustersPagesWithContext
 func (mr *MockECSAPIMockRecorder) ListClustersPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListClustersPagesWithContext", reflect.TypeOf((*MockECSAPI)(nil).ListClustersPagesWithContext), varargs...)
 }
 
 // ListClustersRequest mocks base method
 func (m *MockECSAPI) ListClustersRequest(arg0 *ecs.ListClustersInput) (*request.Request, *ecs.ListClustersOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListClustersRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ecs.ListClustersOutput)
@@ -908,13 +805,11 @@ func (m *MockECSAPI) ListClustersRequest(arg0 *ecs.ListClustersInput) (*request.
 
 // ListClustersRequest indicates an expected call of ListClustersRequest
 func (mr *MockECSAPIMockRecorder) ListClustersRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListClustersRequest", reflect.TypeOf((*MockECSAPI)(nil).ListClustersRequest), arg0)
 }
 
 // ListClustersWithContext mocks base method
 func (m *MockECSAPI) ListClustersWithContext(arg0 context.Context, arg1 *ecs.ListClustersInput, arg2 ...request.Option) (*ecs.ListClustersOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -927,14 +822,12 @@ func (m *MockECSAPI) ListClustersWithContext(arg0 context.Context, arg1 *ecs.Lis
 
 // ListClustersWithContext indicates an expected call of ListClustersWithContext
 func (mr *MockECSAPIMockRecorder) ListClustersWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListClustersWithContext", reflect.TypeOf((*MockECSAPI)(nil).ListClustersWithContext), varargs...)
 }
 
 // ListContainerInstances mocks base method
 func (m *MockECSAPI) ListContainerInstances(arg0 *ecs.ListContainerInstancesInput) (*ecs.ListContainerInstancesOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListContainerInstances", arg0)
 	ret0, _ := ret[0].(*ecs.ListContainerInstancesOutput)
 	ret1, _ := ret[1].(error)
@@ -943,13 +836,11 @@ func (m *MockECSAPI) ListContainerInstances(arg0 *ecs.ListContainerInstancesInpu
 
 // ListContainerInstances indicates an expected call of ListContainerInstances
 func (mr *MockECSAPIMockRecorder) ListContainerInstances(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListContainerInstances", reflect.TypeOf((*MockECSAPI)(nil).ListContainerInstances), arg0)
 }
 
 // ListContainerInstancesPages mocks base method
 func (m *MockECSAPI) ListContainerInstancesPages(arg0 *ecs.ListContainerInstancesInput, arg1 func(*ecs.ListContainerInstancesOutput, bool) bool) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListContainerInstancesPages", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -957,13 +848,11 @@ func (m *MockECSAPI) ListContainerInstancesPages(arg0 *ecs.ListContainerInstance
 
 // ListContainerInstancesPages indicates an expected call of ListContainerInstancesPages
 func (mr *MockECSAPIMockRecorder) ListContainerInstancesPages(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListContainerInstancesPages", reflect.TypeOf((*MockECSAPI)(nil).ListContainerInstancesPages), arg0, arg1)
 }
 
 // ListContainerInstancesPagesWithContext mocks base method
 func (m *MockECSAPI) ListContainerInstancesPagesWithContext(arg0 context.Context, arg1 *ecs.ListContainerInstancesInput, arg2 func(*ecs.ListContainerInstancesOutput, bool) bool, arg3 ...request.Option) error {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1, arg2}
 	for _, a := range arg3 {
 		varargs = append(varargs, a)
@@ -975,14 +864,12 @@ func (m *MockECSAPI) ListContainerInstancesPagesWithContext(arg0 context.Context
 
 // ListContainerInstancesPagesWithContext indicates an expected call of ListContainerInstancesPagesWithContext
 func (mr *MockECSAPIMockRecorder) ListContainerInstancesPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListContainerInstancesPagesWithContext", reflect.TypeOf((*MockECSAPI)(nil).ListContainerInstancesPagesWithContext), varargs...)
 }
 
 // ListContainerInstancesRequest mocks base method
 func (m *MockECSAPI) ListContainerInstancesRequest(arg0 *ecs.ListContainerInstancesInput) (*request.Request, *ecs.ListContainerInstancesOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListContainerInstancesRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ecs.ListContainerInstancesOutput)
@@ -991,13 +878,11 @@ func (m *MockECSAPI) ListContainerInstancesRequest(arg0 *ecs.ListContainerInstan
 
 // ListContainerInstancesRequest indicates an expected call of ListContainerInstancesRequest
 func (mr *MockECSAPIMockRecorder) ListContainerInstancesRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListContainerInstancesRequest", reflect.TypeOf((*MockECSAPI)(nil).ListContainerInstancesRequest), arg0)
 }
 
 // ListContainerInstancesWithContext mocks base method
 func (m *MockECSAPI) ListContainerInstancesWithContext(arg0 context.Context, arg1 *ecs.ListContainerInstancesInput, arg2 ...request.Option) (*ecs.ListContainerInstancesOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -1010,14 +895,12 @@ func (m *MockECSAPI) ListContainerInstancesWithContext(arg0 context.Context, arg
 
 // ListContainerInstancesWithContext indicates an expected call of ListContainerInstancesWithContext
 func (mr *MockECSAPIMockRecorder) ListContainerInstancesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListContainerInstancesWithContext", reflect.TypeOf((*MockECSAPI)(nil).ListContainerInstancesWithContext), varargs...)
 }
 
 // ListServices mocks base method
 func (m *MockECSAPI) ListServices(arg0 *ecs.ListServicesInput) (*ecs.ListServicesOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListServices", arg0)
 	ret0, _ := ret[0].(*ecs.ListServicesOutput)
 	ret1, _ := ret[1].(error)
@@ -1026,13 +909,11 @@ func (m *MockECSAPI) ListServices(arg0 *ecs.ListServicesInput) (*ecs.ListService
 
 // ListServices indicates an expected call of ListServices
 func (mr *MockECSAPIMockRecorder) ListServices(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListServices", reflect.TypeOf((*MockECSAPI)(nil).ListServices), arg0)
 }
 
 // ListServicesPages mocks base method
 func (m *MockECSAPI) ListServicesPages(arg0 *ecs.ListServicesInput, arg1 func(*ecs.ListServicesOutput, bool) bool) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListServicesPages", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -1040,13 +921,11 @@ func (m *MockECSAPI) ListServicesPages(arg0 *ecs.ListServicesInput, arg1 func(*e
 
 // ListServicesPages indicates an expected call of ListServicesPages
 func (mr *MockECSAPIMockRecorder) ListServicesPages(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListServicesPages", reflect.TypeOf((*MockECSAPI)(nil).ListServicesPages), arg0, arg1)
 }
 
 // ListServicesPagesWithContext mocks base method
 func (m *MockECSAPI) ListServicesPagesWithContext(arg0 context.Context, arg1 *ecs.ListServicesInput, arg2 func(*ecs.ListServicesOutput, bool) bool, arg3 ...request.Option) error {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1, arg2}
 	for _, a := range arg3 {
 		varargs = append(varargs, a)
@@ -1058,14 +937,12 @@ func (m *MockECSAPI) ListServicesPagesWithContext(arg0 context.Context, arg1 *ec
 
 // ListServicesPagesWithContext indicates an expected call of ListServicesPagesWithContext
 func (mr *MockECSAPIMockRecorder) ListServicesPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListServicesPagesWithContext", reflect.TypeOf((*MockECSAPI)(nil).ListServicesPagesWithContext), varargs...)
 }
 
 // ListServicesRequest mocks base method
 func (m *MockECSAPI) ListServicesRequest(arg0 *ecs.ListServicesInput) (*request.Request, *ecs.ListServicesOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListServicesRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ecs.ListServicesOutput)
@@ -1074,13 +951,11 @@ func (m *MockECSAPI) ListServicesRequest(arg0 *ecs.ListServicesInput) (*request.
 
 // ListServicesRequest indicates an expected call of ListServicesRequest
 func (mr *MockECSAPIMockRecorder) ListServicesRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListServicesRequest", reflect.TypeOf((*MockECSAPI)(nil).ListServicesRequest), arg0)
 }
 
 // ListServicesWithContext mocks base method
 func (m *MockECSAPI) ListServicesWithContext(arg0 context.Context, arg1 *ecs.ListServicesInput, arg2 ...request.Option) (*ecs.ListServicesOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -1093,14 +968,12 @@ func (m *MockECSAPI) ListServicesWithContext(arg0 context.Context, arg1 *ecs.Lis
 
 // ListServicesWithContext indicates an expected call of ListServicesWithContext
 func (mr *MockECSAPIMockRecorder) ListServicesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListServicesWithContext", reflect.TypeOf((*MockECSAPI)(nil).ListServicesWithContext), varargs...)
 }
 
 // ListTagsForResource mocks base method
 func (m *MockECSAPI) ListTagsForResource(arg0 *ecs.ListTagsForResourceInput) (*ecs.ListTagsForResourceOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListTagsForResource", arg0)
 	ret0, _ := ret[0].(*ecs.ListTagsForResourceOutput)
 	ret1, _ := ret[1].(error)
@@ -1109,13 +982,11 @@ func (m *MockECSAPI) ListTagsForResource(arg0 *ecs.ListTagsForResourceInput) (*e
 
 // ListTagsForResource indicates an expected call of ListTagsForResource
 func (mr *MockECSAPIMockRecorder) ListTagsForResource(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListTagsForResource", reflect.TypeOf((*MockECSAPI)(nil).ListTagsForResource), arg0)
 }
 
 // ListTagsForResourceRequest mocks base method
 func (m *MockECSAPI) ListTagsForResourceRequest(arg0 *ecs.ListTagsForResourceInput) (*request.Request, *ecs.ListTagsForResourceOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListTagsForResourceRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ecs.ListTagsForResourceOutput)
@@ -1124,13 +995,11 @@ func (m *MockECSAPI) ListTagsForResourceRequest(arg0 *ecs.ListTagsForResourceInp
 
 // ListTagsForResourceRequest indicates an expected call of ListTagsForResourceRequest
 func (mr *MockECSAPIMockRecorder) ListTagsForResourceRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListTagsForResourceRequest", reflect.TypeOf((*MockECSAPI)(nil).ListTagsForResourceRequest), arg0)
 }
 
 // ListTagsForResourceWithContext mocks base method
 func (m *MockECSAPI) ListTagsForResourceWithContext(arg0 context.Context, arg1 *ecs.ListTagsForResourceInput, arg2 ...request.Option) (*ecs.ListTagsForResourceOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -1143,14 +1012,12 @@ func (m *MockECSAPI) ListTagsForResourceWithContext(arg0 context.Context, arg1 *
 
 // ListTagsForResourceWithContext indicates an expected call of ListTagsForResourceWithContext
 func (mr *MockECSAPIMockRecorder) ListTagsForResourceWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListTagsForResourceWithContext", reflect.TypeOf((*MockECSAPI)(nil).ListTagsForResourceWithContext), varargs...)
 }
 
 // ListTaskDefinitionFamilies mocks base method
 func (m *MockECSAPI) ListTaskDefinitionFamilies(arg0 *ecs.ListTaskDefinitionFamiliesInput) (*ecs.ListTaskDefinitionFamiliesOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListTaskDefinitionFamilies", arg0)
 	ret0, _ := ret[0].(*ecs.ListTaskDefinitionFamiliesOutput)
 	ret1, _ := ret[1].(error)
@@ -1159,13 +1026,11 @@ func (m *MockECSAPI) ListTaskDefinitionFamilies(arg0 *ecs.ListTaskDefinitionFami
 
 // ListTaskDefinitionFamilies indicates an expected call of ListTaskDefinitionFamilies
 func (mr *MockECSAPIMockRecorder) ListTaskDefinitionFamilies(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListTaskDefinitionFamilies", reflect.TypeOf((*MockECSAPI)(nil).ListTaskDefinitionFamilies), arg0)
 }
 
 // ListTaskDefinitionFamiliesPages mocks base method
 func (m *MockECSAPI) ListTaskDefinitionFamiliesPages(arg0 *ecs.ListTaskDefinitionFamiliesInput, arg1 func(*ecs.ListTaskDefinitionFamiliesOutput, bool) bool) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListTaskDefinitionFamiliesPages", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -1173,13 +1038,11 @@ func (m *MockECSAPI) ListTaskDefinitionFamiliesPages(arg0 *ecs.ListTaskDefinitio
 
 // ListTaskDefinitionFamiliesPages indicates an expected call of ListTaskDefinitionFamiliesPages
 func (mr *MockECSAPIMockRecorder) ListTaskDefinitionFamiliesPages(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListTaskDefinitionFamiliesPages", reflect.TypeOf((*MockECSAPI)(nil).ListTaskDefinitionFamiliesPages), arg0, arg1)
 }
 
 // ListTaskDefinitionFamiliesPagesWithContext mocks base method
 func (m *MockECSAPI) ListTaskDefinitionFamiliesPagesWithContext(arg0 context.Context, arg1 *ecs.ListTaskDefinitionFamiliesInput, arg2 func(*ecs.ListTaskDefinitionFamiliesOutput, bool) bool, arg3 ...request.Option) error {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1, arg2}
 	for _, a := range arg3 {
 		varargs = append(varargs, a)
@@ -1191,14 +1054,12 @@ func (m *MockECSAPI) ListTaskDefinitionFamiliesPagesWithContext(arg0 context.Con
 
 // ListTaskDefinitionFamiliesPagesWithContext indicates an expected call of ListTaskDefinitionFamiliesPagesWithContext
 func (mr *MockECSAPIMockRecorder) ListTaskDefinitionFamiliesPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListTaskDefinitionFamiliesPagesWithContext", reflect.TypeOf((*MockECSAPI)(nil).ListTaskDefinitionFamiliesPagesWithContext), varargs...)
 }
 
 // ListTaskDefinitionFamiliesRequest mocks base method
 func (m *MockECSAPI) ListTaskDefinitionFamiliesRequest(arg0 *ecs.ListTaskDefinitionFamiliesInput) (*request.Request, *ecs.ListTaskDefinitionFamiliesOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListTaskDefinitionFamiliesRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ecs.ListTaskDefinitionFamiliesOutput)
@@ -1207,13 +1068,11 @@ func (m *MockECSAPI) ListTaskDefinitionFamiliesRequest(arg0 *ecs.ListTaskDefinit
 
 // ListTaskDefinitionFamiliesRequest indicates an expected call of ListTaskDefinitionFamiliesRequest
 func (mr *MockECSAPIMockRecorder) ListTaskDefinitionFamiliesRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListTaskDefinitionFamiliesRequest", reflect.TypeOf((*MockECSAPI)(nil).ListTaskDefinitionFamiliesRequest), arg0)
 }
 
 // ListTaskDefinitionFamiliesWithContext mocks base method
 func (m *MockECSAPI) ListTaskDefinitionFamiliesWithContext(arg0 context.Context, arg1 *ecs.ListTaskDefinitionFamiliesInput, arg2 ...request.Option) (*ecs.ListTaskDefinitionFamiliesOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -1226,14 +1085,12 @@ func (m *MockECSAPI) ListTaskDefinitionFamiliesWithContext(arg0 context.Context,
 
 // ListTaskDefinitionFamiliesWithContext indicates an expected call of ListTaskDefinitionFamiliesWithContext
 func (mr *MockECSAPIMockRecorder) ListTaskDefinitionFamiliesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListTaskDefinitionFamiliesWithContext", reflect.TypeOf((*MockECSAPI)(nil).ListTaskDefinitionFamiliesWithContext), varargs...)
 }
 
 // ListTaskDefinitions mocks base method
 func (m *MockECSAPI) ListTaskDefinitions(arg0 *ecs.ListTaskDefinitionsInput) (*ecs.ListTaskDefinitionsOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListTaskDefinitions", arg0)
 	ret0, _ := ret[0].(*ecs.ListTaskDefinitionsOutput)
 	ret1, _ := ret[1].(error)
@@ -1242,13 +1099,11 @@ func (m *MockECSAPI) ListTaskDefinitions(arg0 *ecs.ListTaskDefinitionsInput) (*e
 
 // ListTaskDefinitions indicates an expected call of ListTaskDefinitions
 func (mr *MockECSAPIMockRecorder) ListTaskDefinitions(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListTaskDefinitions", reflect.TypeOf((*MockECSAPI)(nil).ListTaskDefinitions), arg0)
 }
 
 // ListTaskDefinitionsPages mocks base method
 func (m *MockECSAPI) ListTaskDefinitionsPages(arg0 *ecs.ListTaskDefinitionsInput, arg1 func(*ecs.ListTaskDefinitionsOutput, bool) bool) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListTaskDefinitionsPages", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -1256,13 +1111,11 @@ func (m *MockECSAPI) ListTaskDefinitionsPages(arg0 *ecs.ListTaskDefinitionsInput
 
 // ListTaskDefinitionsPages indicates an expected call of ListTaskDefinitionsPages
 func (mr *MockECSAPIMockRecorder) ListTaskDefinitionsPages(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListTaskDefinitionsPages", reflect.TypeOf((*MockECSAPI)(nil).ListTaskDefinitionsPages), arg0, arg1)
 }
 
 // ListTaskDefinitionsPagesWithContext mocks base method
 func (m *MockECSAPI) ListTaskDefinitionsPagesWithContext(arg0 context.Context, arg1 *ecs.ListTaskDefinitionsInput, arg2 func(*ecs.ListTaskDefinitionsOutput, bool) bool, arg3 ...request.Option) error {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1, arg2}
 	for _, a := range arg3 {
 		varargs = append(varargs, a)
@@ -1274,14 +1127,12 @@ func (m *MockECSAPI) ListTaskDefinitionsPagesWithContext(arg0 context.Context, a
 
 // ListTaskDefinitionsPagesWithContext indicates an expected call of ListTaskDefinitionsPagesWithContext
 func (mr *MockECSAPIMockRecorder) ListTaskDefinitionsPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListTaskDefinitionsPagesWithContext", reflect.TypeOf((*MockECSAPI)(nil).ListTaskDefinitionsPagesWithContext), varargs...)
 }
 
 // ListTaskDefinitionsRequest mocks base method
 func (m *MockECSAPI) ListTaskDefinitionsRequest(arg0 *ecs.ListTaskDefinitionsInput) (*request.Request, *ecs.ListTaskDefinitionsOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListTaskDefinitionsRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ecs.ListTaskDefinitionsOutput)
@@ -1290,13 +1141,11 @@ func (m *MockECSAPI) ListTaskDefinitionsRequest(arg0 *ecs.ListTaskDefinitionsInp
 
 // ListTaskDefinitionsRequest indicates an expected call of ListTaskDefinitionsRequest
 func (mr *MockECSAPIMockRecorder) ListTaskDefinitionsRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListTaskDefinitionsRequest", reflect.TypeOf((*MockECSAPI)(nil).ListTaskDefinitionsRequest), arg0)
 }
 
 // ListTaskDefinitionsWithContext mocks base method
 func (m *MockECSAPI) ListTaskDefinitionsWithContext(arg0 context.Context, arg1 *ecs.ListTaskDefinitionsInput, arg2 ...request.Option) (*ecs.ListTaskDefinitionsOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -1309,14 +1158,12 @@ func (m *MockECSAPI) ListTaskDefinitionsWithContext(arg0 context.Context, arg1 *
 
 // ListTaskDefinitionsWithContext indicates an expected call of ListTaskDefinitionsWithContext
 func (mr *MockECSAPIMockRecorder) ListTaskDefinitionsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListTaskDefinitionsWithContext", reflect.TypeOf((*MockECSAPI)(nil).ListTaskDefinitionsWithContext), varargs...)
 }
 
 // ListTasks mocks base method
 func (m *MockECSAPI) ListTasks(arg0 *ecs.ListTasksInput) (*ecs.ListTasksOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListTasks", arg0)
 	ret0, _ := ret[0].(*ecs.ListTasksOutput)
 	ret1, _ := ret[1].(error)
@@ -1325,13 +1172,11 @@ func (m *MockECSAPI) ListTasks(arg0 *ecs.ListTasksInput) (*ecs.ListTasksOutput, 
 
 // ListTasks indicates an expected call of ListTasks
 func (mr *MockECSAPIMockRecorder) ListTasks(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListTasks", reflect.TypeOf((*MockECSAPI)(nil).ListTasks), arg0)
 }
 
 // ListTasksPages mocks base method
 func (m *MockECSAPI) ListTasksPages(arg0 *ecs.ListTasksInput, arg1 func(*ecs.ListTasksOutput, bool) bool) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListTasksPages", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -1339,13 +1184,11 @@ func (m *MockECSAPI) ListTasksPages(arg0 *ecs.ListTasksInput, arg1 func(*ecs.Lis
 
 // ListTasksPages indicates an expected call of ListTasksPages
 func (mr *MockECSAPIMockRecorder) ListTasksPages(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListTasksPages", reflect.TypeOf((*MockECSAPI)(nil).ListTasksPages), arg0, arg1)
 }
 
 // ListTasksPagesWithContext mocks base method
 func (m *MockECSAPI) ListTasksPagesWithContext(arg0 context.Context, arg1 *ecs.ListTasksInput, arg2 func(*ecs.ListTasksOutput, bool) bool, arg3 ...request.Option) error {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1, arg2}
 	for _, a := range arg3 {
 		varargs = append(varargs, a)
@@ -1357,14 +1200,12 @@ func (m *MockECSAPI) ListTasksPagesWithContext(arg0 context.Context, arg1 *ecs.L
 
 // ListTasksPagesWithContext indicates an expected call of ListTasksPagesWithContext
 func (mr *MockECSAPIMockRecorder) ListTasksPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListTasksPagesWithContext", reflect.TypeOf((*MockECSAPI)(nil).ListTasksPagesWithContext), varargs...)
 }
 
 // ListTasksRequest mocks base method
 func (m *MockECSAPI) ListTasksRequest(arg0 *ecs.ListTasksInput) (*request.Request, *ecs.ListTasksOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListTasksRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ecs.ListTasksOutput)
@@ -1373,13 +1214,11 @@ func (m *MockECSAPI) ListTasksRequest(arg0 *ecs.ListTasksInput) (*request.Reques
 
 // ListTasksRequest indicates an expected call of ListTasksRequest
 func (mr *MockECSAPIMockRecorder) ListTasksRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListTasksRequest", reflect.TypeOf((*MockECSAPI)(nil).ListTasksRequest), arg0)
 }
 
 // ListTasksWithContext mocks base method
 func (m *MockECSAPI) ListTasksWithContext(arg0 context.Context, arg1 *ecs.ListTasksInput, arg2 ...request.Option) (*ecs.ListTasksOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -1392,14 +1231,12 @@ func (m *MockECSAPI) ListTasksWithContext(arg0 context.Context, arg1 *ecs.ListTa
 
 // ListTasksWithContext indicates an expected call of ListTasksWithContext
 func (mr *MockECSAPIMockRecorder) ListTasksWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListTasksWithContext", reflect.TypeOf((*MockECSAPI)(nil).ListTasksWithContext), varargs...)
 }
 
 // PutAccountSetting mocks base method
 func (m *MockECSAPI) PutAccountSetting(arg0 *ecs.PutAccountSettingInput) (*ecs.PutAccountSettingOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PutAccountSetting", arg0)
 	ret0, _ := ret[0].(*ecs.PutAccountSettingOutput)
 	ret1, _ := ret[1].(error)
@@ -1408,13 +1245,11 @@ func (m *MockECSAPI) PutAccountSetting(arg0 *ecs.PutAccountSettingInput) (*ecs.P
 
 // PutAccountSetting indicates an expected call of PutAccountSetting
 func (mr *MockECSAPIMockRecorder) PutAccountSetting(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutAccountSetting", reflect.TypeOf((*MockECSAPI)(nil).PutAccountSetting), arg0)
 }
 
 // PutAccountSettingDefault mocks base method
 func (m *MockECSAPI) PutAccountSettingDefault(arg0 *ecs.PutAccountSettingDefaultInput) (*ecs.PutAccountSettingDefaultOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PutAccountSettingDefault", arg0)
 	ret0, _ := ret[0].(*ecs.PutAccountSettingDefaultOutput)
 	ret1, _ := ret[1].(error)
@@ -1423,13 +1258,11 @@ func (m *MockECSAPI) PutAccountSettingDefault(arg0 *ecs.PutAccountSettingDefault
 
 // PutAccountSettingDefault indicates an expected call of PutAccountSettingDefault
 func (mr *MockECSAPIMockRecorder) PutAccountSettingDefault(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutAccountSettingDefault", reflect.TypeOf((*MockECSAPI)(nil).PutAccountSettingDefault), arg0)
 }
 
 // PutAccountSettingDefaultRequest mocks base method
 func (m *MockECSAPI) PutAccountSettingDefaultRequest(arg0 *ecs.PutAccountSettingDefaultInput) (*request.Request, *ecs.PutAccountSettingDefaultOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PutAccountSettingDefaultRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ecs.PutAccountSettingDefaultOutput)
@@ -1438,13 +1271,11 @@ func (m *MockECSAPI) PutAccountSettingDefaultRequest(arg0 *ecs.PutAccountSetting
 
 // PutAccountSettingDefaultRequest indicates an expected call of PutAccountSettingDefaultRequest
 func (mr *MockECSAPIMockRecorder) PutAccountSettingDefaultRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutAccountSettingDefaultRequest", reflect.TypeOf((*MockECSAPI)(nil).PutAccountSettingDefaultRequest), arg0)
 }
 
 // PutAccountSettingDefaultWithContext mocks base method
 func (m *MockECSAPI) PutAccountSettingDefaultWithContext(arg0 context.Context, arg1 *ecs.PutAccountSettingDefaultInput, arg2 ...request.Option) (*ecs.PutAccountSettingDefaultOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -1457,14 +1288,12 @@ func (m *MockECSAPI) PutAccountSettingDefaultWithContext(arg0 context.Context, a
 
 // PutAccountSettingDefaultWithContext indicates an expected call of PutAccountSettingDefaultWithContext
 func (mr *MockECSAPIMockRecorder) PutAccountSettingDefaultWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutAccountSettingDefaultWithContext", reflect.TypeOf((*MockECSAPI)(nil).PutAccountSettingDefaultWithContext), varargs...)
 }
 
 // PutAccountSettingRequest mocks base method
 func (m *MockECSAPI) PutAccountSettingRequest(arg0 *ecs.PutAccountSettingInput) (*request.Request, *ecs.PutAccountSettingOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PutAccountSettingRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ecs.PutAccountSettingOutput)
@@ -1473,13 +1302,11 @@ func (m *MockECSAPI) PutAccountSettingRequest(arg0 *ecs.PutAccountSettingInput) 
 
 // PutAccountSettingRequest indicates an expected call of PutAccountSettingRequest
 func (mr *MockECSAPIMockRecorder) PutAccountSettingRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutAccountSettingRequest", reflect.TypeOf((*MockECSAPI)(nil).PutAccountSettingRequest), arg0)
 }
 
 // PutAccountSettingWithContext mocks base method
 func (m *MockECSAPI) PutAccountSettingWithContext(arg0 context.Context, arg1 *ecs.PutAccountSettingInput, arg2 ...request.Option) (*ecs.PutAccountSettingOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -1492,14 +1319,12 @@ func (m *MockECSAPI) PutAccountSettingWithContext(arg0 context.Context, arg1 *ec
 
 // PutAccountSettingWithContext indicates an expected call of PutAccountSettingWithContext
 func (mr *MockECSAPIMockRecorder) PutAccountSettingWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutAccountSettingWithContext", reflect.TypeOf((*MockECSAPI)(nil).PutAccountSettingWithContext), varargs...)
 }
 
 // PutAttributes mocks base method
 func (m *MockECSAPI) PutAttributes(arg0 *ecs.PutAttributesInput) (*ecs.PutAttributesOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PutAttributes", arg0)
 	ret0, _ := ret[0].(*ecs.PutAttributesOutput)
 	ret1, _ := ret[1].(error)
@@ -1508,13 +1333,11 @@ func (m *MockECSAPI) PutAttributes(arg0 *ecs.PutAttributesInput) (*ecs.PutAttrib
 
 // PutAttributes indicates an expected call of PutAttributes
 func (mr *MockECSAPIMockRecorder) PutAttributes(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutAttributes", reflect.TypeOf((*MockECSAPI)(nil).PutAttributes), arg0)
 }
 
 // PutAttributesRequest mocks base method
 func (m *MockECSAPI) PutAttributesRequest(arg0 *ecs.PutAttributesInput) (*request.Request, *ecs.PutAttributesOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PutAttributesRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ecs.PutAttributesOutput)
@@ -1523,13 +1346,11 @@ func (m *MockECSAPI) PutAttributesRequest(arg0 *ecs.PutAttributesInput) (*reques
 
 // PutAttributesRequest indicates an expected call of PutAttributesRequest
 func (mr *MockECSAPIMockRecorder) PutAttributesRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutAttributesRequest", reflect.TypeOf((*MockECSAPI)(nil).PutAttributesRequest), arg0)
 }
 
 // PutAttributesWithContext mocks base method
 func (m *MockECSAPI) PutAttributesWithContext(arg0 context.Context, arg1 *ecs.PutAttributesInput, arg2 ...request.Option) (*ecs.PutAttributesOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -1542,14 +1363,12 @@ func (m *MockECSAPI) PutAttributesWithContext(arg0 context.Context, arg1 *ecs.Pu
 
 // PutAttributesWithContext indicates an expected call of PutAttributesWithContext
 func (mr *MockECSAPIMockRecorder) PutAttributesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutAttributesWithContext", reflect.TypeOf((*MockECSAPI)(nil).PutAttributesWithContext), varargs...)
 }
 
 // RegisterContainerInstance mocks base method
 func (m *MockECSAPI) RegisterContainerInstance(arg0 *ecs.RegisterContainerInstanceInput) (*ecs.RegisterContainerInstanceOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RegisterContainerInstance", arg0)
 	ret0, _ := ret[0].(*ecs.RegisterContainerInstanceOutput)
 	ret1, _ := ret[1].(error)
@@ -1558,13 +1377,11 @@ func (m *MockECSAPI) RegisterContainerInstance(arg0 *ecs.RegisterContainerInstan
 
 // RegisterContainerInstance indicates an expected call of RegisterContainerInstance
 func (mr *MockECSAPIMockRecorder) RegisterContainerInstance(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterContainerInstance", reflect.TypeOf((*MockECSAPI)(nil).RegisterContainerInstance), arg0)
 }
 
 // RegisterContainerInstanceRequest mocks base method
 func (m *MockECSAPI) RegisterContainerInstanceRequest(arg0 *ecs.RegisterContainerInstanceInput) (*request.Request, *ecs.RegisterContainerInstanceOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RegisterContainerInstanceRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ecs.RegisterContainerInstanceOutput)
@@ -1573,13 +1390,11 @@ func (m *MockECSAPI) RegisterContainerInstanceRequest(arg0 *ecs.RegisterContaine
 
 // RegisterContainerInstanceRequest indicates an expected call of RegisterContainerInstanceRequest
 func (mr *MockECSAPIMockRecorder) RegisterContainerInstanceRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterContainerInstanceRequest", reflect.TypeOf((*MockECSAPI)(nil).RegisterContainerInstanceRequest), arg0)
 }
 
 // RegisterContainerInstanceWithContext mocks base method
 func (m *MockECSAPI) RegisterContainerInstanceWithContext(arg0 context.Context, arg1 *ecs.RegisterContainerInstanceInput, arg2 ...request.Option) (*ecs.RegisterContainerInstanceOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -1592,14 +1407,12 @@ func (m *MockECSAPI) RegisterContainerInstanceWithContext(arg0 context.Context, 
 
 // RegisterContainerInstanceWithContext indicates an expected call of RegisterContainerInstanceWithContext
 func (mr *MockECSAPIMockRecorder) RegisterContainerInstanceWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterContainerInstanceWithContext", reflect.TypeOf((*MockECSAPI)(nil).RegisterContainerInstanceWithContext), varargs...)
 }
 
 // RegisterTaskDefinition mocks base method
 func (m *MockECSAPI) RegisterTaskDefinition(arg0 *ecs.RegisterTaskDefinitionInput) (*ecs.RegisterTaskDefinitionOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RegisterTaskDefinition", arg0)
 	ret0, _ := ret[0].(*ecs.RegisterTaskDefinitionOutput)
 	ret1, _ := ret[1].(error)
@@ -1608,13 +1421,11 @@ func (m *MockECSAPI) RegisterTaskDefinition(arg0 *ecs.RegisterTaskDefinitionInpu
 
 // RegisterTaskDefinition indicates an expected call of RegisterTaskDefinition
 func (mr *MockECSAPIMockRecorder) RegisterTaskDefinition(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterTaskDefinition", reflect.TypeOf((*MockECSAPI)(nil).RegisterTaskDefinition), arg0)
 }
 
 // RegisterTaskDefinitionRequest mocks base method
 func (m *MockECSAPI) RegisterTaskDefinitionRequest(arg0 *ecs.RegisterTaskDefinitionInput) (*request.Request, *ecs.RegisterTaskDefinitionOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RegisterTaskDefinitionRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ecs.RegisterTaskDefinitionOutput)
@@ -1623,13 +1434,11 @@ func (m *MockECSAPI) RegisterTaskDefinitionRequest(arg0 *ecs.RegisterTaskDefinit
 
 // RegisterTaskDefinitionRequest indicates an expected call of RegisterTaskDefinitionRequest
 func (mr *MockECSAPIMockRecorder) RegisterTaskDefinitionRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterTaskDefinitionRequest", reflect.TypeOf((*MockECSAPI)(nil).RegisterTaskDefinitionRequest), arg0)
 }
 
 // RegisterTaskDefinitionWithContext mocks base method
 func (m *MockECSAPI) RegisterTaskDefinitionWithContext(arg0 context.Context, arg1 *ecs.RegisterTaskDefinitionInput, arg2 ...request.Option) (*ecs.RegisterTaskDefinitionOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -1642,14 +1451,12 @@ func (m *MockECSAPI) RegisterTaskDefinitionWithContext(arg0 context.Context, arg
 
 // RegisterTaskDefinitionWithContext indicates an expected call of RegisterTaskDefinitionWithContext
 func (mr *MockECSAPIMockRecorder) RegisterTaskDefinitionWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterTaskDefinitionWithContext", reflect.TypeOf((*MockECSAPI)(nil).RegisterTaskDefinitionWithContext), varargs...)
 }
 
 // RunTask mocks base method
 func (m *MockECSAPI) RunTask(arg0 *ecs.RunTaskInput) (*ecs.RunTaskOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RunTask", arg0)
 	ret0, _ := ret[0].(*ecs.RunTaskOutput)
 	ret1, _ := ret[1].(error)
@@ -1658,13 +1465,11 @@ func (m *MockECSAPI) RunTask(arg0 *ecs.RunTaskInput) (*ecs.RunTaskOutput, error)
 
 // RunTask indicates an expected call of RunTask
 func (mr *MockECSAPIMockRecorder) RunTask(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunTask", reflect.TypeOf((*MockECSAPI)(nil).RunTask), arg0)
 }
 
 // RunTaskRequest mocks base method
 func (m *MockECSAPI) RunTaskRequest(arg0 *ecs.RunTaskInput) (*request.Request, *ecs.RunTaskOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RunTaskRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ecs.RunTaskOutput)
@@ -1673,13 +1478,11 @@ func (m *MockECSAPI) RunTaskRequest(arg0 *ecs.RunTaskInput) (*request.Request, *
 
 // RunTaskRequest indicates an expected call of RunTaskRequest
 func (mr *MockECSAPIMockRecorder) RunTaskRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunTaskRequest", reflect.TypeOf((*MockECSAPI)(nil).RunTaskRequest), arg0)
 }
 
 // RunTaskWithContext mocks base method
 func (m *MockECSAPI) RunTaskWithContext(arg0 context.Context, arg1 *ecs.RunTaskInput, arg2 ...request.Option) (*ecs.RunTaskOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -1692,14 +1495,12 @@ func (m *MockECSAPI) RunTaskWithContext(arg0 context.Context, arg1 *ecs.RunTaskI
 
 // RunTaskWithContext indicates an expected call of RunTaskWithContext
 func (mr *MockECSAPIMockRecorder) RunTaskWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunTaskWithContext", reflect.TypeOf((*MockECSAPI)(nil).RunTaskWithContext), varargs...)
 }
 
 // StartTask mocks base method
 func (m *MockECSAPI) StartTask(arg0 *ecs.StartTaskInput) (*ecs.StartTaskOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StartTask", arg0)
 	ret0, _ := ret[0].(*ecs.StartTaskOutput)
 	ret1, _ := ret[1].(error)
@@ -1708,13 +1509,11 @@ func (m *MockECSAPI) StartTask(arg0 *ecs.StartTaskInput) (*ecs.StartTaskOutput, 
 
 // StartTask indicates an expected call of StartTask
 func (mr *MockECSAPIMockRecorder) StartTask(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartTask", reflect.TypeOf((*MockECSAPI)(nil).StartTask), arg0)
 }
 
 // StartTaskRequest mocks base method
 func (m *MockECSAPI) StartTaskRequest(arg0 *ecs.StartTaskInput) (*request.Request, *ecs.StartTaskOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StartTaskRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ecs.StartTaskOutput)
@@ -1723,13 +1522,11 @@ func (m *MockECSAPI) StartTaskRequest(arg0 *ecs.StartTaskInput) (*request.Reques
 
 // StartTaskRequest indicates an expected call of StartTaskRequest
 func (mr *MockECSAPIMockRecorder) StartTaskRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartTaskRequest", reflect.TypeOf((*MockECSAPI)(nil).StartTaskRequest), arg0)
 }
 
 // StartTaskWithContext mocks base method
 func (m *MockECSAPI) StartTaskWithContext(arg0 context.Context, arg1 *ecs.StartTaskInput, arg2 ...request.Option) (*ecs.StartTaskOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -1742,14 +1539,12 @@ func (m *MockECSAPI) StartTaskWithContext(arg0 context.Context, arg1 *ecs.StartT
 
 // StartTaskWithContext indicates an expected call of StartTaskWithContext
 func (mr *MockECSAPIMockRecorder) StartTaskWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartTaskWithContext", reflect.TypeOf((*MockECSAPI)(nil).StartTaskWithContext), varargs...)
 }
 
 // StopTask mocks base method
 func (m *MockECSAPI) StopTask(arg0 *ecs.StopTaskInput) (*ecs.StopTaskOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StopTask", arg0)
 	ret0, _ := ret[0].(*ecs.StopTaskOutput)
 	ret1, _ := ret[1].(error)
@@ -1758,13 +1553,11 @@ func (m *MockECSAPI) StopTask(arg0 *ecs.StopTaskInput) (*ecs.StopTaskOutput, err
 
 // StopTask indicates an expected call of StopTask
 func (mr *MockECSAPIMockRecorder) StopTask(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StopTask", reflect.TypeOf((*MockECSAPI)(nil).StopTask), arg0)
 }
 
 // StopTaskRequest mocks base method
 func (m *MockECSAPI) StopTaskRequest(arg0 *ecs.StopTaskInput) (*request.Request, *ecs.StopTaskOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StopTaskRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ecs.StopTaskOutput)
@@ -1773,13 +1566,11 @@ func (m *MockECSAPI) StopTaskRequest(arg0 *ecs.StopTaskInput) (*request.Request,
 
 // StopTaskRequest indicates an expected call of StopTaskRequest
 func (mr *MockECSAPIMockRecorder) StopTaskRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StopTaskRequest", reflect.TypeOf((*MockECSAPI)(nil).StopTaskRequest), arg0)
 }
 
 // StopTaskWithContext mocks base method
 func (m *MockECSAPI) StopTaskWithContext(arg0 context.Context, arg1 *ecs.StopTaskInput, arg2 ...request.Option) (*ecs.StopTaskOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -1792,14 +1583,12 @@ func (m *MockECSAPI) StopTaskWithContext(arg0 context.Context, arg1 *ecs.StopTas
 
 // StopTaskWithContext indicates an expected call of StopTaskWithContext
 func (mr *MockECSAPIMockRecorder) StopTaskWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StopTaskWithContext", reflect.TypeOf((*MockECSAPI)(nil).StopTaskWithContext), varargs...)
 }
 
 // SubmitContainerStateChange mocks base method
 func (m *MockECSAPI) SubmitContainerStateChange(arg0 *ecs.SubmitContainerStateChangeInput) (*ecs.SubmitContainerStateChangeOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SubmitContainerStateChange", arg0)
 	ret0, _ := ret[0].(*ecs.SubmitContainerStateChangeOutput)
 	ret1, _ := ret[1].(error)
@@ -1808,13 +1597,11 @@ func (m *MockECSAPI) SubmitContainerStateChange(arg0 *ecs.SubmitContainerStateCh
 
 // SubmitContainerStateChange indicates an expected call of SubmitContainerStateChange
 func (mr *MockECSAPIMockRecorder) SubmitContainerStateChange(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SubmitContainerStateChange", reflect.TypeOf((*MockECSAPI)(nil).SubmitContainerStateChange), arg0)
 }
 
 // SubmitContainerStateChangeRequest mocks base method
 func (m *MockECSAPI) SubmitContainerStateChangeRequest(arg0 *ecs.SubmitContainerStateChangeInput) (*request.Request, *ecs.SubmitContainerStateChangeOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SubmitContainerStateChangeRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ecs.SubmitContainerStateChangeOutput)
@@ -1823,13 +1610,11 @@ func (m *MockECSAPI) SubmitContainerStateChangeRequest(arg0 *ecs.SubmitContainer
 
 // SubmitContainerStateChangeRequest indicates an expected call of SubmitContainerStateChangeRequest
 func (mr *MockECSAPIMockRecorder) SubmitContainerStateChangeRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SubmitContainerStateChangeRequest", reflect.TypeOf((*MockECSAPI)(nil).SubmitContainerStateChangeRequest), arg0)
 }
 
 // SubmitContainerStateChangeWithContext mocks base method
 func (m *MockECSAPI) SubmitContainerStateChangeWithContext(arg0 context.Context, arg1 *ecs.SubmitContainerStateChangeInput, arg2 ...request.Option) (*ecs.SubmitContainerStateChangeOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -1842,14 +1627,12 @@ func (m *MockECSAPI) SubmitContainerStateChangeWithContext(arg0 context.Context,
 
 // SubmitContainerStateChangeWithContext indicates an expected call of SubmitContainerStateChangeWithContext
 func (mr *MockECSAPIMockRecorder) SubmitContainerStateChangeWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SubmitContainerStateChangeWithContext", reflect.TypeOf((*MockECSAPI)(nil).SubmitContainerStateChangeWithContext), varargs...)
 }
 
 // SubmitTaskStateChange mocks base method
 func (m *MockECSAPI) SubmitTaskStateChange(arg0 *ecs.SubmitTaskStateChangeInput) (*ecs.SubmitTaskStateChangeOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SubmitTaskStateChange", arg0)
 	ret0, _ := ret[0].(*ecs.SubmitTaskStateChangeOutput)
 	ret1, _ := ret[1].(error)
@@ -1858,13 +1641,11 @@ func (m *MockECSAPI) SubmitTaskStateChange(arg0 *ecs.SubmitTaskStateChangeInput)
 
 // SubmitTaskStateChange indicates an expected call of SubmitTaskStateChange
 func (mr *MockECSAPIMockRecorder) SubmitTaskStateChange(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SubmitTaskStateChange", reflect.TypeOf((*MockECSAPI)(nil).SubmitTaskStateChange), arg0)
 }
 
 // SubmitTaskStateChangeRequest mocks base method
 func (m *MockECSAPI) SubmitTaskStateChangeRequest(arg0 *ecs.SubmitTaskStateChangeInput) (*request.Request, *ecs.SubmitTaskStateChangeOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SubmitTaskStateChangeRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ecs.SubmitTaskStateChangeOutput)
@@ -1873,13 +1654,11 @@ func (m *MockECSAPI) SubmitTaskStateChangeRequest(arg0 *ecs.SubmitTaskStateChang
 
 // SubmitTaskStateChangeRequest indicates an expected call of SubmitTaskStateChangeRequest
 func (mr *MockECSAPIMockRecorder) SubmitTaskStateChangeRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SubmitTaskStateChangeRequest", reflect.TypeOf((*MockECSAPI)(nil).SubmitTaskStateChangeRequest), arg0)
 }
 
 // SubmitTaskStateChangeWithContext mocks base method
 func (m *MockECSAPI) SubmitTaskStateChangeWithContext(arg0 context.Context, arg1 *ecs.SubmitTaskStateChangeInput, arg2 ...request.Option) (*ecs.SubmitTaskStateChangeOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -1892,14 +1671,12 @@ func (m *MockECSAPI) SubmitTaskStateChangeWithContext(arg0 context.Context, arg1
 
 // SubmitTaskStateChangeWithContext indicates an expected call of SubmitTaskStateChangeWithContext
 func (mr *MockECSAPIMockRecorder) SubmitTaskStateChangeWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SubmitTaskStateChangeWithContext", reflect.TypeOf((*MockECSAPI)(nil).SubmitTaskStateChangeWithContext), varargs...)
 }
 
 // TagResource mocks base method
 func (m *MockECSAPI) TagResource(arg0 *ecs.TagResourceInput) (*ecs.TagResourceOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "TagResource", arg0)
 	ret0, _ := ret[0].(*ecs.TagResourceOutput)
 	ret1, _ := ret[1].(error)
@@ -1908,13 +1685,11 @@ func (m *MockECSAPI) TagResource(arg0 *ecs.TagResourceInput) (*ecs.TagResourceOu
 
 // TagResource indicates an expected call of TagResource
 func (mr *MockECSAPIMockRecorder) TagResource(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TagResource", reflect.TypeOf((*MockECSAPI)(nil).TagResource), arg0)
 }
 
 // TagResourceRequest mocks base method
 func (m *MockECSAPI) TagResourceRequest(arg0 *ecs.TagResourceInput) (*request.Request, *ecs.TagResourceOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "TagResourceRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ecs.TagResourceOutput)
@@ -1923,13 +1698,11 @@ func (m *MockECSAPI) TagResourceRequest(arg0 *ecs.TagResourceInput) (*request.Re
 
 // TagResourceRequest indicates an expected call of TagResourceRequest
 func (mr *MockECSAPIMockRecorder) TagResourceRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TagResourceRequest", reflect.TypeOf((*MockECSAPI)(nil).TagResourceRequest), arg0)
 }
 
 // TagResourceWithContext mocks base method
 func (m *MockECSAPI) TagResourceWithContext(arg0 context.Context, arg1 *ecs.TagResourceInput, arg2 ...request.Option) (*ecs.TagResourceOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -1942,14 +1715,12 @@ func (m *MockECSAPI) TagResourceWithContext(arg0 context.Context, arg1 *ecs.TagR
 
 // TagResourceWithContext indicates an expected call of TagResourceWithContext
 func (mr *MockECSAPIMockRecorder) TagResourceWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TagResourceWithContext", reflect.TypeOf((*MockECSAPI)(nil).TagResourceWithContext), varargs...)
 }
 
 // UntagResource mocks base method
 func (m *MockECSAPI) UntagResource(arg0 *ecs.UntagResourceInput) (*ecs.UntagResourceOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UntagResource", arg0)
 	ret0, _ := ret[0].(*ecs.UntagResourceOutput)
 	ret1, _ := ret[1].(error)
@@ -1958,13 +1729,11 @@ func (m *MockECSAPI) UntagResource(arg0 *ecs.UntagResourceInput) (*ecs.UntagReso
 
 // UntagResource indicates an expected call of UntagResource
 func (mr *MockECSAPIMockRecorder) UntagResource(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UntagResource", reflect.TypeOf((*MockECSAPI)(nil).UntagResource), arg0)
 }
 
 // UntagResourceRequest mocks base method
 func (m *MockECSAPI) UntagResourceRequest(arg0 *ecs.UntagResourceInput) (*request.Request, *ecs.UntagResourceOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UntagResourceRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ecs.UntagResourceOutput)
@@ -1973,13 +1742,11 @@ func (m *MockECSAPI) UntagResourceRequest(arg0 *ecs.UntagResourceInput) (*reques
 
 // UntagResourceRequest indicates an expected call of UntagResourceRequest
 func (mr *MockECSAPIMockRecorder) UntagResourceRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UntagResourceRequest", reflect.TypeOf((*MockECSAPI)(nil).UntagResourceRequest), arg0)
 }
 
 // UntagResourceWithContext mocks base method
 func (m *MockECSAPI) UntagResourceWithContext(arg0 context.Context, arg1 *ecs.UntagResourceInput, arg2 ...request.Option) (*ecs.UntagResourceOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -1992,14 +1759,12 @@ func (m *MockECSAPI) UntagResourceWithContext(arg0 context.Context, arg1 *ecs.Un
 
 // UntagResourceWithContext indicates an expected call of UntagResourceWithContext
 func (mr *MockECSAPIMockRecorder) UntagResourceWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UntagResourceWithContext", reflect.TypeOf((*MockECSAPI)(nil).UntagResourceWithContext), varargs...)
 }
 
 // UpdateContainerAgent mocks base method
 func (m *MockECSAPI) UpdateContainerAgent(arg0 *ecs.UpdateContainerAgentInput) (*ecs.UpdateContainerAgentOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateContainerAgent", arg0)
 	ret0, _ := ret[0].(*ecs.UpdateContainerAgentOutput)
 	ret1, _ := ret[1].(error)
@@ -2008,13 +1773,11 @@ func (m *MockECSAPI) UpdateContainerAgent(arg0 *ecs.UpdateContainerAgentInput) (
 
 // UpdateContainerAgent indicates an expected call of UpdateContainerAgent
 func (mr *MockECSAPIMockRecorder) UpdateContainerAgent(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateContainerAgent", reflect.TypeOf((*MockECSAPI)(nil).UpdateContainerAgent), arg0)
 }
 
 // UpdateContainerAgentRequest mocks base method
 func (m *MockECSAPI) UpdateContainerAgentRequest(arg0 *ecs.UpdateContainerAgentInput) (*request.Request, *ecs.UpdateContainerAgentOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateContainerAgentRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ecs.UpdateContainerAgentOutput)
@@ -2023,13 +1786,11 @@ func (m *MockECSAPI) UpdateContainerAgentRequest(arg0 *ecs.UpdateContainerAgentI
 
 // UpdateContainerAgentRequest indicates an expected call of UpdateContainerAgentRequest
 func (mr *MockECSAPIMockRecorder) UpdateContainerAgentRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateContainerAgentRequest", reflect.TypeOf((*MockECSAPI)(nil).UpdateContainerAgentRequest), arg0)
 }
 
 // UpdateContainerAgentWithContext mocks base method
 func (m *MockECSAPI) UpdateContainerAgentWithContext(arg0 context.Context, arg1 *ecs.UpdateContainerAgentInput, arg2 ...request.Option) (*ecs.UpdateContainerAgentOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -2042,14 +1803,12 @@ func (m *MockECSAPI) UpdateContainerAgentWithContext(arg0 context.Context, arg1 
 
 // UpdateContainerAgentWithContext indicates an expected call of UpdateContainerAgentWithContext
 func (mr *MockECSAPIMockRecorder) UpdateContainerAgentWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateContainerAgentWithContext", reflect.TypeOf((*MockECSAPI)(nil).UpdateContainerAgentWithContext), varargs...)
 }
 
 // UpdateContainerInstancesState mocks base method
 func (m *MockECSAPI) UpdateContainerInstancesState(arg0 *ecs.UpdateContainerInstancesStateInput) (*ecs.UpdateContainerInstancesStateOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateContainerInstancesState", arg0)
 	ret0, _ := ret[0].(*ecs.UpdateContainerInstancesStateOutput)
 	ret1, _ := ret[1].(error)
@@ -2058,13 +1817,11 @@ func (m *MockECSAPI) UpdateContainerInstancesState(arg0 *ecs.UpdateContainerInst
 
 // UpdateContainerInstancesState indicates an expected call of UpdateContainerInstancesState
 func (mr *MockECSAPIMockRecorder) UpdateContainerInstancesState(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateContainerInstancesState", reflect.TypeOf((*MockECSAPI)(nil).UpdateContainerInstancesState), arg0)
 }
 
 // UpdateContainerInstancesStateRequest mocks base method
 func (m *MockECSAPI) UpdateContainerInstancesStateRequest(arg0 *ecs.UpdateContainerInstancesStateInput) (*request.Request, *ecs.UpdateContainerInstancesStateOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateContainerInstancesStateRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ecs.UpdateContainerInstancesStateOutput)
@@ -2073,13 +1830,11 @@ func (m *MockECSAPI) UpdateContainerInstancesStateRequest(arg0 *ecs.UpdateContai
 
 // UpdateContainerInstancesStateRequest indicates an expected call of UpdateContainerInstancesStateRequest
 func (mr *MockECSAPIMockRecorder) UpdateContainerInstancesStateRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateContainerInstancesStateRequest", reflect.TypeOf((*MockECSAPI)(nil).UpdateContainerInstancesStateRequest), arg0)
 }
 
 // UpdateContainerInstancesStateWithContext mocks base method
 func (m *MockECSAPI) UpdateContainerInstancesStateWithContext(arg0 context.Context, arg1 *ecs.UpdateContainerInstancesStateInput, arg2 ...request.Option) (*ecs.UpdateContainerInstancesStateOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -2092,14 +1847,12 @@ func (m *MockECSAPI) UpdateContainerInstancesStateWithContext(arg0 context.Conte
 
 // UpdateContainerInstancesStateWithContext indicates an expected call of UpdateContainerInstancesStateWithContext
 func (mr *MockECSAPIMockRecorder) UpdateContainerInstancesStateWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateContainerInstancesStateWithContext", reflect.TypeOf((*MockECSAPI)(nil).UpdateContainerInstancesStateWithContext), varargs...)
 }
 
 // UpdateService mocks base method
 func (m *MockECSAPI) UpdateService(arg0 *ecs.UpdateServiceInput) (*ecs.UpdateServiceOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateService", arg0)
 	ret0, _ := ret[0].(*ecs.UpdateServiceOutput)
 	ret1, _ := ret[1].(error)
@@ -2108,13 +1861,11 @@ func (m *MockECSAPI) UpdateService(arg0 *ecs.UpdateServiceInput) (*ecs.UpdateSer
 
 // UpdateService indicates an expected call of UpdateService
 func (mr *MockECSAPIMockRecorder) UpdateService(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateService", reflect.TypeOf((*MockECSAPI)(nil).UpdateService), arg0)
 }
 
 // UpdateServiceRequest mocks base method
 func (m *MockECSAPI) UpdateServiceRequest(arg0 *ecs.UpdateServiceInput) (*request.Request, *ecs.UpdateServiceOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateServiceRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*ecs.UpdateServiceOutput)
@@ -2123,13 +1874,11 @@ func (m *MockECSAPI) UpdateServiceRequest(arg0 *ecs.UpdateServiceInput) (*reques
 
 // UpdateServiceRequest indicates an expected call of UpdateServiceRequest
 func (mr *MockECSAPIMockRecorder) UpdateServiceRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateServiceRequest", reflect.TypeOf((*MockECSAPI)(nil).UpdateServiceRequest), arg0)
 }
 
 // UpdateServiceWithContext mocks base method
 func (m *MockECSAPI) UpdateServiceWithContext(arg0 context.Context, arg1 *ecs.UpdateServiceInput, arg2 ...request.Option) (*ecs.UpdateServiceOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -2142,14 +1891,12 @@ func (m *MockECSAPI) UpdateServiceWithContext(arg0 context.Context, arg1 *ecs.Up
 
 // UpdateServiceWithContext indicates an expected call of UpdateServiceWithContext
 func (mr *MockECSAPIMockRecorder) UpdateServiceWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateServiceWithContext", reflect.TypeOf((*MockECSAPI)(nil).UpdateServiceWithContext), varargs...)
 }
 
 // WaitUntilServicesInactive mocks base method
 func (m *MockECSAPI) WaitUntilServicesInactive(arg0 *ecs.DescribeServicesInput) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WaitUntilServicesInactive", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -2157,13 +1904,11 @@ func (m *MockECSAPI) WaitUntilServicesInactive(arg0 *ecs.DescribeServicesInput) 
 
 // WaitUntilServicesInactive indicates an expected call of WaitUntilServicesInactive
 func (mr *MockECSAPIMockRecorder) WaitUntilServicesInactive(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitUntilServicesInactive", reflect.TypeOf((*MockECSAPI)(nil).WaitUntilServicesInactive), arg0)
 }
 
 // WaitUntilServicesInactiveWithContext mocks base method
 func (m *MockECSAPI) WaitUntilServicesInactiveWithContext(arg0 context.Context, arg1 *ecs.DescribeServicesInput, arg2 ...request.WaiterOption) error {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -2175,14 +1920,12 @@ func (m *MockECSAPI) WaitUntilServicesInactiveWithContext(arg0 context.Context, 
 
 // WaitUntilServicesInactiveWithContext indicates an expected call of WaitUntilServicesInactiveWithContext
 func (mr *MockECSAPIMockRecorder) WaitUntilServicesInactiveWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitUntilServicesInactiveWithContext", reflect.TypeOf((*MockECSAPI)(nil).WaitUntilServicesInactiveWithContext), varargs...)
 }
 
 // WaitUntilServicesStable mocks base method
 func (m *MockECSAPI) WaitUntilServicesStable(arg0 *ecs.DescribeServicesInput) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WaitUntilServicesStable", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -2190,13 +1933,11 @@ func (m *MockECSAPI) WaitUntilServicesStable(arg0 *ecs.DescribeServicesInput) er
 
 // WaitUntilServicesStable indicates an expected call of WaitUntilServicesStable
 func (mr *MockECSAPIMockRecorder) WaitUntilServicesStable(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitUntilServicesStable", reflect.TypeOf((*MockECSAPI)(nil).WaitUntilServicesStable), arg0)
 }
 
 // WaitUntilServicesStableWithContext mocks base method
 func (m *MockECSAPI) WaitUntilServicesStableWithContext(arg0 context.Context, arg1 *ecs.DescribeServicesInput, arg2 ...request.WaiterOption) error {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -2208,14 +1949,12 @@ func (m *MockECSAPI) WaitUntilServicesStableWithContext(arg0 context.Context, ar
 
 // WaitUntilServicesStableWithContext indicates an expected call of WaitUntilServicesStableWithContext
 func (mr *MockECSAPIMockRecorder) WaitUntilServicesStableWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitUntilServicesStableWithContext", reflect.TypeOf((*MockECSAPI)(nil).WaitUntilServicesStableWithContext), varargs...)
 }
 
 // WaitUntilTasksRunning mocks base method
 func (m *MockECSAPI) WaitUntilTasksRunning(arg0 *ecs.DescribeTasksInput) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WaitUntilTasksRunning", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -2223,13 +1962,11 @@ func (m *MockECSAPI) WaitUntilTasksRunning(arg0 *ecs.DescribeTasksInput) error {
 
 // WaitUntilTasksRunning indicates an expected call of WaitUntilTasksRunning
 func (mr *MockECSAPIMockRecorder) WaitUntilTasksRunning(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitUntilTasksRunning", reflect.TypeOf((*MockECSAPI)(nil).WaitUntilTasksRunning), arg0)
 }
 
 // WaitUntilTasksRunningWithContext mocks base method
 func (m *MockECSAPI) WaitUntilTasksRunningWithContext(arg0 context.Context, arg1 *ecs.DescribeTasksInput, arg2 ...request.WaiterOption) error {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -2241,14 +1978,12 @@ func (m *MockECSAPI) WaitUntilTasksRunningWithContext(arg0 context.Context, arg1
 
 // WaitUntilTasksRunningWithContext indicates an expected call of WaitUntilTasksRunningWithContext
 func (mr *MockECSAPIMockRecorder) WaitUntilTasksRunningWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitUntilTasksRunningWithContext", reflect.TypeOf((*MockECSAPI)(nil).WaitUntilTasksRunningWithContext), varargs...)
 }
 
 // WaitUntilTasksStopped mocks base method
 func (m *MockECSAPI) WaitUntilTasksStopped(arg0 *ecs.DescribeTasksInput) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WaitUntilTasksStopped", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -2256,13 +1991,11 @@ func (m *MockECSAPI) WaitUntilTasksStopped(arg0 *ecs.DescribeTasksInput) error {
 
 // WaitUntilTasksStopped indicates an expected call of WaitUntilTasksStopped
 func (mr *MockECSAPIMockRecorder) WaitUntilTasksStopped(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitUntilTasksStopped", reflect.TypeOf((*MockECSAPI)(nil).WaitUntilTasksStopped), arg0)
 }
 
 // WaitUntilTasksStoppedWithContext mocks base method
 func (m *MockECSAPI) WaitUntilTasksStoppedWithContext(arg0 context.Context, arg1 *ecs.DescribeTasksInput, arg2 ...request.WaiterOption) error {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -2274,7 +2007,6 @@ func (m *MockECSAPI) WaitUntilTasksStoppedWithContext(arg0 context.Context, arg1
 
 // WaitUntilTasksStoppedWithContext indicates an expected call of WaitUntilTasksStoppedWithContext
 func (mr *MockECSAPIMockRecorder) WaitUntilTasksStoppedWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitUntilTasksStoppedWithContext", reflect.TypeOf((*MockECSAPI)(nil).WaitUntilTasksStoppedWithContext), varargs...)
 }

--- a/ecs-cli/modules/clients/aws/iam/mock/client.go
+++ b/ecs-cli/modules/clients/aws/iam/mock/client.go
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2015-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the
@@ -49,7 +49,6 @@ func (m *MockClient) EXPECT() *MockClientMockRecorder {
 
 // AttachRolePolicy mocks base method
 func (m *MockClient) AttachRolePolicy(arg0, arg1 string) (*iam.AttachRolePolicyOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AttachRolePolicy", arg0, arg1)
 	ret0, _ := ret[0].(*iam.AttachRolePolicyOutput)
 	ret1, _ := ret[1].(error)
@@ -58,13 +57,11 @@ func (m *MockClient) AttachRolePolicy(arg0, arg1 string) (*iam.AttachRolePolicyO
 
 // AttachRolePolicy indicates an expected call of AttachRolePolicy
 func (mr *MockClientMockRecorder) AttachRolePolicy(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AttachRolePolicy", reflect.TypeOf((*MockClient)(nil).AttachRolePolicy), arg0, arg1)
 }
 
 // CreateOrFindRole mocks base method
 func (m *MockClient) CreateOrFindRole(arg0, arg1, arg2 string, arg3 []*iam.Tag) (string, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateOrFindRole", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
@@ -73,13 +70,11 @@ func (m *MockClient) CreateOrFindRole(arg0, arg1, arg2 string, arg3 []*iam.Tag) 
 
 // CreateOrFindRole indicates an expected call of CreateOrFindRole
 func (mr *MockClientMockRecorder) CreateOrFindRole(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateOrFindRole", reflect.TypeOf((*MockClient)(nil).CreateOrFindRole), arg0, arg1, arg2, arg3)
 }
 
 // CreatePolicy mocks base method
 func (m *MockClient) CreatePolicy(arg0 iam.CreatePolicyInput) (*iam.CreatePolicyOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreatePolicy", arg0)
 	ret0, _ := ret[0].(*iam.CreatePolicyOutput)
 	ret1, _ := ret[1].(error)
@@ -88,13 +83,11 @@ func (m *MockClient) CreatePolicy(arg0 iam.CreatePolicyInput) (*iam.CreatePolicy
 
 // CreatePolicy indicates an expected call of CreatePolicy
 func (mr *MockClientMockRecorder) CreatePolicy(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreatePolicy", reflect.TypeOf((*MockClient)(nil).CreatePolicy), arg0)
 }
 
 // CreateRole mocks base method
 func (m *MockClient) CreateRole(arg0 iam.CreateRoleInput) (*iam.CreateRoleOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateRole", arg0)
 	ret0, _ := ret[0].(*iam.CreateRoleOutput)
 	ret1, _ := ret[1].(error)
@@ -103,6 +96,5 @@ func (m *MockClient) CreateRole(arg0 iam.CreateRoleInput) (*iam.CreateRoleOutput
 
 // CreateRole indicates an expected call of CreateRole
 func (mr *MockClientMockRecorder) CreateRole(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateRole", reflect.TypeOf((*MockClient)(nil).CreateRole), arg0)
 }

--- a/ecs-cli/modules/clients/aws/iam/mock/sdk/iamiface_mock.go
+++ b/ecs-cli/modules/clients/aws/iam/mock/sdk/iamiface_mock.go
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2015-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the
@@ -51,7 +51,6 @@ func (m *MockIAMAPI) EXPECT() *MockIAMAPIMockRecorder {
 
 // AddClientIDToOpenIDConnectProvider mocks base method
 func (m *MockIAMAPI) AddClientIDToOpenIDConnectProvider(arg0 *iam.AddClientIDToOpenIDConnectProviderInput) (*iam.AddClientIDToOpenIDConnectProviderOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AddClientIDToOpenIDConnectProvider", arg0)
 	ret0, _ := ret[0].(*iam.AddClientIDToOpenIDConnectProviderOutput)
 	ret1, _ := ret[1].(error)
@@ -60,13 +59,11 @@ func (m *MockIAMAPI) AddClientIDToOpenIDConnectProvider(arg0 *iam.AddClientIDToO
 
 // AddClientIDToOpenIDConnectProvider indicates an expected call of AddClientIDToOpenIDConnectProvider
 func (mr *MockIAMAPIMockRecorder) AddClientIDToOpenIDConnectProvider(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddClientIDToOpenIDConnectProvider", reflect.TypeOf((*MockIAMAPI)(nil).AddClientIDToOpenIDConnectProvider), arg0)
 }
 
 // AddClientIDToOpenIDConnectProviderRequest mocks base method
 func (m *MockIAMAPI) AddClientIDToOpenIDConnectProviderRequest(arg0 *iam.AddClientIDToOpenIDConnectProviderInput) (*request.Request, *iam.AddClientIDToOpenIDConnectProviderOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AddClientIDToOpenIDConnectProviderRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*iam.AddClientIDToOpenIDConnectProviderOutput)
@@ -75,13 +72,11 @@ func (m *MockIAMAPI) AddClientIDToOpenIDConnectProviderRequest(arg0 *iam.AddClie
 
 // AddClientIDToOpenIDConnectProviderRequest indicates an expected call of AddClientIDToOpenIDConnectProviderRequest
 func (mr *MockIAMAPIMockRecorder) AddClientIDToOpenIDConnectProviderRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddClientIDToOpenIDConnectProviderRequest", reflect.TypeOf((*MockIAMAPI)(nil).AddClientIDToOpenIDConnectProviderRequest), arg0)
 }
 
 // AddClientIDToOpenIDConnectProviderWithContext mocks base method
 func (m *MockIAMAPI) AddClientIDToOpenIDConnectProviderWithContext(arg0 context.Context, arg1 *iam.AddClientIDToOpenIDConnectProviderInput, arg2 ...request.Option) (*iam.AddClientIDToOpenIDConnectProviderOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -94,14 +89,12 @@ func (m *MockIAMAPI) AddClientIDToOpenIDConnectProviderWithContext(arg0 context.
 
 // AddClientIDToOpenIDConnectProviderWithContext indicates an expected call of AddClientIDToOpenIDConnectProviderWithContext
 func (mr *MockIAMAPIMockRecorder) AddClientIDToOpenIDConnectProviderWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddClientIDToOpenIDConnectProviderWithContext", reflect.TypeOf((*MockIAMAPI)(nil).AddClientIDToOpenIDConnectProviderWithContext), varargs...)
 }
 
 // AddRoleToInstanceProfile mocks base method
 func (m *MockIAMAPI) AddRoleToInstanceProfile(arg0 *iam.AddRoleToInstanceProfileInput) (*iam.AddRoleToInstanceProfileOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AddRoleToInstanceProfile", arg0)
 	ret0, _ := ret[0].(*iam.AddRoleToInstanceProfileOutput)
 	ret1, _ := ret[1].(error)
@@ -110,13 +103,11 @@ func (m *MockIAMAPI) AddRoleToInstanceProfile(arg0 *iam.AddRoleToInstanceProfile
 
 // AddRoleToInstanceProfile indicates an expected call of AddRoleToInstanceProfile
 func (mr *MockIAMAPIMockRecorder) AddRoleToInstanceProfile(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddRoleToInstanceProfile", reflect.TypeOf((*MockIAMAPI)(nil).AddRoleToInstanceProfile), arg0)
 }
 
 // AddRoleToInstanceProfileRequest mocks base method
 func (m *MockIAMAPI) AddRoleToInstanceProfileRequest(arg0 *iam.AddRoleToInstanceProfileInput) (*request.Request, *iam.AddRoleToInstanceProfileOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AddRoleToInstanceProfileRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*iam.AddRoleToInstanceProfileOutput)
@@ -125,13 +116,11 @@ func (m *MockIAMAPI) AddRoleToInstanceProfileRequest(arg0 *iam.AddRoleToInstance
 
 // AddRoleToInstanceProfileRequest indicates an expected call of AddRoleToInstanceProfileRequest
 func (mr *MockIAMAPIMockRecorder) AddRoleToInstanceProfileRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddRoleToInstanceProfileRequest", reflect.TypeOf((*MockIAMAPI)(nil).AddRoleToInstanceProfileRequest), arg0)
 }
 
 // AddRoleToInstanceProfileWithContext mocks base method
 func (m *MockIAMAPI) AddRoleToInstanceProfileWithContext(arg0 context.Context, arg1 *iam.AddRoleToInstanceProfileInput, arg2 ...request.Option) (*iam.AddRoleToInstanceProfileOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -144,14 +133,12 @@ func (m *MockIAMAPI) AddRoleToInstanceProfileWithContext(arg0 context.Context, a
 
 // AddRoleToInstanceProfileWithContext indicates an expected call of AddRoleToInstanceProfileWithContext
 func (mr *MockIAMAPIMockRecorder) AddRoleToInstanceProfileWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddRoleToInstanceProfileWithContext", reflect.TypeOf((*MockIAMAPI)(nil).AddRoleToInstanceProfileWithContext), varargs...)
 }
 
 // AddUserToGroup mocks base method
 func (m *MockIAMAPI) AddUserToGroup(arg0 *iam.AddUserToGroupInput) (*iam.AddUserToGroupOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AddUserToGroup", arg0)
 	ret0, _ := ret[0].(*iam.AddUserToGroupOutput)
 	ret1, _ := ret[1].(error)
@@ -160,13 +147,11 @@ func (m *MockIAMAPI) AddUserToGroup(arg0 *iam.AddUserToGroupInput) (*iam.AddUser
 
 // AddUserToGroup indicates an expected call of AddUserToGroup
 func (mr *MockIAMAPIMockRecorder) AddUserToGroup(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddUserToGroup", reflect.TypeOf((*MockIAMAPI)(nil).AddUserToGroup), arg0)
 }
 
 // AddUserToGroupRequest mocks base method
 func (m *MockIAMAPI) AddUserToGroupRequest(arg0 *iam.AddUserToGroupInput) (*request.Request, *iam.AddUserToGroupOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AddUserToGroupRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*iam.AddUserToGroupOutput)
@@ -175,13 +160,11 @@ func (m *MockIAMAPI) AddUserToGroupRequest(arg0 *iam.AddUserToGroupInput) (*requ
 
 // AddUserToGroupRequest indicates an expected call of AddUserToGroupRequest
 func (mr *MockIAMAPIMockRecorder) AddUserToGroupRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddUserToGroupRequest", reflect.TypeOf((*MockIAMAPI)(nil).AddUserToGroupRequest), arg0)
 }
 
 // AddUserToGroupWithContext mocks base method
 func (m *MockIAMAPI) AddUserToGroupWithContext(arg0 context.Context, arg1 *iam.AddUserToGroupInput, arg2 ...request.Option) (*iam.AddUserToGroupOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -194,14 +177,12 @@ func (m *MockIAMAPI) AddUserToGroupWithContext(arg0 context.Context, arg1 *iam.A
 
 // AddUserToGroupWithContext indicates an expected call of AddUserToGroupWithContext
 func (mr *MockIAMAPIMockRecorder) AddUserToGroupWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddUserToGroupWithContext", reflect.TypeOf((*MockIAMAPI)(nil).AddUserToGroupWithContext), varargs...)
 }
 
 // AttachGroupPolicy mocks base method
 func (m *MockIAMAPI) AttachGroupPolicy(arg0 *iam.AttachGroupPolicyInput) (*iam.AttachGroupPolicyOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AttachGroupPolicy", arg0)
 	ret0, _ := ret[0].(*iam.AttachGroupPolicyOutput)
 	ret1, _ := ret[1].(error)
@@ -210,13 +191,11 @@ func (m *MockIAMAPI) AttachGroupPolicy(arg0 *iam.AttachGroupPolicyInput) (*iam.A
 
 // AttachGroupPolicy indicates an expected call of AttachGroupPolicy
 func (mr *MockIAMAPIMockRecorder) AttachGroupPolicy(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AttachGroupPolicy", reflect.TypeOf((*MockIAMAPI)(nil).AttachGroupPolicy), arg0)
 }
 
 // AttachGroupPolicyRequest mocks base method
 func (m *MockIAMAPI) AttachGroupPolicyRequest(arg0 *iam.AttachGroupPolicyInput) (*request.Request, *iam.AttachGroupPolicyOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AttachGroupPolicyRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*iam.AttachGroupPolicyOutput)
@@ -225,13 +204,11 @@ func (m *MockIAMAPI) AttachGroupPolicyRequest(arg0 *iam.AttachGroupPolicyInput) 
 
 // AttachGroupPolicyRequest indicates an expected call of AttachGroupPolicyRequest
 func (mr *MockIAMAPIMockRecorder) AttachGroupPolicyRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AttachGroupPolicyRequest", reflect.TypeOf((*MockIAMAPI)(nil).AttachGroupPolicyRequest), arg0)
 }
 
 // AttachGroupPolicyWithContext mocks base method
 func (m *MockIAMAPI) AttachGroupPolicyWithContext(arg0 context.Context, arg1 *iam.AttachGroupPolicyInput, arg2 ...request.Option) (*iam.AttachGroupPolicyOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -244,14 +221,12 @@ func (m *MockIAMAPI) AttachGroupPolicyWithContext(arg0 context.Context, arg1 *ia
 
 // AttachGroupPolicyWithContext indicates an expected call of AttachGroupPolicyWithContext
 func (mr *MockIAMAPIMockRecorder) AttachGroupPolicyWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AttachGroupPolicyWithContext", reflect.TypeOf((*MockIAMAPI)(nil).AttachGroupPolicyWithContext), varargs...)
 }
 
 // AttachRolePolicy mocks base method
 func (m *MockIAMAPI) AttachRolePolicy(arg0 *iam.AttachRolePolicyInput) (*iam.AttachRolePolicyOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AttachRolePolicy", arg0)
 	ret0, _ := ret[0].(*iam.AttachRolePolicyOutput)
 	ret1, _ := ret[1].(error)
@@ -260,13 +235,11 @@ func (m *MockIAMAPI) AttachRolePolicy(arg0 *iam.AttachRolePolicyInput) (*iam.Att
 
 // AttachRolePolicy indicates an expected call of AttachRolePolicy
 func (mr *MockIAMAPIMockRecorder) AttachRolePolicy(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AttachRolePolicy", reflect.TypeOf((*MockIAMAPI)(nil).AttachRolePolicy), arg0)
 }
 
 // AttachRolePolicyRequest mocks base method
 func (m *MockIAMAPI) AttachRolePolicyRequest(arg0 *iam.AttachRolePolicyInput) (*request.Request, *iam.AttachRolePolicyOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AttachRolePolicyRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*iam.AttachRolePolicyOutput)
@@ -275,13 +248,11 @@ func (m *MockIAMAPI) AttachRolePolicyRequest(arg0 *iam.AttachRolePolicyInput) (*
 
 // AttachRolePolicyRequest indicates an expected call of AttachRolePolicyRequest
 func (mr *MockIAMAPIMockRecorder) AttachRolePolicyRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AttachRolePolicyRequest", reflect.TypeOf((*MockIAMAPI)(nil).AttachRolePolicyRequest), arg0)
 }
 
 // AttachRolePolicyWithContext mocks base method
 func (m *MockIAMAPI) AttachRolePolicyWithContext(arg0 context.Context, arg1 *iam.AttachRolePolicyInput, arg2 ...request.Option) (*iam.AttachRolePolicyOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -294,14 +265,12 @@ func (m *MockIAMAPI) AttachRolePolicyWithContext(arg0 context.Context, arg1 *iam
 
 // AttachRolePolicyWithContext indicates an expected call of AttachRolePolicyWithContext
 func (mr *MockIAMAPIMockRecorder) AttachRolePolicyWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AttachRolePolicyWithContext", reflect.TypeOf((*MockIAMAPI)(nil).AttachRolePolicyWithContext), varargs...)
 }
 
 // AttachUserPolicy mocks base method
 func (m *MockIAMAPI) AttachUserPolicy(arg0 *iam.AttachUserPolicyInput) (*iam.AttachUserPolicyOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AttachUserPolicy", arg0)
 	ret0, _ := ret[0].(*iam.AttachUserPolicyOutput)
 	ret1, _ := ret[1].(error)
@@ -310,13 +279,11 @@ func (m *MockIAMAPI) AttachUserPolicy(arg0 *iam.AttachUserPolicyInput) (*iam.Att
 
 // AttachUserPolicy indicates an expected call of AttachUserPolicy
 func (mr *MockIAMAPIMockRecorder) AttachUserPolicy(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AttachUserPolicy", reflect.TypeOf((*MockIAMAPI)(nil).AttachUserPolicy), arg0)
 }
 
 // AttachUserPolicyRequest mocks base method
 func (m *MockIAMAPI) AttachUserPolicyRequest(arg0 *iam.AttachUserPolicyInput) (*request.Request, *iam.AttachUserPolicyOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AttachUserPolicyRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*iam.AttachUserPolicyOutput)
@@ -325,13 +292,11 @@ func (m *MockIAMAPI) AttachUserPolicyRequest(arg0 *iam.AttachUserPolicyInput) (*
 
 // AttachUserPolicyRequest indicates an expected call of AttachUserPolicyRequest
 func (mr *MockIAMAPIMockRecorder) AttachUserPolicyRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AttachUserPolicyRequest", reflect.TypeOf((*MockIAMAPI)(nil).AttachUserPolicyRequest), arg0)
 }
 
 // AttachUserPolicyWithContext mocks base method
 func (m *MockIAMAPI) AttachUserPolicyWithContext(arg0 context.Context, arg1 *iam.AttachUserPolicyInput, arg2 ...request.Option) (*iam.AttachUserPolicyOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -344,14 +309,12 @@ func (m *MockIAMAPI) AttachUserPolicyWithContext(arg0 context.Context, arg1 *iam
 
 // AttachUserPolicyWithContext indicates an expected call of AttachUserPolicyWithContext
 func (mr *MockIAMAPIMockRecorder) AttachUserPolicyWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AttachUserPolicyWithContext", reflect.TypeOf((*MockIAMAPI)(nil).AttachUserPolicyWithContext), varargs...)
 }
 
 // ChangePassword mocks base method
 func (m *MockIAMAPI) ChangePassword(arg0 *iam.ChangePasswordInput) (*iam.ChangePasswordOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ChangePassword", arg0)
 	ret0, _ := ret[0].(*iam.ChangePasswordOutput)
 	ret1, _ := ret[1].(error)
@@ -360,13 +323,11 @@ func (m *MockIAMAPI) ChangePassword(arg0 *iam.ChangePasswordInput) (*iam.ChangeP
 
 // ChangePassword indicates an expected call of ChangePassword
 func (mr *MockIAMAPIMockRecorder) ChangePassword(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ChangePassword", reflect.TypeOf((*MockIAMAPI)(nil).ChangePassword), arg0)
 }
 
 // ChangePasswordRequest mocks base method
 func (m *MockIAMAPI) ChangePasswordRequest(arg0 *iam.ChangePasswordInput) (*request.Request, *iam.ChangePasswordOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ChangePasswordRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*iam.ChangePasswordOutput)
@@ -375,13 +336,11 @@ func (m *MockIAMAPI) ChangePasswordRequest(arg0 *iam.ChangePasswordInput) (*requ
 
 // ChangePasswordRequest indicates an expected call of ChangePasswordRequest
 func (mr *MockIAMAPIMockRecorder) ChangePasswordRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ChangePasswordRequest", reflect.TypeOf((*MockIAMAPI)(nil).ChangePasswordRequest), arg0)
 }
 
 // ChangePasswordWithContext mocks base method
 func (m *MockIAMAPI) ChangePasswordWithContext(arg0 context.Context, arg1 *iam.ChangePasswordInput, arg2 ...request.Option) (*iam.ChangePasswordOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -394,14 +353,12 @@ func (m *MockIAMAPI) ChangePasswordWithContext(arg0 context.Context, arg1 *iam.C
 
 // ChangePasswordWithContext indicates an expected call of ChangePasswordWithContext
 func (mr *MockIAMAPIMockRecorder) ChangePasswordWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ChangePasswordWithContext", reflect.TypeOf((*MockIAMAPI)(nil).ChangePasswordWithContext), varargs...)
 }
 
 // CreateAccessKey mocks base method
 func (m *MockIAMAPI) CreateAccessKey(arg0 *iam.CreateAccessKeyInput) (*iam.CreateAccessKeyOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateAccessKey", arg0)
 	ret0, _ := ret[0].(*iam.CreateAccessKeyOutput)
 	ret1, _ := ret[1].(error)
@@ -410,13 +367,11 @@ func (m *MockIAMAPI) CreateAccessKey(arg0 *iam.CreateAccessKeyInput) (*iam.Creat
 
 // CreateAccessKey indicates an expected call of CreateAccessKey
 func (mr *MockIAMAPIMockRecorder) CreateAccessKey(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateAccessKey", reflect.TypeOf((*MockIAMAPI)(nil).CreateAccessKey), arg0)
 }
 
 // CreateAccessKeyRequest mocks base method
 func (m *MockIAMAPI) CreateAccessKeyRequest(arg0 *iam.CreateAccessKeyInput) (*request.Request, *iam.CreateAccessKeyOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateAccessKeyRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*iam.CreateAccessKeyOutput)
@@ -425,13 +380,11 @@ func (m *MockIAMAPI) CreateAccessKeyRequest(arg0 *iam.CreateAccessKeyInput) (*re
 
 // CreateAccessKeyRequest indicates an expected call of CreateAccessKeyRequest
 func (mr *MockIAMAPIMockRecorder) CreateAccessKeyRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateAccessKeyRequest", reflect.TypeOf((*MockIAMAPI)(nil).CreateAccessKeyRequest), arg0)
 }
 
 // CreateAccessKeyWithContext mocks base method
 func (m *MockIAMAPI) CreateAccessKeyWithContext(arg0 context.Context, arg1 *iam.CreateAccessKeyInput, arg2 ...request.Option) (*iam.CreateAccessKeyOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -444,14 +397,12 @@ func (m *MockIAMAPI) CreateAccessKeyWithContext(arg0 context.Context, arg1 *iam.
 
 // CreateAccessKeyWithContext indicates an expected call of CreateAccessKeyWithContext
 func (mr *MockIAMAPIMockRecorder) CreateAccessKeyWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateAccessKeyWithContext", reflect.TypeOf((*MockIAMAPI)(nil).CreateAccessKeyWithContext), varargs...)
 }
 
 // CreateAccountAlias mocks base method
 func (m *MockIAMAPI) CreateAccountAlias(arg0 *iam.CreateAccountAliasInput) (*iam.CreateAccountAliasOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateAccountAlias", arg0)
 	ret0, _ := ret[0].(*iam.CreateAccountAliasOutput)
 	ret1, _ := ret[1].(error)
@@ -460,13 +411,11 @@ func (m *MockIAMAPI) CreateAccountAlias(arg0 *iam.CreateAccountAliasInput) (*iam
 
 // CreateAccountAlias indicates an expected call of CreateAccountAlias
 func (mr *MockIAMAPIMockRecorder) CreateAccountAlias(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateAccountAlias", reflect.TypeOf((*MockIAMAPI)(nil).CreateAccountAlias), arg0)
 }
 
 // CreateAccountAliasRequest mocks base method
 func (m *MockIAMAPI) CreateAccountAliasRequest(arg0 *iam.CreateAccountAliasInput) (*request.Request, *iam.CreateAccountAliasOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateAccountAliasRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*iam.CreateAccountAliasOutput)
@@ -475,13 +424,11 @@ func (m *MockIAMAPI) CreateAccountAliasRequest(arg0 *iam.CreateAccountAliasInput
 
 // CreateAccountAliasRequest indicates an expected call of CreateAccountAliasRequest
 func (mr *MockIAMAPIMockRecorder) CreateAccountAliasRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateAccountAliasRequest", reflect.TypeOf((*MockIAMAPI)(nil).CreateAccountAliasRequest), arg0)
 }
 
 // CreateAccountAliasWithContext mocks base method
 func (m *MockIAMAPI) CreateAccountAliasWithContext(arg0 context.Context, arg1 *iam.CreateAccountAliasInput, arg2 ...request.Option) (*iam.CreateAccountAliasOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -494,14 +441,12 @@ func (m *MockIAMAPI) CreateAccountAliasWithContext(arg0 context.Context, arg1 *i
 
 // CreateAccountAliasWithContext indicates an expected call of CreateAccountAliasWithContext
 func (mr *MockIAMAPIMockRecorder) CreateAccountAliasWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateAccountAliasWithContext", reflect.TypeOf((*MockIAMAPI)(nil).CreateAccountAliasWithContext), varargs...)
 }
 
 // CreateGroup mocks base method
 func (m *MockIAMAPI) CreateGroup(arg0 *iam.CreateGroupInput) (*iam.CreateGroupOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateGroup", arg0)
 	ret0, _ := ret[0].(*iam.CreateGroupOutput)
 	ret1, _ := ret[1].(error)
@@ -510,13 +455,11 @@ func (m *MockIAMAPI) CreateGroup(arg0 *iam.CreateGroupInput) (*iam.CreateGroupOu
 
 // CreateGroup indicates an expected call of CreateGroup
 func (mr *MockIAMAPIMockRecorder) CreateGroup(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateGroup", reflect.TypeOf((*MockIAMAPI)(nil).CreateGroup), arg0)
 }
 
 // CreateGroupRequest mocks base method
 func (m *MockIAMAPI) CreateGroupRequest(arg0 *iam.CreateGroupInput) (*request.Request, *iam.CreateGroupOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateGroupRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*iam.CreateGroupOutput)
@@ -525,13 +468,11 @@ func (m *MockIAMAPI) CreateGroupRequest(arg0 *iam.CreateGroupInput) (*request.Re
 
 // CreateGroupRequest indicates an expected call of CreateGroupRequest
 func (mr *MockIAMAPIMockRecorder) CreateGroupRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateGroupRequest", reflect.TypeOf((*MockIAMAPI)(nil).CreateGroupRequest), arg0)
 }
 
 // CreateGroupWithContext mocks base method
 func (m *MockIAMAPI) CreateGroupWithContext(arg0 context.Context, arg1 *iam.CreateGroupInput, arg2 ...request.Option) (*iam.CreateGroupOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -544,14 +485,12 @@ func (m *MockIAMAPI) CreateGroupWithContext(arg0 context.Context, arg1 *iam.Crea
 
 // CreateGroupWithContext indicates an expected call of CreateGroupWithContext
 func (mr *MockIAMAPIMockRecorder) CreateGroupWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateGroupWithContext", reflect.TypeOf((*MockIAMAPI)(nil).CreateGroupWithContext), varargs...)
 }
 
 // CreateInstanceProfile mocks base method
 func (m *MockIAMAPI) CreateInstanceProfile(arg0 *iam.CreateInstanceProfileInput) (*iam.CreateInstanceProfileOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateInstanceProfile", arg0)
 	ret0, _ := ret[0].(*iam.CreateInstanceProfileOutput)
 	ret1, _ := ret[1].(error)
@@ -560,13 +499,11 @@ func (m *MockIAMAPI) CreateInstanceProfile(arg0 *iam.CreateInstanceProfileInput)
 
 // CreateInstanceProfile indicates an expected call of CreateInstanceProfile
 func (mr *MockIAMAPIMockRecorder) CreateInstanceProfile(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateInstanceProfile", reflect.TypeOf((*MockIAMAPI)(nil).CreateInstanceProfile), arg0)
 }
 
 // CreateInstanceProfileRequest mocks base method
 func (m *MockIAMAPI) CreateInstanceProfileRequest(arg0 *iam.CreateInstanceProfileInput) (*request.Request, *iam.CreateInstanceProfileOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateInstanceProfileRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*iam.CreateInstanceProfileOutput)
@@ -575,13 +512,11 @@ func (m *MockIAMAPI) CreateInstanceProfileRequest(arg0 *iam.CreateInstanceProfil
 
 // CreateInstanceProfileRequest indicates an expected call of CreateInstanceProfileRequest
 func (mr *MockIAMAPIMockRecorder) CreateInstanceProfileRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateInstanceProfileRequest", reflect.TypeOf((*MockIAMAPI)(nil).CreateInstanceProfileRequest), arg0)
 }
 
 // CreateInstanceProfileWithContext mocks base method
 func (m *MockIAMAPI) CreateInstanceProfileWithContext(arg0 context.Context, arg1 *iam.CreateInstanceProfileInput, arg2 ...request.Option) (*iam.CreateInstanceProfileOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -594,14 +529,12 @@ func (m *MockIAMAPI) CreateInstanceProfileWithContext(arg0 context.Context, arg1
 
 // CreateInstanceProfileWithContext indicates an expected call of CreateInstanceProfileWithContext
 func (mr *MockIAMAPIMockRecorder) CreateInstanceProfileWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateInstanceProfileWithContext", reflect.TypeOf((*MockIAMAPI)(nil).CreateInstanceProfileWithContext), varargs...)
 }
 
 // CreateLoginProfile mocks base method
 func (m *MockIAMAPI) CreateLoginProfile(arg0 *iam.CreateLoginProfileInput) (*iam.CreateLoginProfileOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateLoginProfile", arg0)
 	ret0, _ := ret[0].(*iam.CreateLoginProfileOutput)
 	ret1, _ := ret[1].(error)
@@ -610,13 +543,11 @@ func (m *MockIAMAPI) CreateLoginProfile(arg0 *iam.CreateLoginProfileInput) (*iam
 
 // CreateLoginProfile indicates an expected call of CreateLoginProfile
 func (mr *MockIAMAPIMockRecorder) CreateLoginProfile(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateLoginProfile", reflect.TypeOf((*MockIAMAPI)(nil).CreateLoginProfile), arg0)
 }
 
 // CreateLoginProfileRequest mocks base method
 func (m *MockIAMAPI) CreateLoginProfileRequest(arg0 *iam.CreateLoginProfileInput) (*request.Request, *iam.CreateLoginProfileOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateLoginProfileRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*iam.CreateLoginProfileOutput)
@@ -625,13 +556,11 @@ func (m *MockIAMAPI) CreateLoginProfileRequest(arg0 *iam.CreateLoginProfileInput
 
 // CreateLoginProfileRequest indicates an expected call of CreateLoginProfileRequest
 func (mr *MockIAMAPIMockRecorder) CreateLoginProfileRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateLoginProfileRequest", reflect.TypeOf((*MockIAMAPI)(nil).CreateLoginProfileRequest), arg0)
 }
 
 // CreateLoginProfileWithContext mocks base method
 func (m *MockIAMAPI) CreateLoginProfileWithContext(arg0 context.Context, arg1 *iam.CreateLoginProfileInput, arg2 ...request.Option) (*iam.CreateLoginProfileOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -644,14 +573,12 @@ func (m *MockIAMAPI) CreateLoginProfileWithContext(arg0 context.Context, arg1 *i
 
 // CreateLoginProfileWithContext indicates an expected call of CreateLoginProfileWithContext
 func (mr *MockIAMAPIMockRecorder) CreateLoginProfileWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateLoginProfileWithContext", reflect.TypeOf((*MockIAMAPI)(nil).CreateLoginProfileWithContext), varargs...)
 }
 
 // CreateOpenIDConnectProvider mocks base method
 func (m *MockIAMAPI) CreateOpenIDConnectProvider(arg0 *iam.CreateOpenIDConnectProviderInput) (*iam.CreateOpenIDConnectProviderOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateOpenIDConnectProvider", arg0)
 	ret0, _ := ret[0].(*iam.CreateOpenIDConnectProviderOutput)
 	ret1, _ := ret[1].(error)
@@ -660,13 +587,11 @@ func (m *MockIAMAPI) CreateOpenIDConnectProvider(arg0 *iam.CreateOpenIDConnectPr
 
 // CreateOpenIDConnectProvider indicates an expected call of CreateOpenIDConnectProvider
 func (mr *MockIAMAPIMockRecorder) CreateOpenIDConnectProvider(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateOpenIDConnectProvider", reflect.TypeOf((*MockIAMAPI)(nil).CreateOpenIDConnectProvider), arg0)
 }
 
 // CreateOpenIDConnectProviderRequest mocks base method
 func (m *MockIAMAPI) CreateOpenIDConnectProviderRequest(arg0 *iam.CreateOpenIDConnectProviderInput) (*request.Request, *iam.CreateOpenIDConnectProviderOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateOpenIDConnectProviderRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*iam.CreateOpenIDConnectProviderOutput)
@@ -675,13 +600,11 @@ func (m *MockIAMAPI) CreateOpenIDConnectProviderRequest(arg0 *iam.CreateOpenIDCo
 
 // CreateOpenIDConnectProviderRequest indicates an expected call of CreateOpenIDConnectProviderRequest
 func (mr *MockIAMAPIMockRecorder) CreateOpenIDConnectProviderRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateOpenIDConnectProviderRequest", reflect.TypeOf((*MockIAMAPI)(nil).CreateOpenIDConnectProviderRequest), arg0)
 }
 
 // CreateOpenIDConnectProviderWithContext mocks base method
 func (m *MockIAMAPI) CreateOpenIDConnectProviderWithContext(arg0 context.Context, arg1 *iam.CreateOpenIDConnectProviderInput, arg2 ...request.Option) (*iam.CreateOpenIDConnectProviderOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -694,14 +617,12 @@ func (m *MockIAMAPI) CreateOpenIDConnectProviderWithContext(arg0 context.Context
 
 // CreateOpenIDConnectProviderWithContext indicates an expected call of CreateOpenIDConnectProviderWithContext
 func (mr *MockIAMAPIMockRecorder) CreateOpenIDConnectProviderWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateOpenIDConnectProviderWithContext", reflect.TypeOf((*MockIAMAPI)(nil).CreateOpenIDConnectProviderWithContext), varargs...)
 }
 
 // CreatePolicy mocks base method
 func (m *MockIAMAPI) CreatePolicy(arg0 *iam.CreatePolicyInput) (*iam.CreatePolicyOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreatePolicy", arg0)
 	ret0, _ := ret[0].(*iam.CreatePolicyOutput)
 	ret1, _ := ret[1].(error)
@@ -710,13 +631,11 @@ func (m *MockIAMAPI) CreatePolicy(arg0 *iam.CreatePolicyInput) (*iam.CreatePolic
 
 // CreatePolicy indicates an expected call of CreatePolicy
 func (mr *MockIAMAPIMockRecorder) CreatePolicy(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreatePolicy", reflect.TypeOf((*MockIAMAPI)(nil).CreatePolicy), arg0)
 }
 
 // CreatePolicyRequest mocks base method
 func (m *MockIAMAPI) CreatePolicyRequest(arg0 *iam.CreatePolicyInput) (*request.Request, *iam.CreatePolicyOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreatePolicyRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*iam.CreatePolicyOutput)
@@ -725,13 +644,11 @@ func (m *MockIAMAPI) CreatePolicyRequest(arg0 *iam.CreatePolicyInput) (*request.
 
 // CreatePolicyRequest indicates an expected call of CreatePolicyRequest
 func (mr *MockIAMAPIMockRecorder) CreatePolicyRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreatePolicyRequest", reflect.TypeOf((*MockIAMAPI)(nil).CreatePolicyRequest), arg0)
 }
 
 // CreatePolicyVersion mocks base method
 func (m *MockIAMAPI) CreatePolicyVersion(arg0 *iam.CreatePolicyVersionInput) (*iam.CreatePolicyVersionOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreatePolicyVersion", arg0)
 	ret0, _ := ret[0].(*iam.CreatePolicyVersionOutput)
 	ret1, _ := ret[1].(error)
@@ -740,13 +657,11 @@ func (m *MockIAMAPI) CreatePolicyVersion(arg0 *iam.CreatePolicyVersionInput) (*i
 
 // CreatePolicyVersion indicates an expected call of CreatePolicyVersion
 func (mr *MockIAMAPIMockRecorder) CreatePolicyVersion(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreatePolicyVersion", reflect.TypeOf((*MockIAMAPI)(nil).CreatePolicyVersion), arg0)
 }
 
 // CreatePolicyVersionRequest mocks base method
 func (m *MockIAMAPI) CreatePolicyVersionRequest(arg0 *iam.CreatePolicyVersionInput) (*request.Request, *iam.CreatePolicyVersionOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreatePolicyVersionRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*iam.CreatePolicyVersionOutput)
@@ -755,13 +670,11 @@ func (m *MockIAMAPI) CreatePolicyVersionRequest(arg0 *iam.CreatePolicyVersionInp
 
 // CreatePolicyVersionRequest indicates an expected call of CreatePolicyVersionRequest
 func (mr *MockIAMAPIMockRecorder) CreatePolicyVersionRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreatePolicyVersionRequest", reflect.TypeOf((*MockIAMAPI)(nil).CreatePolicyVersionRequest), arg0)
 }
 
 // CreatePolicyVersionWithContext mocks base method
 func (m *MockIAMAPI) CreatePolicyVersionWithContext(arg0 context.Context, arg1 *iam.CreatePolicyVersionInput, arg2 ...request.Option) (*iam.CreatePolicyVersionOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -774,14 +687,12 @@ func (m *MockIAMAPI) CreatePolicyVersionWithContext(arg0 context.Context, arg1 *
 
 // CreatePolicyVersionWithContext indicates an expected call of CreatePolicyVersionWithContext
 func (mr *MockIAMAPIMockRecorder) CreatePolicyVersionWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreatePolicyVersionWithContext", reflect.TypeOf((*MockIAMAPI)(nil).CreatePolicyVersionWithContext), varargs...)
 }
 
 // CreatePolicyWithContext mocks base method
 func (m *MockIAMAPI) CreatePolicyWithContext(arg0 context.Context, arg1 *iam.CreatePolicyInput, arg2 ...request.Option) (*iam.CreatePolicyOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -794,14 +705,12 @@ func (m *MockIAMAPI) CreatePolicyWithContext(arg0 context.Context, arg1 *iam.Cre
 
 // CreatePolicyWithContext indicates an expected call of CreatePolicyWithContext
 func (mr *MockIAMAPIMockRecorder) CreatePolicyWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreatePolicyWithContext", reflect.TypeOf((*MockIAMAPI)(nil).CreatePolicyWithContext), varargs...)
 }
 
 // CreateRole mocks base method
 func (m *MockIAMAPI) CreateRole(arg0 *iam.CreateRoleInput) (*iam.CreateRoleOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateRole", arg0)
 	ret0, _ := ret[0].(*iam.CreateRoleOutput)
 	ret1, _ := ret[1].(error)
@@ -810,13 +719,11 @@ func (m *MockIAMAPI) CreateRole(arg0 *iam.CreateRoleInput) (*iam.CreateRoleOutpu
 
 // CreateRole indicates an expected call of CreateRole
 func (mr *MockIAMAPIMockRecorder) CreateRole(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateRole", reflect.TypeOf((*MockIAMAPI)(nil).CreateRole), arg0)
 }
 
 // CreateRoleRequest mocks base method
 func (m *MockIAMAPI) CreateRoleRequest(arg0 *iam.CreateRoleInput) (*request.Request, *iam.CreateRoleOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateRoleRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*iam.CreateRoleOutput)
@@ -825,13 +732,11 @@ func (m *MockIAMAPI) CreateRoleRequest(arg0 *iam.CreateRoleInput) (*request.Requ
 
 // CreateRoleRequest indicates an expected call of CreateRoleRequest
 func (mr *MockIAMAPIMockRecorder) CreateRoleRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateRoleRequest", reflect.TypeOf((*MockIAMAPI)(nil).CreateRoleRequest), arg0)
 }
 
 // CreateRoleWithContext mocks base method
 func (m *MockIAMAPI) CreateRoleWithContext(arg0 context.Context, arg1 *iam.CreateRoleInput, arg2 ...request.Option) (*iam.CreateRoleOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -844,14 +749,12 @@ func (m *MockIAMAPI) CreateRoleWithContext(arg0 context.Context, arg1 *iam.Creat
 
 // CreateRoleWithContext indicates an expected call of CreateRoleWithContext
 func (mr *MockIAMAPIMockRecorder) CreateRoleWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateRoleWithContext", reflect.TypeOf((*MockIAMAPI)(nil).CreateRoleWithContext), varargs...)
 }
 
 // CreateSAMLProvider mocks base method
 func (m *MockIAMAPI) CreateSAMLProvider(arg0 *iam.CreateSAMLProviderInput) (*iam.CreateSAMLProviderOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateSAMLProvider", arg0)
 	ret0, _ := ret[0].(*iam.CreateSAMLProviderOutput)
 	ret1, _ := ret[1].(error)
@@ -860,13 +763,11 @@ func (m *MockIAMAPI) CreateSAMLProvider(arg0 *iam.CreateSAMLProviderInput) (*iam
 
 // CreateSAMLProvider indicates an expected call of CreateSAMLProvider
 func (mr *MockIAMAPIMockRecorder) CreateSAMLProvider(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateSAMLProvider", reflect.TypeOf((*MockIAMAPI)(nil).CreateSAMLProvider), arg0)
 }
 
 // CreateSAMLProviderRequest mocks base method
 func (m *MockIAMAPI) CreateSAMLProviderRequest(arg0 *iam.CreateSAMLProviderInput) (*request.Request, *iam.CreateSAMLProviderOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateSAMLProviderRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*iam.CreateSAMLProviderOutput)
@@ -875,13 +776,11 @@ func (m *MockIAMAPI) CreateSAMLProviderRequest(arg0 *iam.CreateSAMLProviderInput
 
 // CreateSAMLProviderRequest indicates an expected call of CreateSAMLProviderRequest
 func (mr *MockIAMAPIMockRecorder) CreateSAMLProviderRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateSAMLProviderRequest", reflect.TypeOf((*MockIAMAPI)(nil).CreateSAMLProviderRequest), arg0)
 }
 
 // CreateSAMLProviderWithContext mocks base method
 func (m *MockIAMAPI) CreateSAMLProviderWithContext(arg0 context.Context, arg1 *iam.CreateSAMLProviderInput, arg2 ...request.Option) (*iam.CreateSAMLProviderOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -894,14 +793,12 @@ func (m *MockIAMAPI) CreateSAMLProviderWithContext(arg0 context.Context, arg1 *i
 
 // CreateSAMLProviderWithContext indicates an expected call of CreateSAMLProviderWithContext
 func (mr *MockIAMAPIMockRecorder) CreateSAMLProviderWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateSAMLProviderWithContext", reflect.TypeOf((*MockIAMAPI)(nil).CreateSAMLProviderWithContext), varargs...)
 }
 
 // CreateServiceLinkedRole mocks base method
 func (m *MockIAMAPI) CreateServiceLinkedRole(arg0 *iam.CreateServiceLinkedRoleInput) (*iam.CreateServiceLinkedRoleOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateServiceLinkedRole", arg0)
 	ret0, _ := ret[0].(*iam.CreateServiceLinkedRoleOutput)
 	ret1, _ := ret[1].(error)
@@ -910,13 +807,11 @@ func (m *MockIAMAPI) CreateServiceLinkedRole(arg0 *iam.CreateServiceLinkedRoleIn
 
 // CreateServiceLinkedRole indicates an expected call of CreateServiceLinkedRole
 func (mr *MockIAMAPIMockRecorder) CreateServiceLinkedRole(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateServiceLinkedRole", reflect.TypeOf((*MockIAMAPI)(nil).CreateServiceLinkedRole), arg0)
 }
 
 // CreateServiceLinkedRoleRequest mocks base method
 func (m *MockIAMAPI) CreateServiceLinkedRoleRequest(arg0 *iam.CreateServiceLinkedRoleInput) (*request.Request, *iam.CreateServiceLinkedRoleOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateServiceLinkedRoleRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*iam.CreateServiceLinkedRoleOutput)
@@ -925,13 +820,11 @@ func (m *MockIAMAPI) CreateServiceLinkedRoleRequest(arg0 *iam.CreateServiceLinke
 
 // CreateServiceLinkedRoleRequest indicates an expected call of CreateServiceLinkedRoleRequest
 func (mr *MockIAMAPIMockRecorder) CreateServiceLinkedRoleRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateServiceLinkedRoleRequest", reflect.TypeOf((*MockIAMAPI)(nil).CreateServiceLinkedRoleRequest), arg0)
 }
 
 // CreateServiceLinkedRoleWithContext mocks base method
 func (m *MockIAMAPI) CreateServiceLinkedRoleWithContext(arg0 context.Context, arg1 *iam.CreateServiceLinkedRoleInput, arg2 ...request.Option) (*iam.CreateServiceLinkedRoleOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -944,14 +837,12 @@ func (m *MockIAMAPI) CreateServiceLinkedRoleWithContext(arg0 context.Context, ar
 
 // CreateServiceLinkedRoleWithContext indicates an expected call of CreateServiceLinkedRoleWithContext
 func (mr *MockIAMAPIMockRecorder) CreateServiceLinkedRoleWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateServiceLinkedRoleWithContext", reflect.TypeOf((*MockIAMAPI)(nil).CreateServiceLinkedRoleWithContext), varargs...)
 }
 
 // CreateServiceSpecificCredential mocks base method
 func (m *MockIAMAPI) CreateServiceSpecificCredential(arg0 *iam.CreateServiceSpecificCredentialInput) (*iam.CreateServiceSpecificCredentialOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateServiceSpecificCredential", arg0)
 	ret0, _ := ret[0].(*iam.CreateServiceSpecificCredentialOutput)
 	ret1, _ := ret[1].(error)
@@ -960,13 +851,11 @@ func (m *MockIAMAPI) CreateServiceSpecificCredential(arg0 *iam.CreateServiceSpec
 
 // CreateServiceSpecificCredential indicates an expected call of CreateServiceSpecificCredential
 func (mr *MockIAMAPIMockRecorder) CreateServiceSpecificCredential(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateServiceSpecificCredential", reflect.TypeOf((*MockIAMAPI)(nil).CreateServiceSpecificCredential), arg0)
 }
 
 // CreateServiceSpecificCredentialRequest mocks base method
 func (m *MockIAMAPI) CreateServiceSpecificCredentialRequest(arg0 *iam.CreateServiceSpecificCredentialInput) (*request.Request, *iam.CreateServiceSpecificCredentialOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateServiceSpecificCredentialRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*iam.CreateServiceSpecificCredentialOutput)
@@ -975,13 +864,11 @@ func (m *MockIAMAPI) CreateServiceSpecificCredentialRequest(arg0 *iam.CreateServ
 
 // CreateServiceSpecificCredentialRequest indicates an expected call of CreateServiceSpecificCredentialRequest
 func (mr *MockIAMAPIMockRecorder) CreateServiceSpecificCredentialRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateServiceSpecificCredentialRequest", reflect.TypeOf((*MockIAMAPI)(nil).CreateServiceSpecificCredentialRequest), arg0)
 }
 
 // CreateServiceSpecificCredentialWithContext mocks base method
 func (m *MockIAMAPI) CreateServiceSpecificCredentialWithContext(arg0 context.Context, arg1 *iam.CreateServiceSpecificCredentialInput, arg2 ...request.Option) (*iam.CreateServiceSpecificCredentialOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -994,14 +881,12 @@ func (m *MockIAMAPI) CreateServiceSpecificCredentialWithContext(arg0 context.Con
 
 // CreateServiceSpecificCredentialWithContext indicates an expected call of CreateServiceSpecificCredentialWithContext
 func (mr *MockIAMAPIMockRecorder) CreateServiceSpecificCredentialWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateServiceSpecificCredentialWithContext", reflect.TypeOf((*MockIAMAPI)(nil).CreateServiceSpecificCredentialWithContext), varargs...)
 }
 
 // CreateUser mocks base method
 func (m *MockIAMAPI) CreateUser(arg0 *iam.CreateUserInput) (*iam.CreateUserOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateUser", arg0)
 	ret0, _ := ret[0].(*iam.CreateUserOutput)
 	ret1, _ := ret[1].(error)
@@ -1010,13 +895,11 @@ func (m *MockIAMAPI) CreateUser(arg0 *iam.CreateUserInput) (*iam.CreateUserOutpu
 
 // CreateUser indicates an expected call of CreateUser
 func (mr *MockIAMAPIMockRecorder) CreateUser(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateUser", reflect.TypeOf((*MockIAMAPI)(nil).CreateUser), arg0)
 }
 
 // CreateUserRequest mocks base method
 func (m *MockIAMAPI) CreateUserRequest(arg0 *iam.CreateUserInput) (*request.Request, *iam.CreateUserOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateUserRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*iam.CreateUserOutput)
@@ -1025,13 +908,11 @@ func (m *MockIAMAPI) CreateUserRequest(arg0 *iam.CreateUserInput) (*request.Requ
 
 // CreateUserRequest indicates an expected call of CreateUserRequest
 func (mr *MockIAMAPIMockRecorder) CreateUserRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateUserRequest", reflect.TypeOf((*MockIAMAPI)(nil).CreateUserRequest), arg0)
 }
 
 // CreateUserWithContext mocks base method
 func (m *MockIAMAPI) CreateUserWithContext(arg0 context.Context, arg1 *iam.CreateUserInput, arg2 ...request.Option) (*iam.CreateUserOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -1044,14 +925,12 @@ func (m *MockIAMAPI) CreateUserWithContext(arg0 context.Context, arg1 *iam.Creat
 
 // CreateUserWithContext indicates an expected call of CreateUserWithContext
 func (mr *MockIAMAPIMockRecorder) CreateUserWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateUserWithContext", reflect.TypeOf((*MockIAMAPI)(nil).CreateUserWithContext), varargs...)
 }
 
 // CreateVirtualMFADevice mocks base method
 func (m *MockIAMAPI) CreateVirtualMFADevice(arg0 *iam.CreateVirtualMFADeviceInput) (*iam.CreateVirtualMFADeviceOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateVirtualMFADevice", arg0)
 	ret0, _ := ret[0].(*iam.CreateVirtualMFADeviceOutput)
 	ret1, _ := ret[1].(error)
@@ -1060,13 +939,11 @@ func (m *MockIAMAPI) CreateVirtualMFADevice(arg0 *iam.CreateVirtualMFADeviceInpu
 
 // CreateVirtualMFADevice indicates an expected call of CreateVirtualMFADevice
 func (mr *MockIAMAPIMockRecorder) CreateVirtualMFADevice(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateVirtualMFADevice", reflect.TypeOf((*MockIAMAPI)(nil).CreateVirtualMFADevice), arg0)
 }
 
 // CreateVirtualMFADeviceRequest mocks base method
 func (m *MockIAMAPI) CreateVirtualMFADeviceRequest(arg0 *iam.CreateVirtualMFADeviceInput) (*request.Request, *iam.CreateVirtualMFADeviceOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateVirtualMFADeviceRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*iam.CreateVirtualMFADeviceOutput)
@@ -1075,13 +952,11 @@ func (m *MockIAMAPI) CreateVirtualMFADeviceRequest(arg0 *iam.CreateVirtualMFADev
 
 // CreateVirtualMFADeviceRequest indicates an expected call of CreateVirtualMFADeviceRequest
 func (mr *MockIAMAPIMockRecorder) CreateVirtualMFADeviceRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateVirtualMFADeviceRequest", reflect.TypeOf((*MockIAMAPI)(nil).CreateVirtualMFADeviceRequest), arg0)
 }
 
 // CreateVirtualMFADeviceWithContext mocks base method
 func (m *MockIAMAPI) CreateVirtualMFADeviceWithContext(arg0 context.Context, arg1 *iam.CreateVirtualMFADeviceInput, arg2 ...request.Option) (*iam.CreateVirtualMFADeviceOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -1094,14 +969,12 @@ func (m *MockIAMAPI) CreateVirtualMFADeviceWithContext(arg0 context.Context, arg
 
 // CreateVirtualMFADeviceWithContext indicates an expected call of CreateVirtualMFADeviceWithContext
 func (mr *MockIAMAPIMockRecorder) CreateVirtualMFADeviceWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateVirtualMFADeviceWithContext", reflect.TypeOf((*MockIAMAPI)(nil).CreateVirtualMFADeviceWithContext), varargs...)
 }
 
 // DeactivateMFADevice mocks base method
 func (m *MockIAMAPI) DeactivateMFADevice(arg0 *iam.DeactivateMFADeviceInput) (*iam.DeactivateMFADeviceOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeactivateMFADevice", arg0)
 	ret0, _ := ret[0].(*iam.DeactivateMFADeviceOutput)
 	ret1, _ := ret[1].(error)
@@ -1110,13 +983,11 @@ func (m *MockIAMAPI) DeactivateMFADevice(arg0 *iam.DeactivateMFADeviceInput) (*i
 
 // DeactivateMFADevice indicates an expected call of DeactivateMFADevice
 func (mr *MockIAMAPIMockRecorder) DeactivateMFADevice(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeactivateMFADevice", reflect.TypeOf((*MockIAMAPI)(nil).DeactivateMFADevice), arg0)
 }
 
 // DeactivateMFADeviceRequest mocks base method
 func (m *MockIAMAPI) DeactivateMFADeviceRequest(arg0 *iam.DeactivateMFADeviceInput) (*request.Request, *iam.DeactivateMFADeviceOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeactivateMFADeviceRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*iam.DeactivateMFADeviceOutput)
@@ -1125,13 +996,11 @@ func (m *MockIAMAPI) DeactivateMFADeviceRequest(arg0 *iam.DeactivateMFADeviceInp
 
 // DeactivateMFADeviceRequest indicates an expected call of DeactivateMFADeviceRequest
 func (mr *MockIAMAPIMockRecorder) DeactivateMFADeviceRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeactivateMFADeviceRequest", reflect.TypeOf((*MockIAMAPI)(nil).DeactivateMFADeviceRequest), arg0)
 }
 
 // DeactivateMFADeviceWithContext mocks base method
 func (m *MockIAMAPI) DeactivateMFADeviceWithContext(arg0 context.Context, arg1 *iam.DeactivateMFADeviceInput, arg2 ...request.Option) (*iam.DeactivateMFADeviceOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -1144,14 +1013,12 @@ func (m *MockIAMAPI) DeactivateMFADeviceWithContext(arg0 context.Context, arg1 *
 
 // DeactivateMFADeviceWithContext indicates an expected call of DeactivateMFADeviceWithContext
 func (mr *MockIAMAPIMockRecorder) DeactivateMFADeviceWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeactivateMFADeviceWithContext", reflect.TypeOf((*MockIAMAPI)(nil).DeactivateMFADeviceWithContext), varargs...)
 }
 
 // DeleteAccessKey mocks base method
 func (m *MockIAMAPI) DeleteAccessKey(arg0 *iam.DeleteAccessKeyInput) (*iam.DeleteAccessKeyOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteAccessKey", arg0)
 	ret0, _ := ret[0].(*iam.DeleteAccessKeyOutput)
 	ret1, _ := ret[1].(error)
@@ -1160,13 +1027,11 @@ func (m *MockIAMAPI) DeleteAccessKey(arg0 *iam.DeleteAccessKeyInput) (*iam.Delet
 
 // DeleteAccessKey indicates an expected call of DeleteAccessKey
 func (mr *MockIAMAPIMockRecorder) DeleteAccessKey(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteAccessKey", reflect.TypeOf((*MockIAMAPI)(nil).DeleteAccessKey), arg0)
 }
 
 // DeleteAccessKeyRequest mocks base method
 func (m *MockIAMAPI) DeleteAccessKeyRequest(arg0 *iam.DeleteAccessKeyInput) (*request.Request, *iam.DeleteAccessKeyOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteAccessKeyRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*iam.DeleteAccessKeyOutput)
@@ -1175,13 +1040,11 @@ func (m *MockIAMAPI) DeleteAccessKeyRequest(arg0 *iam.DeleteAccessKeyInput) (*re
 
 // DeleteAccessKeyRequest indicates an expected call of DeleteAccessKeyRequest
 func (mr *MockIAMAPIMockRecorder) DeleteAccessKeyRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteAccessKeyRequest", reflect.TypeOf((*MockIAMAPI)(nil).DeleteAccessKeyRequest), arg0)
 }
 
 // DeleteAccessKeyWithContext mocks base method
 func (m *MockIAMAPI) DeleteAccessKeyWithContext(arg0 context.Context, arg1 *iam.DeleteAccessKeyInput, arg2 ...request.Option) (*iam.DeleteAccessKeyOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -1194,14 +1057,12 @@ func (m *MockIAMAPI) DeleteAccessKeyWithContext(arg0 context.Context, arg1 *iam.
 
 // DeleteAccessKeyWithContext indicates an expected call of DeleteAccessKeyWithContext
 func (mr *MockIAMAPIMockRecorder) DeleteAccessKeyWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteAccessKeyWithContext", reflect.TypeOf((*MockIAMAPI)(nil).DeleteAccessKeyWithContext), varargs...)
 }
 
 // DeleteAccountAlias mocks base method
 func (m *MockIAMAPI) DeleteAccountAlias(arg0 *iam.DeleteAccountAliasInput) (*iam.DeleteAccountAliasOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteAccountAlias", arg0)
 	ret0, _ := ret[0].(*iam.DeleteAccountAliasOutput)
 	ret1, _ := ret[1].(error)
@@ -1210,13 +1071,11 @@ func (m *MockIAMAPI) DeleteAccountAlias(arg0 *iam.DeleteAccountAliasInput) (*iam
 
 // DeleteAccountAlias indicates an expected call of DeleteAccountAlias
 func (mr *MockIAMAPIMockRecorder) DeleteAccountAlias(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteAccountAlias", reflect.TypeOf((*MockIAMAPI)(nil).DeleteAccountAlias), arg0)
 }
 
 // DeleteAccountAliasRequest mocks base method
 func (m *MockIAMAPI) DeleteAccountAliasRequest(arg0 *iam.DeleteAccountAliasInput) (*request.Request, *iam.DeleteAccountAliasOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteAccountAliasRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*iam.DeleteAccountAliasOutput)
@@ -1225,13 +1084,11 @@ func (m *MockIAMAPI) DeleteAccountAliasRequest(arg0 *iam.DeleteAccountAliasInput
 
 // DeleteAccountAliasRequest indicates an expected call of DeleteAccountAliasRequest
 func (mr *MockIAMAPIMockRecorder) DeleteAccountAliasRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteAccountAliasRequest", reflect.TypeOf((*MockIAMAPI)(nil).DeleteAccountAliasRequest), arg0)
 }
 
 // DeleteAccountAliasWithContext mocks base method
 func (m *MockIAMAPI) DeleteAccountAliasWithContext(arg0 context.Context, arg1 *iam.DeleteAccountAliasInput, arg2 ...request.Option) (*iam.DeleteAccountAliasOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -1244,14 +1101,12 @@ func (m *MockIAMAPI) DeleteAccountAliasWithContext(arg0 context.Context, arg1 *i
 
 // DeleteAccountAliasWithContext indicates an expected call of DeleteAccountAliasWithContext
 func (mr *MockIAMAPIMockRecorder) DeleteAccountAliasWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteAccountAliasWithContext", reflect.TypeOf((*MockIAMAPI)(nil).DeleteAccountAliasWithContext), varargs...)
 }
 
 // DeleteAccountPasswordPolicy mocks base method
 func (m *MockIAMAPI) DeleteAccountPasswordPolicy(arg0 *iam.DeleteAccountPasswordPolicyInput) (*iam.DeleteAccountPasswordPolicyOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteAccountPasswordPolicy", arg0)
 	ret0, _ := ret[0].(*iam.DeleteAccountPasswordPolicyOutput)
 	ret1, _ := ret[1].(error)
@@ -1260,13 +1115,11 @@ func (m *MockIAMAPI) DeleteAccountPasswordPolicy(arg0 *iam.DeleteAccountPassword
 
 // DeleteAccountPasswordPolicy indicates an expected call of DeleteAccountPasswordPolicy
 func (mr *MockIAMAPIMockRecorder) DeleteAccountPasswordPolicy(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteAccountPasswordPolicy", reflect.TypeOf((*MockIAMAPI)(nil).DeleteAccountPasswordPolicy), arg0)
 }
 
 // DeleteAccountPasswordPolicyRequest mocks base method
 func (m *MockIAMAPI) DeleteAccountPasswordPolicyRequest(arg0 *iam.DeleteAccountPasswordPolicyInput) (*request.Request, *iam.DeleteAccountPasswordPolicyOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteAccountPasswordPolicyRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*iam.DeleteAccountPasswordPolicyOutput)
@@ -1275,13 +1128,11 @@ func (m *MockIAMAPI) DeleteAccountPasswordPolicyRequest(arg0 *iam.DeleteAccountP
 
 // DeleteAccountPasswordPolicyRequest indicates an expected call of DeleteAccountPasswordPolicyRequest
 func (mr *MockIAMAPIMockRecorder) DeleteAccountPasswordPolicyRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteAccountPasswordPolicyRequest", reflect.TypeOf((*MockIAMAPI)(nil).DeleteAccountPasswordPolicyRequest), arg0)
 }
 
 // DeleteAccountPasswordPolicyWithContext mocks base method
 func (m *MockIAMAPI) DeleteAccountPasswordPolicyWithContext(arg0 context.Context, arg1 *iam.DeleteAccountPasswordPolicyInput, arg2 ...request.Option) (*iam.DeleteAccountPasswordPolicyOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -1294,14 +1145,12 @@ func (m *MockIAMAPI) DeleteAccountPasswordPolicyWithContext(arg0 context.Context
 
 // DeleteAccountPasswordPolicyWithContext indicates an expected call of DeleteAccountPasswordPolicyWithContext
 func (mr *MockIAMAPIMockRecorder) DeleteAccountPasswordPolicyWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteAccountPasswordPolicyWithContext", reflect.TypeOf((*MockIAMAPI)(nil).DeleteAccountPasswordPolicyWithContext), varargs...)
 }
 
 // DeleteGroup mocks base method
 func (m *MockIAMAPI) DeleteGroup(arg0 *iam.DeleteGroupInput) (*iam.DeleteGroupOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteGroup", arg0)
 	ret0, _ := ret[0].(*iam.DeleteGroupOutput)
 	ret1, _ := ret[1].(error)
@@ -1310,13 +1159,11 @@ func (m *MockIAMAPI) DeleteGroup(arg0 *iam.DeleteGroupInput) (*iam.DeleteGroupOu
 
 // DeleteGroup indicates an expected call of DeleteGroup
 func (mr *MockIAMAPIMockRecorder) DeleteGroup(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteGroup", reflect.TypeOf((*MockIAMAPI)(nil).DeleteGroup), arg0)
 }
 
 // DeleteGroupPolicy mocks base method
 func (m *MockIAMAPI) DeleteGroupPolicy(arg0 *iam.DeleteGroupPolicyInput) (*iam.DeleteGroupPolicyOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteGroupPolicy", arg0)
 	ret0, _ := ret[0].(*iam.DeleteGroupPolicyOutput)
 	ret1, _ := ret[1].(error)
@@ -1325,13 +1172,11 @@ func (m *MockIAMAPI) DeleteGroupPolicy(arg0 *iam.DeleteGroupPolicyInput) (*iam.D
 
 // DeleteGroupPolicy indicates an expected call of DeleteGroupPolicy
 func (mr *MockIAMAPIMockRecorder) DeleteGroupPolicy(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteGroupPolicy", reflect.TypeOf((*MockIAMAPI)(nil).DeleteGroupPolicy), arg0)
 }
 
 // DeleteGroupPolicyRequest mocks base method
 func (m *MockIAMAPI) DeleteGroupPolicyRequest(arg0 *iam.DeleteGroupPolicyInput) (*request.Request, *iam.DeleteGroupPolicyOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteGroupPolicyRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*iam.DeleteGroupPolicyOutput)
@@ -1340,13 +1185,11 @@ func (m *MockIAMAPI) DeleteGroupPolicyRequest(arg0 *iam.DeleteGroupPolicyInput) 
 
 // DeleteGroupPolicyRequest indicates an expected call of DeleteGroupPolicyRequest
 func (mr *MockIAMAPIMockRecorder) DeleteGroupPolicyRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteGroupPolicyRequest", reflect.TypeOf((*MockIAMAPI)(nil).DeleteGroupPolicyRequest), arg0)
 }
 
 // DeleteGroupPolicyWithContext mocks base method
 func (m *MockIAMAPI) DeleteGroupPolicyWithContext(arg0 context.Context, arg1 *iam.DeleteGroupPolicyInput, arg2 ...request.Option) (*iam.DeleteGroupPolicyOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -1359,14 +1202,12 @@ func (m *MockIAMAPI) DeleteGroupPolicyWithContext(arg0 context.Context, arg1 *ia
 
 // DeleteGroupPolicyWithContext indicates an expected call of DeleteGroupPolicyWithContext
 func (mr *MockIAMAPIMockRecorder) DeleteGroupPolicyWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteGroupPolicyWithContext", reflect.TypeOf((*MockIAMAPI)(nil).DeleteGroupPolicyWithContext), varargs...)
 }
 
 // DeleteGroupRequest mocks base method
 func (m *MockIAMAPI) DeleteGroupRequest(arg0 *iam.DeleteGroupInput) (*request.Request, *iam.DeleteGroupOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteGroupRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*iam.DeleteGroupOutput)
@@ -1375,13 +1216,11 @@ func (m *MockIAMAPI) DeleteGroupRequest(arg0 *iam.DeleteGroupInput) (*request.Re
 
 // DeleteGroupRequest indicates an expected call of DeleteGroupRequest
 func (mr *MockIAMAPIMockRecorder) DeleteGroupRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteGroupRequest", reflect.TypeOf((*MockIAMAPI)(nil).DeleteGroupRequest), arg0)
 }
 
 // DeleteGroupWithContext mocks base method
 func (m *MockIAMAPI) DeleteGroupWithContext(arg0 context.Context, arg1 *iam.DeleteGroupInput, arg2 ...request.Option) (*iam.DeleteGroupOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -1394,14 +1233,12 @@ func (m *MockIAMAPI) DeleteGroupWithContext(arg0 context.Context, arg1 *iam.Dele
 
 // DeleteGroupWithContext indicates an expected call of DeleteGroupWithContext
 func (mr *MockIAMAPIMockRecorder) DeleteGroupWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteGroupWithContext", reflect.TypeOf((*MockIAMAPI)(nil).DeleteGroupWithContext), varargs...)
 }
 
 // DeleteInstanceProfile mocks base method
 func (m *MockIAMAPI) DeleteInstanceProfile(arg0 *iam.DeleteInstanceProfileInput) (*iam.DeleteInstanceProfileOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteInstanceProfile", arg0)
 	ret0, _ := ret[0].(*iam.DeleteInstanceProfileOutput)
 	ret1, _ := ret[1].(error)
@@ -1410,13 +1247,11 @@ func (m *MockIAMAPI) DeleteInstanceProfile(arg0 *iam.DeleteInstanceProfileInput)
 
 // DeleteInstanceProfile indicates an expected call of DeleteInstanceProfile
 func (mr *MockIAMAPIMockRecorder) DeleteInstanceProfile(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteInstanceProfile", reflect.TypeOf((*MockIAMAPI)(nil).DeleteInstanceProfile), arg0)
 }
 
 // DeleteInstanceProfileRequest mocks base method
 func (m *MockIAMAPI) DeleteInstanceProfileRequest(arg0 *iam.DeleteInstanceProfileInput) (*request.Request, *iam.DeleteInstanceProfileOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteInstanceProfileRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*iam.DeleteInstanceProfileOutput)
@@ -1425,13 +1260,11 @@ func (m *MockIAMAPI) DeleteInstanceProfileRequest(arg0 *iam.DeleteInstanceProfil
 
 // DeleteInstanceProfileRequest indicates an expected call of DeleteInstanceProfileRequest
 func (mr *MockIAMAPIMockRecorder) DeleteInstanceProfileRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteInstanceProfileRequest", reflect.TypeOf((*MockIAMAPI)(nil).DeleteInstanceProfileRequest), arg0)
 }
 
 // DeleteInstanceProfileWithContext mocks base method
 func (m *MockIAMAPI) DeleteInstanceProfileWithContext(arg0 context.Context, arg1 *iam.DeleteInstanceProfileInput, arg2 ...request.Option) (*iam.DeleteInstanceProfileOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -1444,14 +1277,12 @@ func (m *MockIAMAPI) DeleteInstanceProfileWithContext(arg0 context.Context, arg1
 
 // DeleteInstanceProfileWithContext indicates an expected call of DeleteInstanceProfileWithContext
 func (mr *MockIAMAPIMockRecorder) DeleteInstanceProfileWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteInstanceProfileWithContext", reflect.TypeOf((*MockIAMAPI)(nil).DeleteInstanceProfileWithContext), varargs...)
 }
 
 // DeleteLoginProfile mocks base method
 func (m *MockIAMAPI) DeleteLoginProfile(arg0 *iam.DeleteLoginProfileInput) (*iam.DeleteLoginProfileOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteLoginProfile", arg0)
 	ret0, _ := ret[0].(*iam.DeleteLoginProfileOutput)
 	ret1, _ := ret[1].(error)
@@ -1460,13 +1291,11 @@ func (m *MockIAMAPI) DeleteLoginProfile(arg0 *iam.DeleteLoginProfileInput) (*iam
 
 // DeleteLoginProfile indicates an expected call of DeleteLoginProfile
 func (mr *MockIAMAPIMockRecorder) DeleteLoginProfile(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteLoginProfile", reflect.TypeOf((*MockIAMAPI)(nil).DeleteLoginProfile), arg0)
 }
 
 // DeleteLoginProfileRequest mocks base method
 func (m *MockIAMAPI) DeleteLoginProfileRequest(arg0 *iam.DeleteLoginProfileInput) (*request.Request, *iam.DeleteLoginProfileOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteLoginProfileRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*iam.DeleteLoginProfileOutput)
@@ -1475,13 +1304,11 @@ func (m *MockIAMAPI) DeleteLoginProfileRequest(arg0 *iam.DeleteLoginProfileInput
 
 // DeleteLoginProfileRequest indicates an expected call of DeleteLoginProfileRequest
 func (mr *MockIAMAPIMockRecorder) DeleteLoginProfileRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteLoginProfileRequest", reflect.TypeOf((*MockIAMAPI)(nil).DeleteLoginProfileRequest), arg0)
 }
 
 // DeleteLoginProfileWithContext mocks base method
 func (m *MockIAMAPI) DeleteLoginProfileWithContext(arg0 context.Context, arg1 *iam.DeleteLoginProfileInput, arg2 ...request.Option) (*iam.DeleteLoginProfileOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -1494,14 +1321,12 @@ func (m *MockIAMAPI) DeleteLoginProfileWithContext(arg0 context.Context, arg1 *i
 
 // DeleteLoginProfileWithContext indicates an expected call of DeleteLoginProfileWithContext
 func (mr *MockIAMAPIMockRecorder) DeleteLoginProfileWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteLoginProfileWithContext", reflect.TypeOf((*MockIAMAPI)(nil).DeleteLoginProfileWithContext), varargs...)
 }
 
 // DeleteOpenIDConnectProvider mocks base method
 func (m *MockIAMAPI) DeleteOpenIDConnectProvider(arg0 *iam.DeleteOpenIDConnectProviderInput) (*iam.DeleteOpenIDConnectProviderOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteOpenIDConnectProvider", arg0)
 	ret0, _ := ret[0].(*iam.DeleteOpenIDConnectProviderOutput)
 	ret1, _ := ret[1].(error)
@@ -1510,13 +1335,11 @@ func (m *MockIAMAPI) DeleteOpenIDConnectProvider(arg0 *iam.DeleteOpenIDConnectPr
 
 // DeleteOpenIDConnectProvider indicates an expected call of DeleteOpenIDConnectProvider
 func (mr *MockIAMAPIMockRecorder) DeleteOpenIDConnectProvider(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteOpenIDConnectProvider", reflect.TypeOf((*MockIAMAPI)(nil).DeleteOpenIDConnectProvider), arg0)
 }
 
 // DeleteOpenIDConnectProviderRequest mocks base method
 func (m *MockIAMAPI) DeleteOpenIDConnectProviderRequest(arg0 *iam.DeleteOpenIDConnectProviderInput) (*request.Request, *iam.DeleteOpenIDConnectProviderOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteOpenIDConnectProviderRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*iam.DeleteOpenIDConnectProviderOutput)
@@ -1525,13 +1348,11 @@ func (m *MockIAMAPI) DeleteOpenIDConnectProviderRequest(arg0 *iam.DeleteOpenIDCo
 
 // DeleteOpenIDConnectProviderRequest indicates an expected call of DeleteOpenIDConnectProviderRequest
 func (mr *MockIAMAPIMockRecorder) DeleteOpenIDConnectProviderRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteOpenIDConnectProviderRequest", reflect.TypeOf((*MockIAMAPI)(nil).DeleteOpenIDConnectProviderRequest), arg0)
 }
 
 // DeleteOpenIDConnectProviderWithContext mocks base method
 func (m *MockIAMAPI) DeleteOpenIDConnectProviderWithContext(arg0 context.Context, arg1 *iam.DeleteOpenIDConnectProviderInput, arg2 ...request.Option) (*iam.DeleteOpenIDConnectProviderOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -1544,14 +1365,12 @@ func (m *MockIAMAPI) DeleteOpenIDConnectProviderWithContext(arg0 context.Context
 
 // DeleteOpenIDConnectProviderWithContext indicates an expected call of DeleteOpenIDConnectProviderWithContext
 func (mr *MockIAMAPIMockRecorder) DeleteOpenIDConnectProviderWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteOpenIDConnectProviderWithContext", reflect.TypeOf((*MockIAMAPI)(nil).DeleteOpenIDConnectProviderWithContext), varargs...)
 }
 
 // DeletePolicy mocks base method
 func (m *MockIAMAPI) DeletePolicy(arg0 *iam.DeletePolicyInput) (*iam.DeletePolicyOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeletePolicy", arg0)
 	ret0, _ := ret[0].(*iam.DeletePolicyOutput)
 	ret1, _ := ret[1].(error)
@@ -1560,13 +1379,11 @@ func (m *MockIAMAPI) DeletePolicy(arg0 *iam.DeletePolicyInput) (*iam.DeletePolic
 
 // DeletePolicy indicates an expected call of DeletePolicy
 func (mr *MockIAMAPIMockRecorder) DeletePolicy(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeletePolicy", reflect.TypeOf((*MockIAMAPI)(nil).DeletePolicy), arg0)
 }
 
 // DeletePolicyRequest mocks base method
 func (m *MockIAMAPI) DeletePolicyRequest(arg0 *iam.DeletePolicyInput) (*request.Request, *iam.DeletePolicyOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeletePolicyRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*iam.DeletePolicyOutput)
@@ -1575,13 +1392,11 @@ func (m *MockIAMAPI) DeletePolicyRequest(arg0 *iam.DeletePolicyInput) (*request.
 
 // DeletePolicyRequest indicates an expected call of DeletePolicyRequest
 func (mr *MockIAMAPIMockRecorder) DeletePolicyRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeletePolicyRequest", reflect.TypeOf((*MockIAMAPI)(nil).DeletePolicyRequest), arg0)
 }
 
 // DeletePolicyVersion mocks base method
 func (m *MockIAMAPI) DeletePolicyVersion(arg0 *iam.DeletePolicyVersionInput) (*iam.DeletePolicyVersionOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeletePolicyVersion", arg0)
 	ret0, _ := ret[0].(*iam.DeletePolicyVersionOutput)
 	ret1, _ := ret[1].(error)
@@ -1590,13 +1405,11 @@ func (m *MockIAMAPI) DeletePolicyVersion(arg0 *iam.DeletePolicyVersionInput) (*i
 
 // DeletePolicyVersion indicates an expected call of DeletePolicyVersion
 func (mr *MockIAMAPIMockRecorder) DeletePolicyVersion(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeletePolicyVersion", reflect.TypeOf((*MockIAMAPI)(nil).DeletePolicyVersion), arg0)
 }
 
 // DeletePolicyVersionRequest mocks base method
 func (m *MockIAMAPI) DeletePolicyVersionRequest(arg0 *iam.DeletePolicyVersionInput) (*request.Request, *iam.DeletePolicyVersionOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeletePolicyVersionRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*iam.DeletePolicyVersionOutput)
@@ -1605,13 +1418,11 @@ func (m *MockIAMAPI) DeletePolicyVersionRequest(arg0 *iam.DeletePolicyVersionInp
 
 // DeletePolicyVersionRequest indicates an expected call of DeletePolicyVersionRequest
 func (mr *MockIAMAPIMockRecorder) DeletePolicyVersionRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeletePolicyVersionRequest", reflect.TypeOf((*MockIAMAPI)(nil).DeletePolicyVersionRequest), arg0)
 }
 
 // DeletePolicyVersionWithContext mocks base method
 func (m *MockIAMAPI) DeletePolicyVersionWithContext(arg0 context.Context, arg1 *iam.DeletePolicyVersionInput, arg2 ...request.Option) (*iam.DeletePolicyVersionOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -1624,14 +1435,12 @@ func (m *MockIAMAPI) DeletePolicyVersionWithContext(arg0 context.Context, arg1 *
 
 // DeletePolicyVersionWithContext indicates an expected call of DeletePolicyVersionWithContext
 func (mr *MockIAMAPIMockRecorder) DeletePolicyVersionWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeletePolicyVersionWithContext", reflect.TypeOf((*MockIAMAPI)(nil).DeletePolicyVersionWithContext), varargs...)
 }
 
 // DeletePolicyWithContext mocks base method
 func (m *MockIAMAPI) DeletePolicyWithContext(arg0 context.Context, arg1 *iam.DeletePolicyInput, arg2 ...request.Option) (*iam.DeletePolicyOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -1644,14 +1453,12 @@ func (m *MockIAMAPI) DeletePolicyWithContext(arg0 context.Context, arg1 *iam.Del
 
 // DeletePolicyWithContext indicates an expected call of DeletePolicyWithContext
 func (mr *MockIAMAPIMockRecorder) DeletePolicyWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeletePolicyWithContext", reflect.TypeOf((*MockIAMAPI)(nil).DeletePolicyWithContext), varargs...)
 }
 
 // DeleteRole mocks base method
 func (m *MockIAMAPI) DeleteRole(arg0 *iam.DeleteRoleInput) (*iam.DeleteRoleOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteRole", arg0)
 	ret0, _ := ret[0].(*iam.DeleteRoleOutput)
 	ret1, _ := ret[1].(error)
@@ -1660,13 +1467,11 @@ func (m *MockIAMAPI) DeleteRole(arg0 *iam.DeleteRoleInput) (*iam.DeleteRoleOutpu
 
 // DeleteRole indicates an expected call of DeleteRole
 func (mr *MockIAMAPIMockRecorder) DeleteRole(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteRole", reflect.TypeOf((*MockIAMAPI)(nil).DeleteRole), arg0)
 }
 
 // DeleteRolePermissionsBoundary mocks base method
 func (m *MockIAMAPI) DeleteRolePermissionsBoundary(arg0 *iam.DeleteRolePermissionsBoundaryInput) (*iam.DeleteRolePermissionsBoundaryOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteRolePermissionsBoundary", arg0)
 	ret0, _ := ret[0].(*iam.DeleteRolePermissionsBoundaryOutput)
 	ret1, _ := ret[1].(error)
@@ -1675,13 +1480,11 @@ func (m *MockIAMAPI) DeleteRolePermissionsBoundary(arg0 *iam.DeleteRolePermissio
 
 // DeleteRolePermissionsBoundary indicates an expected call of DeleteRolePermissionsBoundary
 func (mr *MockIAMAPIMockRecorder) DeleteRolePermissionsBoundary(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteRolePermissionsBoundary", reflect.TypeOf((*MockIAMAPI)(nil).DeleteRolePermissionsBoundary), arg0)
 }
 
 // DeleteRolePermissionsBoundaryRequest mocks base method
 func (m *MockIAMAPI) DeleteRolePermissionsBoundaryRequest(arg0 *iam.DeleteRolePermissionsBoundaryInput) (*request.Request, *iam.DeleteRolePermissionsBoundaryOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteRolePermissionsBoundaryRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*iam.DeleteRolePermissionsBoundaryOutput)
@@ -1690,13 +1493,11 @@ func (m *MockIAMAPI) DeleteRolePermissionsBoundaryRequest(arg0 *iam.DeleteRolePe
 
 // DeleteRolePermissionsBoundaryRequest indicates an expected call of DeleteRolePermissionsBoundaryRequest
 func (mr *MockIAMAPIMockRecorder) DeleteRolePermissionsBoundaryRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteRolePermissionsBoundaryRequest", reflect.TypeOf((*MockIAMAPI)(nil).DeleteRolePermissionsBoundaryRequest), arg0)
 }
 
 // DeleteRolePermissionsBoundaryWithContext mocks base method
 func (m *MockIAMAPI) DeleteRolePermissionsBoundaryWithContext(arg0 context.Context, arg1 *iam.DeleteRolePermissionsBoundaryInput, arg2 ...request.Option) (*iam.DeleteRolePermissionsBoundaryOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -1709,14 +1510,12 @@ func (m *MockIAMAPI) DeleteRolePermissionsBoundaryWithContext(arg0 context.Conte
 
 // DeleteRolePermissionsBoundaryWithContext indicates an expected call of DeleteRolePermissionsBoundaryWithContext
 func (mr *MockIAMAPIMockRecorder) DeleteRolePermissionsBoundaryWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteRolePermissionsBoundaryWithContext", reflect.TypeOf((*MockIAMAPI)(nil).DeleteRolePermissionsBoundaryWithContext), varargs...)
 }
 
 // DeleteRolePolicy mocks base method
 func (m *MockIAMAPI) DeleteRolePolicy(arg0 *iam.DeleteRolePolicyInput) (*iam.DeleteRolePolicyOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteRolePolicy", arg0)
 	ret0, _ := ret[0].(*iam.DeleteRolePolicyOutput)
 	ret1, _ := ret[1].(error)
@@ -1725,13 +1524,11 @@ func (m *MockIAMAPI) DeleteRolePolicy(arg0 *iam.DeleteRolePolicyInput) (*iam.Del
 
 // DeleteRolePolicy indicates an expected call of DeleteRolePolicy
 func (mr *MockIAMAPIMockRecorder) DeleteRolePolicy(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteRolePolicy", reflect.TypeOf((*MockIAMAPI)(nil).DeleteRolePolicy), arg0)
 }
 
 // DeleteRolePolicyRequest mocks base method
 func (m *MockIAMAPI) DeleteRolePolicyRequest(arg0 *iam.DeleteRolePolicyInput) (*request.Request, *iam.DeleteRolePolicyOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteRolePolicyRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*iam.DeleteRolePolicyOutput)
@@ -1740,13 +1537,11 @@ func (m *MockIAMAPI) DeleteRolePolicyRequest(arg0 *iam.DeleteRolePolicyInput) (*
 
 // DeleteRolePolicyRequest indicates an expected call of DeleteRolePolicyRequest
 func (mr *MockIAMAPIMockRecorder) DeleteRolePolicyRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteRolePolicyRequest", reflect.TypeOf((*MockIAMAPI)(nil).DeleteRolePolicyRequest), arg0)
 }
 
 // DeleteRolePolicyWithContext mocks base method
 func (m *MockIAMAPI) DeleteRolePolicyWithContext(arg0 context.Context, arg1 *iam.DeleteRolePolicyInput, arg2 ...request.Option) (*iam.DeleteRolePolicyOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -1759,14 +1554,12 @@ func (m *MockIAMAPI) DeleteRolePolicyWithContext(arg0 context.Context, arg1 *iam
 
 // DeleteRolePolicyWithContext indicates an expected call of DeleteRolePolicyWithContext
 func (mr *MockIAMAPIMockRecorder) DeleteRolePolicyWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteRolePolicyWithContext", reflect.TypeOf((*MockIAMAPI)(nil).DeleteRolePolicyWithContext), varargs...)
 }
 
 // DeleteRoleRequest mocks base method
 func (m *MockIAMAPI) DeleteRoleRequest(arg0 *iam.DeleteRoleInput) (*request.Request, *iam.DeleteRoleOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteRoleRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*iam.DeleteRoleOutput)
@@ -1775,13 +1568,11 @@ func (m *MockIAMAPI) DeleteRoleRequest(arg0 *iam.DeleteRoleInput) (*request.Requ
 
 // DeleteRoleRequest indicates an expected call of DeleteRoleRequest
 func (mr *MockIAMAPIMockRecorder) DeleteRoleRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteRoleRequest", reflect.TypeOf((*MockIAMAPI)(nil).DeleteRoleRequest), arg0)
 }
 
 // DeleteRoleWithContext mocks base method
 func (m *MockIAMAPI) DeleteRoleWithContext(arg0 context.Context, arg1 *iam.DeleteRoleInput, arg2 ...request.Option) (*iam.DeleteRoleOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -1794,14 +1585,12 @@ func (m *MockIAMAPI) DeleteRoleWithContext(arg0 context.Context, arg1 *iam.Delet
 
 // DeleteRoleWithContext indicates an expected call of DeleteRoleWithContext
 func (mr *MockIAMAPIMockRecorder) DeleteRoleWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteRoleWithContext", reflect.TypeOf((*MockIAMAPI)(nil).DeleteRoleWithContext), varargs...)
 }
 
 // DeleteSAMLProvider mocks base method
 func (m *MockIAMAPI) DeleteSAMLProvider(arg0 *iam.DeleteSAMLProviderInput) (*iam.DeleteSAMLProviderOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteSAMLProvider", arg0)
 	ret0, _ := ret[0].(*iam.DeleteSAMLProviderOutput)
 	ret1, _ := ret[1].(error)
@@ -1810,13 +1599,11 @@ func (m *MockIAMAPI) DeleteSAMLProvider(arg0 *iam.DeleteSAMLProviderInput) (*iam
 
 // DeleteSAMLProvider indicates an expected call of DeleteSAMLProvider
 func (mr *MockIAMAPIMockRecorder) DeleteSAMLProvider(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteSAMLProvider", reflect.TypeOf((*MockIAMAPI)(nil).DeleteSAMLProvider), arg0)
 }
 
 // DeleteSAMLProviderRequest mocks base method
 func (m *MockIAMAPI) DeleteSAMLProviderRequest(arg0 *iam.DeleteSAMLProviderInput) (*request.Request, *iam.DeleteSAMLProviderOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteSAMLProviderRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*iam.DeleteSAMLProviderOutput)
@@ -1825,13 +1612,11 @@ func (m *MockIAMAPI) DeleteSAMLProviderRequest(arg0 *iam.DeleteSAMLProviderInput
 
 // DeleteSAMLProviderRequest indicates an expected call of DeleteSAMLProviderRequest
 func (mr *MockIAMAPIMockRecorder) DeleteSAMLProviderRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteSAMLProviderRequest", reflect.TypeOf((*MockIAMAPI)(nil).DeleteSAMLProviderRequest), arg0)
 }
 
 // DeleteSAMLProviderWithContext mocks base method
 func (m *MockIAMAPI) DeleteSAMLProviderWithContext(arg0 context.Context, arg1 *iam.DeleteSAMLProviderInput, arg2 ...request.Option) (*iam.DeleteSAMLProviderOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -1844,14 +1629,12 @@ func (m *MockIAMAPI) DeleteSAMLProviderWithContext(arg0 context.Context, arg1 *i
 
 // DeleteSAMLProviderWithContext indicates an expected call of DeleteSAMLProviderWithContext
 func (mr *MockIAMAPIMockRecorder) DeleteSAMLProviderWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteSAMLProviderWithContext", reflect.TypeOf((*MockIAMAPI)(nil).DeleteSAMLProviderWithContext), varargs...)
 }
 
 // DeleteSSHPublicKey mocks base method
 func (m *MockIAMAPI) DeleteSSHPublicKey(arg0 *iam.DeleteSSHPublicKeyInput) (*iam.DeleteSSHPublicKeyOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteSSHPublicKey", arg0)
 	ret0, _ := ret[0].(*iam.DeleteSSHPublicKeyOutput)
 	ret1, _ := ret[1].(error)
@@ -1860,13 +1643,11 @@ func (m *MockIAMAPI) DeleteSSHPublicKey(arg0 *iam.DeleteSSHPublicKeyInput) (*iam
 
 // DeleteSSHPublicKey indicates an expected call of DeleteSSHPublicKey
 func (mr *MockIAMAPIMockRecorder) DeleteSSHPublicKey(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteSSHPublicKey", reflect.TypeOf((*MockIAMAPI)(nil).DeleteSSHPublicKey), arg0)
 }
 
 // DeleteSSHPublicKeyRequest mocks base method
 func (m *MockIAMAPI) DeleteSSHPublicKeyRequest(arg0 *iam.DeleteSSHPublicKeyInput) (*request.Request, *iam.DeleteSSHPublicKeyOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteSSHPublicKeyRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*iam.DeleteSSHPublicKeyOutput)
@@ -1875,13 +1656,11 @@ func (m *MockIAMAPI) DeleteSSHPublicKeyRequest(arg0 *iam.DeleteSSHPublicKeyInput
 
 // DeleteSSHPublicKeyRequest indicates an expected call of DeleteSSHPublicKeyRequest
 func (mr *MockIAMAPIMockRecorder) DeleteSSHPublicKeyRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteSSHPublicKeyRequest", reflect.TypeOf((*MockIAMAPI)(nil).DeleteSSHPublicKeyRequest), arg0)
 }
 
 // DeleteSSHPublicKeyWithContext mocks base method
 func (m *MockIAMAPI) DeleteSSHPublicKeyWithContext(arg0 context.Context, arg1 *iam.DeleteSSHPublicKeyInput, arg2 ...request.Option) (*iam.DeleteSSHPublicKeyOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -1894,14 +1673,12 @@ func (m *MockIAMAPI) DeleteSSHPublicKeyWithContext(arg0 context.Context, arg1 *i
 
 // DeleteSSHPublicKeyWithContext indicates an expected call of DeleteSSHPublicKeyWithContext
 func (mr *MockIAMAPIMockRecorder) DeleteSSHPublicKeyWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteSSHPublicKeyWithContext", reflect.TypeOf((*MockIAMAPI)(nil).DeleteSSHPublicKeyWithContext), varargs...)
 }
 
 // DeleteServerCertificate mocks base method
 func (m *MockIAMAPI) DeleteServerCertificate(arg0 *iam.DeleteServerCertificateInput) (*iam.DeleteServerCertificateOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteServerCertificate", arg0)
 	ret0, _ := ret[0].(*iam.DeleteServerCertificateOutput)
 	ret1, _ := ret[1].(error)
@@ -1910,13 +1687,11 @@ func (m *MockIAMAPI) DeleteServerCertificate(arg0 *iam.DeleteServerCertificateIn
 
 // DeleteServerCertificate indicates an expected call of DeleteServerCertificate
 func (mr *MockIAMAPIMockRecorder) DeleteServerCertificate(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteServerCertificate", reflect.TypeOf((*MockIAMAPI)(nil).DeleteServerCertificate), arg0)
 }
 
 // DeleteServerCertificateRequest mocks base method
 func (m *MockIAMAPI) DeleteServerCertificateRequest(arg0 *iam.DeleteServerCertificateInput) (*request.Request, *iam.DeleteServerCertificateOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteServerCertificateRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*iam.DeleteServerCertificateOutput)
@@ -1925,13 +1700,11 @@ func (m *MockIAMAPI) DeleteServerCertificateRequest(arg0 *iam.DeleteServerCertif
 
 // DeleteServerCertificateRequest indicates an expected call of DeleteServerCertificateRequest
 func (mr *MockIAMAPIMockRecorder) DeleteServerCertificateRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteServerCertificateRequest", reflect.TypeOf((*MockIAMAPI)(nil).DeleteServerCertificateRequest), arg0)
 }
 
 // DeleteServerCertificateWithContext mocks base method
 func (m *MockIAMAPI) DeleteServerCertificateWithContext(arg0 context.Context, arg1 *iam.DeleteServerCertificateInput, arg2 ...request.Option) (*iam.DeleteServerCertificateOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -1944,14 +1717,12 @@ func (m *MockIAMAPI) DeleteServerCertificateWithContext(arg0 context.Context, ar
 
 // DeleteServerCertificateWithContext indicates an expected call of DeleteServerCertificateWithContext
 func (mr *MockIAMAPIMockRecorder) DeleteServerCertificateWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteServerCertificateWithContext", reflect.TypeOf((*MockIAMAPI)(nil).DeleteServerCertificateWithContext), varargs...)
 }
 
 // DeleteServiceLinkedRole mocks base method
 func (m *MockIAMAPI) DeleteServiceLinkedRole(arg0 *iam.DeleteServiceLinkedRoleInput) (*iam.DeleteServiceLinkedRoleOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteServiceLinkedRole", arg0)
 	ret0, _ := ret[0].(*iam.DeleteServiceLinkedRoleOutput)
 	ret1, _ := ret[1].(error)
@@ -1960,13 +1731,11 @@ func (m *MockIAMAPI) DeleteServiceLinkedRole(arg0 *iam.DeleteServiceLinkedRoleIn
 
 // DeleteServiceLinkedRole indicates an expected call of DeleteServiceLinkedRole
 func (mr *MockIAMAPIMockRecorder) DeleteServiceLinkedRole(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteServiceLinkedRole", reflect.TypeOf((*MockIAMAPI)(nil).DeleteServiceLinkedRole), arg0)
 }
 
 // DeleteServiceLinkedRoleRequest mocks base method
 func (m *MockIAMAPI) DeleteServiceLinkedRoleRequest(arg0 *iam.DeleteServiceLinkedRoleInput) (*request.Request, *iam.DeleteServiceLinkedRoleOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteServiceLinkedRoleRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*iam.DeleteServiceLinkedRoleOutput)
@@ -1975,13 +1744,11 @@ func (m *MockIAMAPI) DeleteServiceLinkedRoleRequest(arg0 *iam.DeleteServiceLinke
 
 // DeleteServiceLinkedRoleRequest indicates an expected call of DeleteServiceLinkedRoleRequest
 func (mr *MockIAMAPIMockRecorder) DeleteServiceLinkedRoleRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteServiceLinkedRoleRequest", reflect.TypeOf((*MockIAMAPI)(nil).DeleteServiceLinkedRoleRequest), arg0)
 }
 
 // DeleteServiceLinkedRoleWithContext mocks base method
 func (m *MockIAMAPI) DeleteServiceLinkedRoleWithContext(arg0 context.Context, arg1 *iam.DeleteServiceLinkedRoleInput, arg2 ...request.Option) (*iam.DeleteServiceLinkedRoleOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -1994,14 +1761,12 @@ func (m *MockIAMAPI) DeleteServiceLinkedRoleWithContext(arg0 context.Context, ar
 
 // DeleteServiceLinkedRoleWithContext indicates an expected call of DeleteServiceLinkedRoleWithContext
 func (mr *MockIAMAPIMockRecorder) DeleteServiceLinkedRoleWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteServiceLinkedRoleWithContext", reflect.TypeOf((*MockIAMAPI)(nil).DeleteServiceLinkedRoleWithContext), varargs...)
 }
 
 // DeleteServiceSpecificCredential mocks base method
 func (m *MockIAMAPI) DeleteServiceSpecificCredential(arg0 *iam.DeleteServiceSpecificCredentialInput) (*iam.DeleteServiceSpecificCredentialOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteServiceSpecificCredential", arg0)
 	ret0, _ := ret[0].(*iam.DeleteServiceSpecificCredentialOutput)
 	ret1, _ := ret[1].(error)
@@ -2010,13 +1775,11 @@ func (m *MockIAMAPI) DeleteServiceSpecificCredential(arg0 *iam.DeleteServiceSpec
 
 // DeleteServiceSpecificCredential indicates an expected call of DeleteServiceSpecificCredential
 func (mr *MockIAMAPIMockRecorder) DeleteServiceSpecificCredential(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteServiceSpecificCredential", reflect.TypeOf((*MockIAMAPI)(nil).DeleteServiceSpecificCredential), arg0)
 }
 
 // DeleteServiceSpecificCredentialRequest mocks base method
 func (m *MockIAMAPI) DeleteServiceSpecificCredentialRequest(arg0 *iam.DeleteServiceSpecificCredentialInput) (*request.Request, *iam.DeleteServiceSpecificCredentialOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteServiceSpecificCredentialRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*iam.DeleteServiceSpecificCredentialOutput)
@@ -2025,13 +1788,11 @@ func (m *MockIAMAPI) DeleteServiceSpecificCredentialRequest(arg0 *iam.DeleteServ
 
 // DeleteServiceSpecificCredentialRequest indicates an expected call of DeleteServiceSpecificCredentialRequest
 func (mr *MockIAMAPIMockRecorder) DeleteServiceSpecificCredentialRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteServiceSpecificCredentialRequest", reflect.TypeOf((*MockIAMAPI)(nil).DeleteServiceSpecificCredentialRequest), arg0)
 }
 
 // DeleteServiceSpecificCredentialWithContext mocks base method
 func (m *MockIAMAPI) DeleteServiceSpecificCredentialWithContext(arg0 context.Context, arg1 *iam.DeleteServiceSpecificCredentialInput, arg2 ...request.Option) (*iam.DeleteServiceSpecificCredentialOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -2044,14 +1805,12 @@ func (m *MockIAMAPI) DeleteServiceSpecificCredentialWithContext(arg0 context.Con
 
 // DeleteServiceSpecificCredentialWithContext indicates an expected call of DeleteServiceSpecificCredentialWithContext
 func (mr *MockIAMAPIMockRecorder) DeleteServiceSpecificCredentialWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteServiceSpecificCredentialWithContext", reflect.TypeOf((*MockIAMAPI)(nil).DeleteServiceSpecificCredentialWithContext), varargs...)
 }
 
 // DeleteSigningCertificate mocks base method
 func (m *MockIAMAPI) DeleteSigningCertificate(arg0 *iam.DeleteSigningCertificateInput) (*iam.DeleteSigningCertificateOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteSigningCertificate", arg0)
 	ret0, _ := ret[0].(*iam.DeleteSigningCertificateOutput)
 	ret1, _ := ret[1].(error)
@@ -2060,13 +1819,11 @@ func (m *MockIAMAPI) DeleteSigningCertificate(arg0 *iam.DeleteSigningCertificate
 
 // DeleteSigningCertificate indicates an expected call of DeleteSigningCertificate
 func (mr *MockIAMAPIMockRecorder) DeleteSigningCertificate(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteSigningCertificate", reflect.TypeOf((*MockIAMAPI)(nil).DeleteSigningCertificate), arg0)
 }
 
 // DeleteSigningCertificateRequest mocks base method
 func (m *MockIAMAPI) DeleteSigningCertificateRequest(arg0 *iam.DeleteSigningCertificateInput) (*request.Request, *iam.DeleteSigningCertificateOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteSigningCertificateRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*iam.DeleteSigningCertificateOutput)
@@ -2075,13 +1832,11 @@ func (m *MockIAMAPI) DeleteSigningCertificateRequest(arg0 *iam.DeleteSigningCert
 
 // DeleteSigningCertificateRequest indicates an expected call of DeleteSigningCertificateRequest
 func (mr *MockIAMAPIMockRecorder) DeleteSigningCertificateRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteSigningCertificateRequest", reflect.TypeOf((*MockIAMAPI)(nil).DeleteSigningCertificateRequest), arg0)
 }
 
 // DeleteSigningCertificateWithContext mocks base method
 func (m *MockIAMAPI) DeleteSigningCertificateWithContext(arg0 context.Context, arg1 *iam.DeleteSigningCertificateInput, arg2 ...request.Option) (*iam.DeleteSigningCertificateOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -2094,14 +1849,12 @@ func (m *MockIAMAPI) DeleteSigningCertificateWithContext(arg0 context.Context, a
 
 // DeleteSigningCertificateWithContext indicates an expected call of DeleteSigningCertificateWithContext
 func (mr *MockIAMAPIMockRecorder) DeleteSigningCertificateWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteSigningCertificateWithContext", reflect.TypeOf((*MockIAMAPI)(nil).DeleteSigningCertificateWithContext), varargs...)
 }
 
 // DeleteUser mocks base method
 func (m *MockIAMAPI) DeleteUser(arg0 *iam.DeleteUserInput) (*iam.DeleteUserOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteUser", arg0)
 	ret0, _ := ret[0].(*iam.DeleteUserOutput)
 	ret1, _ := ret[1].(error)
@@ -2110,13 +1863,11 @@ func (m *MockIAMAPI) DeleteUser(arg0 *iam.DeleteUserInput) (*iam.DeleteUserOutpu
 
 // DeleteUser indicates an expected call of DeleteUser
 func (mr *MockIAMAPIMockRecorder) DeleteUser(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteUser", reflect.TypeOf((*MockIAMAPI)(nil).DeleteUser), arg0)
 }
 
 // DeleteUserPermissionsBoundary mocks base method
 func (m *MockIAMAPI) DeleteUserPermissionsBoundary(arg0 *iam.DeleteUserPermissionsBoundaryInput) (*iam.DeleteUserPermissionsBoundaryOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteUserPermissionsBoundary", arg0)
 	ret0, _ := ret[0].(*iam.DeleteUserPermissionsBoundaryOutput)
 	ret1, _ := ret[1].(error)
@@ -2125,13 +1876,11 @@ func (m *MockIAMAPI) DeleteUserPermissionsBoundary(arg0 *iam.DeleteUserPermissio
 
 // DeleteUserPermissionsBoundary indicates an expected call of DeleteUserPermissionsBoundary
 func (mr *MockIAMAPIMockRecorder) DeleteUserPermissionsBoundary(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteUserPermissionsBoundary", reflect.TypeOf((*MockIAMAPI)(nil).DeleteUserPermissionsBoundary), arg0)
 }
 
 // DeleteUserPermissionsBoundaryRequest mocks base method
 func (m *MockIAMAPI) DeleteUserPermissionsBoundaryRequest(arg0 *iam.DeleteUserPermissionsBoundaryInput) (*request.Request, *iam.DeleteUserPermissionsBoundaryOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteUserPermissionsBoundaryRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*iam.DeleteUserPermissionsBoundaryOutput)
@@ -2140,13 +1889,11 @@ func (m *MockIAMAPI) DeleteUserPermissionsBoundaryRequest(arg0 *iam.DeleteUserPe
 
 // DeleteUserPermissionsBoundaryRequest indicates an expected call of DeleteUserPermissionsBoundaryRequest
 func (mr *MockIAMAPIMockRecorder) DeleteUserPermissionsBoundaryRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteUserPermissionsBoundaryRequest", reflect.TypeOf((*MockIAMAPI)(nil).DeleteUserPermissionsBoundaryRequest), arg0)
 }
 
 // DeleteUserPermissionsBoundaryWithContext mocks base method
 func (m *MockIAMAPI) DeleteUserPermissionsBoundaryWithContext(arg0 context.Context, arg1 *iam.DeleteUserPermissionsBoundaryInput, arg2 ...request.Option) (*iam.DeleteUserPermissionsBoundaryOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -2159,14 +1906,12 @@ func (m *MockIAMAPI) DeleteUserPermissionsBoundaryWithContext(arg0 context.Conte
 
 // DeleteUserPermissionsBoundaryWithContext indicates an expected call of DeleteUserPermissionsBoundaryWithContext
 func (mr *MockIAMAPIMockRecorder) DeleteUserPermissionsBoundaryWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteUserPermissionsBoundaryWithContext", reflect.TypeOf((*MockIAMAPI)(nil).DeleteUserPermissionsBoundaryWithContext), varargs...)
 }
 
 // DeleteUserPolicy mocks base method
 func (m *MockIAMAPI) DeleteUserPolicy(arg0 *iam.DeleteUserPolicyInput) (*iam.DeleteUserPolicyOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteUserPolicy", arg0)
 	ret0, _ := ret[0].(*iam.DeleteUserPolicyOutput)
 	ret1, _ := ret[1].(error)
@@ -2175,13 +1920,11 @@ func (m *MockIAMAPI) DeleteUserPolicy(arg0 *iam.DeleteUserPolicyInput) (*iam.Del
 
 // DeleteUserPolicy indicates an expected call of DeleteUserPolicy
 func (mr *MockIAMAPIMockRecorder) DeleteUserPolicy(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteUserPolicy", reflect.TypeOf((*MockIAMAPI)(nil).DeleteUserPolicy), arg0)
 }
 
 // DeleteUserPolicyRequest mocks base method
 func (m *MockIAMAPI) DeleteUserPolicyRequest(arg0 *iam.DeleteUserPolicyInput) (*request.Request, *iam.DeleteUserPolicyOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteUserPolicyRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*iam.DeleteUserPolicyOutput)
@@ -2190,13 +1933,11 @@ func (m *MockIAMAPI) DeleteUserPolicyRequest(arg0 *iam.DeleteUserPolicyInput) (*
 
 // DeleteUserPolicyRequest indicates an expected call of DeleteUserPolicyRequest
 func (mr *MockIAMAPIMockRecorder) DeleteUserPolicyRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteUserPolicyRequest", reflect.TypeOf((*MockIAMAPI)(nil).DeleteUserPolicyRequest), arg0)
 }
 
 // DeleteUserPolicyWithContext mocks base method
 func (m *MockIAMAPI) DeleteUserPolicyWithContext(arg0 context.Context, arg1 *iam.DeleteUserPolicyInput, arg2 ...request.Option) (*iam.DeleteUserPolicyOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -2209,14 +1950,12 @@ func (m *MockIAMAPI) DeleteUserPolicyWithContext(arg0 context.Context, arg1 *iam
 
 // DeleteUserPolicyWithContext indicates an expected call of DeleteUserPolicyWithContext
 func (mr *MockIAMAPIMockRecorder) DeleteUserPolicyWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteUserPolicyWithContext", reflect.TypeOf((*MockIAMAPI)(nil).DeleteUserPolicyWithContext), varargs...)
 }
 
 // DeleteUserRequest mocks base method
 func (m *MockIAMAPI) DeleteUserRequest(arg0 *iam.DeleteUserInput) (*request.Request, *iam.DeleteUserOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteUserRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*iam.DeleteUserOutput)
@@ -2225,13 +1964,11 @@ func (m *MockIAMAPI) DeleteUserRequest(arg0 *iam.DeleteUserInput) (*request.Requ
 
 // DeleteUserRequest indicates an expected call of DeleteUserRequest
 func (mr *MockIAMAPIMockRecorder) DeleteUserRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteUserRequest", reflect.TypeOf((*MockIAMAPI)(nil).DeleteUserRequest), arg0)
 }
 
 // DeleteUserWithContext mocks base method
 func (m *MockIAMAPI) DeleteUserWithContext(arg0 context.Context, arg1 *iam.DeleteUserInput, arg2 ...request.Option) (*iam.DeleteUserOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -2244,14 +1981,12 @@ func (m *MockIAMAPI) DeleteUserWithContext(arg0 context.Context, arg1 *iam.Delet
 
 // DeleteUserWithContext indicates an expected call of DeleteUserWithContext
 func (mr *MockIAMAPIMockRecorder) DeleteUserWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteUserWithContext", reflect.TypeOf((*MockIAMAPI)(nil).DeleteUserWithContext), varargs...)
 }
 
 // DeleteVirtualMFADevice mocks base method
 func (m *MockIAMAPI) DeleteVirtualMFADevice(arg0 *iam.DeleteVirtualMFADeviceInput) (*iam.DeleteVirtualMFADeviceOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteVirtualMFADevice", arg0)
 	ret0, _ := ret[0].(*iam.DeleteVirtualMFADeviceOutput)
 	ret1, _ := ret[1].(error)
@@ -2260,13 +1995,11 @@ func (m *MockIAMAPI) DeleteVirtualMFADevice(arg0 *iam.DeleteVirtualMFADeviceInpu
 
 // DeleteVirtualMFADevice indicates an expected call of DeleteVirtualMFADevice
 func (mr *MockIAMAPIMockRecorder) DeleteVirtualMFADevice(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteVirtualMFADevice", reflect.TypeOf((*MockIAMAPI)(nil).DeleteVirtualMFADevice), arg0)
 }
 
 // DeleteVirtualMFADeviceRequest mocks base method
 func (m *MockIAMAPI) DeleteVirtualMFADeviceRequest(arg0 *iam.DeleteVirtualMFADeviceInput) (*request.Request, *iam.DeleteVirtualMFADeviceOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteVirtualMFADeviceRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*iam.DeleteVirtualMFADeviceOutput)
@@ -2275,13 +2008,11 @@ func (m *MockIAMAPI) DeleteVirtualMFADeviceRequest(arg0 *iam.DeleteVirtualMFADev
 
 // DeleteVirtualMFADeviceRequest indicates an expected call of DeleteVirtualMFADeviceRequest
 func (mr *MockIAMAPIMockRecorder) DeleteVirtualMFADeviceRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteVirtualMFADeviceRequest", reflect.TypeOf((*MockIAMAPI)(nil).DeleteVirtualMFADeviceRequest), arg0)
 }
 
 // DeleteVirtualMFADeviceWithContext mocks base method
 func (m *MockIAMAPI) DeleteVirtualMFADeviceWithContext(arg0 context.Context, arg1 *iam.DeleteVirtualMFADeviceInput, arg2 ...request.Option) (*iam.DeleteVirtualMFADeviceOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -2294,14 +2025,12 @@ func (m *MockIAMAPI) DeleteVirtualMFADeviceWithContext(arg0 context.Context, arg
 
 // DeleteVirtualMFADeviceWithContext indicates an expected call of DeleteVirtualMFADeviceWithContext
 func (mr *MockIAMAPIMockRecorder) DeleteVirtualMFADeviceWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteVirtualMFADeviceWithContext", reflect.TypeOf((*MockIAMAPI)(nil).DeleteVirtualMFADeviceWithContext), varargs...)
 }
 
 // DetachGroupPolicy mocks base method
 func (m *MockIAMAPI) DetachGroupPolicy(arg0 *iam.DetachGroupPolicyInput) (*iam.DetachGroupPolicyOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DetachGroupPolicy", arg0)
 	ret0, _ := ret[0].(*iam.DetachGroupPolicyOutput)
 	ret1, _ := ret[1].(error)
@@ -2310,13 +2039,11 @@ func (m *MockIAMAPI) DetachGroupPolicy(arg0 *iam.DetachGroupPolicyInput) (*iam.D
 
 // DetachGroupPolicy indicates an expected call of DetachGroupPolicy
 func (mr *MockIAMAPIMockRecorder) DetachGroupPolicy(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DetachGroupPolicy", reflect.TypeOf((*MockIAMAPI)(nil).DetachGroupPolicy), arg0)
 }
 
 // DetachGroupPolicyRequest mocks base method
 func (m *MockIAMAPI) DetachGroupPolicyRequest(arg0 *iam.DetachGroupPolicyInput) (*request.Request, *iam.DetachGroupPolicyOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DetachGroupPolicyRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*iam.DetachGroupPolicyOutput)
@@ -2325,13 +2052,11 @@ func (m *MockIAMAPI) DetachGroupPolicyRequest(arg0 *iam.DetachGroupPolicyInput) 
 
 // DetachGroupPolicyRequest indicates an expected call of DetachGroupPolicyRequest
 func (mr *MockIAMAPIMockRecorder) DetachGroupPolicyRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DetachGroupPolicyRequest", reflect.TypeOf((*MockIAMAPI)(nil).DetachGroupPolicyRequest), arg0)
 }
 
 // DetachGroupPolicyWithContext mocks base method
 func (m *MockIAMAPI) DetachGroupPolicyWithContext(arg0 context.Context, arg1 *iam.DetachGroupPolicyInput, arg2 ...request.Option) (*iam.DetachGroupPolicyOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -2344,14 +2069,12 @@ func (m *MockIAMAPI) DetachGroupPolicyWithContext(arg0 context.Context, arg1 *ia
 
 // DetachGroupPolicyWithContext indicates an expected call of DetachGroupPolicyWithContext
 func (mr *MockIAMAPIMockRecorder) DetachGroupPolicyWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DetachGroupPolicyWithContext", reflect.TypeOf((*MockIAMAPI)(nil).DetachGroupPolicyWithContext), varargs...)
 }
 
 // DetachRolePolicy mocks base method
 func (m *MockIAMAPI) DetachRolePolicy(arg0 *iam.DetachRolePolicyInput) (*iam.DetachRolePolicyOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DetachRolePolicy", arg0)
 	ret0, _ := ret[0].(*iam.DetachRolePolicyOutput)
 	ret1, _ := ret[1].(error)
@@ -2360,13 +2083,11 @@ func (m *MockIAMAPI) DetachRolePolicy(arg0 *iam.DetachRolePolicyInput) (*iam.Det
 
 // DetachRolePolicy indicates an expected call of DetachRolePolicy
 func (mr *MockIAMAPIMockRecorder) DetachRolePolicy(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DetachRolePolicy", reflect.TypeOf((*MockIAMAPI)(nil).DetachRolePolicy), arg0)
 }
 
 // DetachRolePolicyRequest mocks base method
 func (m *MockIAMAPI) DetachRolePolicyRequest(arg0 *iam.DetachRolePolicyInput) (*request.Request, *iam.DetachRolePolicyOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DetachRolePolicyRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*iam.DetachRolePolicyOutput)
@@ -2375,13 +2096,11 @@ func (m *MockIAMAPI) DetachRolePolicyRequest(arg0 *iam.DetachRolePolicyInput) (*
 
 // DetachRolePolicyRequest indicates an expected call of DetachRolePolicyRequest
 func (mr *MockIAMAPIMockRecorder) DetachRolePolicyRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DetachRolePolicyRequest", reflect.TypeOf((*MockIAMAPI)(nil).DetachRolePolicyRequest), arg0)
 }
 
 // DetachRolePolicyWithContext mocks base method
 func (m *MockIAMAPI) DetachRolePolicyWithContext(arg0 context.Context, arg1 *iam.DetachRolePolicyInput, arg2 ...request.Option) (*iam.DetachRolePolicyOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -2394,14 +2113,12 @@ func (m *MockIAMAPI) DetachRolePolicyWithContext(arg0 context.Context, arg1 *iam
 
 // DetachRolePolicyWithContext indicates an expected call of DetachRolePolicyWithContext
 func (mr *MockIAMAPIMockRecorder) DetachRolePolicyWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DetachRolePolicyWithContext", reflect.TypeOf((*MockIAMAPI)(nil).DetachRolePolicyWithContext), varargs...)
 }
 
 // DetachUserPolicy mocks base method
 func (m *MockIAMAPI) DetachUserPolicy(arg0 *iam.DetachUserPolicyInput) (*iam.DetachUserPolicyOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DetachUserPolicy", arg0)
 	ret0, _ := ret[0].(*iam.DetachUserPolicyOutput)
 	ret1, _ := ret[1].(error)
@@ -2410,13 +2127,11 @@ func (m *MockIAMAPI) DetachUserPolicy(arg0 *iam.DetachUserPolicyInput) (*iam.Det
 
 // DetachUserPolicy indicates an expected call of DetachUserPolicy
 func (mr *MockIAMAPIMockRecorder) DetachUserPolicy(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DetachUserPolicy", reflect.TypeOf((*MockIAMAPI)(nil).DetachUserPolicy), arg0)
 }
 
 // DetachUserPolicyRequest mocks base method
 func (m *MockIAMAPI) DetachUserPolicyRequest(arg0 *iam.DetachUserPolicyInput) (*request.Request, *iam.DetachUserPolicyOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DetachUserPolicyRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*iam.DetachUserPolicyOutput)
@@ -2425,13 +2140,11 @@ func (m *MockIAMAPI) DetachUserPolicyRequest(arg0 *iam.DetachUserPolicyInput) (*
 
 // DetachUserPolicyRequest indicates an expected call of DetachUserPolicyRequest
 func (mr *MockIAMAPIMockRecorder) DetachUserPolicyRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DetachUserPolicyRequest", reflect.TypeOf((*MockIAMAPI)(nil).DetachUserPolicyRequest), arg0)
 }
 
 // DetachUserPolicyWithContext mocks base method
 func (m *MockIAMAPI) DetachUserPolicyWithContext(arg0 context.Context, arg1 *iam.DetachUserPolicyInput, arg2 ...request.Option) (*iam.DetachUserPolicyOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -2444,14 +2157,12 @@ func (m *MockIAMAPI) DetachUserPolicyWithContext(arg0 context.Context, arg1 *iam
 
 // DetachUserPolicyWithContext indicates an expected call of DetachUserPolicyWithContext
 func (mr *MockIAMAPIMockRecorder) DetachUserPolicyWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DetachUserPolicyWithContext", reflect.TypeOf((*MockIAMAPI)(nil).DetachUserPolicyWithContext), varargs...)
 }
 
 // EnableMFADevice mocks base method
 func (m *MockIAMAPI) EnableMFADevice(arg0 *iam.EnableMFADeviceInput) (*iam.EnableMFADeviceOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "EnableMFADevice", arg0)
 	ret0, _ := ret[0].(*iam.EnableMFADeviceOutput)
 	ret1, _ := ret[1].(error)
@@ -2460,13 +2171,11 @@ func (m *MockIAMAPI) EnableMFADevice(arg0 *iam.EnableMFADeviceInput) (*iam.Enabl
 
 // EnableMFADevice indicates an expected call of EnableMFADevice
 func (mr *MockIAMAPIMockRecorder) EnableMFADevice(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnableMFADevice", reflect.TypeOf((*MockIAMAPI)(nil).EnableMFADevice), arg0)
 }
 
 // EnableMFADeviceRequest mocks base method
 func (m *MockIAMAPI) EnableMFADeviceRequest(arg0 *iam.EnableMFADeviceInput) (*request.Request, *iam.EnableMFADeviceOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "EnableMFADeviceRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*iam.EnableMFADeviceOutput)
@@ -2475,13 +2184,11 @@ func (m *MockIAMAPI) EnableMFADeviceRequest(arg0 *iam.EnableMFADeviceInput) (*re
 
 // EnableMFADeviceRequest indicates an expected call of EnableMFADeviceRequest
 func (mr *MockIAMAPIMockRecorder) EnableMFADeviceRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnableMFADeviceRequest", reflect.TypeOf((*MockIAMAPI)(nil).EnableMFADeviceRequest), arg0)
 }
 
 // EnableMFADeviceWithContext mocks base method
 func (m *MockIAMAPI) EnableMFADeviceWithContext(arg0 context.Context, arg1 *iam.EnableMFADeviceInput, arg2 ...request.Option) (*iam.EnableMFADeviceOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -2494,14 +2201,12 @@ func (m *MockIAMAPI) EnableMFADeviceWithContext(arg0 context.Context, arg1 *iam.
 
 // EnableMFADeviceWithContext indicates an expected call of EnableMFADeviceWithContext
 func (mr *MockIAMAPIMockRecorder) EnableMFADeviceWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnableMFADeviceWithContext", reflect.TypeOf((*MockIAMAPI)(nil).EnableMFADeviceWithContext), varargs...)
 }
 
 // GenerateCredentialReport mocks base method
 func (m *MockIAMAPI) GenerateCredentialReport(arg0 *iam.GenerateCredentialReportInput) (*iam.GenerateCredentialReportOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GenerateCredentialReport", arg0)
 	ret0, _ := ret[0].(*iam.GenerateCredentialReportOutput)
 	ret1, _ := ret[1].(error)
@@ -2510,13 +2215,11 @@ func (m *MockIAMAPI) GenerateCredentialReport(arg0 *iam.GenerateCredentialReport
 
 // GenerateCredentialReport indicates an expected call of GenerateCredentialReport
 func (mr *MockIAMAPIMockRecorder) GenerateCredentialReport(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GenerateCredentialReport", reflect.TypeOf((*MockIAMAPI)(nil).GenerateCredentialReport), arg0)
 }
 
 // GenerateCredentialReportRequest mocks base method
 func (m *MockIAMAPI) GenerateCredentialReportRequest(arg0 *iam.GenerateCredentialReportInput) (*request.Request, *iam.GenerateCredentialReportOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GenerateCredentialReportRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*iam.GenerateCredentialReportOutput)
@@ -2525,13 +2228,11 @@ func (m *MockIAMAPI) GenerateCredentialReportRequest(arg0 *iam.GenerateCredentia
 
 // GenerateCredentialReportRequest indicates an expected call of GenerateCredentialReportRequest
 func (mr *MockIAMAPIMockRecorder) GenerateCredentialReportRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GenerateCredentialReportRequest", reflect.TypeOf((*MockIAMAPI)(nil).GenerateCredentialReportRequest), arg0)
 }
 
 // GenerateCredentialReportWithContext mocks base method
 func (m *MockIAMAPI) GenerateCredentialReportWithContext(arg0 context.Context, arg1 *iam.GenerateCredentialReportInput, arg2 ...request.Option) (*iam.GenerateCredentialReportOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -2544,14 +2245,12 @@ func (m *MockIAMAPI) GenerateCredentialReportWithContext(arg0 context.Context, a
 
 // GenerateCredentialReportWithContext indicates an expected call of GenerateCredentialReportWithContext
 func (mr *MockIAMAPIMockRecorder) GenerateCredentialReportWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GenerateCredentialReportWithContext", reflect.TypeOf((*MockIAMAPI)(nil).GenerateCredentialReportWithContext), varargs...)
 }
 
 // GenerateServiceLastAccessedDetails mocks base method
 func (m *MockIAMAPI) GenerateServiceLastAccessedDetails(arg0 *iam.GenerateServiceLastAccessedDetailsInput) (*iam.GenerateServiceLastAccessedDetailsOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GenerateServiceLastAccessedDetails", arg0)
 	ret0, _ := ret[0].(*iam.GenerateServiceLastAccessedDetailsOutput)
 	ret1, _ := ret[1].(error)
@@ -2560,13 +2259,11 @@ func (m *MockIAMAPI) GenerateServiceLastAccessedDetails(arg0 *iam.GenerateServic
 
 // GenerateServiceLastAccessedDetails indicates an expected call of GenerateServiceLastAccessedDetails
 func (mr *MockIAMAPIMockRecorder) GenerateServiceLastAccessedDetails(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GenerateServiceLastAccessedDetails", reflect.TypeOf((*MockIAMAPI)(nil).GenerateServiceLastAccessedDetails), arg0)
 }
 
 // GenerateServiceLastAccessedDetailsRequest mocks base method
 func (m *MockIAMAPI) GenerateServiceLastAccessedDetailsRequest(arg0 *iam.GenerateServiceLastAccessedDetailsInput) (*request.Request, *iam.GenerateServiceLastAccessedDetailsOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GenerateServiceLastAccessedDetailsRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*iam.GenerateServiceLastAccessedDetailsOutput)
@@ -2575,13 +2272,11 @@ func (m *MockIAMAPI) GenerateServiceLastAccessedDetailsRequest(arg0 *iam.Generat
 
 // GenerateServiceLastAccessedDetailsRequest indicates an expected call of GenerateServiceLastAccessedDetailsRequest
 func (mr *MockIAMAPIMockRecorder) GenerateServiceLastAccessedDetailsRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GenerateServiceLastAccessedDetailsRequest", reflect.TypeOf((*MockIAMAPI)(nil).GenerateServiceLastAccessedDetailsRequest), arg0)
 }
 
 // GenerateServiceLastAccessedDetailsWithContext mocks base method
 func (m *MockIAMAPI) GenerateServiceLastAccessedDetailsWithContext(arg0 context.Context, arg1 *iam.GenerateServiceLastAccessedDetailsInput, arg2 ...request.Option) (*iam.GenerateServiceLastAccessedDetailsOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -2594,14 +2289,12 @@ func (m *MockIAMAPI) GenerateServiceLastAccessedDetailsWithContext(arg0 context.
 
 // GenerateServiceLastAccessedDetailsWithContext indicates an expected call of GenerateServiceLastAccessedDetailsWithContext
 func (mr *MockIAMAPIMockRecorder) GenerateServiceLastAccessedDetailsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GenerateServiceLastAccessedDetailsWithContext", reflect.TypeOf((*MockIAMAPI)(nil).GenerateServiceLastAccessedDetailsWithContext), varargs...)
 }
 
 // GetAccessKeyLastUsed mocks base method
 func (m *MockIAMAPI) GetAccessKeyLastUsed(arg0 *iam.GetAccessKeyLastUsedInput) (*iam.GetAccessKeyLastUsedOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetAccessKeyLastUsed", arg0)
 	ret0, _ := ret[0].(*iam.GetAccessKeyLastUsedOutput)
 	ret1, _ := ret[1].(error)
@@ -2610,13 +2303,11 @@ func (m *MockIAMAPI) GetAccessKeyLastUsed(arg0 *iam.GetAccessKeyLastUsedInput) (
 
 // GetAccessKeyLastUsed indicates an expected call of GetAccessKeyLastUsed
 func (mr *MockIAMAPIMockRecorder) GetAccessKeyLastUsed(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAccessKeyLastUsed", reflect.TypeOf((*MockIAMAPI)(nil).GetAccessKeyLastUsed), arg0)
 }
 
 // GetAccessKeyLastUsedRequest mocks base method
 func (m *MockIAMAPI) GetAccessKeyLastUsedRequest(arg0 *iam.GetAccessKeyLastUsedInput) (*request.Request, *iam.GetAccessKeyLastUsedOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetAccessKeyLastUsedRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*iam.GetAccessKeyLastUsedOutput)
@@ -2625,13 +2316,11 @@ func (m *MockIAMAPI) GetAccessKeyLastUsedRequest(arg0 *iam.GetAccessKeyLastUsedI
 
 // GetAccessKeyLastUsedRequest indicates an expected call of GetAccessKeyLastUsedRequest
 func (mr *MockIAMAPIMockRecorder) GetAccessKeyLastUsedRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAccessKeyLastUsedRequest", reflect.TypeOf((*MockIAMAPI)(nil).GetAccessKeyLastUsedRequest), arg0)
 }
 
 // GetAccessKeyLastUsedWithContext mocks base method
 func (m *MockIAMAPI) GetAccessKeyLastUsedWithContext(arg0 context.Context, arg1 *iam.GetAccessKeyLastUsedInput, arg2 ...request.Option) (*iam.GetAccessKeyLastUsedOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -2644,14 +2333,12 @@ func (m *MockIAMAPI) GetAccessKeyLastUsedWithContext(arg0 context.Context, arg1 
 
 // GetAccessKeyLastUsedWithContext indicates an expected call of GetAccessKeyLastUsedWithContext
 func (mr *MockIAMAPIMockRecorder) GetAccessKeyLastUsedWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAccessKeyLastUsedWithContext", reflect.TypeOf((*MockIAMAPI)(nil).GetAccessKeyLastUsedWithContext), varargs...)
 }
 
 // GetAccountAuthorizationDetails mocks base method
 func (m *MockIAMAPI) GetAccountAuthorizationDetails(arg0 *iam.GetAccountAuthorizationDetailsInput) (*iam.GetAccountAuthorizationDetailsOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetAccountAuthorizationDetails", arg0)
 	ret0, _ := ret[0].(*iam.GetAccountAuthorizationDetailsOutput)
 	ret1, _ := ret[1].(error)
@@ -2660,13 +2347,11 @@ func (m *MockIAMAPI) GetAccountAuthorizationDetails(arg0 *iam.GetAccountAuthoriz
 
 // GetAccountAuthorizationDetails indicates an expected call of GetAccountAuthorizationDetails
 func (mr *MockIAMAPIMockRecorder) GetAccountAuthorizationDetails(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAccountAuthorizationDetails", reflect.TypeOf((*MockIAMAPI)(nil).GetAccountAuthorizationDetails), arg0)
 }
 
 // GetAccountAuthorizationDetailsPages mocks base method
 func (m *MockIAMAPI) GetAccountAuthorizationDetailsPages(arg0 *iam.GetAccountAuthorizationDetailsInput, arg1 func(*iam.GetAccountAuthorizationDetailsOutput, bool) bool) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetAccountAuthorizationDetailsPages", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -2674,13 +2359,11 @@ func (m *MockIAMAPI) GetAccountAuthorizationDetailsPages(arg0 *iam.GetAccountAut
 
 // GetAccountAuthorizationDetailsPages indicates an expected call of GetAccountAuthorizationDetailsPages
 func (mr *MockIAMAPIMockRecorder) GetAccountAuthorizationDetailsPages(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAccountAuthorizationDetailsPages", reflect.TypeOf((*MockIAMAPI)(nil).GetAccountAuthorizationDetailsPages), arg0, arg1)
 }
 
 // GetAccountAuthorizationDetailsPagesWithContext mocks base method
 func (m *MockIAMAPI) GetAccountAuthorizationDetailsPagesWithContext(arg0 context.Context, arg1 *iam.GetAccountAuthorizationDetailsInput, arg2 func(*iam.GetAccountAuthorizationDetailsOutput, bool) bool, arg3 ...request.Option) error {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1, arg2}
 	for _, a := range arg3 {
 		varargs = append(varargs, a)
@@ -2692,14 +2375,12 @@ func (m *MockIAMAPI) GetAccountAuthorizationDetailsPagesWithContext(arg0 context
 
 // GetAccountAuthorizationDetailsPagesWithContext indicates an expected call of GetAccountAuthorizationDetailsPagesWithContext
 func (mr *MockIAMAPIMockRecorder) GetAccountAuthorizationDetailsPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAccountAuthorizationDetailsPagesWithContext", reflect.TypeOf((*MockIAMAPI)(nil).GetAccountAuthorizationDetailsPagesWithContext), varargs...)
 }
 
 // GetAccountAuthorizationDetailsRequest mocks base method
 func (m *MockIAMAPI) GetAccountAuthorizationDetailsRequest(arg0 *iam.GetAccountAuthorizationDetailsInput) (*request.Request, *iam.GetAccountAuthorizationDetailsOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetAccountAuthorizationDetailsRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*iam.GetAccountAuthorizationDetailsOutput)
@@ -2708,13 +2389,11 @@ func (m *MockIAMAPI) GetAccountAuthorizationDetailsRequest(arg0 *iam.GetAccountA
 
 // GetAccountAuthorizationDetailsRequest indicates an expected call of GetAccountAuthorizationDetailsRequest
 func (mr *MockIAMAPIMockRecorder) GetAccountAuthorizationDetailsRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAccountAuthorizationDetailsRequest", reflect.TypeOf((*MockIAMAPI)(nil).GetAccountAuthorizationDetailsRequest), arg0)
 }
 
 // GetAccountAuthorizationDetailsWithContext mocks base method
 func (m *MockIAMAPI) GetAccountAuthorizationDetailsWithContext(arg0 context.Context, arg1 *iam.GetAccountAuthorizationDetailsInput, arg2 ...request.Option) (*iam.GetAccountAuthorizationDetailsOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -2727,14 +2406,12 @@ func (m *MockIAMAPI) GetAccountAuthorizationDetailsWithContext(arg0 context.Cont
 
 // GetAccountAuthorizationDetailsWithContext indicates an expected call of GetAccountAuthorizationDetailsWithContext
 func (mr *MockIAMAPIMockRecorder) GetAccountAuthorizationDetailsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAccountAuthorizationDetailsWithContext", reflect.TypeOf((*MockIAMAPI)(nil).GetAccountAuthorizationDetailsWithContext), varargs...)
 }
 
 // GetAccountPasswordPolicy mocks base method
 func (m *MockIAMAPI) GetAccountPasswordPolicy(arg0 *iam.GetAccountPasswordPolicyInput) (*iam.GetAccountPasswordPolicyOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetAccountPasswordPolicy", arg0)
 	ret0, _ := ret[0].(*iam.GetAccountPasswordPolicyOutput)
 	ret1, _ := ret[1].(error)
@@ -2743,13 +2420,11 @@ func (m *MockIAMAPI) GetAccountPasswordPolicy(arg0 *iam.GetAccountPasswordPolicy
 
 // GetAccountPasswordPolicy indicates an expected call of GetAccountPasswordPolicy
 func (mr *MockIAMAPIMockRecorder) GetAccountPasswordPolicy(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAccountPasswordPolicy", reflect.TypeOf((*MockIAMAPI)(nil).GetAccountPasswordPolicy), arg0)
 }
 
 // GetAccountPasswordPolicyRequest mocks base method
 func (m *MockIAMAPI) GetAccountPasswordPolicyRequest(arg0 *iam.GetAccountPasswordPolicyInput) (*request.Request, *iam.GetAccountPasswordPolicyOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetAccountPasswordPolicyRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*iam.GetAccountPasswordPolicyOutput)
@@ -2758,13 +2433,11 @@ func (m *MockIAMAPI) GetAccountPasswordPolicyRequest(arg0 *iam.GetAccountPasswor
 
 // GetAccountPasswordPolicyRequest indicates an expected call of GetAccountPasswordPolicyRequest
 func (mr *MockIAMAPIMockRecorder) GetAccountPasswordPolicyRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAccountPasswordPolicyRequest", reflect.TypeOf((*MockIAMAPI)(nil).GetAccountPasswordPolicyRequest), arg0)
 }
 
 // GetAccountPasswordPolicyWithContext mocks base method
 func (m *MockIAMAPI) GetAccountPasswordPolicyWithContext(arg0 context.Context, arg1 *iam.GetAccountPasswordPolicyInput, arg2 ...request.Option) (*iam.GetAccountPasswordPolicyOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -2777,14 +2450,12 @@ func (m *MockIAMAPI) GetAccountPasswordPolicyWithContext(arg0 context.Context, a
 
 // GetAccountPasswordPolicyWithContext indicates an expected call of GetAccountPasswordPolicyWithContext
 func (mr *MockIAMAPIMockRecorder) GetAccountPasswordPolicyWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAccountPasswordPolicyWithContext", reflect.TypeOf((*MockIAMAPI)(nil).GetAccountPasswordPolicyWithContext), varargs...)
 }
 
 // GetAccountSummary mocks base method
 func (m *MockIAMAPI) GetAccountSummary(arg0 *iam.GetAccountSummaryInput) (*iam.GetAccountSummaryOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetAccountSummary", arg0)
 	ret0, _ := ret[0].(*iam.GetAccountSummaryOutput)
 	ret1, _ := ret[1].(error)
@@ -2793,13 +2464,11 @@ func (m *MockIAMAPI) GetAccountSummary(arg0 *iam.GetAccountSummaryInput) (*iam.G
 
 // GetAccountSummary indicates an expected call of GetAccountSummary
 func (mr *MockIAMAPIMockRecorder) GetAccountSummary(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAccountSummary", reflect.TypeOf((*MockIAMAPI)(nil).GetAccountSummary), arg0)
 }
 
 // GetAccountSummaryRequest mocks base method
 func (m *MockIAMAPI) GetAccountSummaryRequest(arg0 *iam.GetAccountSummaryInput) (*request.Request, *iam.GetAccountSummaryOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetAccountSummaryRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*iam.GetAccountSummaryOutput)
@@ -2808,13 +2477,11 @@ func (m *MockIAMAPI) GetAccountSummaryRequest(arg0 *iam.GetAccountSummaryInput) 
 
 // GetAccountSummaryRequest indicates an expected call of GetAccountSummaryRequest
 func (mr *MockIAMAPIMockRecorder) GetAccountSummaryRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAccountSummaryRequest", reflect.TypeOf((*MockIAMAPI)(nil).GetAccountSummaryRequest), arg0)
 }
 
 // GetAccountSummaryWithContext mocks base method
 func (m *MockIAMAPI) GetAccountSummaryWithContext(arg0 context.Context, arg1 *iam.GetAccountSummaryInput, arg2 ...request.Option) (*iam.GetAccountSummaryOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -2827,14 +2494,12 @@ func (m *MockIAMAPI) GetAccountSummaryWithContext(arg0 context.Context, arg1 *ia
 
 // GetAccountSummaryWithContext indicates an expected call of GetAccountSummaryWithContext
 func (mr *MockIAMAPIMockRecorder) GetAccountSummaryWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAccountSummaryWithContext", reflect.TypeOf((*MockIAMAPI)(nil).GetAccountSummaryWithContext), varargs...)
 }
 
 // GetContextKeysForCustomPolicy mocks base method
 func (m *MockIAMAPI) GetContextKeysForCustomPolicy(arg0 *iam.GetContextKeysForCustomPolicyInput) (*iam.GetContextKeysForPolicyResponse, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetContextKeysForCustomPolicy", arg0)
 	ret0, _ := ret[0].(*iam.GetContextKeysForPolicyResponse)
 	ret1, _ := ret[1].(error)
@@ -2843,13 +2508,11 @@ func (m *MockIAMAPI) GetContextKeysForCustomPolicy(arg0 *iam.GetContextKeysForCu
 
 // GetContextKeysForCustomPolicy indicates an expected call of GetContextKeysForCustomPolicy
 func (mr *MockIAMAPIMockRecorder) GetContextKeysForCustomPolicy(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetContextKeysForCustomPolicy", reflect.TypeOf((*MockIAMAPI)(nil).GetContextKeysForCustomPolicy), arg0)
 }
 
 // GetContextKeysForCustomPolicyRequest mocks base method
 func (m *MockIAMAPI) GetContextKeysForCustomPolicyRequest(arg0 *iam.GetContextKeysForCustomPolicyInput) (*request.Request, *iam.GetContextKeysForPolicyResponse) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetContextKeysForCustomPolicyRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*iam.GetContextKeysForPolicyResponse)
@@ -2858,13 +2521,11 @@ func (m *MockIAMAPI) GetContextKeysForCustomPolicyRequest(arg0 *iam.GetContextKe
 
 // GetContextKeysForCustomPolicyRequest indicates an expected call of GetContextKeysForCustomPolicyRequest
 func (mr *MockIAMAPIMockRecorder) GetContextKeysForCustomPolicyRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetContextKeysForCustomPolicyRequest", reflect.TypeOf((*MockIAMAPI)(nil).GetContextKeysForCustomPolicyRequest), arg0)
 }
 
 // GetContextKeysForCustomPolicyWithContext mocks base method
 func (m *MockIAMAPI) GetContextKeysForCustomPolicyWithContext(arg0 context.Context, arg1 *iam.GetContextKeysForCustomPolicyInput, arg2 ...request.Option) (*iam.GetContextKeysForPolicyResponse, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -2877,14 +2538,12 @@ func (m *MockIAMAPI) GetContextKeysForCustomPolicyWithContext(arg0 context.Conte
 
 // GetContextKeysForCustomPolicyWithContext indicates an expected call of GetContextKeysForCustomPolicyWithContext
 func (mr *MockIAMAPIMockRecorder) GetContextKeysForCustomPolicyWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetContextKeysForCustomPolicyWithContext", reflect.TypeOf((*MockIAMAPI)(nil).GetContextKeysForCustomPolicyWithContext), varargs...)
 }
 
 // GetContextKeysForPrincipalPolicy mocks base method
 func (m *MockIAMAPI) GetContextKeysForPrincipalPolicy(arg0 *iam.GetContextKeysForPrincipalPolicyInput) (*iam.GetContextKeysForPolicyResponse, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetContextKeysForPrincipalPolicy", arg0)
 	ret0, _ := ret[0].(*iam.GetContextKeysForPolicyResponse)
 	ret1, _ := ret[1].(error)
@@ -2893,13 +2552,11 @@ func (m *MockIAMAPI) GetContextKeysForPrincipalPolicy(arg0 *iam.GetContextKeysFo
 
 // GetContextKeysForPrincipalPolicy indicates an expected call of GetContextKeysForPrincipalPolicy
 func (mr *MockIAMAPIMockRecorder) GetContextKeysForPrincipalPolicy(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetContextKeysForPrincipalPolicy", reflect.TypeOf((*MockIAMAPI)(nil).GetContextKeysForPrincipalPolicy), arg0)
 }
 
 // GetContextKeysForPrincipalPolicyRequest mocks base method
 func (m *MockIAMAPI) GetContextKeysForPrincipalPolicyRequest(arg0 *iam.GetContextKeysForPrincipalPolicyInput) (*request.Request, *iam.GetContextKeysForPolicyResponse) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetContextKeysForPrincipalPolicyRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*iam.GetContextKeysForPolicyResponse)
@@ -2908,13 +2565,11 @@ func (m *MockIAMAPI) GetContextKeysForPrincipalPolicyRequest(arg0 *iam.GetContex
 
 // GetContextKeysForPrincipalPolicyRequest indicates an expected call of GetContextKeysForPrincipalPolicyRequest
 func (mr *MockIAMAPIMockRecorder) GetContextKeysForPrincipalPolicyRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetContextKeysForPrincipalPolicyRequest", reflect.TypeOf((*MockIAMAPI)(nil).GetContextKeysForPrincipalPolicyRequest), arg0)
 }
 
 // GetContextKeysForPrincipalPolicyWithContext mocks base method
 func (m *MockIAMAPI) GetContextKeysForPrincipalPolicyWithContext(arg0 context.Context, arg1 *iam.GetContextKeysForPrincipalPolicyInput, arg2 ...request.Option) (*iam.GetContextKeysForPolicyResponse, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -2927,14 +2582,12 @@ func (m *MockIAMAPI) GetContextKeysForPrincipalPolicyWithContext(arg0 context.Co
 
 // GetContextKeysForPrincipalPolicyWithContext indicates an expected call of GetContextKeysForPrincipalPolicyWithContext
 func (mr *MockIAMAPIMockRecorder) GetContextKeysForPrincipalPolicyWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetContextKeysForPrincipalPolicyWithContext", reflect.TypeOf((*MockIAMAPI)(nil).GetContextKeysForPrincipalPolicyWithContext), varargs...)
 }
 
 // GetCredentialReport mocks base method
 func (m *MockIAMAPI) GetCredentialReport(arg0 *iam.GetCredentialReportInput) (*iam.GetCredentialReportOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetCredentialReport", arg0)
 	ret0, _ := ret[0].(*iam.GetCredentialReportOutput)
 	ret1, _ := ret[1].(error)
@@ -2943,13 +2596,11 @@ func (m *MockIAMAPI) GetCredentialReport(arg0 *iam.GetCredentialReportInput) (*i
 
 // GetCredentialReport indicates an expected call of GetCredentialReport
 func (mr *MockIAMAPIMockRecorder) GetCredentialReport(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCredentialReport", reflect.TypeOf((*MockIAMAPI)(nil).GetCredentialReport), arg0)
 }
 
 // GetCredentialReportRequest mocks base method
 func (m *MockIAMAPI) GetCredentialReportRequest(arg0 *iam.GetCredentialReportInput) (*request.Request, *iam.GetCredentialReportOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetCredentialReportRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*iam.GetCredentialReportOutput)
@@ -2958,13 +2609,11 @@ func (m *MockIAMAPI) GetCredentialReportRequest(arg0 *iam.GetCredentialReportInp
 
 // GetCredentialReportRequest indicates an expected call of GetCredentialReportRequest
 func (mr *MockIAMAPIMockRecorder) GetCredentialReportRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCredentialReportRequest", reflect.TypeOf((*MockIAMAPI)(nil).GetCredentialReportRequest), arg0)
 }
 
 // GetCredentialReportWithContext mocks base method
 func (m *MockIAMAPI) GetCredentialReportWithContext(arg0 context.Context, arg1 *iam.GetCredentialReportInput, arg2 ...request.Option) (*iam.GetCredentialReportOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -2977,14 +2626,12 @@ func (m *MockIAMAPI) GetCredentialReportWithContext(arg0 context.Context, arg1 *
 
 // GetCredentialReportWithContext indicates an expected call of GetCredentialReportWithContext
 func (mr *MockIAMAPIMockRecorder) GetCredentialReportWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCredentialReportWithContext", reflect.TypeOf((*MockIAMAPI)(nil).GetCredentialReportWithContext), varargs...)
 }
 
 // GetGroup mocks base method
 func (m *MockIAMAPI) GetGroup(arg0 *iam.GetGroupInput) (*iam.GetGroupOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetGroup", arg0)
 	ret0, _ := ret[0].(*iam.GetGroupOutput)
 	ret1, _ := ret[1].(error)
@@ -2993,13 +2640,11 @@ func (m *MockIAMAPI) GetGroup(arg0 *iam.GetGroupInput) (*iam.GetGroupOutput, err
 
 // GetGroup indicates an expected call of GetGroup
 func (mr *MockIAMAPIMockRecorder) GetGroup(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetGroup", reflect.TypeOf((*MockIAMAPI)(nil).GetGroup), arg0)
 }
 
 // GetGroupPages mocks base method
 func (m *MockIAMAPI) GetGroupPages(arg0 *iam.GetGroupInput, arg1 func(*iam.GetGroupOutput, bool) bool) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetGroupPages", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -3007,13 +2652,11 @@ func (m *MockIAMAPI) GetGroupPages(arg0 *iam.GetGroupInput, arg1 func(*iam.GetGr
 
 // GetGroupPages indicates an expected call of GetGroupPages
 func (mr *MockIAMAPIMockRecorder) GetGroupPages(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetGroupPages", reflect.TypeOf((*MockIAMAPI)(nil).GetGroupPages), arg0, arg1)
 }
 
 // GetGroupPagesWithContext mocks base method
 func (m *MockIAMAPI) GetGroupPagesWithContext(arg0 context.Context, arg1 *iam.GetGroupInput, arg2 func(*iam.GetGroupOutput, bool) bool, arg3 ...request.Option) error {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1, arg2}
 	for _, a := range arg3 {
 		varargs = append(varargs, a)
@@ -3025,14 +2668,12 @@ func (m *MockIAMAPI) GetGroupPagesWithContext(arg0 context.Context, arg1 *iam.Ge
 
 // GetGroupPagesWithContext indicates an expected call of GetGroupPagesWithContext
 func (mr *MockIAMAPIMockRecorder) GetGroupPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetGroupPagesWithContext", reflect.TypeOf((*MockIAMAPI)(nil).GetGroupPagesWithContext), varargs...)
 }
 
 // GetGroupPolicy mocks base method
 func (m *MockIAMAPI) GetGroupPolicy(arg0 *iam.GetGroupPolicyInput) (*iam.GetGroupPolicyOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetGroupPolicy", arg0)
 	ret0, _ := ret[0].(*iam.GetGroupPolicyOutput)
 	ret1, _ := ret[1].(error)
@@ -3041,13 +2682,11 @@ func (m *MockIAMAPI) GetGroupPolicy(arg0 *iam.GetGroupPolicyInput) (*iam.GetGrou
 
 // GetGroupPolicy indicates an expected call of GetGroupPolicy
 func (mr *MockIAMAPIMockRecorder) GetGroupPolicy(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetGroupPolicy", reflect.TypeOf((*MockIAMAPI)(nil).GetGroupPolicy), arg0)
 }
 
 // GetGroupPolicyRequest mocks base method
 func (m *MockIAMAPI) GetGroupPolicyRequest(arg0 *iam.GetGroupPolicyInput) (*request.Request, *iam.GetGroupPolicyOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetGroupPolicyRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*iam.GetGroupPolicyOutput)
@@ -3056,13 +2695,11 @@ func (m *MockIAMAPI) GetGroupPolicyRequest(arg0 *iam.GetGroupPolicyInput) (*requ
 
 // GetGroupPolicyRequest indicates an expected call of GetGroupPolicyRequest
 func (mr *MockIAMAPIMockRecorder) GetGroupPolicyRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetGroupPolicyRequest", reflect.TypeOf((*MockIAMAPI)(nil).GetGroupPolicyRequest), arg0)
 }
 
 // GetGroupPolicyWithContext mocks base method
 func (m *MockIAMAPI) GetGroupPolicyWithContext(arg0 context.Context, arg1 *iam.GetGroupPolicyInput, arg2 ...request.Option) (*iam.GetGroupPolicyOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -3075,14 +2712,12 @@ func (m *MockIAMAPI) GetGroupPolicyWithContext(arg0 context.Context, arg1 *iam.G
 
 // GetGroupPolicyWithContext indicates an expected call of GetGroupPolicyWithContext
 func (mr *MockIAMAPIMockRecorder) GetGroupPolicyWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetGroupPolicyWithContext", reflect.TypeOf((*MockIAMAPI)(nil).GetGroupPolicyWithContext), varargs...)
 }
 
 // GetGroupRequest mocks base method
 func (m *MockIAMAPI) GetGroupRequest(arg0 *iam.GetGroupInput) (*request.Request, *iam.GetGroupOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetGroupRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*iam.GetGroupOutput)
@@ -3091,13 +2726,11 @@ func (m *MockIAMAPI) GetGroupRequest(arg0 *iam.GetGroupInput) (*request.Request,
 
 // GetGroupRequest indicates an expected call of GetGroupRequest
 func (mr *MockIAMAPIMockRecorder) GetGroupRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetGroupRequest", reflect.TypeOf((*MockIAMAPI)(nil).GetGroupRequest), arg0)
 }
 
 // GetGroupWithContext mocks base method
 func (m *MockIAMAPI) GetGroupWithContext(arg0 context.Context, arg1 *iam.GetGroupInput, arg2 ...request.Option) (*iam.GetGroupOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -3110,14 +2743,12 @@ func (m *MockIAMAPI) GetGroupWithContext(arg0 context.Context, arg1 *iam.GetGrou
 
 // GetGroupWithContext indicates an expected call of GetGroupWithContext
 func (mr *MockIAMAPIMockRecorder) GetGroupWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetGroupWithContext", reflect.TypeOf((*MockIAMAPI)(nil).GetGroupWithContext), varargs...)
 }
 
 // GetInstanceProfile mocks base method
 func (m *MockIAMAPI) GetInstanceProfile(arg0 *iam.GetInstanceProfileInput) (*iam.GetInstanceProfileOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetInstanceProfile", arg0)
 	ret0, _ := ret[0].(*iam.GetInstanceProfileOutput)
 	ret1, _ := ret[1].(error)
@@ -3126,13 +2757,11 @@ func (m *MockIAMAPI) GetInstanceProfile(arg0 *iam.GetInstanceProfileInput) (*iam
 
 // GetInstanceProfile indicates an expected call of GetInstanceProfile
 func (mr *MockIAMAPIMockRecorder) GetInstanceProfile(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetInstanceProfile", reflect.TypeOf((*MockIAMAPI)(nil).GetInstanceProfile), arg0)
 }
 
 // GetInstanceProfileRequest mocks base method
 func (m *MockIAMAPI) GetInstanceProfileRequest(arg0 *iam.GetInstanceProfileInput) (*request.Request, *iam.GetInstanceProfileOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetInstanceProfileRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*iam.GetInstanceProfileOutput)
@@ -3141,13 +2770,11 @@ func (m *MockIAMAPI) GetInstanceProfileRequest(arg0 *iam.GetInstanceProfileInput
 
 // GetInstanceProfileRequest indicates an expected call of GetInstanceProfileRequest
 func (mr *MockIAMAPIMockRecorder) GetInstanceProfileRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetInstanceProfileRequest", reflect.TypeOf((*MockIAMAPI)(nil).GetInstanceProfileRequest), arg0)
 }
 
 // GetInstanceProfileWithContext mocks base method
 func (m *MockIAMAPI) GetInstanceProfileWithContext(arg0 context.Context, arg1 *iam.GetInstanceProfileInput, arg2 ...request.Option) (*iam.GetInstanceProfileOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -3160,14 +2787,12 @@ func (m *MockIAMAPI) GetInstanceProfileWithContext(arg0 context.Context, arg1 *i
 
 // GetInstanceProfileWithContext indicates an expected call of GetInstanceProfileWithContext
 func (mr *MockIAMAPIMockRecorder) GetInstanceProfileWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetInstanceProfileWithContext", reflect.TypeOf((*MockIAMAPI)(nil).GetInstanceProfileWithContext), varargs...)
 }
 
 // GetLoginProfile mocks base method
 func (m *MockIAMAPI) GetLoginProfile(arg0 *iam.GetLoginProfileInput) (*iam.GetLoginProfileOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetLoginProfile", arg0)
 	ret0, _ := ret[0].(*iam.GetLoginProfileOutput)
 	ret1, _ := ret[1].(error)
@@ -3176,13 +2801,11 @@ func (m *MockIAMAPI) GetLoginProfile(arg0 *iam.GetLoginProfileInput) (*iam.GetLo
 
 // GetLoginProfile indicates an expected call of GetLoginProfile
 func (mr *MockIAMAPIMockRecorder) GetLoginProfile(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLoginProfile", reflect.TypeOf((*MockIAMAPI)(nil).GetLoginProfile), arg0)
 }
 
 // GetLoginProfileRequest mocks base method
 func (m *MockIAMAPI) GetLoginProfileRequest(arg0 *iam.GetLoginProfileInput) (*request.Request, *iam.GetLoginProfileOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetLoginProfileRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*iam.GetLoginProfileOutput)
@@ -3191,13 +2814,11 @@ func (m *MockIAMAPI) GetLoginProfileRequest(arg0 *iam.GetLoginProfileInput) (*re
 
 // GetLoginProfileRequest indicates an expected call of GetLoginProfileRequest
 func (mr *MockIAMAPIMockRecorder) GetLoginProfileRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLoginProfileRequest", reflect.TypeOf((*MockIAMAPI)(nil).GetLoginProfileRequest), arg0)
 }
 
 // GetLoginProfileWithContext mocks base method
 func (m *MockIAMAPI) GetLoginProfileWithContext(arg0 context.Context, arg1 *iam.GetLoginProfileInput, arg2 ...request.Option) (*iam.GetLoginProfileOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -3210,14 +2831,12 @@ func (m *MockIAMAPI) GetLoginProfileWithContext(arg0 context.Context, arg1 *iam.
 
 // GetLoginProfileWithContext indicates an expected call of GetLoginProfileWithContext
 func (mr *MockIAMAPIMockRecorder) GetLoginProfileWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLoginProfileWithContext", reflect.TypeOf((*MockIAMAPI)(nil).GetLoginProfileWithContext), varargs...)
 }
 
 // GetOpenIDConnectProvider mocks base method
 func (m *MockIAMAPI) GetOpenIDConnectProvider(arg0 *iam.GetOpenIDConnectProviderInput) (*iam.GetOpenIDConnectProviderOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetOpenIDConnectProvider", arg0)
 	ret0, _ := ret[0].(*iam.GetOpenIDConnectProviderOutput)
 	ret1, _ := ret[1].(error)
@@ -3226,13 +2845,11 @@ func (m *MockIAMAPI) GetOpenIDConnectProvider(arg0 *iam.GetOpenIDConnectProvider
 
 // GetOpenIDConnectProvider indicates an expected call of GetOpenIDConnectProvider
 func (mr *MockIAMAPIMockRecorder) GetOpenIDConnectProvider(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOpenIDConnectProvider", reflect.TypeOf((*MockIAMAPI)(nil).GetOpenIDConnectProvider), arg0)
 }
 
 // GetOpenIDConnectProviderRequest mocks base method
 func (m *MockIAMAPI) GetOpenIDConnectProviderRequest(arg0 *iam.GetOpenIDConnectProviderInput) (*request.Request, *iam.GetOpenIDConnectProviderOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetOpenIDConnectProviderRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*iam.GetOpenIDConnectProviderOutput)
@@ -3241,13 +2858,11 @@ func (m *MockIAMAPI) GetOpenIDConnectProviderRequest(arg0 *iam.GetOpenIDConnectP
 
 // GetOpenIDConnectProviderRequest indicates an expected call of GetOpenIDConnectProviderRequest
 func (mr *MockIAMAPIMockRecorder) GetOpenIDConnectProviderRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOpenIDConnectProviderRequest", reflect.TypeOf((*MockIAMAPI)(nil).GetOpenIDConnectProviderRequest), arg0)
 }
 
 // GetOpenIDConnectProviderWithContext mocks base method
 func (m *MockIAMAPI) GetOpenIDConnectProviderWithContext(arg0 context.Context, arg1 *iam.GetOpenIDConnectProviderInput, arg2 ...request.Option) (*iam.GetOpenIDConnectProviderOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -3260,14 +2875,12 @@ func (m *MockIAMAPI) GetOpenIDConnectProviderWithContext(arg0 context.Context, a
 
 // GetOpenIDConnectProviderWithContext indicates an expected call of GetOpenIDConnectProviderWithContext
 func (mr *MockIAMAPIMockRecorder) GetOpenIDConnectProviderWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOpenIDConnectProviderWithContext", reflect.TypeOf((*MockIAMAPI)(nil).GetOpenIDConnectProviderWithContext), varargs...)
 }
 
 // GetPolicy mocks base method
 func (m *MockIAMAPI) GetPolicy(arg0 *iam.GetPolicyInput) (*iam.GetPolicyOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetPolicy", arg0)
 	ret0, _ := ret[0].(*iam.GetPolicyOutput)
 	ret1, _ := ret[1].(error)
@@ -3276,13 +2889,11 @@ func (m *MockIAMAPI) GetPolicy(arg0 *iam.GetPolicyInput) (*iam.GetPolicyOutput, 
 
 // GetPolicy indicates an expected call of GetPolicy
 func (mr *MockIAMAPIMockRecorder) GetPolicy(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPolicy", reflect.TypeOf((*MockIAMAPI)(nil).GetPolicy), arg0)
 }
 
 // GetPolicyRequest mocks base method
 func (m *MockIAMAPI) GetPolicyRequest(arg0 *iam.GetPolicyInput) (*request.Request, *iam.GetPolicyOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetPolicyRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*iam.GetPolicyOutput)
@@ -3291,13 +2902,11 @@ func (m *MockIAMAPI) GetPolicyRequest(arg0 *iam.GetPolicyInput) (*request.Reques
 
 // GetPolicyRequest indicates an expected call of GetPolicyRequest
 func (mr *MockIAMAPIMockRecorder) GetPolicyRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPolicyRequest", reflect.TypeOf((*MockIAMAPI)(nil).GetPolicyRequest), arg0)
 }
 
 // GetPolicyVersion mocks base method
 func (m *MockIAMAPI) GetPolicyVersion(arg0 *iam.GetPolicyVersionInput) (*iam.GetPolicyVersionOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetPolicyVersion", arg0)
 	ret0, _ := ret[0].(*iam.GetPolicyVersionOutput)
 	ret1, _ := ret[1].(error)
@@ -3306,13 +2915,11 @@ func (m *MockIAMAPI) GetPolicyVersion(arg0 *iam.GetPolicyVersionInput) (*iam.Get
 
 // GetPolicyVersion indicates an expected call of GetPolicyVersion
 func (mr *MockIAMAPIMockRecorder) GetPolicyVersion(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPolicyVersion", reflect.TypeOf((*MockIAMAPI)(nil).GetPolicyVersion), arg0)
 }
 
 // GetPolicyVersionRequest mocks base method
 func (m *MockIAMAPI) GetPolicyVersionRequest(arg0 *iam.GetPolicyVersionInput) (*request.Request, *iam.GetPolicyVersionOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetPolicyVersionRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*iam.GetPolicyVersionOutput)
@@ -3321,13 +2928,11 @@ func (m *MockIAMAPI) GetPolicyVersionRequest(arg0 *iam.GetPolicyVersionInput) (*
 
 // GetPolicyVersionRequest indicates an expected call of GetPolicyVersionRequest
 func (mr *MockIAMAPIMockRecorder) GetPolicyVersionRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPolicyVersionRequest", reflect.TypeOf((*MockIAMAPI)(nil).GetPolicyVersionRequest), arg0)
 }
 
 // GetPolicyVersionWithContext mocks base method
 func (m *MockIAMAPI) GetPolicyVersionWithContext(arg0 context.Context, arg1 *iam.GetPolicyVersionInput, arg2 ...request.Option) (*iam.GetPolicyVersionOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -3340,14 +2945,12 @@ func (m *MockIAMAPI) GetPolicyVersionWithContext(arg0 context.Context, arg1 *iam
 
 // GetPolicyVersionWithContext indicates an expected call of GetPolicyVersionWithContext
 func (mr *MockIAMAPIMockRecorder) GetPolicyVersionWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPolicyVersionWithContext", reflect.TypeOf((*MockIAMAPI)(nil).GetPolicyVersionWithContext), varargs...)
 }
 
 // GetPolicyWithContext mocks base method
 func (m *MockIAMAPI) GetPolicyWithContext(arg0 context.Context, arg1 *iam.GetPolicyInput, arg2 ...request.Option) (*iam.GetPolicyOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -3360,14 +2963,12 @@ func (m *MockIAMAPI) GetPolicyWithContext(arg0 context.Context, arg1 *iam.GetPol
 
 // GetPolicyWithContext indicates an expected call of GetPolicyWithContext
 func (mr *MockIAMAPIMockRecorder) GetPolicyWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPolicyWithContext", reflect.TypeOf((*MockIAMAPI)(nil).GetPolicyWithContext), varargs...)
 }
 
 // GetRole mocks base method
 func (m *MockIAMAPI) GetRole(arg0 *iam.GetRoleInput) (*iam.GetRoleOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetRole", arg0)
 	ret0, _ := ret[0].(*iam.GetRoleOutput)
 	ret1, _ := ret[1].(error)
@@ -3376,13 +2977,11 @@ func (m *MockIAMAPI) GetRole(arg0 *iam.GetRoleInput) (*iam.GetRoleOutput, error)
 
 // GetRole indicates an expected call of GetRole
 func (mr *MockIAMAPIMockRecorder) GetRole(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRole", reflect.TypeOf((*MockIAMAPI)(nil).GetRole), arg0)
 }
 
 // GetRolePolicy mocks base method
 func (m *MockIAMAPI) GetRolePolicy(arg0 *iam.GetRolePolicyInput) (*iam.GetRolePolicyOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetRolePolicy", arg0)
 	ret0, _ := ret[0].(*iam.GetRolePolicyOutput)
 	ret1, _ := ret[1].(error)
@@ -3391,13 +2990,11 @@ func (m *MockIAMAPI) GetRolePolicy(arg0 *iam.GetRolePolicyInput) (*iam.GetRolePo
 
 // GetRolePolicy indicates an expected call of GetRolePolicy
 func (mr *MockIAMAPIMockRecorder) GetRolePolicy(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRolePolicy", reflect.TypeOf((*MockIAMAPI)(nil).GetRolePolicy), arg0)
 }
 
 // GetRolePolicyRequest mocks base method
 func (m *MockIAMAPI) GetRolePolicyRequest(arg0 *iam.GetRolePolicyInput) (*request.Request, *iam.GetRolePolicyOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetRolePolicyRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*iam.GetRolePolicyOutput)
@@ -3406,13 +3003,11 @@ func (m *MockIAMAPI) GetRolePolicyRequest(arg0 *iam.GetRolePolicyInput) (*reques
 
 // GetRolePolicyRequest indicates an expected call of GetRolePolicyRequest
 func (mr *MockIAMAPIMockRecorder) GetRolePolicyRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRolePolicyRequest", reflect.TypeOf((*MockIAMAPI)(nil).GetRolePolicyRequest), arg0)
 }
 
 // GetRolePolicyWithContext mocks base method
 func (m *MockIAMAPI) GetRolePolicyWithContext(arg0 context.Context, arg1 *iam.GetRolePolicyInput, arg2 ...request.Option) (*iam.GetRolePolicyOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -3425,14 +3020,12 @@ func (m *MockIAMAPI) GetRolePolicyWithContext(arg0 context.Context, arg1 *iam.Ge
 
 // GetRolePolicyWithContext indicates an expected call of GetRolePolicyWithContext
 func (mr *MockIAMAPIMockRecorder) GetRolePolicyWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRolePolicyWithContext", reflect.TypeOf((*MockIAMAPI)(nil).GetRolePolicyWithContext), varargs...)
 }
 
 // GetRoleRequest mocks base method
 func (m *MockIAMAPI) GetRoleRequest(arg0 *iam.GetRoleInput) (*request.Request, *iam.GetRoleOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetRoleRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*iam.GetRoleOutput)
@@ -3441,13 +3034,11 @@ func (m *MockIAMAPI) GetRoleRequest(arg0 *iam.GetRoleInput) (*request.Request, *
 
 // GetRoleRequest indicates an expected call of GetRoleRequest
 func (mr *MockIAMAPIMockRecorder) GetRoleRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRoleRequest", reflect.TypeOf((*MockIAMAPI)(nil).GetRoleRequest), arg0)
 }
 
 // GetRoleWithContext mocks base method
 func (m *MockIAMAPI) GetRoleWithContext(arg0 context.Context, arg1 *iam.GetRoleInput, arg2 ...request.Option) (*iam.GetRoleOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -3460,14 +3051,12 @@ func (m *MockIAMAPI) GetRoleWithContext(arg0 context.Context, arg1 *iam.GetRoleI
 
 // GetRoleWithContext indicates an expected call of GetRoleWithContext
 func (mr *MockIAMAPIMockRecorder) GetRoleWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRoleWithContext", reflect.TypeOf((*MockIAMAPI)(nil).GetRoleWithContext), varargs...)
 }
 
 // GetSAMLProvider mocks base method
 func (m *MockIAMAPI) GetSAMLProvider(arg0 *iam.GetSAMLProviderInput) (*iam.GetSAMLProviderOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetSAMLProvider", arg0)
 	ret0, _ := ret[0].(*iam.GetSAMLProviderOutput)
 	ret1, _ := ret[1].(error)
@@ -3476,13 +3065,11 @@ func (m *MockIAMAPI) GetSAMLProvider(arg0 *iam.GetSAMLProviderInput) (*iam.GetSA
 
 // GetSAMLProvider indicates an expected call of GetSAMLProvider
 func (mr *MockIAMAPIMockRecorder) GetSAMLProvider(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSAMLProvider", reflect.TypeOf((*MockIAMAPI)(nil).GetSAMLProvider), arg0)
 }
 
 // GetSAMLProviderRequest mocks base method
 func (m *MockIAMAPI) GetSAMLProviderRequest(arg0 *iam.GetSAMLProviderInput) (*request.Request, *iam.GetSAMLProviderOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetSAMLProviderRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*iam.GetSAMLProviderOutput)
@@ -3491,13 +3078,11 @@ func (m *MockIAMAPI) GetSAMLProviderRequest(arg0 *iam.GetSAMLProviderInput) (*re
 
 // GetSAMLProviderRequest indicates an expected call of GetSAMLProviderRequest
 func (mr *MockIAMAPIMockRecorder) GetSAMLProviderRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSAMLProviderRequest", reflect.TypeOf((*MockIAMAPI)(nil).GetSAMLProviderRequest), arg0)
 }
 
 // GetSAMLProviderWithContext mocks base method
 func (m *MockIAMAPI) GetSAMLProviderWithContext(arg0 context.Context, arg1 *iam.GetSAMLProviderInput, arg2 ...request.Option) (*iam.GetSAMLProviderOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -3510,14 +3095,12 @@ func (m *MockIAMAPI) GetSAMLProviderWithContext(arg0 context.Context, arg1 *iam.
 
 // GetSAMLProviderWithContext indicates an expected call of GetSAMLProviderWithContext
 func (mr *MockIAMAPIMockRecorder) GetSAMLProviderWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSAMLProviderWithContext", reflect.TypeOf((*MockIAMAPI)(nil).GetSAMLProviderWithContext), varargs...)
 }
 
 // GetSSHPublicKey mocks base method
 func (m *MockIAMAPI) GetSSHPublicKey(arg0 *iam.GetSSHPublicKeyInput) (*iam.GetSSHPublicKeyOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetSSHPublicKey", arg0)
 	ret0, _ := ret[0].(*iam.GetSSHPublicKeyOutput)
 	ret1, _ := ret[1].(error)
@@ -3526,13 +3109,11 @@ func (m *MockIAMAPI) GetSSHPublicKey(arg0 *iam.GetSSHPublicKeyInput) (*iam.GetSS
 
 // GetSSHPublicKey indicates an expected call of GetSSHPublicKey
 func (mr *MockIAMAPIMockRecorder) GetSSHPublicKey(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSSHPublicKey", reflect.TypeOf((*MockIAMAPI)(nil).GetSSHPublicKey), arg0)
 }
 
 // GetSSHPublicKeyRequest mocks base method
 func (m *MockIAMAPI) GetSSHPublicKeyRequest(arg0 *iam.GetSSHPublicKeyInput) (*request.Request, *iam.GetSSHPublicKeyOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetSSHPublicKeyRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*iam.GetSSHPublicKeyOutput)
@@ -3541,13 +3122,11 @@ func (m *MockIAMAPI) GetSSHPublicKeyRequest(arg0 *iam.GetSSHPublicKeyInput) (*re
 
 // GetSSHPublicKeyRequest indicates an expected call of GetSSHPublicKeyRequest
 func (mr *MockIAMAPIMockRecorder) GetSSHPublicKeyRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSSHPublicKeyRequest", reflect.TypeOf((*MockIAMAPI)(nil).GetSSHPublicKeyRequest), arg0)
 }
 
 // GetSSHPublicKeyWithContext mocks base method
 func (m *MockIAMAPI) GetSSHPublicKeyWithContext(arg0 context.Context, arg1 *iam.GetSSHPublicKeyInput, arg2 ...request.Option) (*iam.GetSSHPublicKeyOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -3560,14 +3139,12 @@ func (m *MockIAMAPI) GetSSHPublicKeyWithContext(arg0 context.Context, arg1 *iam.
 
 // GetSSHPublicKeyWithContext indicates an expected call of GetSSHPublicKeyWithContext
 func (mr *MockIAMAPIMockRecorder) GetSSHPublicKeyWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSSHPublicKeyWithContext", reflect.TypeOf((*MockIAMAPI)(nil).GetSSHPublicKeyWithContext), varargs...)
 }
 
 // GetServerCertificate mocks base method
 func (m *MockIAMAPI) GetServerCertificate(arg0 *iam.GetServerCertificateInput) (*iam.GetServerCertificateOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetServerCertificate", arg0)
 	ret0, _ := ret[0].(*iam.GetServerCertificateOutput)
 	ret1, _ := ret[1].(error)
@@ -3576,13 +3153,11 @@ func (m *MockIAMAPI) GetServerCertificate(arg0 *iam.GetServerCertificateInput) (
 
 // GetServerCertificate indicates an expected call of GetServerCertificate
 func (mr *MockIAMAPIMockRecorder) GetServerCertificate(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetServerCertificate", reflect.TypeOf((*MockIAMAPI)(nil).GetServerCertificate), arg0)
 }
 
 // GetServerCertificateRequest mocks base method
 func (m *MockIAMAPI) GetServerCertificateRequest(arg0 *iam.GetServerCertificateInput) (*request.Request, *iam.GetServerCertificateOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetServerCertificateRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*iam.GetServerCertificateOutput)
@@ -3591,13 +3166,11 @@ func (m *MockIAMAPI) GetServerCertificateRequest(arg0 *iam.GetServerCertificateI
 
 // GetServerCertificateRequest indicates an expected call of GetServerCertificateRequest
 func (mr *MockIAMAPIMockRecorder) GetServerCertificateRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetServerCertificateRequest", reflect.TypeOf((*MockIAMAPI)(nil).GetServerCertificateRequest), arg0)
 }
 
 // GetServerCertificateWithContext mocks base method
 func (m *MockIAMAPI) GetServerCertificateWithContext(arg0 context.Context, arg1 *iam.GetServerCertificateInput, arg2 ...request.Option) (*iam.GetServerCertificateOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -3610,14 +3183,12 @@ func (m *MockIAMAPI) GetServerCertificateWithContext(arg0 context.Context, arg1 
 
 // GetServerCertificateWithContext indicates an expected call of GetServerCertificateWithContext
 func (mr *MockIAMAPIMockRecorder) GetServerCertificateWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetServerCertificateWithContext", reflect.TypeOf((*MockIAMAPI)(nil).GetServerCertificateWithContext), varargs...)
 }
 
 // GetServiceLastAccessedDetails mocks base method
 func (m *MockIAMAPI) GetServiceLastAccessedDetails(arg0 *iam.GetServiceLastAccessedDetailsInput) (*iam.GetServiceLastAccessedDetailsOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetServiceLastAccessedDetails", arg0)
 	ret0, _ := ret[0].(*iam.GetServiceLastAccessedDetailsOutput)
 	ret1, _ := ret[1].(error)
@@ -3626,13 +3197,11 @@ func (m *MockIAMAPI) GetServiceLastAccessedDetails(arg0 *iam.GetServiceLastAcces
 
 // GetServiceLastAccessedDetails indicates an expected call of GetServiceLastAccessedDetails
 func (mr *MockIAMAPIMockRecorder) GetServiceLastAccessedDetails(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetServiceLastAccessedDetails", reflect.TypeOf((*MockIAMAPI)(nil).GetServiceLastAccessedDetails), arg0)
 }
 
 // GetServiceLastAccessedDetailsRequest mocks base method
 func (m *MockIAMAPI) GetServiceLastAccessedDetailsRequest(arg0 *iam.GetServiceLastAccessedDetailsInput) (*request.Request, *iam.GetServiceLastAccessedDetailsOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetServiceLastAccessedDetailsRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*iam.GetServiceLastAccessedDetailsOutput)
@@ -3641,13 +3210,11 @@ func (m *MockIAMAPI) GetServiceLastAccessedDetailsRequest(arg0 *iam.GetServiceLa
 
 // GetServiceLastAccessedDetailsRequest indicates an expected call of GetServiceLastAccessedDetailsRequest
 func (mr *MockIAMAPIMockRecorder) GetServiceLastAccessedDetailsRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetServiceLastAccessedDetailsRequest", reflect.TypeOf((*MockIAMAPI)(nil).GetServiceLastAccessedDetailsRequest), arg0)
 }
 
 // GetServiceLastAccessedDetailsWithContext mocks base method
 func (m *MockIAMAPI) GetServiceLastAccessedDetailsWithContext(arg0 context.Context, arg1 *iam.GetServiceLastAccessedDetailsInput, arg2 ...request.Option) (*iam.GetServiceLastAccessedDetailsOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -3660,14 +3227,12 @@ func (m *MockIAMAPI) GetServiceLastAccessedDetailsWithContext(arg0 context.Conte
 
 // GetServiceLastAccessedDetailsWithContext indicates an expected call of GetServiceLastAccessedDetailsWithContext
 func (mr *MockIAMAPIMockRecorder) GetServiceLastAccessedDetailsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetServiceLastAccessedDetailsWithContext", reflect.TypeOf((*MockIAMAPI)(nil).GetServiceLastAccessedDetailsWithContext), varargs...)
 }
 
 // GetServiceLastAccessedDetailsWithEntities mocks base method
 func (m *MockIAMAPI) GetServiceLastAccessedDetailsWithEntities(arg0 *iam.GetServiceLastAccessedDetailsWithEntitiesInput) (*iam.GetServiceLastAccessedDetailsWithEntitiesOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetServiceLastAccessedDetailsWithEntities", arg0)
 	ret0, _ := ret[0].(*iam.GetServiceLastAccessedDetailsWithEntitiesOutput)
 	ret1, _ := ret[1].(error)
@@ -3676,13 +3241,11 @@ func (m *MockIAMAPI) GetServiceLastAccessedDetailsWithEntities(arg0 *iam.GetServ
 
 // GetServiceLastAccessedDetailsWithEntities indicates an expected call of GetServiceLastAccessedDetailsWithEntities
 func (mr *MockIAMAPIMockRecorder) GetServiceLastAccessedDetailsWithEntities(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetServiceLastAccessedDetailsWithEntities", reflect.TypeOf((*MockIAMAPI)(nil).GetServiceLastAccessedDetailsWithEntities), arg0)
 }
 
 // GetServiceLastAccessedDetailsWithEntitiesRequest mocks base method
 func (m *MockIAMAPI) GetServiceLastAccessedDetailsWithEntitiesRequest(arg0 *iam.GetServiceLastAccessedDetailsWithEntitiesInput) (*request.Request, *iam.GetServiceLastAccessedDetailsWithEntitiesOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetServiceLastAccessedDetailsWithEntitiesRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*iam.GetServiceLastAccessedDetailsWithEntitiesOutput)
@@ -3691,13 +3254,11 @@ func (m *MockIAMAPI) GetServiceLastAccessedDetailsWithEntitiesRequest(arg0 *iam.
 
 // GetServiceLastAccessedDetailsWithEntitiesRequest indicates an expected call of GetServiceLastAccessedDetailsWithEntitiesRequest
 func (mr *MockIAMAPIMockRecorder) GetServiceLastAccessedDetailsWithEntitiesRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetServiceLastAccessedDetailsWithEntitiesRequest", reflect.TypeOf((*MockIAMAPI)(nil).GetServiceLastAccessedDetailsWithEntitiesRequest), arg0)
 }
 
 // GetServiceLastAccessedDetailsWithEntitiesWithContext mocks base method
 func (m *MockIAMAPI) GetServiceLastAccessedDetailsWithEntitiesWithContext(arg0 context.Context, arg1 *iam.GetServiceLastAccessedDetailsWithEntitiesInput, arg2 ...request.Option) (*iam.GetServiceLastAccessedDetailsWithEntitiesOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -3710,14 +3271,12 @@ func (m *MockIAMAPI) GetServiceLastAccessedDetailsWithEntitiesWithContext(arg0 c
 
 // GetServiceLastAccessedDetailsWithEntitiesWithContext indicates an expected call of GetServiceLastAccessedDetailsWithEntitiesWithContext
 func (mr *MockIAMAPIMockRecorder) GetServiceLastAccessedDetailsWithEntitiesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetServiceLastAccessedDetailsWithEntitiesWithContext", reflect.TypeOf((*MockIAMAPI)(nil).GetServiceLastAccessedDetailsWithEntitiesWithContext), varargs...)
 }
 
 // GetServiceLinkedRoleDeletionStatus mocks base method
 func (m *MockIAMAPI) GetServiceLinkedRoleDeletionStatus(arg0 *iam.GetServiceLinkedRoleDeletionStatusInput) (*iam.GetServiceLinkedRoleDeletionStatusOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetServiceLinkedRoleDeletionStatus", arg0)
 	ret0, _ := ret[0].(*iam.GetServiceLinkedRoleDeletionStatusOutput)
 	ret1, _ := ret[1].(error)
@@ -3726,13 +3285,11 @@ func (m *MockIAMAPI) GetServiceLinkedRoleDeletionStatus(arg0 *iam.GetServiceLink
 
 // GetServiceLinkedRoleDeletionStatus indicates an expected call of GetServiceLinkedRoleDeletionStatus
 func (mr *MockIAMAPIMockRecorder) GetServiceLinkedRoleDeletionStatus(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetServiceLinkedRoleDeletionStatus", reflect.TypeOf((*MockIAMAPI)(nil).GetServiceLinkedRoleDeletionStatus), arg0)
 }
 
 // GetServiceLinkedRoleDeletionStatusRequest mocks base method
 func (m *MockIAMAPI) GetServiceLinkedRoleDeletionStatusRequest(arg0 *iam.GetServiceLinkedRoleDeletionStatusInput) (*request.Request, *iam.GetServiceLinkedRoleDeletionStatusOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetServiceLinkedRoleDeletionStatusRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*iam.GetServiceLinkedRoleDeletionStatusOutput)
@@ -3741,13 +3298,11 @@ func (m *MockIAMAPI) GetServiceLinkedRoleDeletionStatusRequest(arg0 *iam.GetServ
 
 // GetServiceLinkedRoleDeletionStatusRequest indicates an expected call of GetServiceLinkedRoleDeletionStatusRequest
 func (mr *MockIAMAPIMockRecorder) GetServiceLinkedRoleDeletionStatusRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetServiceLinkedRoleDeletionStatusRequest", reflect.TypeOf((*MockIAMAPI)(nil).GetServiceLinkedRoleDeletionStatusRequest), arg0)
 }
 
 // GetServiceLinkedRoleDeletionStatusWithContext mocks base method
 func (m *MockIAMAPI) GetServiceLinkedRoleDeletionStatusWithContext(arg0 context.Context, arg1 *iam.GetServiceLinkedRoleDeletionStatusInput, arg2 ...request.Option) (*iam.GetServiceLinkedRoleDeletionStatusOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -3760,14 +3315,12 @@ func (m *MockIAMAPI) GetServiceLinkedRoleDeletionStatusWithContext(arg0 context.
 
 // GetServiceLinkedRoleDeletionStatusWithContext indicates an expected call of GetServiceLinkedRoleDeletionStatusWithContext
 func (mr *MockIAMAPIMockRecorder) GetServiceLinkedRoleDeletionStatusWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetServiceLinkedRoleDeletionStatusWithContext", reflect.TypeOf((*MockIAMAPI)(nil).GetServiceLinkedRoleDeletionStatusWithContext), varargs...)
 }
 
 // GetUser mocks base method
 func (m *MockIAMAPI) GetUser(arg0 *iam.GetUserInput) (*iam.GetUserOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetUser", arg0)
 	ret0, _ := ret[0].(*iam.GetUserOutput)
 	ret1, _ := ret[1].(error)
@@ -3776,13 +3329,11 @@ func (m *MockIAMAPI) GetUser(arg0 *iam.GetUserInput) (*iam.GetUserOutput, error)
 
 // GetUser indicates an expected call of GetUser
 func (mr *MockIAMAPIMockRecorder) GetUser(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUser", reflect.TypeOf((*MockIAMAPI)(nil).GetUser), arg0)
 }
 
 // GetUserPolicy mocks base method
 func (m *MockIAMAPI) GetUserPolicy(arg0 *iam.GetUserPolicyInput) (*iam.GetUserPolicyOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetUserPolicy", arg0)
 	ret0, _ := ret[0].(*iam.GetUserPolicyOutput)
 	ret1, _ := ret[1].(error)
@@ -3791,13 +3342,11 @@ func (m *MockIAMAPI) GetUserPolicy(arg0 *iam.GetUserPolicyInput) (*iam.GetUserPo
 
 // GetUserPolicy indicates an expected call of GetUserPolicy
 func (mr *MockIAMAPIMockRecorder) GetUserPolicy(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUserPolicy", reflect.TypeOf((*MockIAMAPI)(nil).GetUserPolicy), arg0)
 }
 
 // GetUserPolicyRequest mocks base method
 func (m *MockIAMAPI) GetUserPolicyRequest(arg0 *iam.GetUserPolicyInput) (*request.Request, *iam.GetUserPolicyOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetUserPolicyRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*iam.GetUserPolicyOutput)
@@ -3806,13 +3355,11 @@ func (m *MockIAMAPI) GetUserPolicyRequest(arg0 *iam.GetUserPolicyInput) (*reques
 
 // GetUserPolicyRequest indicates an expected call of GetUserPolicyRequest
 func (mr *MockIAMAPIMockRecorder) GetUserPolicyRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUserPolicyRequest", reflect.TypeOf((*MockIAMAPI)(nil).GetUserPolicyRequest), arg0)
 }
 
 // GetUserPolicyWithContext mocks base method
 func (m *MockIAMAPI) GetUserPolicyWithContext(arg0 context.Context, arg1 *iam.GetUserPolicyInput, arg2 ...request.Option) (*iam.GetUserPolicyOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -3825,14 +3372,12 @@ func (m *MockIAMAPI) GetUserPolicyWithContext(arg0 context.Context, arg1 *iam.Ge
 
 // GetUserPolicyWithContext indicates an expected call of GetUserPolicyWithContext
 func (mr *MockIAMAPIMockRecorder) GetUserPolicyWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUserPolicyWithContext", reflect.TypeOf((*MockIAMAPI)(nil).GetUserPolicyWithContext), varargs...)
 }
 
 // GetUserRequest mocks base method
 func (m *MockIAMAPI) GetUserRequest(arg0 *iam.GetUserInput) (*request.Request, *iam.GetUserOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetUserRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*iam.GetUserOutput)
@@ -3841,13 +3386,11 @@ func (m *MockIAMAPI) GetUserRequest(arg0 *iam.GetUserInput) (*request.Request, *
 
 // GetUserRequest indicates an expected call of GetUserRequest
 func (mr *MockIAMAPIMockRecorder) GetUserRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUserRequest", reflect.TypeOf((*MockIAMAPI)(nil).GetUserRequest), arg0)
 }
 
 // GetUserWithContext mocks base method
 func (m *MockIAMAPI) GetUserWithContext(arg0 context.Context, arg1 *iam.GetUserInput, arg2 ...request.Option) (*iam.GetUserOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -3860,14 +3403,12 @@ func (m *MockIAMAPI) GetUserWithContext(arg0 context.Context, arg1 *iam.GetUserI
 
 // GetUserWithContext indicates an expected call of GetUserWithContext
 func (mr *MockIAMAPIMockRecorder) GetUserWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUserWithContext", reflect.TypeOf((*MockIAMAPI)(nil).GetUserWithContext), varargs...)
 }
 
 // ListAccessKeys mocks base method
 func (m *MockIAMAPI) ListAccessKeys(arg0 *iam.ListAccessKeysInput) (*iam.ListAccessKeysOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListAccessKeys", arg0)
 	ret0, _ := ret[0].(*iam.ListAccessKeysOutput)
 	ret1, _ := ret[1].(error)
@@ -3876,13 +3417,11 @@ func (m *MockIAMAPI) ListAccessKeys(arg0 *iam.ListAccessKeysInput) (*iam.ListAcc
 
 // ListAccessKeys indicates an expected call of ListAccessKeys
 func (mr *MockIAMAPIMockRecorder) ListAccessKeys(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAccessKeys", reflect.TypeOf((*MockIAMAPI)(nil).ListAccessKeys), arg0)
 }
 
 // ListAccessKeysPages mocks base method
 func (m *MockIAMAPI) ListAccessKeysPages(arg0 *iam.ListAccessKeysInput, arg1 func(*iam.ListAccessKeysOutput, bool) bool) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListAccessKeysPages", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -3890,13 +3429,11 @@ func (m *MockIAMAPI) ListAccessKeysPages(arg0 *iam.ListAccessKeysInput, arg1 fun
 
 // ListAccessKeysPages indicates an expected call of ListAccessKeysPages
 func (mr *MockIAMAPIMockRecorder) ListAccessKeysPages(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAccessKeysPages", reflect.TypeOf((*MockIAMAPI)(nil).ListAccessKeysPages), arg0, arg1)
 }
 
 // ListAccessKeysPagesWithContext mocks base method
 func (m *MockIAMAPI) ListAccessKeysPagesWithContext(arg0 context.Context, arg1 *iam.ListAccessKeysInput, arg2 func(*iam.ListAccessKeysOutput, bool) bool, arg3 ...request.Option) error {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1, arg2}
 	for _, a := range arg3 {
 		varargs = append(varargs, a)
@@ -3908,14 +3445,12 @@ func (m *MockIAMAPI) ListAccessKeysPagesWithContext(arg0 context.Context, arg1 *
 
 // ListAccessKeysPagesWithContext indicates an expected call of ListAccessKeysPagesWithContext
 func (mr *MockIAMAPIMockRecorder) ListAccessKeysPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAccessKeysPagesWithContext", reflect.TypeOf((*MockIAMAPI)(nil).ListAccessKeysPagesWithContext), varargs...)
 }
 
 // ListAccessKeysRequest mocks base method
 func (m *MockIAMAPI) ListAccessKeysRequest(arg0 *iam.ListAccessKeysInput) (*request.Request, *iam.ListAccessKeysOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListAccessKeysRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*iam.ListAccessKeysOutput)
@@ -3924,13 +3459,11 @@ func (m *MockIAMAPI) ListAccessKeysRequest(arg0 *iam.ListAccessKeysInput) (*requ
 
 // ListAccessKeysRequest indicates an expected call of ListAccessKeysRequest
 func (mr *MockIAMAPIMockRecorder) ListAccessKeysRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAccessKeysRequest", reflect.TypeOf((*MockIAMAPI)(nil).ListAccessKeysRequest), arg0)
 }
 
 // ListAccessKeysWithContext mocks base method
 func (m *MockIAMAPI) ListAccessKeysWithContext(arg0 context.Context, arg1 *iam.ListAccessKeysInput, arg2 ...request.Option) (*iam.ListAccessKeysOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -3943,14 +3476,12 @@ func (m *MockIAMAPI) ListAccessKeysWithContext(arg0 context.Context, arg1 *iam.L
 
 // ListAccessKeysWithContext indicates an expected call of ListAccessKeysWithContext
 func (mr *MockIAMAPIMockRecorder) ListAccessKeysWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAccessKeysWithContext", reflect.TypeOf((*MockIAMAPI)(nil).ListAccessKeysWithContext), varargs...)
 }
 
 // ListAccountAliases mocks base method
 func (m *MockIAMAPI) ListAccountAliases(arg0 *iam.ListAccountAliasesInput) (*iam.ListAccountAliasesOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListAccountAliases", arg0)
 	ret0, _ := ret[0].(*iam.ListAccountAliasesOutput)
 	ret1, _ := ret[1].(error)
@@ -3959,13 +3490,11 @@ func (m *MockIAMAPI) ListAccountAliases(arg0 *iam.ListAccountAliasesInput) (*iam
 
 // ListAccountAliases indicates an expected call of ListAccountAliases
 func (mr *MockIAMAPIMockRecorder) ListAccountAliases(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAccountAliases", reflect.TypeOf((*MockIAMAPI)(nil).ListAccountAliases), arg0)
 }
 
 // ListAccountAliasesPages mocks base method
 func (m *MockIAMAPI) ListAccountAliasesPages(arg0 *iam.ListAccountAliasesInput, arg1 func(*iam.ListAccountAliasesOutput, bool) bool) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListAccountAliasesPages", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -3973,13 +3502,11 @@ func (m *MockIAMAPI) ListAccountAliasesPages(arg0 *iam.ListAccountAliasesInput, 
 
 // ListAccountAliasesPages indicates an expected call of ListAccountAliasesPages
 func (mr *MockIAMAPIMockRecorder) ListAccountAliasesPages(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAccountAliasesPages", reflect.TypeOf((*MockIAMAPI)(nil).ListAccountAliasesPages), arg0, arg1)
 }
 
 // ListAccountAliasesPagesWithContext mocks base method
 func (m *MockIAMAPI) ListAccountAliasesPagesWithContext(arg0 context.Context, arg1 *iam.ListAccountAliasesInput, arg2 func(*iam.ListAccountAliasesOutput, bool) bool, arg3 ...request.Option) error {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1, arg2}
 	for _, a := range arg3 {
 		varargs = append(varargs, a)
@@ -3991,14 +3518,12 @@ func (m *MockIAMAPI) ListAccountAliasesPagesWithContext(arg0 context.Context, ar
 
 // ListAccountAliasesPagesWithContext indicates an expected call of ListAccountAliasesPagesWithContext
 func (mr *MockIAMAPIMockRecorder) ListAccountAliasesPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAccountAliasesPagesWithContext", reflect.TypeOf((*MockIAMAPI)(nil).ListAccountAliasesPagesWithContext), varargs...)
 }
 
 // ListAccountAliasesRequest mocks base method
 func (m *MockIAMAPI) ListAccountAliasesRequest(arg0 *iam.ListAccountAliasesInput) (*request.Request, *iam.ListAccountAliasesOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListAccountAliasesRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*iam.ListAccountAliasesOutput)
@@ -4007,13 +3532,11 @@ func (m *MockIAMAPI) ListAccountAliasesRequest(arg0 *iam.ListAccountAliasesInput
 
 // ListAccountAliasesRequest indicates an expected call of ListAccountAliasesRequest
 func (mr *MockIAMAPIMockRecorder) ListAccountAliasesRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAccountAliasesRequest", reflect.TypeOf((*MockIAMAPI)(nil).ListAccountAliasesRequest), arg0)
 }
 
 // ListAccountAliasesWithContext mocks base method
 func (m *MockIAMAPI) ListAccountAliasesWithContext(arg0 context.Context, arg1 *iam.ListAccountAliasesInput, arg2 ...request.Option) (*iam.ListAccountAliasesOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -4026,14 +3549,12 @@ func (m *MockIAMAPI) ListAccountAliasesWithContext(arg0 context.Context, arg1 *i
 
 // ListAccountAliasesWithContext indicates an expected call of ListAccountAliasesWithContext
 func (mr *MockIAMAPIMockRecorder) ListAccountAliasesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAccountAliasesWithContext", reflect.TypeOf((*MockIAMAPI)(nil).ListAccountAliasesWithContext), varargs...)
 }
 
 // ListAttachedGroupPolicies mocks base method
 func (m *MockIAMAPI) ListAttachedGroupPolicies(arg0 *iam.ListAttachedGroupPoliciesInput) (*iam.ListAttachedGroupPoliciesOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListAttachedGroupPolicies", arg0)
 	ret0, _ := ret[0].(*iam.ListAttachedGroupPoliciesOutput)
 	ret1, _ := ret[1].(error)
@@ -4042,13 +3563,11 @@ func (m *MockIAMAPI) ListAttachedGroupPolicies(arg0 *iam.ListAttachedGroupPolici
 
 // ListAttachedGroupPolicies indicates an expected call of ListAttachedGroupPolicies
 func (mr *MockIAMAPIMockRecorder) ListAttachedGroupPolicies(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAttachedGroupPolicies", reflect.TypeOf((*MockIAMAPI)(nil).ListAttachedGroupPolicies), arg0)
 }
 
 // ListAttachedGroupPoliciesPages mocks base method
 func (m *MockIAMAPI) ListAttachedGroupPoliciesPages(arg0 *iam.ListAttachedGroupPoliciesInput, arg1 func(*iam.ListAttachedGroupPoliciesOutput, bool) bool) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListAttachedGroupPoliciesPages", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -4056,13 +3575,11 @@ func (m *MockIAMAPI) ListAttachedGroupPoliciesPages(arg0 *iam.ListAttachedGroupP
 
 // ListAttachedGroupPoliciesPages indicates an expected call of ListAttachedGroupPoliciesPages
 func (mr *MockIAMAPIMockRecorder) ListAttachedGroupPoliciesPages(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAttachedGroupPoliciesPages", reflect.TypeOf((*MockIAMAPI)(nil).ListAttachedGroupPoliciesPages), arg0, arg1)
 }
 
 // ListAttachedGroupPoliciesPagesWithContext mocks base method
 func (m *MockIAMAPI) ListAttachedGroupPoliciesPagesWithContext(arg0 context.Context, arg1 *iam.ListAttachedGroupPoliciesInput, arg2 func(*iam.ListAttachedGroupPoliciesOutput, bool) bool, arg3 ...request.Option) error {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1, arg2}
 	for _, a := range arg3 {
 		varargs = append(varargs, a)
@@ -4074,14 +3591,12 @@ func (m *MockIAMAPI) ListAttachedGroupPoliciesPagesWithContext(arg0 context.Cont
 
 // ListAttachedGroupPoliciesPagesWithContext indicates an expected call of ListAttachedGroupPoliciesPagesWithContext
 func (mr *MockIAMAPIMockRecorder) ListAttachedGroupPoliciesPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAttachedGroupPoliciesPagesWithContext", reflect.TypeOf((*MockIAMAPI)(nil).ListAttachedGroupPoliciesPagesWithContext), varargs...)
 }
 
 // ListAttachedGroupPoliciesRequest mocks base method
 func (m *MockIAMAPI) ListAttachedGroupPoliciesRequest(arg0 *iam.ListAttachedGroupPoliciesInput) (*request.Request, *iam.ListAttachedGroupPoliciesOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListAttachedGroupPoliciesRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*iam.ListAttachedGroupPoliciesOutput)
@@ -4090,13 +3605,11 @@ func (m *MockIAMAPI) ListAttachedGroupPoliciesRequest(arg0 *iam.ListAttachedGrou
 
 // ListAttachedGroupPoliciesRequest indicates an expected call of ListAttachedGroupPoliciesRequest
 func (mr *MockIAMAPIMockRecorder) ListAttachedGroupPoliciesRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAttachedGroupPoliciesRequest", reflect.TypeOf((*MockIAMAPI)(nil).ListAttachedGroupPoliciesRequest), arg0)
 }
 
 // ListAttachedGroupPoliciesWithContext mocks base method
 func (m *MockIAMAPI) ListAttachedGroupPoliciesWithContext(arg0 context.Context, arg1 *iam.ListAttachedGroupPoliciesInput, arg2 ...request.Option) (*iam.ListAttachedGroupPoliciesOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -4109,14 +3622,12 @@ func (m *MockIAMAPI) ListAttachedGroupPoliciesWithContext(arg0 context.Context, 
 
 // ListAttachedGroupPoliciesWithContext indicates an expected call of ListAttachedGroupPoliciesWithContext
 func (mr *MockIAMAPIMockRecorder) ListAttachedGroupPoliciesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAttachedGroupPoliciesWithContext", reflect.TypeOf((*MockIAMAPI)(nil).ListAttachedGroupPoliciesWithContext), varargs...)
 }
 
 // ListAttachedRolePolicies mocks base method
 func (m *MockIAMAPI) ListAttachedRolePolicies(arg0 *iam.ListAttachedRolePoliciesInput) (*iam.ListAttachedRolePoliciesOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListAttachedRolePolicies", arg0)
 	ret0, _ := ret[0].(*iam.ListAttachedRolePoliciesOutput)
 	ret1, _ := ret[1].(error)
@@ -4125,13 +3636,11 @@ func (m *MockIAMAPI) ListAttachedRolePolicies(arg0 *iam.ListAttachedRolePolicies
 
 // ListAttachedRolePolicies indicates an expected call of ListAttachedRolePolicies
 func (mr *MockIAMAPIMockRecorder) ListAttachedRolePolicies(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAttachedRolePolicies", reflect.TypeOf((*MockIAMAPI)(nil).ListAttachedRolePolicies), arg0)
 }
 
 // ListAttachedRolePoliciesPages mocks base method
 func (m *MockIAMAPI) ListAttachedRolePoliciesPages(arg0 *iam.ListAttachedRolePoliciesInput, arg1 func(*iam.ListAttachedRolePoliciesOutput, bool) bool) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListAttachedRolePoliciesPages", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -4139,13 +3648,11 @@ func (m *MockIAMAPI) ListAttachedRolePoliciesPages(arg0 *iam.ListAttachedRolePol
 
 // ListAttachedRolePoliciesPages indicates an expected call of ListAttachedRolePoliciesPages
 func (mr *MockIAMAPIMockRecorder) ListAttachedRolePoliciesPages(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAttachedRolePoliciesPages", reflect.TypeOf((*MockIAMAPI)(nil).ListAttachedRolePoliciesPages), arg0, arg1)
 }
 
 // ListAttachedRolePoliciesPagesWithContext mocks base method
 func (m *MockIAMAPI) ListAttachedRolePoliciesPagesWithContext(arg0 context.Context, arg1 *iam.ListAttachedRolePoliciesInput, arg2 func(*iam.ListAttachedRolePoliciesOutput, bool) bool, arg3 ...request.Option) error {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1, arg2}
 	for _, a := range arg3 {
 		varargs = append(varargs, a)
@@ -4157,14 +3664,12 @@ func (m *MockIAMAPI) ListAttachedRolePoliciesPagesWithContext(arg0 context.Conte
 
 // ListAttachedRolePoliciesPagesWithContext indicates an expected call of ListAttachedRolePoliciesPagesWithContext
 func (mr *MockIAMAPIMockRecorder) ListAttachedRolePoliciesPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAttachedRolePoliciesPagesWithContext", reflect.TypeOf((*MockIAMAPI)(nil).ListAttachedRolePoliciesPagesWithContext), varargs...)
 }
 
 // ListAttachedRolePoliciesRequest mocks base method
 func (m *MockIAMAPI) ListAttachedRolePoliciesRequest(arg0 *iam.ListAttachedRolePoliciesInput) (*request.Request, *iam.ListAttachedRolePoliciesOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListAttachedRolePoliciesRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*iam.ListAttachedRolePoliciesOutput)
@@ -4173,13 +3678,11 @@ func (m *MockIAMAPI) ListAttachedRolePoliciesRequest(arg0 *iam.ListAttachedRoleP
 
 // ListAttachedRolePoliciesRequest indicates an expected call of ListAttachedRolePoliciesRequest
 func (mr *MockIAMAPIMockRecorder) ListAttachedRolePoliciesRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAttachedRolePoliciesRequest", reflect.TypeOf((*MockIAMAPI)(nil).ListAttachedRolePoliciesRequest), arg0)
 }
 
 // ListAttachedRolePoliciesWithContext mocks base method
 func (m *MockIAMAPI) ListAttachedRolePoliciesWithContext(arg0 context.Context, arg1 *iam.ListAttachedRolePoliciesInput, arg2 ...request.Option) (*iam.ListAttachedRolePoliciesOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -4192,14 +3695,12 @@ func (m *MockIAMAPI) ListAttachedRolePoliciesWithContext(arg0 context.Context, a
 
 // ListAttachedRolePoliciesWithContext indicates an expected call of ListAttachedRolePoliciesWithContext
 func (mr *MockIAMAPIMockRecorder) ListAttachedRolePoliciesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAttachedRolePoliciesWithContext", reflect.TypeOf((*MockIAMAPI)(nil).ListAttachedRolePoliciesWithContext), varargs...)
 }
 
 // ListAttachedUserPolicies mocks base method
 func (m *MockIAMAPI) ListAttachedUserPolicies(arg0 *iam.ListAttachedUserPoliciesInput) (*iam.ListAttachedUserPoliciesOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListAttachedUserPolicies", arg0)
 	ret0, _ := ret[0].(*iam.ListAttachedUserPoliciesOutput)
 	ret1, _ := ret[1].(error)
@@ -4208,13 +3709,11 @@ func (m *MockIAMAPI) ListAttachedUserPolicies(arg0 *iam.ListAttachedUserPolicies
 
 // ListAttachedUserPolicies indicates an expected call of ListAttachedUserPolicies
 func (mr *MockIAMAPIMockRecorder) ListAttachedUserPolicies(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAttachedUserPolicies", reflect.TypeOf((*MockIAMAPI)(nil).ListAttachedUserPolicies), arg0)
 }
 
 // ListAttachedUserPoliciesPages mocks base method
 func (m *MockIAMAPI) ListAttachedUserPoliciesPages(arg0 *iam.ListAttachedUserPoliciesInput, arg1 func(*iam.ListAttachedUserPoliciesOutput, bool) bool) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListAttachedUserPoliciesPages", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -4222,13 +3721,11 @@ func (m *MockIAMAPI) ListAttachedUserPoliciesPages(arg0 *iam.ListAttachedUserPol
 
 // ListAttachedUserPoliciesPages indicates an expected call of ListAttachedUserPoliciesPages
 func (mr *MockIAMAPIMockRecorder) ListAttachedUserPoliciesPages(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAttachedUserPoliciesPages", reflect.TypeOf((*MockIAMAPI)(nil).ListAttachedUserPoliciesPages), arg0, arg1)
 }
 
 // ListAttachedUserPoliciesPagesWithContext mocks base method
 func (m *MockIAMAPI) ListAttachedUserPoliciesPagesWithContext(arg0 context.Context, arg1 *iam.ListAttachedUserPoliciesInput, arg2 func(*iam.ListAttachedUserPoliciesOutput, bool) bool, arg3 ...request.Option) error {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1, arg2}
 	for _, a := range arg3 {
 		varargs = append(varargs, a)
@@ -4240,14 +3737,12 @@ func (m *MockIAMAPI) ListAttachedUserPoliciesPagesWithContext(arg0 context.Conte
 
 // ListAttachedUserPoliciesPagesWithContext indicates an expected call of ListAttachedUserPoliciesPagesWithContext
 func (mr *MockIAMAPIMockRecorder) ListAttachedUserPoliciesPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAttachedUserPoliciesPagesWithContext", reflect.TypeOf((*MockIAMAPI)(nil).ListAttachedUserPoliciesPagesWithContext), varargs...)
 }
 
 // ListAttachedUserPoliciesRequest mocks base method
 func (m *MockIAMAPI) ListAttachedUserPoliciesRequest(arg0 *iam.ListAttachedUserPoliciesInput) (*request.Request, *iam.ListAttachedUserPoliciesOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListAttachedUserPoliciesRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*iam.ListAttachedUserPoliciesOutput)
@@ -4256,13 +3751,11 @@ func (m *MockIAMAPI) ListAttachedUserPoliciesRequest(arg0 *iam.ListAttachedUserP
 
 // ListAttachedUserPoliciesRequest indicates an expected call of ListAttachedUserPoliciesRequest
 func (mr *MockIAMAPIMockRecorder) ListAttachedUserPoliciesRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAttachedUserPoliciesRequest", reflect.TypeOf((*MockIAMAPI)(nil).ListAttachedUserPoliciesRequest), arg0)
 }
 
 // ListAttachedUserPoliciesWithContext mocks base method
 func (m *MockIAMAPI) ListAttachedUserPoliciesWithContext(arg0 context.Context, arg1 *iam.ListAttachedUserPoliciesInput, arg2 ...request.Option) (*iam.ListAttachedUserPoliciesOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -4275,14 +3768,12 @@ func (m *MockIAMAPI) ListAttachedUserPoliciesWithContext(arg0 context.Context, a
 
 // ListAttachedUserPoliciesWithContext indicates an expected call of ListAttachedUserPoliciesWithContext
 func (mr *MockIAMAPIMockRecorder) ListAttachedUserPoliciesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAttachedUserPoliciesWithContext", reflect.TypeOf((*MockIAMAPI)(nil).ListAttachedUserPoliciesWithContext), varargs...)
 }
 
 // ListEntitiesForPolicy mocks base method
 func (m *MockIAMAPI) ListEntitiesForPolicy(arg0 *iam.ListEntitiesForPolicyInput) (*iam.ListEntitiesForPolicyOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListEntitiesForPolicy", arg0)
 	ret0, _ := ret[0].(*iam.ListEntitiesForPolicyOutput)
 	ret1, _ := ret[1].(error)
@@ -4291,13 +3782,11 @@ func (m *MockIAMAPI) ListEntitiesForPolicy(arg0 *iam.ListEntitiesForPolicyInput)
 
 // ListEntitiesForPolicy indicates an expected call of ListEntitiesForPolicy
 func (mr *MockIAMAPIMockRecorder) ListEntitiesForPolicy(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListEntitiesForPolicy", reflect.TypeOf((*MockIAMAPI)(nil).ListEntitiesForPolicy), arg0)
 }
 
 // ListEntitiesForPolicyPages mocks base method
 func (m *MockIAMAPI) ListEntitiesForPolicyPages(arg0 *iam.ListEntitiesForPolicyInput, arg1 func(*iam.ListEntitiesForPolicyOutput, bool) bool) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListEntitiesForPolicyPages", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -4305,13 +3794,11 @@ func (m *MockIAMAPI) ListEntitiesForPolicyPages(arg0 *iam.ListEntitiesForPolicyI
 
 // ListEntitiesForPolicyPages indicates an expected call of ListEntitiesForPolicyPages
 func (mr *MockIAMAPIMockRecorder) ListEntitiesForPolicyPages(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListEntitiesForPolicyPages", reflect.TypeOf((*MockIAMAPI)(nil).ListEntitiesForPolicyPages), arg0, arg1)
 }
 
 // ListEntitiesForPolicyPagesWithContext mocks base method
 func (m *MockIAMAPI) ListEntitiesForPolicyPagesWithContext(arg0 context.Context, arg1 *iam.ListEntitiesForPolicyInput, arg2 func(*iam.ListEntitiesForPolicyOutput, bool) bool, arg3 ...request.Option) error {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1, arg2}
 	for _, a := range arg3 {
 		varargs = append(varargs, a)
@@ -4323,14 +3810,12 @@ func (m *MockIAMAPI) ListEntitiesForPolicyPagesWithContext(arg0 context.Context,
 
 // ListEntitiesForPolicyPagesWithContext indicates an expected call of ListEntitiesForPolicyPagesWithContext
 func (mr *MockIAMAPIMockRecorder) ListEntitiesForPolicyPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListEntitiesForPolicyPagesWithContext", reflect.TypeOf((*MockIAMAPI)(nil).ListEntitiesForPolicyPagesWithContext), varargs...)
 }
 
 // ListEntitiesForPolicyRequest mocks base method
 func (m *MockIAMAPI) ListEntitiesForPolicyRequest(arg0 *iam.ListEntitiesForPolicyInput) (*request.Request, *iam.ListEntitiesForPolicyOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListEntitiesForPolicyRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*iam.ListEntitiesForPolicyOutput)
@@ -4339,13 +3824,11 @@ func (m *MockIAMAPI) ListEntitiesForPolicyRequest(arg0 *iam.ListEntitiesForPolic
 
 // ListEntitiesForPolicyRequest indicates an expected call of ListEntitiesForPolicyRequest
 func (mr *MockIAMAPIMockRecorder) ListEntitiesForPolicyRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListEntitiesForPolicyRequest", reflect.TypeOf((*MockIAMAPI)(nil).ListEntitiesForPolicyRequest), arg0)
 }
 
 // ListEntitiesForPolicyWithContext mocks base method
 func (m *MockIAMAPI) ListEntitiesForPolicyWithContext(arg0 context.Context, arg1 *iam.ListEntitiesForPolicyInput, arg2 ...request.Option) (*iam.ListEntitiesForPolicyOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -4358,14 +3841,12 @@ func (m *MockIAMAPI) ListEntitiesForPolicyWithContext(arg0 context.Context, arg1
 
 // ListEntitiesForPolicyWithContext indicates an expected call of ListEntitiesForPolicyWithContext
 func (mr *MockIAMAPIMockRecorder) ListEntitiesForPolicyWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListEntitiesForPolicyWithContext", reflect.TypeOf((*MockIAMAPI)(nil).ListEntitiesForPolicyWithContext), varargs...)
 }
 
 // ListGroupPolicies mocks base method
 func (m *MockIAMAPI) ListGroupPolicies(arg0 *iam.ListGroupPoliciesInput) (*iam.ListGroupPoliciesOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListGroupPolicies", arg0)
 	ret0, _ := ret[0].(*iam.ListGroupPoliciesOutput)
 	ret1, _ := ret[1].(error)
@@ -4374,13 +3855,11 @@ func (m *MockIAMAPI) ListGroupPolicies(arg0 *iam.ListGroupPoliciesInput) (*iam.L
 
 // ListGroupPolicies indicates an expected call of ListGroupPolicies
 func (mr *MockIAMAPIMockRecorder) ListGroupPolicies(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListGroupPolicies", reflect.TypeOf((*MockIAMAPI)(nil).ListGroupPolicies), arg0)
 }
 
 // ListGroupPoliciesPages mocks base method
 func (m *MockIAMAPI) ListGroupPoliciesPages(arg0 *iam.ListGroupPoliciesInput, arg1 func(*iam.ListGroupPoliciesOutput, bool) bool) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListGroupPoliciesPages", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -4388,13 +3867,11 @@ func (m *MockIAMAPI) ListGroupPoliciesPages(arg0 *iam.ListGroupPoliciesInput, ar
 
 // ListGroupPoliciesPages indicates an expected call of ListGroupPoliciesPages
 func (mr *MockIAMAPIMockRecorder) ListGroupPoliciesPages(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListGroupPoliciesPages", reflect.TypeOf((*MockIAMAPI)(nil).ListGroupPoliciesPages), arg0, arg1)
 }
 
 // ListGroupPoliciesPagesWithContext mocks base method
 func (m *MockIAMAPI) ListGroupPoliciesPagesWithContext(arg0 context.Context, arg1 *iam.ListGroupPoliciesInput, arg2 func(*iam.ListGroupPoliciesOutput, bool) bool, arg3 ...request.Option) error {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1, arg2}
 	for _, a := range arg3 {
 		varargs = append(varargs, a)
@@ -4406,14 +3883,12 @@ func (m *MockIAMAPI) ListGroupPoliciesPagesWithContext(arg0 context.Context, arg
 
 // ListGroupPoliciesPagesWithContext indicates an expected call of ListGroupPoliciesPagesWithContext
 func (mr *MockIAMAPIMockRecorder) ListGroupPoliciesPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListGroupPoliciesPagesWithContext", reflect.TypeOf((*MockIAMAPI)(nil).ListGroupPoliciesPagesWithContext), varargs...)
 }
 
 // ListGroupPoliciesRequest mocks base method
 func (m *MockIAMAPI) ListGroupPoliciesRequest(arg0 *iam.ListGroupPoliciesInput) (*request.Request, *iam.ListGroupPoliciesOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListGroupPoliciesRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*iam.ListGroupPoliciesOutput)
@@ -4422,13 +3897,11 @@ func (m *MockIAMAPI) ListGroupPoliciesRequest(arg0 *iam.ListGroupPoliciesInput) 
 
 // ListGroupPoliciesRequest indicates an expected call of ListGroupPoliciesRequest
 func (mr *MockIAMAPIMockRecorder) ListGroupPoliciesRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListGroupPoliciesRequest", reflect.TypeOf((*MockIAMAPI)(nil).ListGroupPoliciesRequest), arg0)
 }
 
 // ListGroupPoliciesWithContext mocks base method
 func (m *MockIAMAPI) ListGroupPoliciesWithContext(arg0 context.Context, arg1 *iam.ListGroupPoliciesInput, arg2 ...request.Option) (*iam.ListGroupPoliciesOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -4441,14 +3914,12 @@ func (m *MockIAMAPI) ListGroupPoliciesWithContext(arg0 context.Context, arg1 *ia
 
 // ListGroupPoliciesWithContext indicates an expected call of ListGroupPoliciesWithContext
 func (mr *MockIAMAPIMockRecorder) ListGroupPoliciesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListGroupPoliciesWithContext", reflect.TypeOf((*MockIAMAPI)(nil).ListGroupPoliciesWithContext), varargs...)
 }
 
 // ListGroups mocks base method
 func (m *MockIAMAPI) ListGroups(arg0 *iam.ListGroupsInput) (*iam.ListGroupsOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListGroups", arg0)
 	ret0, _ := ret[0].(*iam.ListGroupsOutput)
 	ret1, _ := ret[1].(error)
@@ -4457,13 +3928,11 @@ func (m *MockIAMAPI) ListGroups(arg0 *iam.ListGroupsInput) (*iam.ListGroupsOutpu
 
 // ListGroups indicates an expected call of ListGroups
 func (mr *MockIAMAPIMockRecorder) ListGroups(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListGroups", reflect.TypeOf((*MockIAMAPI)(nil).ListGroups), arg0)
 }
 
 // ListGroupsForUser mocks base method
 func (m *MockIAMAPI) ListGroupsForUser(arg0 *iam.ListGroupsForUserInput) (*iam.ListGroupsForUserOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListGroupsForUser", arg0)
 	ret0, _ := ret[0].(*iam.ListGroupsForUserOutput)
 	ret1, _ := ret[1].(error)
@@ -4472,13 +3941,11 @@ func (m *MockIAMAPI) ListGroupsForUser(arg0 *iam.ListGroupsForUserInput) (*iam.L
 
 // ListGroupsForUser indicates an expected call of ListGroupsForUser
 func (mr *MockIAMAPIMockRecorder) ListGroupsForUser(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListGroupsForUser", reflect.TypeOf((*MockIAMAPI)(nil).ListGroupsForUser), arg0)
 }
 
 // ListGroupsForUserPages mocks base method
 func (m *MockIAMAPI) ListGroupsForUserPages(arg0 *iam.ListGroupsForUserInput, arg1 func(*iam.ListGroupsForUserOutput, bool) bool) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListGroupsForUserPages", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -4486,13 +3953,11 @@ func (m *MockIAMAPI) ListGroupsForUserPages(arg0 *iam.ListGroupsForUserInput, ar
 
 // ListGroupsForUserPages indicates an expected call of ListGroupsForUserPages
 func (mr *MockIAMAPIMockRecorder) ListGroupsForUserPages(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListGroupsForUserPages", reflect.TypeOf((*MockIAMAPI)(nil).ListGroupsForUserPages), arg0, arg1)
 }
 
 // ListGroupsForUserPagesWithContext mocks base method
 func (m *MockIAMAPI) ListGroupsForUserPagesWithContext(arg0 context.Context, arg1 *iam.ListGroupsForUserInput, arg2 func(*iam.ListGroupsForUserOutput, bool) bool, arg3 ...request.Option) error {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1, arg2}
 	for _, a := range arg3 {
 		varargs = append(varargs, a)
@@ -4504,14 +3969,12 @@ func (m *MockIAMAPI) ListGroupsForUserPagesWithContext(arg0 context.Context, arg
 
 // ListGroupsForUserPagesWithContext indicates an expected call of ListGroupsForUserPagesWithContext
 func (mr *MockIAMAPIMockRecorder) ListGroupsForUserPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListGroupsForUserPagesWithContext", reflect.TypeOf((*MockIAMAPI)(nil).ListGroupsForUserPagesWithContext), varargs...)
 }
 
 // ListGroupsForUserRequest mocks base method
 func (m *MockIAMAPI) ListGroupsForUserRequest(arg0 *iam.ListGroupsForUserInput) (*request.Request, *iam.ListGroupsForUserOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListGroupsForUserRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*iam.ListGroupsForUserOutput)
@@ -4520,13 +3983,11 @@ func (m *MockIAMAPI) ListGroupsForUserRequest(arg0 *iam.ListGroupsForUserInput) 
 
 // ListGroupsForUserRequest indicates an expected call of ListGroupsForUserRequest
 func (mr *MockIAMAPIMockRecorder) ListGroupsForUserRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListGroupsForUserRequest", reflect.TypeOf((*MockIAMAPI)(nil).ListGroupsForUserRequest), arg0)
 }
 
 // ListGroupsForUserWithContext mocks base method
 func (m *MockIAMAPI) ListGroupsForUserWithContext(arg0 context.Context, arg1 *iam.ListGroupsForUserInput, arg2 ...request.Option) (*iam.ListGroupsForUserOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -4539,14 +4000,12 @@ func (m *MockIAMAPI) ListGroupsForUserWithContext(arg0 context.Context, arg1 *ia
 
 // ListGroupsForUserWithContext indicates an expected call of ListGroupsForUserWithContext
 func (mr *MockIAMAPIMockRecorder) ListGroupsForUserWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListGroupsForUserWithContext", reflect.TypeOf((*MockIAMAPI)(nil).ListGroupsForUserWithContext), varargs...)
 }
 
 // ListGroupsPages mocks base method
 func (m *MockIAMAPI) ListGroupsPages(arg0 *iam.ListGroupsInput, arg1 func(*iam.ListGroupsOutput, bool) bool) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListGroupsPages", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -4554,13 +4013,11 @@ func (m *MockIAMAPI) ListGroupsPages(arg0 *iam.ListGroupsInput, arg1 func(*iam.L
 
 // ListGroupsPages indicates an expected call of ListGroupsPages
 func (mr *MockIAMAPIMockRecorder) ListGroupsPages(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListGroupsPages", reflect.TypeOf((*MockIAMAPI)(nil).ListGroupsPages), arg0, arg1)
 }
 
 // ListGroupsPagesWithContext mocks base method
 func (m *MockIAMAPI) ListGroupsPagesWithContext(arg0 context.Context, arg1 *iam.ListGroupsInput, arg2 func(*iam.ListGroupsOutput, bool) bool, arg3 ...request.Option) error {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1, arg2}
 	for _, a := range arg3 {
 		varargs = append(varargs, a)
@@ -4572,14 +4029,12 @@ func (m *MockIAMAPI) ListGroupsPagesWithContext(arg0 context.Context, arg1 *iam.
 
 // ListGroupsPagesWithContext indicates an expected call of ListGroupsPagesWithContext
 func (mr *MockIAMAPIMockRecorder) ListGroupsPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListGroupsPagesWithContext", reflect.TypeOf((*MockIAMAPI)(nil).ListGroupsPagesWithContext), varargs...)
 }
 
 // ListGroupsRequest mocks base method
 func (m *MockIAMAPI) ListGroupsRequest(arg0 *iam.ListGroupsInput) (*request.Request, *iam.ListGroupsOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListGroupsRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*iam.ListGroupsOutput)
@@ -4588,13 +4043,11 @@ func (m *MockIAMAPI) ListGroupsRequest(arg0 *iam.ListGroupsInput) (*request.Requ
 
 // ListGroupsRequest indicates an expected call of ListGroupsRequest
 func (mr *MockIAMAPIMockRecorder) ListGroupsRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListGroupsRequest", reflect.TypeOf((*MockIAMAPI)(nil).ListGroupsRequest), arg0)
 }
 
 // ListGroupsWithContext mocks base method
 func (m *MockIAMAPI) ListGroupsWithContext(arg0 context.Context, arg1 *iam.ListGroupsInput, arg2 ...request.Option) (*iam.ListGroupsOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -4607,14 +4060,12 @@ func (m *MockIAMAPI) ListGroupsWithContext(arg0 context.Context, arg1 *iam.ListG
 
 // ListGroupsWithContext indicates an expected call of ListGroupsWithContext
 func (mr *MockIAMAPIMockRecorder) ListGroupsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListGroupsWithContext", reflect.TypeOf((*MockIAMAPI)(nil).ListGroupsWithContext), varargs...)
 }
 
 // ListInstanceProfiles mocks base method
 func (m *MockIAMAPI) ListInstanceProfiles(arg0 *iam.ListInstanceProfilesInput) (*iam.ListInstanceProfilesOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListInstanceProfiles", arg0)
 	ret0, _ := ret[0].(*iam.ListInstanceProfilesOutput)
 	ret1, _ := ret[1].(error)
@@ -4623,13 +4074,11 @@ func (m *MockIAMAPI) ListInstanceProfiles(arg0 *iam.ListInstanceProfilesInput) (
 
 // ListInstanceProfiles indicates an expected call of ListInstanceProfiles
 func (mr *MockIAMAPIMockRecorder) ListInstanceProfiles(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListInstanceProfiles", reflect.TypeOf((*MockIAMAPI)(nil).ListInstanceProfiles), arg0)
 }
 
 // ListInstanceProfilesForRole mocks base method
 func (m *MockIAMAPI) ListInstanceProfilesForRole(arg0 *iam.ListInstanceProfilesForRoleInput) (*iam.ListInstanceProfilesForRoleOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListInstanceProfilesForRole", arg0)
 	ret0, _ := ret[0].(*iam.ListInstanceProfilesForRoleOutput)
 	ret1, _ := ret[1].(error)
@@ -4638,13 +4087,11 @@ func (m *MockIAMAPI) ListInstanceProfilesForRole(arg0 *iam.ListInstanceProfilesF
 
 // ListInstanceProfilesForRole indicates an expected call of ListInstanceProfilesForRole
 func (mr *MockIAMAPIMockRecorder) ListInstanceProfilesForRole(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListInstanceProfilesForRole", reflect.TypeOf((*MockIAMAPI)(nil).ListInstanceProfilesForRole), arg0)
 }
 
 // ListInstanceProfilesForRolePages mocks base method
 func (m *MockIAMAPI) ListInstanceProfilesForRolePages(arg0 *iam.ListInstanceProfilesForRoleInput, arg1 func(*iam.ListInstanceProfilesForRoleOutput, bool) bool) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListInstanceProfilesForRolePages", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -4652,13 +4099,11 @@ func (m *MockIAMAPI) ListInstanceProfilesForRolePages(arg0 *iam.ListInstanceProf
 
 // ListInstanceProfilesForRolePages indicates an expected call of ListInstanceProfilesForRolePages
 func (mr *MockIAMAPIMockRecorder) ListInstanceProfilesForRolePages(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListInstanceProfilesForRolePages", reflect.TypeOf((*MockIAMAPI)(nil).ListInstanceProfilesForRolePages), arg0, arg1)
 }
 
 // ListInstanceProfilesForRolePagesWithContext mocks base method
 func (m *MockIAMAPI) ListInstanceProfilesForRolePagesWithContext(arg0 context.Context, arg1 *iam.ListInstanceProfilesForRoleInput, arg2 func(*iam.ListInstanceProfilesForRoleOutput, bool) bool, arg3 ...request.Option) error {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1, arg2}
 	for _, a := range arg3 {
 		varargs = append(varargs, a)
@@ -4670,14 +4115,12 @@ func (m *MockIAMAPI) ListInstanceProfilesForRolePagesWithContext(arg0 context.Co
 
 // ListInstanceProfilesForRolePagesWithContext indicates an expected call of ListInstanceProfilesForRolePagesWithContext
 func (mr *MockIAMAPIMockRecorder) ListInstanceProfilesForRolePagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListInstanceProfilesForRolePagesWithContext", reflect.TypeOf((*MockIAMAPI)(nil).ListInstanceProfilesForRolePagesWithContext), varargs...)
 }
 
 // ListInstanceProfilesForRoleRequest mocks base method
 func (m *MockIAMAPI) ListInstanceProfilesForRoleRequest(arg0 *iam.ListInstanceProfilesForRoleInput) (*request.Request, *iam.ListInstanceProfilesForRoleOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListInstanceProfilesForRoleRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*iam.ListInstanceProfilesForRoleOutput)
@@ -4686,13 +4129,11 @@ func (m *MockIAMAPI) ListInstanceProfilesForRoleRequest(arg0 *iam.ListInstancePr
 
 // ListInstanceProfilesForRoleRequest indicates an expected call of ListInstanceProfilesForRoleRequest
 func (mr *MockIAMAPIMockRecorder) ListInstanceProfilesForRoleRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListInstanceProfilesForRoleRequest", reflect.TypeOf((*MockIAMAPI)(nil).ListInstanceProfilesForRoleRequest), arg0)
 }
 
 // ListInstanceProfilesForRoleWithContext mocks base method
 func (m *MockIAMAPI) ListInstanceProfilesForRoleWithContext(arg0 context.Context, arg1 *iam.ListInstanceProfilesForRoleInput, arg2 ...request.Option) (*iam.ListInstanceProfilesForRoleOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -4705,14 +4146,12 @@ func (m *MockIAMAPI) ListInstanceProfilesForRoleWithContext(arg0 context.Context
 
 // ListInstanceProfilesForRoleWithContext indicates an expected call of ListInstanceProfilesForRoleWithContext
 func (mr *MockIAMAPIMockRecorder) ListInstanceProfilesForRoleWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListInstanceProfilesForRoleWithContext", reflect.TypeOf((*MockIAMAPI)(nil).ListInstanceProfilesForRoleWithContext), varargs...)
 }
 
 // ListInstanceProfilesPages mocks base method
 func (m *MockIAMAPI) ListInstanceProfilesPages(arg0 *iam.ListInstanceProfilesInput, arg1 func(*iam.ListInstanceProfilesOutput, bool) bool) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListInstanceProfilesPages", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -4720,13 +4159,11 @@ func (m *MockIAMAPI) ListInstanceProfilesPages(arg0 *iam.ListInstanceProfilesInp
 
 // ListInstanceProfilesPages indicates an expected call of ListInstanceProfilesPages
 func (mr *MockIAMAPIMockRecorder) ListInstanceProfilesPages(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListInstanceProfilesPages", reflect.TypeOf((*MockIAMAPI)(nil).ListInstanceProfilesPages), arg0, arg1)
 }
 
 // ListInstanceProfilesPagesWithContext mocks base method
 func (m *MockIAMAPI) ListInstanceProfilesPagesWithContext(arg0 context.Context, arg1 *iam.ListInstanceProfilesInput, arg2 func(*iam.ListInstanceProfilesOutput, bool) bool, arg3 ...request.Option) error {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1, arg2}
 	for _, a := range arg3 {
 		varargs = append(varargs, a)
@@ -4738,14 +4175,12 @@ func (m *MockIAMAPI) ListInstanceProfilesPagesWithContext(arg0 context.Context, 
 
 // ListInstanceProfilesPagesWithContext indicates an expected call of ListInstanceProfilesPagesWithContext
 func (mr *MockIAMAPIMockRecorder) ListInstanceProfilesPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListInstanceProfilesPagesWithContext", reflect.TypeOf((*MockIAMAPI)(nil).ListInstanceProfilesPagesWithContext), varargs...)
 }
 
 // ListInstanceProfilesRequest mocks base method
 func (m *MockIAMAPI) ListInstanceProfilesRequest(arg0 *iam.ListInstanceProfilesInput) (*request.Request, *iam.ListInstanceProfilesOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListInstanceProfilesRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*iam.ListInstanceProfilesOutput)
@@ -4754,13 +4189,11 @@ func (m *MockIAMAPI) ListInstanceProfilesRequest(arg0 *iam.ListInstanceProfilesI
 
 // ListInstanceProfilesRequest indicates an expected call of ListInstanceProfilesRequest
 func (mr *MockIAMAPIMockRecorder) ListInstanceProfilesRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListInstanceProfilesRequest", reflect.TypeOf((*MockIAMAPI)(nil).ListInstanceProfilesRequest), arg0)
 }
 
 // ListInstanceProfilesWithContext mocks base method
 func (m *MockIAMAPI) ListInstanceProfilesWithContext(arg0 context.Context, arg1 *iam.ListInstanceProfilesInput, arg2 ...request.Option) (*iam.ListInstanceProfilesOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -4773,14 +4206,12 @@ func (m *MockIAMAPI) ListInstanceProfilesWithContext(arg0 context.Context, arg1 
 
 // ListInstanceProfilesWithContext indicates an expected call of ListInstanceProfilesWithContext
 func (mr *MockIAMAPIMockRecorder) ListInstanceProfilesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListInstanceProfilesWithContext", reflect.TypeOf((*MockIAMAPI)(nil).ListInstanceProfilesWithContext), varargs...)
 }
 
 // ListMFADevices mocks base method
 func (m *MockIAMAPI) ListMFADevices(arg0 *iam.ListMFADevicesInput) (*iam.ListMFADevicesOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListMFADevices", arg0)
 	ret0, _ := ret[0].(*iam.ListMFADevicesOutput)
 	ret1, _ := ret[1].(error)
@@ -4789,13 +4220,11 @@ func (m *MockIAMAPI) ListMFADevices(arg0 *iam.ListMFADevicesInput) (*iam.ListMFA
 
 // ListMFADevices indicates an expected call of ListMFADevices
 func (mr *MockIAMAPIMockRecorder) ListMFADevices(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListMFADevices", reflect.TypeOf((*MockIAMAPI)(nil).ListMFADevices), arg0)
 }
 
 // ListMFADevicesPages mocks base method
 func (m *MockIAMAPI) ListMFADevicesPages(arg0 *iam.ListMFADevicesInput, arg1 func(*iam.ListMFADevicesOutput, bool) bool) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListMFADevicesPages", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -4803,13 +4232,11 @@ func (m *MockIAMAPI) ListMFADevicesPages(arg0 *iam.ListMFADevicesInput, arg1 fun
 
 // ListMFADevicesPages indicates an expected call of ListMFADevicesPages
 func (mr *MockIAMAPIMockRecorder) ListMFADevicesPages(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListMFADevicesPages", reflect.TypeOf((*MockIAMAPI)(nil).ListMFADevicesPages), arg0, arg1)
 }
 
 // ListMFADevicesPagesWithContext mocks base method
 func (m *MockIAMAPI) ListMFADevicesPagesWithContext(arg0 context.Context, arg1 *iam.ListMFADevicesInput, arg2 func(*iam.ListMFADevicesOutput, bool) bool, arg3 ...request.Option) error {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1, arg2}
 	for _, a := range arg3 {
 		varargs = append(varargs, a)
@@ -4821,14 +4248,12 @@ func (m *MockIAMAPI) ListMFADevicesPagesWithContext(arg0 context.Context, arg1 *
 
 // ListMFADevicesPagesWithContext indicates an expected call of ListMFADevicesPagesWithContext
 func (mr *MockIAMAPIMockRecorder) ListMFADevicesPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListMFADevicesPagesWithContext", reflect.TypeOf((*MockIAMAPI)(nil).ListMFADevicesPagesWithContext), varargs...)
 }
 
 // ListMFADevicesRequest mocks base method
 func (m *MockIAMAPI) ListMFADevicesRequest(arg0 *iam.ListMFADevicesInput) (*request.Request, *iam.ListMFADevicesOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListMFADevicesRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*iam.ListMFADevicesOutput)
@@ -4837,13 +4262,11 @@ func (m *MockIAMAPI) ListMFADevicesRequest(arg0 *iam.ListMFADevicesInput) (*requ
 
 // ListMFADevicesRequest indicates an expected call of ListMFADevicesRequest
 func (mr *MockIAMAPIMockRecorder) ListMFADevicesRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListMFADevicesRequest", reflect.TypeOf((*MockIAMAPI)(nil).ListMFADevicesRequest), arg0)
 }
 
 // ListMFADevicesWithContext mocks base method
 func (m *MockIAMAPI) ListMFADevicesWithContext(arg0 context.Context, arg1 *iam.ListMFADevicesInput, arg2 ...request.Option) (*iam.ListMFADevicesOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -4856,14 +4279,12 @@ func (m *MockIAMAPI) ListMFADevicesWithContext(arg0 context.Context, arg1 *iam.L
 
 // ListMFADevicesWithContext indicates an expected call of ListMFADevicesWithContext
 func (mr *MockIAMAPIMockRecorder) ListMFADevicesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListMFADevicesWithContext", reflect.TypeOf((*MockIAMAPI)(nil).ListMFADevicesWithContext), varargs...)
 }
 
 // ListOpenIDConnectProviders mocks base method
 func (m *MockIAMAPI) ListOpenIDConnectProviders(arg0 *iam.ListOpenIDConnectProvidersInput) (*iam.ListOpenIDConnectProvidersOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListOpenIDConnectProviders", arg0)
 	ret0, _ := ret[0].(*iam.ListOpenIDConnectProvidersOutput)
 	ret1, _ := ret[1].(error)
@@ -4872,13 +4293,11 @@ func (m *MockIAMAPI) ListOpenIDConnectProviders(arg0 *iam.ListOpenIDConnectProvi
 
 // ListOpenIDConnectProviders indicates an expected call of ListOpenIDConnectProviders
 func (mr *MockIAMAPIMockRecorder) ListOpenIDConnectProviders(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListOpenIDConnectProviders", reflect.TypeOf((*MockIAMAPI)(nil).ListOpenIDConnectProviders), arg0)
 }
 
 // ListOpenIDConnectProvidersRequest mocks base method
 func (m *MockIAMAPI) ListOpenIDConnectProvidersRequest(arg0 *iam.ListOpenIDConnectProvidersInput) (*request.Request, *iam.ListOpenIDConnectProvidersOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListOpenIDConnectProvidersRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*iam.ListOpenIDConnectProvidersOutput)
@@ -4887,13 +4306,11 @@ func (m *MockIAMAPI) ListOpenIDConnectProvidersRequest(arg0 *iam.ListOpenIDConne
 
 // ListOpenIDConnectProvidersRequest indicates an expected call of ListOpenIDConnectProvidersRequest
 func (mr *MockIAMAPIMockRecorder) ListOpenIDConnectProvidersRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListOpenIDConnectProvidersRequest", reflect.TypeOf((*MockIAMAPI)(nil).ListOpenIDConnectProvidersRequest), arg0)
 }
 
 // ListOpenIDConnectProvidersWithContext mocks base method
 func (m *MockIAMAPI) ListOpenIDConnectProvidersWithContext(arg0 context.Context, arg1 *iam.ListOpenIDConnectProvidersInput, arg2 ...request.Option) (*iam.ListOpenIDConnectProvidersOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -4906,14 +4323,12 @@ func (m *MockIAMAPI) ListOpenIDConnectProvidersWithContext(arg0 context.Context,
 
 // ListOpenIDConnectProvidersWithContext indicates an expected call of ListOpenIDConnectProvidersWithContext
 func (mr *MockIAMAPIMockRecorder) ListOpenIDConnectProvidersWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListOpenIDConnectProvidersWithContext", reflect.TypeOf((*MockIAMAPI)(nil).ListOpenIDConnectProvidersWithContext), varargs...)
 }
 
 // ListPolicies mocks base method
 func (m *MockIAMAPI) ListPolicies(arg0 *iam.ListPoliciesInput) (*iam.ListPoliciesOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListPolicies", arg0)
 	ret0, _ := ret[0].(*iam.ListPoliciesOutput)
 	ret1, _ := ret[1].(error)
@@ -4922,13 +4337,11 @@ func (m *MockIAMAPI) ListPolicies(arg0 *iam.ListPoliciesInput) (*iam.ListPolicie
 
 // ListPolicies indicates an expected call of ListPolicies
 func (mr *MockIAMAPIMockRecorder) ListPolicies(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListPolicies", reflect.TypeOf((*MockIAMAPI)(nil).ListPolicies), arg0)
 }
 
 // ListPoliciesGrantingServiceAccess mocks base method
 func (m *MockIAMAPI) ListPoliciesGrantingServiceAccess(arg0 *iam.ListPoliciesGrantingServiceAccessInput) (*iam.ListPoliciesGrantingServiceAccessOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListPoliciesGrantingServiceAccess", arg0)
 	ret0, _ := ret[0].(*iam.ListPoliciesGrantingServiceAccessOutput)
 	ret1, _ := ret[1].(error)
@@ -4937,13 +4350,11 @@ func (m *MockIAMAPI) ListPoliciesGrantingServiceAccess(arg0 *iam.ListPoliciesGra
 
 // ListPoliciesGrantingServiceAccess indicates an expected call of ListPoliciesGrantingServiceAccess
 func (mr *MockIAMAPIMockRecorder) ListPoliciesGrantingServiceAccess(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListPoliciesGrantingServiceAccess", reflect.TypeOf((*MockIAMAPI)(nil).ListPoliciesGrantingServiceAccess), arg0)
 }
 
 // ListPoliciesGrantingServiceAccessRequest mocks base method
 func (m *MockIAMAPI) ListPoliciesGrantingServiceAccessRequest(arg0 *iam.ListPoliciesGrantingServiceAccessInput) (*request.Request, *iam.ListPoliciesGrantingServiceAccessOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListPoliciesGrantingServiceAccessRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*iam.ListPoliciesGrantingServiceAccessOutput)
@@ -4952,13 +4363,11 @@ func (m *MockIAMAPI) ListPoliciesGrantingServiceAccessRequest(arg0 *iam.ListPoli
 
 // ListPoliciesGrantingServiceAccessRequest indicates an expected call of ListPoliciesGrantingServiceAccessRequest
 func (mr *MockIAMAPIMockRecorder) ListPoliciesGrantingServiceAccessRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListPoliciesGrantingServiceAccessRequest", reflect.TypeOf((*MockIAMAPI)(nil).ListPoliciesGrantingServiceAccessRequest), arg0)
 }
 
 // ListPoliciesGrantingServiceAccessWithContext mocks base method
 func (m *MockIAMAPI) ListPoliciesGrantingServiceAccessWithContext(arg0 context.Context, arg1 *iam.ListPoliciesGrantingServiceAccessInput, arg2 ...request.Option) (*iam.ListPoliciesGrantingServiceAccessOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -4971,14 +4380,12 @@ func (m *MockIAMAPI) ListPoliciesGrantingServiceAccessWithContext(arg0 context.C
 
 // ListPoliciesGrantingServiceAccessWithContext indicates an expected call of ListPoliciesGrantingServiceAccessWithContext
 func (mr *MockIAMAPIMockRecorder) ListPoliciesGrantingServiceAccessWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListPoliciesGrantingServiceAccessWithContext", reflect.TypeOf((*MockIAMAPI)(nil).ListPoliciesGrantingServiceAccessWithContext), varargs...)
 }
 
 // ListPoliciesPages mocks base method
 func (m *MockIAMAPI) ListPoliciesPages(arg0 *iam.ListPoliciesInput, arg1 func(*iam.ListPoliciesOutput, bool) bool) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListPoliciesPages", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -4986,13 +4393,11 @@ func (m *MockIAMAPI) ListPoliciesPages(arg0 *iam.ListPoliciesInput, arg1 func(*i
 
 // ListPoliciesPages indicates an expected call of ListPoliciesPages
 func (mr *MockIAMAPIMockRecorder) ListPoliciesPages(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListPoliciesPages", reflect.TypeOf((*MockIAMAPI)(nil).ListPoliciesPages), arg0, arg1)
 }
 
 // ListPoliciesPagesWithContext mocks base method
 func (m *MockIAMAPI) ListPoliciesPagesWithContext(arg0 context.Context, arg1 *iam.ListPoliciesInput, arg2 func(*iam.ListPoliciesOutput, bool) bool, arg3 ...request.Option) error {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1, arg2}
 	for _, a := range arg3 {
 		varargs = append(varargs, a)
@@ -5004,14 +4409,12 @@ func (m *MockIAMAPI) ListPoliciesPagesWithContext(arg0 context.Context, arg1 *ia
 
 // ListPoliciesPagesWithContext indicates an expected call of ListPoliciesPagesWithContext
 func (mr *MockIAMAPIMockRecorder) ListPoliciesPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListPoliciesPagesWithContext", reflect.TypeOf((*MockIAMAPI)(nil).ListPoliciesPagesWithContext), varargs...)
 }
 
 // ListPoliciesRequest mocks base method
 func (m *MockIAMAPI) ListPoliciesRequest(arg0 *iam.ListPoliciesInput) (*request.Request, *iam.ListPoliciesOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListPoliciesRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*iam.ListPoliciesOutput)
@@ -5020,13 +4423,11 @@ func (m *MockIAMAPI) ListPoliciesRequest(arg0 *iam.ListPoliciesInput) (*request.
 
 // ListPoliciesRequest indicates an expected call of ListPoliciesRequest
 func (mr *MockIAMAPIMockRecorder) ListPoliciesRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListPoliciesRequest", reflect.TypeOf((*MockIAMAPI)(nil).ListPoliciesRequest), arg0)
 }
 
 // ListPoliciesWithContext mocks base method
 func (m *MockIAMAPI) ListPoliciesWithContext(arg0 context.Context, arg1 *iam.ListPoliciesInput, arg2 ...request.Option) (*iam.ListPoliciesOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -5039,14 +4440,12 @@ func (m *MockIAMAPI) ListPoliciesWithContext(arg0 context.Context, arg1 *iam.Lis
 
 // ListPoliciesWithContext indicates an expected call of ListPoliciesWithContext
 func (mr *MockIAMAPIMockRecorder) ListPoliciesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListPoliciesWithContext", reflect.TypeOf((*MockIAMAPI)(nil).ListPoliciesWithContext), varargs...)
 }
 
 // ListPolicyVersions mocks base method
 func (m *MockIAMAPI) ListPolicyVersions(arg0 *iam.ListPolicyVersionsInput) (*iam.ListPolicyVersionsOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListPolicyVersions", arg0)
 	ret0, _ := ret[0].(*iam.ListPolicyVersionsOutput)
 	ret1, _ := ret[1].(error)
@@ -5055,13 +4454,11 @@ func (m *MockIAMAPI) ListPolicyVersions(arg0 *iam.ListPolicyVersionsInput) (*iam
 
 // ListPolicyVersions indicates an expected call of ListPolicyVersions
 func (mr *MockIAMAPIMockRecorder) ListPolicyVersions(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListPolicyVersions", reflect.TypeOf((*MockIAMAPI)(nil).ListPolicyVersions), arg0)
 }
 
 // ListPolicyVersionsPages mocks base method
 func (m *MockIAMAPI) ListPolicyVersionsPages(arg0 *iam.ListPolicyVersionsInput, arg1 func(*iam.ListPolicyVersionsOutput, bool) bool) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListPolicyVersionsPages", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -5069,13 +4466,11 @@ func (m *MockIAMAPI) ListPolicyVersionsPages(arg0 *iam.ListPolicyVersionsInput, 
 
 // ListPolicyVersionsPages indicates an expected call of ListPolicyVersionsPages
 func (mr *MockIAMAPIMockRecorder) ListPolicyVersionsPages(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListPolicyVersionsPages", reflect.TypeOf((*MockIAMAPI)(nil).ListPolicyVersionsPages), arg0, arg1)
 }
 
 // ListPolicyVersionsPagesWithContext mocks base method
 func (m *MockIAMAPI) ListPolicyVersionsPagesWithContext(arg0 context.Context, arg1 *iam.ListPolicyVersionsInput, arg2 func(*iam.ListPolicyVersionsOutput, bool) bool, arg3 ...request.Option) error {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1, arg2}
 	for _, a := range arg3 {
 		varargs = append(varargs, a)
@@ -5087,14 +4482,12 @@ func (m *MockIAMAPI) ListPolicyVersionsPagesWithContext(arg0 context.Context, ar
 
 // ListPolicyVersionsPagesWithContext indicates an expected call of ListPolicyVersionsPagesWithContext
 func (mr *MockIAMAPIMockRecorder) ListPolicyVersionsPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListPolicyVersionsPagesWithContext", reflect.TypeOf((*MockIAMAPI)(nil).ListPolicyVersionsPagesWithContext), varargs...)
 }
 
 // ListPolicyVersionsRequest mocks base method
 func (m *MockIAMAPI) ListPolicyVersionsRequest(arg0 *iam.ListPolicyVersionsInput) (*request.Request, *iam.ListPolicyVersionsOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListPolicyVersionsRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*iam.ListPolicyVersionsOutput)
@@ -5103,13 +4496,11 @@ func (m *MockIAMAPI) ListPolicyVersionsRequest(arg0 *iam.ListPolicyVersionsInput
 
 // ListPolicyVersionsRequest indicates an expected call of ListPolicyVersionsRequest
 func (mr *MockIAMAPIMockRecorder) ListPolicyVersionsRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListPolicyVersionsRequest", reflect.TypeOf((*MockIAMAPI)(nil).ListPolicyVersionsRequest), arg0)
 }
 
 // ListPolicyVersionsWithContext mocks base method
 func (m *MockIAMAPI) ListPolicyVersionsWithContext(arg0 context.Context, arg1 *iam.ListPolicyVersionsInput, arg2 ...request.Option) (*iam.ListPolicyVersionsOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -5122,14 +4513,12 @@ func (m *MockIAMAPI) ListPolicyVersionsWithContext(arg0 context.Context, arg1 *i
 
 // ListPolicyVersionsWithContext indicates an expected call of ListPolicyVersionsWithContext
 func (mr *MockIAMAPIMockRecorder) ListPolicyVersionsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListPolicyVersionsWithContext", reflect.TypeOf((*MockIAMAPI)(nil).ListPolicyVersionsWithContext), varargs...)
 }
 
 // ListRolePolicies mocks base method
 func (m *MockIAMAPI) ListRolePolicies(arg0 *iam.ListRolePoliciesInput) (*iam.ListRolePoliciesOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListRolePolicies", arg0)
 	ret0, _ := ret[0].(*iam.ListRolePoliciesOutput)
 	ret1, _ := ret[1].(error)
@@ -5138,13 +4527,11 @@ func (m *MockIAMAPI) ListRolePolicies(arg0 *iam.ListRolePoliciesInput) (*iam.Lis
 
 // ListRolePolicies indicates an expected call of ListRolePolicies
 func (mr *MockIAMAPIMockRecorder) ListRolePolicies(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListRolePolicies", reflect.TypeOf((*MockIAMAPI)(nil).ListRolePolicies), arg0)
 }
 
 // ListRolePoliciesPages mocks base method
 func (m *MockIAMAPI) ListRolePoliciesPages(arg0 *iam.ListRolePoliciesInput, arg1 func(*iam.ListRolePoliciesOutput, bool) bool) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListRolePoliciesPages", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -5152,13 +4539,11 @@ func (m *MockIAMAPI) ListRolePoliciesPages(arg0 *iam.ListRolePoliciesInput, arg1
 
 // ListRolePoliciesPages indicates an expected call of ListRolePoliciesPages
 func (mr *MockIAMAPIMockRecorder) ListRolePoliciesPages(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListRolePoliciesPages", reflect.TypeOf((*MockIAMAPI)(nil).ListRolePoliciesPages), arg0, arg1)
 }
 
 // ListRolePoliciesPagesWithContext mocks base method
 func (m *MockIAMAPI) ListRolePoliciesPagesWithContext(arg0 context.Context, arg1 *iam.ListRolePoliciesInput, arg2 func(*iam.ListRolePoliciesOutput, bool) bool, arg3 ...request.Option) error {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1, arg2}
 	for _, a := range arg3 {
 		varargs = append(varargs, a)
@@ -5170,14 +4555,12 @@ func (m *MockIAMAPI) ListRolePoliciesPagesWithContext(arg0 context.Context, arg1
 
 // ListRolePoliciesPagesWithContext indicates an expected call of ListRolePoliciesPagesWithContext
 func (mr *MockIAMAPIMockRecorder) ListRolePoliciesPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListRolePoliciesPagesWithContext", reflect.TypeOf((*MockIAMAPI)(nil).ListRolePoliciesPagesWithContext), varargs...)
 }
 
 // ListRolePoliciesRequest mocks base method
 func (m *MockIAMAPI) ListRolePoliciesRequest(arg0 *iam.ListRolePoliciesInput) (*request.Request, *iam.ListRolePoliciesOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListRolePoliciesRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*iam.ListRolePoliciesOutput)
@@ -5186,13 +4569,11 @@ func (m *MockIAMAPI) ListRolePoliciesRequest(arg0 *iam.ListRolePoliciesInput) (*
 
 // ListRolePoliciesRequest indicates an expected call of ListRolePoliciesRequest
 func (mr *MockIAMAPIMockRecorder) ListRolePoliciesRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListRolePoliciesRequest", reflect.TypeOf((*MockIAMAPI)(nil).ListRolePoliciesRequest), arg0)
 }
 
 // ListRolePoliciesWithContext mocks base method
 func (m *MockIAMAPI) ListRolePoliciesWithContext(arg0 context.Context, arg1 *iam.ListRolePoliciesInput, arg2 ...request.Option) (*iam.ListRolePoliciesOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -5205,14 +4586,12 @@ func (m *MockIAMAPI) ListRolePoliciesWithContext(arg0 context.Context, arg1 *iam
 
 // ListRolePoliciesWithContext indicates an expected call of ListRolePoliciesWithContext
 func (mr *MockIAMAPIMockRecorder) ListRolePoliciesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListRolePoliciesWithContext", reflect.TypeOf((*MockIAMAPI)(nil).ListRolePoliciesWithContext), varargs...)
 }
 
 // ListRoleTags mocks base method
 func (m *MockIAMAPI) ListRoleTags(arg0 *iam.ListRoleTagsInput) (*iam.ListRoleTagsOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListRoleTags", arg0)
 	ret0, _ := ret[0].(*iam.ListRoleTagsOutput)
 	ret1, _ := ret[1].(error)
@@ -5221,13 +4600,11 @@ func (m *MockIAMAPI) ListRoleTags(arg0 *iam.ListRoleTagsInput) (*iam.ListRoleTag
 
 // ListRoleTags indicates an expected call of ListRoleTags
 func (mr *MockIAMAPIMockRecorder) ListRoleTags(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListRoleTags", reflect.TypeOf((*MockIAMAPI)(nil).ListRoleTags), arg0)
 }
 
 // ListRoleTagsRequest mocks base method
 func (m *MockIAMAPI) ListRoleTagsRequest(arg0 *iam.ListRoleTagsInput) (*request.Request, *iam.ListRoleTagsOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListRoleTagsRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*iam.ListRoleTagsOutput)
@@ -5236,13 +4613,11 @@ func (m *MockIAMAPI) ListRoleTagsRequest(arg0 *iam.ListRoleTagsInput) (*request.
 
 // ListRoleTagsRequest indicates an expected call of ListRoleTagsRequest
 func (mr *MockIAMAPIMockRecorder) ListRoleTagsRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListRoleTagsRequest", reflect.TypeOf((*MockIAMAPI)(nil).ListRoleTagsRequest), arg0)
 }
 
 // ListRoleTagsWithContext mocks base method
 func (m *MockIAMAPI) ListRoleTagsWithContext(arg0 context.Context, arg1 *iam.ListRoleTagsInput, arg2 ...request.Option) (*iam.ListRoleTagsOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -5255,14 +4630,12 @@ func (m *MockIAMAPI) ListRoleTagsWithContext(arg0 context.Context, arg1 *iam.Lis
 
 // ListRoleTagsWithContext indicates an expected call of ListRoleTagsWithContext
 func (mr *MockIAMAPIMockRecorder) ListRoleTagsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListRoleTagsWithContext", reflect.TypeOf((*MockIAMAPI)(nil).ListRoleTagsWithContext), varargs...)
 }
 
 // ListRoles mocks base method
 func (m *MockIAMAPI) ListRoles(arg0 *iam.ListRolesInput) (*iam.ListRolesOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListRoles", arg0)
 	ret0, _ := ret[0].(*iam.ListRolesOutput)
 	ret1, _ := ret[1].(error)
@@ -5271,13 +4644,11 @@ func (m *MockIAMAPI) ListRoles(arg0 *iam.ListRolesInput) (*iam.ListRolesOutput, 
 
 // ListRoles indicates an expected call of ListRoles
 func (mr *MockIAMAPIMockRecorder) ListRoles(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListRoles", reflect.TypeOf((*MockIAMAPI)(nil).ListRoles), arg0)
 }
 
 // ListRolesPages mocks base method
 func (m *MockIAMAPI) ListRolesPages(arg0 *iam.ListRolesInput, arg1 func(*iam.ListRolesOutput, bool) bool) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListRolesPages", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -5285,13 +4656,11 @@ func (m *MockIAMAPI) ListRolesPages(arg0 *iam.ListRolesInput, arg1 func(*iam.Lis
 
 // ListRolesPages indicates an expected call of ListRolesPages
 func (mr *MockIAMAPIMockRecorder) ListRolesPages(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListRolesPages", reflect.TypeOf((*MockIAMAPI)(nil).ListRolesPages), arg0, arg1)
 }
 
 // ListRolesPagesWithContext mocks base method
 func (m *MockIAMAPI) ListRolesPagesWithContext(arg0 context.Context, arg1 *iam.ListRolesInput, arg2 func(*iam.ListRolesOutput, bool) bool, arg3 ...request.Option) error {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1, arg2}
 	for _, a := range arg3 {
 		varargs = append(varargs, a)
@@ -5303,14 +4672,12 @@ func (m *MockIAMAPI) ListRolesPagesWithContext(arg0 context.Context, arg1 *iam.L
 
 // ListRolesPagesWithContext indicates an expected call of ListRolesPagesWithContext
 func (mr *MockIAMAPIMockRecorder) ListRolesPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListRolesPagesWithContext", reflect.TypeOf((*MockIAMAPI)(nil).ListRolesPagesWithContext), varargs...)
 }
 
 // ListRolesRequest mocks base method
 func (m *MockIAMAPI) ListRolesRequest(arg0 *iam.ListRolesInput) (*request.Request, *iam.ListRolesOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListRolesRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*iam.ListRolesOutput)
@@ -5319,13 +4686,11 @@ func (m *MockIAMAPI) ListRolesRequest(arg0 *iam.ListRolesInput) (*request.Reques
 
 // ListRolesRequest indicates an expected call of ListRolesRequest
 func (mr *MockIAMAPIMockRecorder) ListRolesRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListRolesRequest", reflect.TypeOf((*MockIAMAPI)(nil).ListRolesRequest), arg0)
 }
 
 // ListRolesWithContext mocks base method
 func (m *MockIAMAPI) ListRolesWithContext(arg0 context.Context, arg1 *iam.ListRolesInput, arg2 ...request.Option) (*iam.ListRolesOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -5338,14 +4703,12 @@ func (m *MockIAMAPI) ListRolesWithContext(arg0 context.Context, arg1 *iam.ListRo
 
 // ListRolesWithContext indicates an expected call of ListRolesWithContext
 func (mr *MockIAMAPIMockRecorder) ListRolesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListRolesWithContext", reflect.TypeOf((*MockIAMAPI)(nil).ListRolesWithContext), varargs...)
 }
 
 // ListSAMLProviders mocks base method
 func (m *MockIAMAPI) ListSAMLProviders(arg0 *iam.ListSAMLProvidersInput) (*iam.ListSAMLProvidersOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListSAMLProviders", arg0)
 	ret0, _ := ret[0].(*iam.ListSAMLProvidersOutput)
 	ret1, _ := ret[1].(error)
@@ -5354,13 +4717,11 @@ func (m *MockIAMAPI) ListSAMLProviders(arg0 *iam.ListSAMLProvidersInput) (*iam.L
 
 // ListSAMLProviders indicates an expected call of ListSAMLProviders
 func (mr *MockIAMAPIMockRecorder) ListSAMLProviders(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSAMLProviders", reflect.TypeOf((*MockIAMAPI)(nil).ListSAMLProviders), arg0)
 }
 
 // ListSAMLProvidersRequest mocks base method
 func (m *MockIAMAPI) ListSAMLProvidersRequest(arg0 *iam.ListSAMLProvidersInput) (*request.Request, *iam.ListSAMLProvidersOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListSAMLProvidersRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*iam.ListSAMLProvidersOutput)
@@ -5369,13 +4730,11 @@ func (m *MockIAMAPI) ListSAMLProvidersRequest(arg0 *iam.ListSAMLProvidersInput) 
 
 // ListSAMLProvidersRequest indicates an expected call of ListSAMLProvidersRequest
 func (mr *MockIAMAPIMockRecorder) ListSAMLProvidersRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSAMLProvidersRequest", reflect.TypeOf((*MockIAMAPI)(nil).ListSAMLProvidersRequest), arg0)
 }
 
 // ListSAMLProvidersWithContext mocks base method
 func (m *MockIAMAPI) ListSAMLProvidersWithContext(arg0 context.Context, arg1 *iam.ListSAMLProvidersInput, arg2 ...request.Option) (*iam.ListSAMLProvidersOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -5388,14 +4747,12 @@ func (m *MockIAMAPI) ListSAMLProvidersWithContext(arg0 context.Context, arg1 *ia
 
 // ListSAMLProvidersWithContext indicates an expected call of ListSAMLProvidersWithContext
 func (mr *MockIAMAPIMockRecorder) ListSAMLProvidersWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSAMLProvidersWithContext", reflect.TypeOf((*MockIAMAPI)(nil).ListSAMLProvidersWithContext), varargs...)
 }
 
 // ListSSHPublicKeys mocks base method
 func (m *MockIAMAPI) ListSSHPublicKeys(arg0 *iam.ListSSHPublicKeysInput) (*iam.ListSSHPublicKeysOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListSSHPublicKeys", arg0)
 	ret0, _ := ret[0].(*iam.ListSSHPublicKeysOutput)
 	ret1, _ := ret[1].(error)
@@ -5404,13 +4761,11 @@ func (m *MockIAMAPI) ListSSHPublicKeys(arg0 *iam.ListSSHPublicKeysInput) (*iam.L
 
 // ListSSHPublicKeys indicates an expected call of ListSSHPublicKeys
 func (mr *MockIAMAPIMockRecorder) ListSSHPublicKeys(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSSHPublicKeys", reflect.TypeOf((*MockIAMAPI)(nil).ListSSHPublicKeys), arg0)
 }
 
 // ListSSHPublicKeysPages mocks base method
 func (m *MockIAMAPI) ListSSHPublicKeysPages(arg0 *iam.ListSSHPublicKeysInput, arg1 func(*iam.ListSSHPublicKeysOutput, bool) bool) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListSSHPublicKeysPages", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -5418,13 +4773,11 @@ func (m *MockIAMAPI) ListSSHPublicKeysPages(arg0 *iam.ListSSHPublicKeysInput, ar
 
 // ListSSHPublicKeysPages indicates an expected call of ListSSHPublicKeysPages
 func (mr *MockIAMAPIMockRecorder) ListSSHPublicKeysPages(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSSHPublicKeysPages", reflect.TypeOf((*MockIAMAPI)(nil).ListSSHPublicKeysPages), arg0, arg1)
 }
 
 // ListSSHPublicKeysPagesWithContext mocks base method
 func (m *MockIAMAPI) ListSSHPublicKeysPagesWithContext(arg0 context.Context, arg1 *iam.ListSSHPublicKeysInput, arg2 func(*iam.ListSSHPublicKeysOutput, bool) bool, arg3 ...request.Option) error {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1, arg2}
 	for _, a := range arg3 {
 		varargs = append(varargs, a)
@@ -5436,14 +4789,12 @@ func (m *MockIAMAPI) ListSSHPublicKeysPagesWithContext(arg0 context.Context, arg
 
 // ListSSHPublicKeysPagesWithContext indicates an expected call of ListSSHPublicKeysPagesWithContext
 func (mr *MockIAMAPIMockRecorder) ListSSHPublicKeysPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSSHPublicKeysPagesWithContext", reflect.TypeOf((*MockIAMAPI)(nil).ListSSHPublicKeysPagesWithContext), varargs...)
 }
 
 // ListSSHPublicKeysRequest mocks base method
 func (m *MockIAMAPI) ListSSHPublicKeysRequest(arg0 *iam.ListSSHPublicKeysInput) (*request.Request, *iam.ListSSHPublicKeysOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListSSHPublicKeysRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*iam.ListSSHPublicKeysOutput)
@@ -5452,13 +4803,11 @@ func (m *MockIAMAPI) ListSSHPublicKeysRequest(arg0 *iam.ListSSHPublicKeysInput) 
 
 // ListSSHPublicKeysRequest indicates an expected call of ListSSHPublicKeysRequest
 func (mr *MockIAMAPIMockRecorder) ListSSHPublicKeysRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSSHPublicKeysRequest", reflect.TypeOf((*MockIAMAPI)(nil).ListSSHPublicKeysRequest), arg0)
 }
 
 // ListSSHPublicKeysWithContext mocks base method
 func (m *MockIAMAPI) ListSSHPublicKeysWithContext(arg0 context.Context, arg1 *iam.ListSSHPublicKeysInput, arg2 ...request.Option) (*iam.ListSSHPublicKeysOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -5471,14 +4820,12 @@ func (m *MockIAMAPI) ListSSHPublicKeysWithContext(arg0 context.Context, arg1 *ia
 
 // ListSSHPublicKeysWithContext indicates an expected call of ListSSHPublicKeysWithContext
 func (mr *MockIAMAPIMockRecorder) ListSSHPublicKeysWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSSHPublicKeysWithContext", reflect.TypeOf((*MockIAMAPI)(nil).ListSSHPublicKeysWithContext), varargs...)
 }
 
 // ListServerCertificates mocks base method
 func (m *MockIAMAPI) ListServerCertificates(arg0 *iam.ListServerCertificatesInput) (*iam.ListServerCertificatesOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListServerCertificates", arg0)
 	ret0, _ := ret[0].(*iam.ListServerCertificatesOutput)
 	ret1, _ := ret[1].(error)
@@ -5487,13 +4834,11 @@ func (m *MockIAMAPI) ListServerCertificates(arg0 *iam.ListServerCertificatesInpu
 
 // ListServerCertificates indicates an expected call of ListServerCertificates
 func (mr *MockIAMAPIMockRecorder) ListServerCertificates(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListServerCertificates", reflect.TypeOf((*MockIAMAPI)(nil).ListServerCertificates), arg0)
 }
 
 // ListServerCertificatesPages mocks base method
 func (m *MockIAMAPI) ListServerCertificatesPages(arg0 *iam.ListServerCertificatesInput, arg1 func(*iam.ListServerCertificatesOutput, bool) bool) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListServerCertificatesPages", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -5501,13 +4846,11 @@ func (m *MockIAMAPI) ListServerCertificatesPages(arg0 *iam.ListServerCertificate
 
 // ListServerCertificatesPages indicates an expected call of ListServerCertificatesPages
 func (mr *MockIAMAPIMockRecorder) ListServerCertificatesPages(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListServerCertificatesPages", reflect.TypeOf((*MockIAMAPI)(nil).ListServerCertificatesPages), arg0, arg1)
 }
 
 // ListServerCertificatesPagesWithContext mocks base method
 func (m *MockIAMAPI) ListServerCertificatesPagesWithContext(arg0 context.Context, arg1 *iam.ListServerCertificatesInput, arg2 func(*iam.ListServerCertificatesOutput, bool) bool, arg3 ...request.Option) error {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1, arg2}
 	for _, a := range arg3 {
 		varargs = append(varargs, a)
@@ -5519,14 +4862,12 @@ func (m *MockIAMAPI) ListServerCertificatesPagesWithContext(arg0 context.Context
 
 // ListServerCertificatesPagesWithContext indicates an expected call of ListServerCertificatesPagesWithContext
 func (mr *MockIAMAPIMockRecorder) ListServerCertificatesPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListServerCertificatesPagesWithContext", reflect.TypeOf((*MockIAMAPI)(nil).ListServerCertificatesPagesWithContext), varargs...)
 }
 
 // ListServerCertificatesRequest mocks base method
 func (m *MockIAMAPI) ListServerCertificatesRequest(arg0 *iam.ListServerCertificatesInput) (*request.Request, *iam.ListServerCertificatesOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListServerCertificatesRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*iam.ListServerCertificatesOutput)
@@ -5535,13 +4876,11 @@ func (m *MockIAMAPI) ListServerCertificatesRequest(arg0 *iam.ListServerCertifica
 
 // ListServerCertificatesRequest indicates an expected call of ListServerCertificatesRequest
 func (mr *MockIAMAPIMockRecorder) ListServerCertificatesRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListServerCertificatesRequest", reflect.TypeOf((*MockIAMAPI)(nil).ListServerCertificatesRequest), arg0)
 }
 
 // ListServerCertificatesWithContext mocks base method
 func (m *MockIAMAPI) ListServerCertificatesWithContext(arg0 context.Context, arg1 *iam.ListServerCertificatesInput, arg2 ...request.Option) (*iam.ListServerCertificatesOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -5554,14 +4893,12 @@ func (m *MockIAMAPI) ListServerCertificatesWithContext(arg0 context.Context, arg
 
 // ListServerCertificatesWithContext indicates an expected call of ListServerCertificatesWithContext
 func (mr *MockIAMAPIMockRecorder) ListServerCertificatesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListServerCertificatesWithContext", reflect.TypeOf((*MockIAMAPI)(nil).ListServerCertificatesWithContext), varargs...)
 }
 
 // ListServiceSpecificCredentials mocks base method
 func (m *MockIAMAPI) ListServiceSpecificCredentials(arg0 *iam.ListServiceSpecificCredentialsInput) (*iam.ListServiceSpecificCredentialsOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListServiceSpecificCredentials", arg0)
 	ret0, _ := ret[0].(*iam.ListServiceSpecificCredentialsOutput)
 	ret1, _ := ret[1].(error)
@@ -5570,13 +4907,11 @@ func (m *MockIAMAPI) ListServiceSpecificCredentials(arg0 *iam.ListServiceSpecifi
 
 // ListServiceSpecificCredentials indicates an expected call of ListServiceSpecificCredentials
 func (mr *MockIAMAPIMockRecorder) ListServiceSpecificCredentials(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListServiceSpecificCredentials", reflect.TypeOf((*MockIAMAPI)(nil).ListServiceSpecificCredentials), arg0)
 }
 
 // ListServiceSpecificCredentialsRequest mocks base method
 func (m *MockIAMAPI) ListServiceSpecificCredentialsRequest(arg0 *iam.ListServiceSpecificCredentialsInput) (*request.Request, *iam.ListServiceSpecificCredentialsOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListServiceSpecificCredentialsRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*iam.ListServiceSpecificCredentialsOutput)
@@ -5585,13 +4920,11 @@ func (m *MockIAMAPI) ListServiceSpecificCredentialsRequest(arg0 *iam.ListService
 
 // ListServiceSpecificCredentialsRequest indicates an expected call of ListServiceSpecificCredentialsRequest
 func (mr *MockIAMAPIMockRecorder) ListServiceSpecificCredentialsRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListServiceSpecificCredentialsRequest", reflect.TypeOf((*MockIAMAPI)(nil).ListServiceSpecificCredentialsRequest), arg0)
 }
 
 // ListServiceSpecificCredentialsWithContext mocks base method
 func (m *MockIAMAPI) ListServiceSpecificCredentialsWithContext(arg0 context.Context, arg1 *iam.ListServiceSpecificCredentialsInput, arg2 ...request.Option) (*iam.ListServiceSpecificCredentialsOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -5604,14 +4937,12 @@ func (m *MockIAMAPI) ListServiceSpecificCredentialsWithContext(arg0 context.Cont
 
 // ListServiceSpecificCredentialsWithContext indicates an expected call of ListServiceSpecificCredentialsWithContext
 func (mr *MockIAMAPIMockRecorder) ListServiceSpecificCredentialsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListServiceSpecificCredentialsWithContext", reflect.TypeOf((*MockIAMAPI)(nil).ListServiceSpecificCredentialsWithContext), varargs...)
 }
 
 // ListSigningCertificates mocks base method
 func (m *MockIAMAPI) ListSigningCertificates(arg0 *iam.ListSigningCertificatesInput) (*iam.ListSigningCertificatesOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListSigningCertificates", arg0)
 	ret0, _ := ret[0].(*iam.ListSigningCertificatesOutput)
 	ret1, _ := ret[1].(error)
@@ -5620,13 +4951,11 @@ func (m *MockIAMAPI) ListSigningCertificates(arg0 *iam.ListSigningCertificatesIn
 
 // ListSigningCertificates indicates an expected call of ListSigningCertificates
 func (mr *MockIAMAPIMockRecorder) ListSigningCertificates(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSigningCertificates", reflect.TypeOf((*MockIAMAPI)(nil).ListSigningCertificates), arg0)
 }
 
 // ListSigningCertificatesPages mocks base method
 func (m *MockIAMAPI) ListSigningCertificatesPages(arg0 *iam.ListSigningCertificatesInput, arg1 func(*iam.ListSigningCertificatesOutput, bool) bool) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListSigningCertificatesPages", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -5634,13 +4963,11 @@ func (m *MockIAMAPI) ListSigningCertificatesPages(arg0 *iam.ListSigningCertifica
 
 // ListSigningCertificatesPages indicates an expected call of ListSigningCertificatesPages
 func (mr *MockIAMAPIMockRecorder) ListSigningCertificatesPages(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSigningCertificatesPages", reflect.TypeOf((*MockIAMAPI)(nil).ListSigningCertificatesPages), arg0, arg1)
 }
 
 // ListSigningCertificatesPagesWithContext mocks base method
 func (m *MockIAMAPI) ListSigningCertificatesPagesWithContext(arg0 context.Context, arg1 *iam.ListSigningCertificatesInput, arg2 func(*iam.ListSigningCertificatesOutput, bool) bool, arg3 ...request.Option) error {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1, arg2}
 	for _, a := range arg3 {
 		varargs = append(varargs, a)
@@ -5652,14 +4979,12 @@ func (m *MockIAMAPI) ListSigningCertificatesPagesWithContext(arg0 context.Contex
 
 // ListSigningCertificatesPagesWithContext indicates an expected call of ListSigningCertificatesPagesWithContext
 func (mr *MockIAMAPIMockRecorder) ListSigningCertificatesPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSigningCertificatesPagesWithContext", reflect.TypeOf((*MockIAMAPI)(nil).ListSigningCertificatesPagesWithContext), varargs...)
 }
 
 // ListSigningCertificatesRequest mocks base method
 func (m *MockIAMAPI) ListSigningCertificatesRequest(arg0 *iam.ListSigningCertificatesInput) (*request.Request, *iam.ListSigningCertificatesOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListSigningCertificatesRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*iam.ListSigningCertificatesOutput)
@@ -5668,13 +4993,11 @@ func (m *MockIAMAPI) ListSigningCertificatesRequest(arg0 *iam.ListSigningCertifi
 
 // ListSigningCertificatesRequest indicates an expected call of ListSigningCertificatesRequest
 func (mr *MockIAMAPIMockRecorder) ListSigningCertificatesRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSigningCertificatesRequest", reflect.TypeOf((*MockIAMAPI)(nil).ListSigningCertificatesRequest), arg0)
 }
 
 // ListSigningCertificatesWithContext mocks base method
 func (m *MockIAMAPI) ListSigningCertificatesWithContext(arg0 context.Context, arg1 *iam.ListSigningCertificatesInput, arg2 ...request.Option) (*iam.ListSigningCertificatesOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -5687,14 +5010,12 @@ func (m *MockIAMAPI) ListSigningCertificatesWithContext(arg0 context.Context, ar
 
 // ListSigningCertificatesWithContext indicates an expected call of ListSigningCertificatesWithContext
 func (mr *MockIAMAPIMockRecorder) ListSigningCertificatesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSigningCertificatesWithContext", reflect.TypeOf((*MockIAMAPI)(nil).ListSigningCertificatesWithContext), varargs...)
 }
 
 // ListUserPolicies mocks base method
 func (m *MockIAMAPI) ListUserPolicies(arg0 *iam.ListUserPoliciesInput) (*iam.ListUserPoliciesOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListUserPolicies", arg0)
 	ret0, _ := ret[0].(*iam.ListUserPoliciesOutput)
 	ret1, _ := ret[1].(error)
@@ -5703,13 +5024,11 @@ func (m *MockIAMAPI) ListUserPolicies(arg0 *iam.ListUserPoliciesInput) (*iam.Lis
 
 // ListUserPolicies indicates an expected call of ListUserPolicies
 func (mr *MockIAMAPIMockRecorder) ListUserPolicies(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListUserPolicies", reflect.TypeOf((*MockIAMAPI)(nil).ListUserPolicies), arg0)
 }
 
 // ListUserPoliciesPages mocks base method
 func (m *MockIAMAPI) ListUserPoliciesPages(arg0 *iam.ListUserPoliciesInput, arg1 func(*iam.ListUserPoliciesOutput, bool) bool) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListUserPoliciesPages", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -5717,13 +5036,11 @@ func (m *MockIAMAPI) ListUserPoliciesPages(arg0 *iam.ListUserPoliciesInput, arg1
 
 // ListUserPoliciesPages indicates an expected call of ListUserPoliciesPages
 func (mr *MockIAMAPIMockRecorder) ListUserPoliciesPages(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListUserPoliciesPages", reflect.TypeOf((*MockIAMAPI)(nil).ListUserPoliciesPages), arg0, arg1)
 }
 
 // ListUserPoliciesPagesWithContext mocks base method
 func (m *MockIAMAPI) ListUserPoliciesPagesWithContext(arg0 context.Context, arg1 *iam.ListUserPoliciesInput, arg2 func(*iam.ListUserPoliciesOutput, bool) bool, arg3 ...request.Option) error {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1, arg2}
 	for _, a := range arg3 {
 		varargs = append(varargs, a)
@@ -5735,14 +5052,12 @@ func (m *MockIAMAPI) ListUserPoliciesPagesWithContext(arg0 context.Context, arg1
 
 // ListUserPoliciesPagesWithContext indicates an expected call of ListUserPoliciesPagesWithContext
 func (mr *MockIAMAPIMockRecorder) ListUserPoliciesPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListUserPoliciesPagesWithContext", reflect.TypeOf((*MockIAMAPI)(nil).ListUserPoliciesPagesWithContext), varargs...)
 }
 
 // ListUserPoliciesRequest mocks base method
 func (m *MockIAMAPI) ListUserPoliciesRequest(arg0 *iam.ListUserPoliciesInput) (*request.Request, *iam.ListUserPoliciesOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListUserPoliciesRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*iam.ListUserPoliciesOutput)
@@ -5751,13 +5066,11 @@ func (m *MockIAMAPI) ListUserPoliciesRequest(arg0 *iam.ListUserPoliciesInput) (*
 
 // ListUserPoliciesRequest indicates an expected call of ListUserPoliciesRequest
 func (mr *MockIAMAPIMockRecorder) ListUserPoliciesRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListUserPoliciesRequest", reflect.TypeOf((*MockIAMAPI)(nil).ListUserPoliciesRequest), arg0)
 }
 
 // ListUserPoliciesWithContext mocks base method
 func (m *MockIAMAPI) ListUserPoliciesWithContext(arg0 context.Context, arg1 *iam.ListUserPoliciesInput, arg2 ...request.Option) (*iam.ListUserPoliciesOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -5770,14 +5083,12 @@ func (m *MockIAMAPI) ListUserPoliciesWithContext(arg0 context.Context, arg1 *iam
 
 // ListUserPoliciesWithContext indicates an expected call of ListUserPoliciesWithContext
 func (mr *MockIAMAPIMockRecorder) ListUserPoliciesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListUserPoliciesWithContext", reflect.TypeOf((*MockIAMAPI)(nil).ListUserPoliciesWithContext), varargs...)
 }
 
 // ListUserTags mocks base method
 func (m *MockIAMAPI) ListUserTags(arg0 *iam.ListUserTagsInput) (*iam.ListUserTagsOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListUserTags", arg0)
 	ret0, _ := ret[0].(*iam.ListUserTagsOutput)
 	ret1, _ := ret[1].(error)
@@ -5786,13 +5097,11 @@ func (m *MockIAMAPI) ListUserTags(arg0 *iam.ListUserTagsInput) (*iam.ListUserTag
 
 // ListUserTags indicates an expected call of ListUserTags
 func (mr *MockIAMAPIMockRecorder) ListUserTags(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListUserTags", reflect.TypeOf((*MockIAMAPI)(nil).ListUserTags), arg0)
 }
 
 // ListUserTagsRequest mocks base method
 func (m *MockIAMAPI) ListUserTagsRequest(arg0 *iam.ListUserTagsInput) (*request.Request, *iam.ListUserTagsOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListUserTagsRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*iam.ListUserTagsOutput)
@@ -5801,13 +5110,11 @@ func (m *MockIAMAPI) ListUserTagsRequest(arg0 *iam.ListUserTagsInput) (*request.
 
 // ListUserTagsRequest indicates an expected call of ListUserTagsRequest
 func (mr *MockIAMAPIMockRecorder) ListUserTagsRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListUserTagsRequest", reflect.TypeOf((*MockIAMAPI)(nil).ListUserTagsRequest), arg0)
 }
 
 // ListUserTagsWithContext mocks base method
 func (m *MockIAMAPI) ListUserTagsWithContext(arg0 context.Context, arg1 *iam.ListUserTagsInput, arg2 ...request.Option) (*iam.ListUserTagsOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -5820,14 +5127,12 @@ func (m *MockIAMAPI) ListUserTagsWithContext(arg0 context.Context, arg1 *iam.Lis
 
 // ListUserTagsWithContext indicates an expected call of ListUserTagsWithContext
 func (mr *MockIAMAPIMockRecorder) ListUserTagsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListUserTagsWithContext", reflect.TypeOf((*MockIAMAPI)(nil).ListUserTagsWithContext), varargs...)
 }
 
 // ListUsers mocks base method
 func (m *MockIAMAPI) ListUsers(arg0 *iam.ListUsersInput) (*iam.ListUsersOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListUsers", arg0)
 	ret0, _ := ret[0].(*iam.ListUsersOutput)
 	ret1, _ := ret[1].(error)
@@ -5836,13 +5141,11 @@ func (m *MockIAMAPI) ListUsers(arg0 *iam.ListUsersInput) (*iam.ListUsersOutput, 
 
 // ListUsers indicates an expected call of ListUsers
 func (mr *MockIAMAPIMockRecorder) ListUsers(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListUsers", reflect.TypeOf((*MockIAMAPI)(nil).ListUsers), arg0)
 }
 
 // ListUsersPages mocks base method
 func (m *MockIAMAPI) ListUsersPages(arg0 *iam.ListUsersInput, arg1 func(*iam.ListUsersOutput, bool) bool) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListUsersPages", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -5850,13 +5153,11 @@ func (m *MockIAMAPI) ListUsersPages(arg0 *iam.ListUsersInput, arg1 func(*iam.Lis
 
 // ListUsersPages indicates an expected call of ListUsersPages
 func (mr *MockIAMAPIMockRecorder) ListUsersPages(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListUsersPages", reflect.TypeOf((*MockIAMAPI)(nil).ListUsersPages), arg0, arg1)
 }
 
 // ListUsersPagesWithContext mocks base method
 func (m *MockIAMAPI) ListUsersPagesWithContext(arg0 context.Context, arg1 *iam.ListUsersInput, arg2 func(*iam.ListUsersOutput, bool) bool, arg3 ...request.Option) error {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1, arg2}
 	for _, a := range arg3 {
 		varargs = append(varargs, a)
@@ -5868,14 +5169,12 @@ func (m *MockIAMAPI) ListUsersPagesWithContext(arg0 context.Context, arg1 *iam.L
 
 // ListUsersPagesWithContext indicates an expected call of ListUsersPagesWithContext
 func (mr *MockIAMAPIMockRecorder) ListUsersPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListUsersPagesWithContext", reflect.TypeOf((*MockIAMAPI)(nil).ListUsersPagesWithContext), varargs...)
 }
 
 // ListUsersRequest mocks base method
 func (m *MockIAMAPI) ListUsersRequest(arg0 *iam.ListUsersInput) (*request.Request, *iam.ListUsersOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListUsersRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*iam.ListUsersOutput)
@@ -5884,13 +5183,11 @@ func (m *MockIAMAPI) ListUsersRequest(arg0 *iam.ListUsersInput) (*request.Reques
 
 // ListUsersRequest indicates an expected call of ListUsersRequest
 func (mr *MockIAMAPIMockRecorder) ListUsersRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListUsersRequest", reflect.TypeOf((*MockIAMAPI)(nil).ListUsersRequest), arg0)
 }
 
 // ListUsersWithContext mocks base method
 func (m *MockIAMAPI) ListUsersWithContext(arg0 context.Context, arg1 *iam.ListUsersInput, arg2 ...request.Option) (*iam.ListUsersOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -5903,14 +5200,12 @@ func (m *MockIAMAPI) ListUsersWithContext(arg0 context.Context, arg1 *iam.ListUs
 
 // ListUsersWithContext indicates an expected call of ListUsersWithContext
 func (mr *MockIAMAPIMockRecorder) ListUsersWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListUsersWithContext", reflect.TypeOf((*MockIAMAPI)(nil).ListUsersWithContext), varargs...)
 }
 
 // ListVirtualMFADevices mocks base method
 func (m *MockIAMAPI) ListVirtualMFADevices(arg0 *iam.ListVirtualMFADevicesInput) (*iam.ListVirtualMFADevicesOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListVirtualMFADevices", arg0)
 	ret0, _ := ret[0].(*iam.ListVirtualMFADevicesOutput)
 	ret1, _ := ret[1].(error)
@@ -5919,13 +5214,11 @@ func (m *MockIAMAPI) ListVirtualMFADevices(arg0 *iam.ListVirtualMFADevicesInput)
 
 // ListVirtualMFADevices indicates an expected call of ListVirtualMFADevices
 func (mr *MockIAMAPIMockRecorder) ListVirtualMFADevices(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListVirtualMFADevices", reflect.TypeOf((*MockIAMAPI)(nil).ListVirtualMFADevices), arg0)
 }
 
 // ListVirtualMFADevicesPages mocks base method
 func (m *MockIAMAPI) ListVirtualMFADevicesPages(arg0 *iam.ListVirtualMFADevicesInput, arg1 func(*iam.ListVirtualMFADevicesOutput, bool) bool) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListVirtualMFADevicesPages", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -5933,13 +5226,11 @@ func (m *MockIAMAPI) ListVirtualMFADevicesPages(arg0 *iam.ListVirtualMFADevicesI
 
 // ListVirtualMFADevicesPages indicates an expected call of ListVirtualMFADevicesPages
 func (mr *MockIAMAPIMockRecorder) ListVirtualMFADevicesPages(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListVirtualMFADevicesPages", reflect.TypeOf((*MockIAMAPI)(nil).ListVirtualMFADevicesPages), arg0, arg1)
 }
 
 // ListVirtualMFADevicesPagesWithContext mocks base method
 func (m *MockIAMAPI) ListVirtualMFADevicesPagesWithContext(arg0 context.Context, arg1 *iam.ListVirtualMFADevicesInput, arg2 func(*iam.ListVirtualMFADevicesOutput, bool) bool, arg3 ...request.Option) error {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1, arg2}
 	for _, a := range arg3 {
 		varargs = append(varargs, a)
@@ -5951,14 +5242,12 @@ func (m *MockIAMAPI) ListVirtualMFADevicesPagesWithContext(arg0 context.Context,
 
 // ListVirtualMFADevicesPagesWithContext indicates an expected call of ListVirtualMFADevicesPagesWithContext
 func (mr *MockIAMAPIMockRecorder) ListVirtualMFADevicesPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListVirtualMFADevicesPagesWithContext", reflect.TypeOf((*MockIAMAPI)(nil).ListVirtualMFADevicesPagesWithContext), varargs...)
 }
 
 // ListVirtualMFADevicesRequest mocks base method
 func (m *MockIAMAPI) ListVirtualMFADevicesRequest(arg0 *iam.ListVirtualMFADevicesInput) (*request.Request, *iam.ListVirtualMFADevicesOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListVirtualMFADevicesRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*iam.ListVirtualMFADevicesOutput)
@@ -5967,13 +5256,11 @@ func (m *MockIAMAPI) ListVirtualMFADevicesRequest(arg0 *iam.ListVirtualMFADevice
 
 // ListVirtualMFADevicesRequest indicates an expected call of ListVirtualMFADevicesRequest
 func (mr *MockIAMAPIMockRecorder) ListVirtualMFADevicesRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListVirtualMFADevicesRequest", reflect.TypeOf((*MockIAMAPI)(nil).ListVirtualMFADevicesRequest), arg0)
 }
 
 // ListVirtualMFADevicesWithContext mocks base method
 func (m *MockIAMAPI) ListVirtualMFADevicesWithContext(arg0 context.Context, arg1 *iam.ListVirtualMFADevicesInput, arg2 ...request.Option) (*iam.ListVirtualMFADevicesOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -5986,14 +5273,12 @@ func (m *MockIAMAPI) ListVirtualMFADevicesWithContext(arg0 context.Context, arg1
 
 // ListVirtualMFADevicesWithContext indicates an expected call of ListVirtualMFADevicesWithContext
 func (mr *MockIAMAPIMockRecorder) ListVirtualMFADevicesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListVirtualMFADevicesWithContext", reflect.TypeOf((*MockIAMAPI)(nil).ListVirtualMFADevicesWithContext), varargs...)
 }
 
 // PutGroupPolicy mocks base method
 func (m *MockIAMAPI) PutGroupPolicy(arg0 *iam.PutGroupPolicyInput) (*iam.PutGroupPolicyOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PutGroupPolicy", arg0)
 	ret0, _ := ret[0].(*iam.PutGroupPolicyOutput)
 	ret1, _ := ret[1].(error)
@@ -6002,13 +5287,11 @@ func (m *MockIAMAPI) PutGroupPolicy(arg0 *iam.PutGroupPolicyInput) (*iam.PutGrou
 
 // PutGroupPolicy indicates an expected call of PutGroupPolicy
 func (mr *MockIAMAPIMockRecorder) PutGroupPolicy(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutGroupPolicy", reflect.TypeOf((*MockIAMAPI)(nil).PutGroupPolicy), arg0)
 }
 
 // PutGroupPolicyRequest mocks base method
 func (m *MockIAMAPI) PutGroupPolicyRequest(arg0 *iam.PutGroupPolicyInput) (*request.Request, *iam.PutGroupPolicyOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PutGroupPolicyRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*iam.PutGroupPolicyOutput)
@@ -6017,13 +5300,11 @@ func (m *MockIAMAPI) PutGroupPolicyRequest(arg0 *iam.PutGroupPolicyInput) (*requ
 
 // PutGroupPolicyRequest indicates an expected call of PutGroupPolicyRequest
 func (mr *MockIAMAPIMockRecorder) PutGroupPolicyRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutGroupPolicyRequest", reflect.TypeOf((*MockIAMAPI)(nil).PutGroupPolicyRequest), arg0)
 }
 
 // PutGroupPolicyWithContext mocks base method
 func (m *MockIAMAPI) PutGroupPolicyWithContext(arg0 context.Context, arg1 *iam.PutGroupPolicyInput, arg2 ...request.Option) (*iam.PutGroupPolicyOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -6036,14 +5317,12 @@ func (m *MockIAMAPI) PutGroupPolicyWithContext(arg0 context.Context, arg1 *iam.P
 
 // PutGroupPolicyWithContext indicates an expected call of PutGroupPolicyWithContext
 func (mr *MockIAMAPIMockRecorder) PutGroupPolicyWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutGroupPolicyWithContext", reflect.TypeOf((*MockIAMAPI)(nil).PutGroupPolicyWithContext), varargs...)
 }
 
 // PutRolePermissionsBoundary mocks base method
 func (m *MockIAMAPI) PutRolePermissionsBoundary(arg0 *iam.PutRolePermissionsBoundaryInput) (*iam.PutRolePermissionsBoundaryOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PutRolePermissionsBoundary", arg0)
 	ret0, _ := ret[0].(*iam.PutRolePermissionsBoundaryOutput)
 	ret1, _ := ret[1].(error)
@@ -6052,13 +5331,11 @@ func (m *MockIAMAPI) PutRolePermissionsBoundary(arg0 *iam.PutRolePermissionsBoun
 
 // PutRolePermissionsBoundary indicates an expected call of PutRolePermissionsBoundary
 func (mr *MockIAMAPIMockRecorder) PutRolePermissionsBoundary(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutRolePermissionsBoundary", reflect.TypeOf((*MockIAMAPI)(nil).PutRolePermissionsBoundary), arg0)
 }
 
 // PutRolePermissionsBoundaryRequest mocks base method
 func (m *MockIAMAPI) PutRolePermissionsBoundaryRequest(arg0 *iam.PutRolePermissionsBoundaryInput) (*request.Request, *iam.PutRolePermissionsBoundaryOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PutRolePermissionsBoundaryRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*iam.PutRolePermissionsBoundaryOutput)
@@ -6067,13 +5344,11 @@ func (m *MockIAMAPI) PutRolePermissionsBoundaryRequest(arg0 *iam.PutRolePermissi
 
 // PutRolePermissionsBoundaryRequest indicates an expected call of PutRolePermissionsBoundaryRequest
 func (mr *MockIAMAPIMockRecorder) PutRolePermissionsBoundaryRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutRolePermissionsBoundaryRequest", reflect.TypeOf((*MockIAMAPI)(nil).PutRolePermissionsBoundaryRequest), arg0)
 }
 
 // PutRolePermissionsBoundaryWithContext mocks base method
 func (m *MockIAMAPI) PutRolePermissionsBoundaryWithContext(arg0 context.Context, arg1 *iam.PutRolePermissionsBoundaryInput, arg2 ...request.Option) (*iam.PutRolePermissionsBoundaryOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -6086,14 +5361,12 @@ func (m *MockIAMAPI) PutRolePermissionsBoundaryWithContext(arg0 context.Context,
 
 // PutRolePermissionsBoundaryWithContext indicates an expected call of PutRolePermissionsBoundaryWithContext
 func (mr *MockIAMAPIMockRecorder) PutRolePermissionsBoundaryWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutRolePermissionsBoundaryWithContext", reflect.TypeOf((*MockIAMAPI)(nil).PutRolePermissionsBoundaryWithContext), varargs...)
 }
 
 // PutRolePolicy mocks base method
 func (m *MockIAMAPI) PutRolePolicy(arg0 *iam.PutRolePolicyInput) (*iam.PutRolePolicyOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PutRolePolicy", arg0)
 	ret0, _ := ret[0].(*iam.PutRolePolicyOutput)
 	ret1, _ := ret[1].(error)
@@ -6102,13 +5375,11 @@ func (m *MockIAMAPI) PutRolePolicy(arg0 *iam.PutRolePolicyInput) (*iam.PutRolePo
 
 // PutRolePolicy indicates an expected call of PutRolePolicy
 func (mr *MockIAMAPIMockRecorder) PutRolePolicy(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutRolePolicy", reflect.TypeOf((*MockIAMAPI)(nil).PutRolePolicy), arg0)
 }
 
 // PutRolePolicyRequest mocks base method
 func (m *MockIAMAPI) PutRolePolicyRequest(arg0 *iam.PutRolePolicyInput) (*request.Request, *iam.PutRolePolicyOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PutRolePolicyRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*iam.PutRolePolicyOutput)
@@ -6117,13 +5388,11 @@ func (m *MockIAMAPI) PutRolePolicyRequest(arg0 *iam.PutRolePolicyInput) (*reques
 
 // PutRolePolicyRequest indicates an expected call of PutRolePolicyRequest
 func (mr *MockIAMAPIMockRecorder) PutRolePolicyRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutRolePolicyRequest", reflect.TypeOf((*MockIAMAPI)(nil).PutRolePolicyRequest), arg0)
 }
 
 // PutRolePolicyWithContext mocks base method
 func (m *MockIAMAPI) PutRolePolicyWithContext(arg0 context.Context, arg1 *iam.PutRolePolicyInput, arg2 ...request.Option) (*iam.PutRolePolicyOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -6136,14 +5405,12 @@ func (m *MockIAMAPI) PutRolePolicyWithContext(arg0 context.Context, arg1 *iam.Pu
 
 // PutRolePolicyWithContext indicates an expected call of PutRolePolicyWithContext
 func (mr *MockIAMAPIMockRecorder) PutRolePolicyWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutRolePolicyWithContext", reflect.TypeOf((*MockIAMAPI)(nil).PutRolePolicyWithContext), varargs...)
 }
 
 // PutUserPermissionsBoundary mocks base method
 func (m *MockIAMAPI) PutUserPermissionsBoundary(arg0 *iam.PutUserPermissionsBoundaryInput) (*iam.PutUserPermissionsBoundaryOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PutUserPermissionsBoundary", arg0)
 	ret0, _ := ret[0].(*iam.PutUserPermissionsBoundaryOutput)
 	ret1, _ := ret[1].(error)
@@ -6152,13 +5419,11 @@ func (m *MockIAMAPI) PutUserPermissionsBoundary(arg0 *iam.PutUserPermissionsBoun
 
 // PutUserPermissionsBoundary indicates an expected call of PutUserPermissionsBoundary
 func (mr *MockIAMAPIMockRecorder) PutUserPermissionsBoundary(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutUserPermissionsBoundary", reflect.TypeOf((*MockIAMAPI)(nil).PutUserPermissionsBoundary), arg0)
 }
 
 // PutUserPermissionsBoundaryRequest mocks base method
 func (m *MockIAMAPI) PutUserPermissionsBoundaryRequest(arg0 *iam.PutUserPermissionsBoundaryInput) (*request.Request, *iam.PutUserPermissionsBoundaryOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PutUserPermissionsBoundaryRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*iam.PutUserPermissionsBoundaryOutput)
@@ -6167,13 +5432,11 @@ func (m *MockIAMAPI) PutUserPermissionsBoundaryRequest(arg0 *iam.PutUserPermissi
 
 // PutUserPermissionsBoundaryRequest indicates an expected call of PutUserPermissionsBoundaryRequest
 func (mr *MockIAMAPIMockRecorder) PutUserPermissionsBoundaryRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutUserPermissionsBoundaryRequest", reflect.TypeOf((*MockIAMAPI)(nil).PutUserPermissionsBoundaryRequest), arg0)
 }
 
 // PutUserPermissionsBoundaryWithContext mocks base method
 func (m *MockIAMAPI) PutUserPermissionsBoundaryWithContext(arg0 context.Context, arg1 *iam.PutUserPermissionsBoundaryInput, arg2 ...request.Option) (*iam.PutUserPermissionsBoundaryOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -6186,14 +5449,12 @@ func (m *MockIAMAPI) PutUserPermissionsBoundaryWithContext(arg0 context.Context,
 
 // PutUserPermissionsBoundaryWithContext indicates an expected call of PutUserPermissionsBoundaryWithContext
 func (mr *MockIAMAPIMockRecorder) PutUserPermissionsBoundaryWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutUserPermissionsBoundaryWithContext", reflect.TypeOf((*MockIAMAPI)(nil).PutUserPermissionsBoundaryWithContext), varargs...)
 }
 
 // PutUserPolicy mocks base method
 func (m *MockIAMAPI) PutUserPolicy(arg0 *iam.PutUserPolicyInput) (*iam.PutUserPolicyOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PutUserPolicy", arg0)
 	ret0, _ := ret[0].(*iam.PutUserPolicyOutput)
 	ret1, _ := ret[1].(error)
@@ -6202,13 +5463,11 @@ func (m *MockIAMAPI) PutUserPolicy(arg0 *iam.PutUserPolicyInput) (*iam.PutUserPo
 
 // PutUserPolicy indicates an expected call of PutUserPolicy
 func (mr *MockIAMAPIMockRecorder) PutUserPolicy(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutUserPolicy", reflect.TypeOf((*MockIAMAPI)(nil).PutUserPolicy), arg0)
 }
 
 // PutUserPolicyRequest mocks base method
 func (m *MockIAMAPI) PutUserPolicyRequest(arg0 *iam.PutUserPolicyInput) (*request.Request, *iam.PutUserPolicyOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PutUserPolicyRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*iam.PutUserPolicyOutput)
@@ -6217,13 +5476,11 @@ func (m *MockIAMAPI) PutUserPolicyRequest(arg0 *iam.PutUserPolicyInput) (*reques
 
 // PutUserPolicyRequest indicates an expected call of PutUserPolicyRequest
 func (mr *MockIAMAPIMockRecorder) PutUserPolicyRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutUserPolicyRequest", reflect.TypeOf((*MockIAMAPI)(nil).PutUserPolicyRequest), arg0)
 }
 
 // PutUserPolicyWithContext mocks base method
 func (m *MockIAMAPI) PutUserPolicyWithContext(arg0 context.Context, arg1 *iam.PutUserPolicyInput, arg2 ...request.Option) (*iam.PutUserPolicyOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -6236,14 +5493,12 @@ func (m *MockIAMAPI) PutUserPolicyWithContext(arg0 context.Context, arg1 *iam.Pu
 
 // PutUserPolicyWithContext indicates an expected call of PutUserPolicyWithContext
 func (mr *MockIAMAPIMockRecorder) PutUserPolicyWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutUserPolicyWithContext", reflect.TypeOf((*MockIAMAPI)(nil).PutUserPolicyWithContext), varargs...)
 }
 
 // RemoveClientIDFromOpenIDConnectProvider mocks base method
 func (m *MockIAMAPI) RemoveClientIDFromOpenIDConnectProvider(arg0 *iam.RemoveClientIDFromOpenIDConnectProviderInput) (*iam.RemoveClientIDFromOpenIDConnectProviderOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RemoveClientIDFromOpenIDConnectProvider", arg0)
 	ret0, _ := ret[0].(*iam.RemoveClientIDFromOpenIDConnectProviderOutput)
 	ret1, _ := ret[1].(error)
@@ -6252,13 +5507,11 @@ func (m *MockIAMAPI) RemoveClientIDFromOpenIDConnectProvider(arg0 *iam.RemoveCli
 
 // RemoveClientIDFromOpenIDConnectProvider indicates an expected call of RemoveClientIDFromOpenIDConnectProvider
 func (mr *MockIAMAPIMockRecorder) RemoveClientIDFromOpenIDConnectProvider(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveClientIDFromOpenIDConnectProvider", reflect.TypeOf((*MockIAMAPI)(nil).RemoveClientIDFromOpenIDConnectProvider), arg0)
 }
 
 // RemoveClientIDFromOpenIDConnectProviderRequest mocks base method
 func (m *MockIAMAPI) RemoveClientIDFromOpenIDConnectProviderRequest(arg0 *iam.RemoveClientIDFromOpenIDConnectProviderInput) (*request.Request, *iam.RemoveClientIDFromOpenIDConnectProviderOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RemoveClientIDFromOpenIDConnectProviderRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*iam.RemoveClientIDFromOpenIDConnectProviderOutput)
@@ -6267,13 +5520,11 @@ func (m *MockIAMAPI) RemoveClientIDFromOpenIDConnectProviderRequest(arg0 *iam.Re
 
 // RemoveClientIDFromOpenIDConnectProviderRequest indicates an expected call of RemoveClientIDFromOpenIDConnectProviderRequest
 func (mr *MockIAMAPIMockRecorder) RemoveClientIDFromOpenIDConnectProviderRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveClientIDFromOpenIDConnectProviderRequest", reflect.TypeOf((*MockIAMAPI)(nil).RemoveClientIDFromOpenIDConnectProviderRequest), arg0)
 }
 
 // RemoveClientIDFromOpenIDConnectProviderWithContext mocks base method
 func (m *MockIAMAPI) RemoveClientIDFromOpenIDConnectProviderWithContext(arg0 context.Context, arg1 *iam.RemoveClientIDFromOpenIDConnectProviderInput, arg2 ...request.Option) (*iam.RemoveClientIDFromOpenIDConnectProviderOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -6286,14 +5537,12 @@ func (m *MockIAMAPI) RemoveClientIDFromOpenIDConnectProviderWithContext(arg0 con
 
 // RemoveClientIDFromOpenIDConnectProviderWithContext indicates an expected call of RemoveClientIDFromOpenIDConnectProviderWithContext
 func (mr *MockIAMAPIMockRecorder) RemoveClientIDFromOpenIDConnectProviderWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveClientIDFromOpenIDConnectProviderWithContext", reflect.TypeOf((*MockIAMAPI)(nil).RemoveClientIDFromOpenIDConnectProviderWithContext), varargs...)
 }
 
 // RemoveRoleFromInstanceProfile mocks base method
 func (m *MockIAMAPI) RemoveRoleFromInstanceProfile(arg0 *iam.RemoveRoleFromInstanceProfileInput) (*iam.RemoveRoleFromInstanceProfileOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RemoveRoleFromInstanceProfile", arg0)
 	ret0, _ := ret[0].(*iam.RemoveRoleFromInstanceProfileOutput)
 	ret1, _ := ret[1].(error)
@@ -6302,13 +5551,11 @@ func (m *MockIAMAPI) RemoveRoleFromInstanceProfile(arg0 *iam.RemoveRoleFromInsta
 
 // RemoveRoleFromInstanceProfile indicates an expected call of RemoveRoleFromInstanceProfile
 func (mr *MockIAMAPIMockRecorder) RemoveRoleFromInstanceProfile(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveRoleFromInstanceProfile", reflect.TypeOf((*MockIAMAPI)(nil).RemoveRoleFromInstanceProfile), arg0)
 }
 
 // RemoveRoleFromInstanceProfileRequest mocks base method
 func (m *MockIAMAPI) RemoveRoleFromInstanceProfileRequest(arg0 *iam.RemoveRoleFromInstanceProfileInput) (*request.Request, *iam.RemoveRoleFromInstanceProfileOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RemoveRoleFromInstanceProfileRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*iam.RemoveRoleFromInstanceProfileOutput)
@@ -6317,13 +5564,11 @@ func (m *MockIAMAPI) RemoveRoleFromInstanceProfileRequest(arg0 *iam.RemoveRoleFr
 
 // RemoveRoleFromInstanceProfileRequest indicates an expected call of RemoveRoleFromInstanceProfileRequest
 func (mr *MockIAMAPIMockRecorder) RemoveRoleFromInstanceProfileRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveRoleFromInstanceProfileRequest", reflect.TypeOf((*MockIAMAPI)(nil).RemoveRoleFromInstanceProfileRequest), arg0)
 }
 
 // RemoveRoleFromInstanceProfileWithContext mocks base method
 func (m *MockIAMAPI) RemoveRoleFromInstanceProfileWithContext(arg0 context.Context, arg1 *iam.RemoveRoleFromInstanceProfileInput, arg2 ...request.Option) (*iam.RemoveRoleFromInstanceProfileOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -6336,14 +5581,12 @@ func (m *MockIAMAPI) RemoveRoleFromInstanceProfileWithContext(arg0 context.Conte
 
 // RemoveRoleFromInstanceProfileWithContext indicates an expected call of RemoveRoleFromInstanceProfileWithContext
 func (mr *MockIAMAPIMockRecorder) RemoveRoleFromInstanceProfileWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveRoleFromInstanceProfileWithContext", reflect.TypeOf((*MockIAMAPI)(nil).RemoveRoleFromInstanceProfileWithContext), varargs...)
 }
 
 // RemoveUserFromGroup mocks base method
 func (m *MockIAMAPI) RemoveUserFromGroup(arg0 *iam.RemoveUserFromGroupInput) (*iam.RemoveUserFromGroupOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RemoveUserFromGroup", arg0)
 	ret0, _ := ret[0].(*iam.RemoveUserFromGroupOutput)
 	ret1, _ := ret[1].(error)
@@ -6352,13 +5595,11 @@ func (m *MockIAMAPI) RemoveUserFromGroup(arg0 *iam.RemoveUserFromGroupInput) (*i
 
 // RemoveUserFromGroup indicates an expected call of RemoveUserFromGroup
 func (mr *MockIAMAPIMockRecorder) RemoveUserFromGroup(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveUserFromGroup", reflect.TypeOf((*MockIAMAPI)(nil).RemoveUserFromGroup), arg0)
 }
 
 // RemoveUserFromGroupRequest mocks base method
 func (m *MockIAMAPI) RemoveUserFromGroupRequest(arg0 *iam.RemoveUserFromGroupInput) (*request.Request, *iam.RemoveUserFromGroupOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RemoveUserFromGroupRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*iam.RemoveUserFromGroupOutput)
@@ -6367,13 +5608,11 @@ func (m *MockIAMAPI) RemoveUserFromGroupRequest(arg0 *iam.RemoveUserFromGroupInp
 
 // RemoveUserFromGroupRequest indicates an expected call of RemoveUserFromGroupRequest
 func (mr *MockIAMAPIMockRecorder) RemoveUserFromGroupRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveUserFromGroupRequest", reflect.TypeOf((*MockIAMAPI)(nil).RemoveUserFromGroupRequest), arg0)
 }
 
 // RemoveUserFromGroupWithContext mocks base method
 func (m *MockIAMAPI) RemoveUserFromGroupWithContext(arg0 context.Context, arg1 *iam.RemoveUserFromGroupInput, arg2 ...request.Option) (*iam.RemoveUserFromGroupOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -6386,14 +5625,12 @@ func (m *MockIAMAPI) RemoveUserFromGroupWithContext(arg0 context.Context, arg1 *
 
 // RemoveUserFromGroupWithContext indicates an expected call of RemoveUserFromGroupWithContext
 func (mr *MockIAMAPIMockRecorder) RemoveUserFromGroupWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveUserFromGroupWithContext", reflect.TypeOf((*MockIAMAPI)(nil).RemoveUserFromGroupWithContext), varargs...)
 }
 
 // ResetServiceSpecificCredential mocks base method
 func (m *MockIAMAPI) ResetServiceSpecificCredential(arg0 *iam.ResetServiceSpecificCredentialInput) (*iam.ResetServiceSpecificCredentialOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ResetServiceSpecificCredential", arg0)
 	ret0, _ := ret[0].(*iam.ResetServiceSpecificCredentialOutput)
 	ret1, _ := ret[1].(error)
@@ -6402,13 +5639,11 @@ func (m *MockIAMAPI) ResetServiceSpecificCredential(arg0 *iam.ResetServiceSpecif
 
 // ResetServiceSpecificCredential indicates an expected call of ResetServiceSpecificCredential
 func (mr *MockIAMAPIMockRecorder) ResetServiceSpecificCredential(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResetServiceSpecificCredential", reflect.TypeOf((*MockIAMAPI)(nil).ResetServiceSpecificCredential), arg0)
 }
 
 // ResetServiceSpecificCredentialRequest mocks base method
 func (m *MockIAMAPI) ResetServiceSpecificCredentialRequest(arg0 *iam.ResetServiceSpecificCredentialInput) (*request.Request, *iam.ResetServiceSpecificCredentialOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ResetServiceSpecificCredentialRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*iam.ResetServiceSpecificCredentialOutput)
@@ -6417,13 +5652,11 @@ func (m *MockIAMAPI) ResetServiceSpecificCredentialRequest(arg0 *iam.ResetServic
 
 // ResetServiceSpecificCredentialRequest indicates an expected call of ResetServiceSpecificCredentialRequest
 func (mr *MockIAMAPIMockRecorder) ResetServiceSpecificCredentialRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResetServiceSpecificCredentialRequest", reflect.TypeOf((*MockIAMAPI)(nil).ResetServiceSpecificCredentialRequest), arg0)
 }
 
 // ResetServiceSpecificCredentialWithContext mocks base method
 func (m *MockIAMAPI) ResetServiceSpecificCredentialWithContext(arg0 context.Context, arg1 *iam.ResetServiceSpecificCredentialInput, arg2 ...request.Option) (*iam.ResetServiceSpecificCredentialOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -6436,14 +5669,12 @@ func (m *MockIAMAPI) ResetServiceSpecificCredentialWithContext(arg0 context.Cont
 
 // ResetServiceSpecificCredentialWithContext indicates an expected call of ResetServiceSpecificCredentialWithContext
 func (mr *MockIAMAPIMockRecorder) ResetServiceSpecificCredentialWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResetServiceSpecificCredentialWithContext", reflect.TypeOf((*MockIAMAPI)(nil).ResetServiceSpecificCredentialWithContext), varargs...)
 }
 
 // ResyncMFADevice mocks base method
 func (m *MockIAMAPI) ResyncMFADevice(arg0 *iam.ResyncMFADeviceInput) (*iam.ResyncMFADeviceOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ResyncMFADevice", arg0)
 	ret0, _ := ret[0].(*iam.ResyncMFADeviceOutput)
 	ret1, _ := ret[1].(error)
@@ -6452,13 +5683,11 @@ func (m *MockIAMAPI) ResyncMFADevice(arg0 *iam.ResyncMFADeviceInput) (*iam.Resyn
 
 // ResyncMFADevice indicates an expected call of ResyncMFADevice
 func (mr *MockIAMAPIMockRecorder) ResyncMFADevice(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResyncMFADevice", reflect.TypeOf((*MockIAMAPI)(nil).ResyncMFADevice), arg0)
 }
 
 // ResyncMFADeviceRequest mocks base method
 func (m *MockIAMAPI) ResyncMFADeviceRequest(arg0 *iam.ResyncMFADeviceInput) (*request.Request, *iam.ResyncMFADeviceOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ResyncMFADeviceRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*iam.ResyncMFADeviceOutput)
@@ -6467,13 +5696,11 @@ func (m *MockIAMAPI) ResyncMFADeviceRequest(arg0 *iam.ResyncMFADeviceInput) (*re
 
 // ResyncMFADeviceRequest indicates an expected call of ResyncMFADeviceRequest
 func (mr *MockIAMAPIMockRecorder) ResyncMFADeviceRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResyncMFADeviceRequest", reflect.TypeOf((*MockIAMAPI)(nil).ResyncMFADeviceRequest), arg0)
 }
 
 // ResyncMFADeviceWithContext mocks base method
 func (m *MockIAMAPI) ResyncMFADeviceWithContext(arg0 context.Context, arg1 *iam.ResyncMFADeviceInput, arg2 ...request.Option) (*iam.ResyncMFADeviceOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -6486,14 +5713,12 @@ func (m *MockIAMAPI) ResyncMFADeviceWithContext(arg0 context.Context, arg1 *iam.
 
 // ResyncMFADeviceWithContext indicates an expected call of ResyncMFADeviceWithContext
 func (mr *MockIAMAPIMockRecorder) ResyncMFADeviceWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResyncMFADeviceWithContext", reflect.TypeOf((*MockIAMAPI)(nil).ResyncMFADeviceWithContext), varargs...)
 }
 
 // SetDefaultPolicyVersion mocks base method
 func (m *MockIAMAPI) SetDefaultPolicyVersion(arg0 *iam.SetDefaultPolicyVersionInput) (*iam.SetDefaultPolicyVersionOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetDefaultPolicyVersion", arg0)
 	ret0, _ := ret[0].(*iam.SetDefaultPolicyVersionOutput)
 	ret1, _ := ret[1].(error)
@@ -6502,13 +5727,11 @@ func (m *MockIAMAPI) SetDefaultPolicyVersion(arg0 *iam.SetDefaultPolicyVersionIn
 
 // SetDefaultPolicyVersion indicates an expected call of SetDefaultPolicyVersion
 func (mr *MockIAMAPIMockRecorder) SetDefaultPolicyVersion(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetDefaultPolicyVersion", reflect.TypeOf((*MockIAMAPI)(nil).SetDefaultPolicyVersion), arg0)
 }
 
 // SetDefaultPolicyVersionRequest mocks base method
 func (m *MockIAMAPI) SetDefaultPolicyVersionRequest(arg0 *iam.SetDefaultPolicyVersionInput) (*request.Request, *iam.SetDefaultPolicyVersionOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetDefaultPolicyVersionRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*iam.SetDefaultPolicyVersionOutput)
@@ -6517,13 +5740,11 @@ func (m *MockIAMAPI) SetDefaultPolicyVersionRequest(arg0 *iam.SetDefaultPolicyVe
 
 // SetDefaultPolicyVersionRequest indicates an expected call of SetDefaultPolicyVersionRequest
 func (mr *MockIAMAPIMockRecorder) SetDefaultPolicyVersionRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetDefaultPolicyVersionRequest", reflect.TypeOf((*MockIAMAPI)(nil).SetDefaultPolicyVersionRequest), arg0)
 }
 
 // SetDefaultPolicyVersionWithContext mocks base method
 func (m *MockIAMAPI) SetDefaultPolicyVersionWithContext(arg0 context.Context, arg1 *iam.SetDefaultPolicyVersionInput, arg2 ...request.Option) (*iam.SetDefaultPolicyVersionOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -6536,14 +5757,12 @@ func (m *MockIAMAPI) SetDefaultPolicyVersionWithContext(arg0 context.Context, ar
 
 // SetDefaultPolicyVersionWithContext indicates an expected call of SetDefaultPolicyVersionWithContext
 func (mr *MockIAMAPIMockRecorder) SetDefaultPolicyVersionWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetDefaultPolicyVersionWithContext", reflect.TypeOf((*MockIAMAPI)(nil).SetDefaultPolicyVersionWithContext), varargs...)
 }
 
 // SimulateCustomPolicy mocks base method
 func (m *MockIAMAPI) SimulateCustomPolicy(arg0 *iam.SimulateCustomPolicyInput) (*iam.SimulatePolicyResponse, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SimulateCustomPolicy", arg0)
 	ret0, _ := ret[0].(*iam.SimulatePolicyResponse)
 	ret1, _ := ret[1].(error)
@@ -6552,13 +5771,11 @@ func (m *MockIAMAPI) SimulateCustomPolicy(arg0 *iam.SimulateCustomPolicyInput) (
 
 // SimulateCustomPolicy indicates an expected call of SimulateCustomPolicy
 func (mr *MockIAMAPIMockRecorder) SimulateCustomPolicy(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SimulateCustomPolicy", reflect.TypeOf((*MockIAMAPI)(nil).SimulateCustomPolicy), arg0)
 }
 
 // SimulateCustomPolicyPages mocks base method
 func (m *MockIAMAPI) SimulateCustomPolicyPages(arg0 *iam.SimulateCustomPolicyInput, arg1 func(*iam.SimulatePolicyResponse, bool) bool) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SimulateCustomPolicyPages", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -6566,13 +5783,11 @@ func (m *MockIAMAPI) SimulateCustomPolicyPages(arg0 *iam.SimulateCustomPolicyInp
 
 // SimulateCustomPolicyPages indicates an expected call of SimulateCustomPolicyPages
 func (mr *MockIAMAPIMockRecorder) SimulateCustomPolicyPages(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SimulateCustomPolicyPages", reflect.TypeOf((*MockIAMAPI)(nil).SimulateCustomPolicyPages), arg0, arg1)
 }
 
 // SimulateCustomPolicyPagesWithContext mocks base method
 func (m *MockIAMAPI) SimulateCustomPolicyPagesWithContext(arg0 context.Context, arg1 *iam.SimulateCustomPolicyInput, arg2 func(*iam.SimulatePolicyResponse, bool) bool, arg3 ...request.Option) error {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1, arg2}
 	for _, a := range arg3 {
 		varargs = append(varargs, a)
@@ -6584,14 +5799,12 @@ func (m *MockIAMAPI) SimulateCustomPolicyPagesWithContext(arg0 context.Context, 
 
 // SimulateCustomPolicyPagesWithContext indicates an expected call of SimulateCustomPolicyPagesWithContext
 func (mr *MockIAMAPIMockRecorder) SimulateCustomPolicyPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SimulateCustomPolicyPagesWithContext", reflect.TypeOf((*MockIAMAPI)(nil).SimulateCustomPolicyPagesWithContext), varargs...)
 }
 
 // SimulateCustomPolicyRequest mocks base method
 func (m *MockIAMAPI) SimulateCustomPolicyRequest(arg0 *iam.SimulateCustomPolicyInput) (*request.Request, *iam.SimulatePolicyResponse) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SimulateCustomPolicyRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*iam.SimulatePolicyResponse)
@@ -6600,13 +5813,11 @@ func (m *MockIAMAPI) SimulateCustomPolicyRequest(arg0 *iam.SimulateCustomPolicyI
 
 // SimulateCustomPolicyRequest indicates an expected call of SimulateCustomPolicyRequest
 func (mr *MockIAMAPIMockRecorder) SimulateCustomPolicyRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SimulateCustomPolicyRequest", reflect.TypeOf((*MockIAMAPI)(nil).SimulateCustomPolicyRequest), arg0)
 }
 
 // SimulateCustomPolicyWithContext mocks base method
 func (m *MockIAMAPI) SimulateCustomPolicyWithContext(arg0 context.Context, arg1 *iam.SimulateCustomPolicyInput, arg2 ...request.Option) (*iam.SimulatePolicyResponse, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -6619,14 +5830,12 @@ func (m *MockIAMAPI) SimulateCustomPolicyWithContext(arg0 context.Context, arg1 
 
 // SimulateCustomPolicyWithContext indicates an expected call of SimulateCustomPolicyWithContext
 func (mr *MockIAMAPIMockRecorder) SimulateCustomPolicyWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SimulateCustomPolicyWithContext", reflect.TypeOf((*MockIAMAPI)(nil).SimulateCustomPolicyWithContext), varargs...)
 }
 
 // SimulatePrincipalPolicy mocks base method
 func (m *MockIAMAPI) SimulatePrincipalPolicy(arg0 *iam.SimulatePrincipalPolicyInput) (*iam.SimulatePolicyResponse, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SimulatePrincipalPolicy", arg0)
 	ret0, _ := ret[0].(*iam.SimulatePolicyResponse)
 	ret1, _ := ret[1].(error)
@@ -6635,13 +5844,11 @@ func (m *MockIAMAPI) SimulatePrincipalPolicy(arg0 *iam.SimulatePrincipalPolicyIn
 
 // SimulatePrincipalPolicy indicates an expected call of SimulatePrincipalPolicy
 func (mr *MockIAMAPIMockRecorder) SimulatePrincipalPolicy(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SimulatePrincipalPolicy", reflect.TypeOf((*MockIAMAPI)(nil).SimulatePrincipalPolicy), arg0)
 }
 
 // SimulatePrincipalPolicyPages mocks base method
 func (m *MockIAMAPI) SimulatePrincipalPolicyPages(arg0 *iam.SimulatePrincipalPolicyInput, arg1 func(*iam.SimulatePolicyResponse, bool) bool) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SimulatePrincipalPolicyPages", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -6649,13 +5856,11 @@ func (m *MockIAMAPI) SimulatePrincipalPolicyPages(arg0 *iam.SimulatePrincipalPol
 
 // SimulatePrincipalPolicyPages indicates an expected call of SimulatePrincipalPolicyPages
 func (mr *MockIAMAPIMockRecorder) SimulatePrincipalPolicyPages(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SimulatePrincipalPolicyPages", reflect.TypeOf((*MockIAMAPI)(nil).SimulatePrincipalPolicyPages), arg0, arg1)
 }
 
 // SimulatePrincipalPolicyPagesWithContext mocks base method
 func (m *MockIAMAPI) SimulatePrincipalPolicyPagesWithContext(arg0 context.Context, arg1 *iam.SimulatePrincipalPolicyInput, arg2 func(*iam.SimulatePolicyResponse, bool) bool, arg3 ...request.Option) error {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1, arg2}
 	for _, a := range arg3 {
 		varargs = append(varargs, a)
@@ -6667,14 +5872,12 @@ func (m *MockIAMAPI) SimulatePrincipalPolicyPagesWithContext(arg0 context.Contex
 
 // SimulatePrincipalPolicyPagesWithContext indicates an expected call of SimulatePrincipalPolicyPagesWithContext
 func (mr *MockIAMAPIMockRecorder) SimulatePrincipalPolicyPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SimulatePrincipalPolicyPagesWithContext", reflect.TypeOf((*MockIAMAPI)(nil).SimulatePrincipalPolicyPagesWithContext), varargs...)
 }
 
 // SimulatePrincipalPolicyRequest mocks base method
 func (m *MockIAMAPI) SimulatePrincipalPolicyRequest(arg0 *iam.SimulatePrincipalPolicyInput) (*request.Request, *iam.SimulatePolicyResponse) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SimulatePrincipalPolicyRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*iam.SimulatePolicyResponse)
@@ -6683,13 +5886,11 @@ func (m *MockIAMAPI) SimulatePrincipalPolicyRequest(arg0 *iam.SimulatePrincipalP
 
 // SimulatePrincipalPolicyRequest indicates an expected call of SimulatePrincipalPolicyRequest
 func (mr *MockIAMAPIMockRecorder) SimulatePrincipalPolicyRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SimulatePrincipalPolicyRequest", reflect.TypeOf((*MockIAMAPI)(nil).SimulatePrincipalPolicyRequest), arg0)
 }
 
 // SimulatePrincipalPolicyWithContext mocks base method
 func (m *MockIAMAPI) SimulatePrincipalPolicyWithContext(arg0 context.Context, arg1 *iam.SimulatePrincipalPolicyInput, arg2 ...request.Option) (*iam.SimulatePolicyResponse, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -6702,14 +5903,12 @@ func (m *MockIAMAPI) SimulatePrincipalPolicyWithContext(arg0 context.Context, ar
 
 // SimulatePrincipalPolicyWithContext indicates an expected call of SimulatePrincipalPolicyWithContext
 func (mr *MockIAMAPIMockRecorder) SimulatePrincipalPolicyWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SimulatePrincipalPolicyWithContext", reflect.TypeOf((*MockIAMAPI)(nil).SimulatePrincipalPolicyWithContext), varargs...)
 }
 
 // TagRole mocks base method
 func (m *MockIAMAPI) TagRole(arg0 *iam.TagRoleInput) (*iam.TagRoleOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "TagRole", arg0)
 	ret0, _ := ret[0].(*iam.TagRoleOutput)
 	ret1, _ := ret[1].(error)
@@ -6718,13 +5917,11 @@ func (m *MockIAMAPI) TagRole(arg0 *iam.TagRoleInput) (*iam.TagRoleOutput, error)
 
 // TagRole indicates an expected call of TagRole
 func (mr *MockIAMAPIMockRecorder) TagRole(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TagRole", reflect.TypeOf((*MockIAMAPI)(nil).TagRole), arg0)
 }
 
 // TagRoleRequest mocks base method
 func (m *MockIAMAPI) TagRoleRequest(arg0 *iam.TagRoleInput) (*request.Request, *iam.TagRoleOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "TagRoleRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*iam.TagRoleOutput)
@@ -6733,13 +5930,11 @@ func (m *MockIAMAPI) TagRoleRequest(arg0 *iam.TagRoleInput) (*request.Request, *
 
 // TagRoleRequest indicates an expected call of TagRoleRequest
 func (mr *MockIAMAPIMockRecorder) TagRoleRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TagRoleRequest", reflect.TypeOf((*MockIAMAPI)(nil).TagRoleRequest), arg0)
 }
 
 // TagRoleWithContext mocks base method
 func (m *MockIAMAPI) TagRoleWithContext(arg0 context.Context, arg1 *iam.TagRoleInput, arg2 ...request.Option) (*iam.TagRoleOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -6752,14 +5947,12 @@ func (m *MockIAMAPI) TagRoleWithContext(arg0 context.Context, arg1 *iam.TagRoleI
 
 // TagRoleWithContext indicates an expected call of TagRoleWithContext
 func (mr *MockIAMAPIMockRecorder) TagRoleWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TagRoleWithContext", reflect.TypeOf((*MockIAMAPI)(nil).TagRoleWithContext), varargs...)
 }
 
 // TagUser mocks base method
 func (m *MockIAMAPI) TagUser(arg0 *iam.TagUserInput) (*iam.TagUserOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "TagUser", arg0)
 	ret0, _ := ret[0].(*iam.TagUserOutput)
 	ret1, _ := ret[1].(error)
@@ -6768,13 +5961,11 @@ func (m *MockIAMAPI) TagUser(arg0 *iam.TagUserInput) (*iam.TagUserOutput, error)
 
 // TagUser indicates an expected call of TagUser
 func (mr *MockIAMAPIMockRecorder) TagUser(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TagUser", reflect.TypeOf((*MockIAMAPI)(nil).TagUser), arg0)
 }
 
 // TagUserRequest mocks base method
 func (m *MockIAMAPI) TagUserRequest(arg0 *iam.TagUserInput) (*request.Request, *iam.TagUserOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "TagUserRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*iam.TagUserOutput)
@@ -6783,13 +5974,11 @@ func (m *MockIAMAPI) TagUserRequest(arg0 *iam.TagUserInput) (*request.Request, *
 
 // TagUserRequest indicates an expected call of TagUserRequest
 func (mr *MockIAMAPIMockRecorder) TagUserRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TagUserRequest", reflect.TypeOf((*MockIAMAPI)(nil).TagUserRequest), arg0)
 }
 
 // TagUserWithContext mocks base method
 func (m *MockIAMAPI) TagUserWithContext(arg0 context.Context, arg1 *iam.TagUserInput, arg2 ...request.Option) (*iam.TagUserOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -6802,14 +5991,12 @@ func (m *MockIAMAPI) TagUserWithContext(arg0 context.Context, arg1 *iam.TagUserI
 
 // TagUserWithContext indicates an expected call of TagUserWithContext
 func (mr *MockIAMAPIMockRecorder) TagUserWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TagUserWithContext", reflect.TypeOf((*MockIAMAPI)(nil).TagUserWithContext), varargs...)
 }
 
 // UntagRole mocks base method
 func (m *MockIAMAPI) UntagRole(arg0 *iam.UntagRoleInput) (*iam.UntagRoleOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UntagRole", arg0)
 	ret0, _ := ret[0].(*iam.UntagRoleOutput)
 	ret1, _ := ret[1].(error)
@@ -6818,13 +6005,11 @@ func (m *MockIAMAPI) UntagRole(arg0 *iam.UntagRoleInput) (*iam.UntagRoleOutput, 
 
 // UntagRole indicates an expected call of UntagRole
 func (mr *MockIAMAPIMockRecorder) UntagRole(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UntagRole", reflect.TypeOf((*MockIAMAPI)(nil).UntagRole), arg0)
 }
 
 // UntagRoleRequest mocks base method
 func (m *MockIAMAPI) UntagRoleRequest(arg0 *iam.UntagRoleInput) (*request.Request, *iam.UntagRoleOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UntagRoleRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*iam.UntagRoleOutput)
@@ -6833,13 +6018,11 @@ func (m *MockIAMAPI) UntagRoleRequest(arg0 *iam.UntagRoleInput) (*request.Reques
 
 // UntagRoleRequest indicates an expected call of UntagRoleRequest
 func (mr *MockIAMAPIMockRecorder) UntagRoleRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UntagRoleRequest", reflect.TypeOf((*MockIAMAPI)(nil).UntagRoleRequest), arg0)
 }
 
 // UntagRoleWithContext mocks base method
 func (m *MockIAMAPI) UntagRoleWithContext(arg0 context.Context, arg1 *iam.UntagRoleInput, arg2 ...request.Option) (*iam.UntagRoleOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -6852,14 +6035,12 @@ func (m *MockIAMAPI) UntagRoleWithContext(arg0 context.Context, arg1 *iam.UntagR
 
 // UntagRoleWithContext indicates an expected call of UntagRoleWithContext
 func (mr *MockIAMAPIMockRecorder) UntagRoleWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UntagRoleWithContext", reflect.TypeOf((*MockIAMAPI)(nil).UntagRoleWithContext), varargs...)
 }
 
 // UntagUser mocks base method
 func (m *MockIAMAPI) UntagUser(arg0 *iam.UntagUserInput) (*iam.UntagUserOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UntagUser", arg0)
 	ret0, _ := ret[0].(*iam.UntagUserOutput)
 	ret1, _ := ret[1].(error)
@@ -6868,13 +6049,11 @@ func (m *MockIAMAPI) UntagUser(arg0 *iam.UntagUserInput) (*iam.UntagUserOutput, 
 
 // UntagUser indicates an expected call of UntagUser
 func (mr *MockIAMAPIMockRecorder) UntagUser(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UntagUser", reflect.TypeOf((*MockIAMAPI)(nil).UntagUser), arg0)
 }
 
 // UntagUserRequest mocks base method
 func (m *MockIAMAPI) UntagUserRequest(arg0 *iam.UntagUserInput) (*request.Request, *iam.UntagUserOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UntagUserRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*iam.UntagUserOutput)
@@ -6883,13 +6062,11 @@ func (m *MockIAMAPI) UntagUserRequest(arg0 *iam.UntagUserInput) (*request.Reques
 
 // UntagUserRequest indicates an expected call of UntagUserRequest
 func (mr *MockIAMAPIMockRecorder) UntagUserRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UntagUserRequest", reflect.TypeOf((*MockIAMAPI)(nil).UntagUserRequest), arg0)
 }
 
 // UntagUserWithContext mocks base method
 func (m *MockIAMAPI) UntagUserWithContext(arg0 context.Context, arg1 *iam.UntagUserInput, arg2 ...request.Option) (*iam.UntagUserOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -6902,14 +6079,12 @@ func (m *MockIAMAPI) UntagUserWithContext(arg0 context.Context, arg1 *iam.UntagU
 
 // UntagUserWithContext indicates an expected call of UntagUserWithContext
 func (mr *MockIAMAPIMockRecorder) UntagUserWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UntagUserWithContext", reflect.TypeOf((*MockIAMAPI)(nil).UntagUserWithContext), varargs...)
 }
 
 // UpdateAccessKey mocks base method
 func (m *MockIAMAPI) UpdateAccessKey(arg0 *iam.UpdateAccessKeyInput) (*iam.UpdateAccessKeyOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateAccessKey", arg0)
 	ret0, _ := ret[0].(*iam.UpdateAccessKeyOutput)
 	ret1, _ := ret[1].(error)
@@ -6918,13 +6093,11 @@ func (m *MockIAMAPI) UpdateAccessKey(arg0 *iam.UpdateAccessKeyInput) (*iam.Updat
 
 // UpdateAccessKey indicates an expected call of UpdateAccessKey
 func (mr *MockIAMAPIMockRecorder) UpdateAccessKey(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateAccessKey", reflect.TypeOf((*MockIAMAPI)(nil).UpdateAccessKey), arg0)
 }
 
 // UpdateAccessKeyRequest mocks base method
 func (m *MockIAMAPI) UpdateAccessKeyRequest(arg0 *iam.UpdateAccessKeyInput) (*request.Request, *iam.UpdateAccessKeyOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateAccessKeyRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*iam.UpdateAccessKeyOutput)
@@ -6933,13 +6106,11 @@ func (m *MockIAMAPI) UpdateAccessKeyRequest(arg0 *iam.UpdateAccessKeyInput) (*re
 
 // UpdateAccessKeyRequest indicates an expected call of UpdateAccessKeyRequest
 func (mr *MockIAMAPIMockRecorder) UpdateAccessKeyRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateAccessKeyRequest", reflect.TypeOf((*MockIAMAPI)(nil).UpdateAccessKeyRequest), arg0)
 }
 
 // UpdateAccessKeyWithContext mocks base method
 func (m *MockIAMAPI) UpdateAccessKeyWithContext(arg0 context.Context, arg1 *iam.UpdateAccessKeyInput, arg2 ...request.Option) (*iam.UpdateAccessKeyOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -6952,14 +6123,12 @@ func (m *MockIAMAPI) UpdateAccessKeyWithContext(arg0 context.Context, arg1 *iam.
 
 // UpdateAccessKeyWithContext indicates an expected call of UpdateAccessKeyWithContext
 func (mr *MockIAMAPIMockRecorder) UpdateAccessKeyWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateAccessKeyWithContext", reflect.TypeOf((*MockIAMAPI)(nil).UpdateAccessKeyWithContext), varargs...)
 }
 
 // UpdateAccountPasswordPolicy mocks base method
 func (m *MockIAMAPI) UpdateAccountPasswordPolicy(arg0 *iam.UpdateAccountPasswordPolicyInput) (*iam.UpdateAccountPasswordPolicyOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateAccountPasswordPolicy", arg0)
 	ret0, _ := ret[0].(*iam.UpdateAccountPasswordPolicyOutput)
 	ret1, _ := ret[1].(error)
@@ -6968,13 +6137,11 @@ func (m *MockIAMAPI) UpdateAccountPasswordPolicy(arg0 *iam.UpdateAccountPassword
 
 // UpdateAccountPasswordPolicy indicates an expected call of UpdateAccountPasswordPolicy
 func (mr *MockIAMAPIMockRecorder) UpdateAccountPasswordPolicy(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateAccountPasswordPolicy", reflect.TypeOf((*MockIAMAPI)(nil).UpdateAccountPasswordPolicy), arg0)
 }
 
 // UpdateAccountPasswordPolicyRequest mocks base method
 func (m *MockIAMAPI) UpdateAccountPasswordPolicyRequest(arg0 *iam.UpdateAccountPasswordPolicyInput) (*request.Request, *iam.UpdateAccountPasswordPolicyOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateAccountPasswordPolicyRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*iam.UpdateAccountPasswordPolicyOutput)
@@ -6983,13 +6150,11 @@ func (m *MockIAMAPI) UpdateAccountPasswordPolicyRequest(arg0 *iam.UpdateAccountP
 
 // UpdateAccountPasswordPolicyRequest indicates an expected call of UpdateAccountPasswordPolicyRequest
 func (mr *MockIAMAPIMockRecorder) UpdateAccountPasswordPolicyRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateAccountPasswordPolicyRequest", reflect.TypeOf((*MockIAMAPI)(nil).UpdateAccountPasswordPolicyRequest), arg0)
 }
 
 // UpdateAccountPasswordPolicyWithContext mocks base method
 func (m *MockIAMAPI) UpdateAccountPasswordPolicyWithContext(arg0 context.Context, arg1 *iam.UpdateAccountPasswordPolicyInput, arg2 ...request.Option) (*iam.UpdateAccountPasswordPolicyOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -7002,14 +6167,12 @@ func (m *MockIAMAPI) UpdateAccountPasswordPolicyWithContext(arg0 context.Context
 
 // UpdateAccountPasswordPolicyWithContext indicates an expected call of UpdateAccountPasswordPolicyWithContext
 func (mr *MockIAMAPIMockRecorder) UpdateAccountPasswordPolicyWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateAccountPasswordPolicyWithContext", reflect.TypeOf((*MockIAMAPI)(nil).UpdateAccountPasswordPolicyWithContext), varargs...)
 }
 
 // UpdateAssumeRolePolicy mocks base method
 func (m *MockIAMAPI) UpdateAssumeRolePolicy(arg0 *iam.UpdateAssumeRolePolicyInput) (*iam.UpdateAssumeRolePolicyOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateAssumeRolePolicy", arg0)
 	ret0, _ := ret[0].(*iam.UpdateAssumeRolePolicyOutput)
 	ret1, _ := ret[1].(error)
@@ -7018,13 +6181,11 @@ func (m *MockIAMAPI) UpdateAssumeRolePolicy(arg0 *iam.UpdateAssumeRolePolicyInpu
 
 // UpdateAssumeRolePolicy indicates an expected call of UpdateAssumeRolePolicy
 func (mr *MockIAMAPIMockRecorder) UpdateAssumeRolePolicy(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateAssumeRolePolicy", reflect.TypeOf((*MockIAMAPI)(nil).UpdateAssumeRolePolicy), arg0)
 }
 
 // UpdateAssumeRolePolicyRequest mocks base method
 func (m *MockIAMAPI) UpdateAssumeRolePolicyRequest(arg0 *iam.UpdateAssumeRolePolicyInput) (*request.Request, *iam.UpdateAssumeRolePolicyOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateAssumeRolePolicyRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*iam.UpdateAssumeRolePolicyOutput)
@@ -7033,13 +6194,11 @@ func (m *MockIAMAPI) UpdateAssumeRolePolicyRequest(arg0 *iam.UpdateAssumeRolePol
 
 // UpdateAssumeRolePolicyRequest indicates an expected call of UpdateAssumeRolePolicyRequest
 func (mr *MockIAMAPIMockRecorder) UpdateAssumeRolePolicyRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateAssumeRolePolicyRequest", reflect.TypeOf((*MockIAMAPI)(nil).UpdateAssumeRolePolicyRequest), arg0)
 }
 
 // UpdateAssumeRolePolicyWithContext mocks base method
 func (m *MockIAMAPI) UpdateAssumeRolePolicyWithContext(arg0 context.Context, arg1 *iam.UpdateAssumeRolePolicyInput, arg2 ...request.Option) (*iam.UpdateAssumeRolePolicyOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -7052,14 +6211,12 @@ func (m *MockIAMAPI) UpdateAssumeRolePolicyWithContext(arg0 context.Context, arg
 
 // UpdateAssumeRolePolicyWithContext indicates an expected call of UpdateAssumeRolePolicyWithContext
 func (mr *MockIAMAPIMockRecorder) UpdateAssumeRolePolicyWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateAssumeRolePolicyWithContext", reflect.TypeOf((*MockIAMAPI)(nil).UpdateAssumeRolePolicyWithContext), varargs...)
 }
 
 // UpdateGroup mocks base method
 func (m *MockIAMAPI) UpdateGroup(arg0 *iam.UpdateGroupInput) (*iam.UpdateGroupOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateGroup", arg0)
 	ret0, _ := ret[0].(*iam.UpdateGroupOutput)
 	ret1, _ := ret[1].(error)
@@ -7068,13 +6225,11 @@ func (m *MockIAMAPI) UpdateGroup(arg0 *iam.UpdateGroupInput) (*iam.UpdateGroupOu
 
 // UpdateGroup indicates an expected call of UpdateGroup
 func (mr *MockIAMAPIMockRecorder) UpdateGroup(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateGroup", reflect.TypeOf((*MockIAMAPI)(nil).UpdateGroup), arg0)
 }
 
 // UpdateGroupRequest mocks base method
 func (m *MockIAMAPI) UpdateGroupRequest(arg0 *iam.UpdateGroupInput) (*request.Request, *iam.UpdateGroupOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateGroupRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*iam.UpdateGroupOutput)
@@ -7083,13 +6238,11 @@ func (m *MockIAMAPI) UpdateGroupRequest(arg0 *iam.UpdateGroupInput) (*request.Re
 
 // UpdateGroupRequest indicates an expected call of UpdateGroupRequest
 func (mr *MockIAMAPIMockRecorder) UpdateGroupRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateGroupRequest", reflect.TypeOf((*MockIAMAPI)(nil).UpdateGroupRequest), arg0)
 }
 
 // UpdateGroupWithContext mocks base method
 func (m *MockIAMAPI) UpdateGroupWithContext(arg0 context.Context, arg1 *iam.UpdateGroupInput, arg2 ...request.Option) (*iam.UpdateGroupOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -7102,14 +6255,12 @@ func (m *MockIAMAPI) UpdateGroupWithContext(arg0 context.Context, arg1 *iam.Upda
 
 // UpdateGroupWithContext indicates an expected call of UpdateGroupWithContext
 func (mr *MockIAMAPIMockRecorder) UpdateGroupWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateGroupWithContext", reflect.TypeOf((*MockIAMAPI)(nil).UpdateGroupWithContext), varargs...)
 }
 
 // UpdateLoginProfile mocks base method
 func (m *MockIAMAPI) UpdateLoginProfile(arg0 *iam.UpdateLoginProfileInput) (*iam.UpdateLoginProfileOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateLoginProfile", arg0)
 	ret0, _ := ret[0].(*iam.UpdateLoginProfileOutput)
 	ret1, _ := ret[1].(error)
@@ -7118,13 +6269,11 @@ func (m *MockIAMAPI) UpdateLoginProfile(arg0 *iam.UpdateLoginProfileInput) (*iam
 
 // UpdateLoginProfile indicates an expected call of UpdateLoginProfile
 func (mr *MockIAMAPIMockRecorder) UpdateLoginProfile(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateLoginProfile", reflect.TypeOf((*MockIAMAPI)(nil).UpdateLoginProfile), arg0)
 }
 
 // UpdateLoginProfileRequest mocks base method
 func (m *MockIAMAPI) UpdateLoginProfileRequest(arg0 *iam.UpdateLoginProfileInput) (*request.Request, *iam.UpdateLoginProfileOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateLoginProfileRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*iam.UpdateLoginProfileOutput)
@@ -7133,13 +6282,11 @@ func (m *MockIAMAPI) UpdateLoginProfileRequest(arg0 *iam.UpdateLoginProfileInput
 
 // UpdateLoginProfileRequest indicates an expected call of UpdateLoginProfileRequest
 func (mr *MockIAMAPIMockRecorder) UpdateLoginProfileRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateLoginProfileRequest", reflect.TypeOf((*MockIAMAPI)(nil).UpdateLoginProfileRequest), arg0)
 }
 
 // UpdateLoginProfileWithContext mocks base method
 func (m *MockIAMAPI) UpdateLoginProfileWithContext(arg0 context.Context, arg1 *iam.UpdateLoginProfileInput, arg2 ...request.Option) (*iam.UpdateLoginProfileOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -7152,14 +6299,12 @@ func (m *MockIAMAPI) UpdateLoginProfileWithContext(arg0 context.Context, arg1 *i
 
 // UpdateLoginProfileWithContext indicates an expected call of UpdateLoginProfileWithContext
 func (mr *MockIAMAPIMockRecorder) UpdateLoginProfileWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateLoginProfileWithContext", reflect.TypeOf((*MockIAMAPI)(nil).UpdateLoginProfileWithContext), varargs...)
 }
 
 // UpdateOpenIDConnectProviderThumbprint mocks base method
 func (m *MockIAMAPI) UpdateOpenIDConnectProviderThumbprint(arg0 *iam.UpdateOpenIDConnectProviderThumbprintInput) (*iam.UpdateOpenIDConnectProviderThumbprintOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateOpenIDConnectProviderThumbprint", arg0)
 	ret0, _ := ret[0].(*iam.UpdateOpenIDConnectProviderThumbprintOutput)
 	ret1, _ := ret[1].(error)
@@ -7168,13 +6313,11 @@ func (m *MockIAMAPI) UpdateOpenIDConnectProviderThumbprint(arg0 *iam.UpdateOpenI
 
 // UpdateOpenIDConnectProviderThumbprint indicates an expected call of UpdateOpenIDConnectProviderThumbprint
 func (mr *MockIAMAPIMockRecorder) UpdateOpenIDConnectProviderThumbprint(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateOpenIDConnectProviderThumbprint", reflect.TypeOf((*MockIAMAPI)(nil).UpdateOpenIDConnectProviderThumbprint), arg0)
 }
 
 // UpdateOpenIDConnectProviderThumbprintRequest mocks base method
 func (m *MockIAMAPI) UpdateOpenIDConnectProviderThumbprintRequest(arg0 *iam.UpdateOpenIDConnectProviderThumbprintInput) (*request.Request, *iam.UpdateOpenIDConnectProviderThumbprintOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateOpenIDConnectProviderThumbprintRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*iam.UpdateOpenIDConnectProviderThumbprintOutput)
@@ -7183,13 +6326,11 @@ func (m *MockIAMAPI) UpdateOpenIDConnectProviderThumbprintRequest(arg0 *iam.Upda
 
 // UpdateOpenIDConnectProviderThumbprintRequest indicates an expected call of UpdateOpenIDConnectProviderThumbprintRequest
 func (mr *MockIAMAPIMockRecorder) UpdateOpenIDConnectProviderThumbprintRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateOpenIDConnectProviderThumbprintRequest", reflect.TypeOf((*MockIAMAPI)(nil).UpdateOpenIDConnectProviderThumbprintRequest), arg0)
 }
 
 // UpdateOpenIDConnectProviderThumbprintWithContext mocks base method
 func (m *MockIAMAPI) UpdateOpenIDConnectProviderThumbprintWithContext(arg0 context.Context, arg1 *iam.UpdateOpenIDConnectProviderThumbprintInput, arg2 ...request.Option) (*iam.UpdateOpenIDConnectProviderThumbprintOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -7202,14 +6343,12 @@ func (m *MockIAMAPI) UpdateOpenIDConnectProviderThumbprintWithContext(arg0 conte
 
 // UpdateOpenIDConnectProviderThumbprintWithContext indicates an expected call of UpdateOpenIDConnectProviderThumbprintWithContext
 func (mr *MockIAMAPIMockRecorder) UpdateOpenIDConnectProviderThumbprintWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateOpenIDConnectProviderThumbprintWithContext", reflect.TypeOf((*MockIAMAPI)(nil).UpdateOpenIDConnectProviderThumbprintWithContext), varargs...)
 }
 
 // UpdateRole mocks base method
 func (m *MockIAMAPI) UpdateRole(arg0 *iam.UpdateRoleInput) (*iam.UpdateRoleOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateRole", arg0)
 	ret0, _ := ret[0].(*iam.UpdateRoleOutput)
 	ret1, _ := ret[1].(error)
@@ -7218,13 +6357,11 @@ func (m *MockIAMAPI) UpdateRole(arg0 *iam.UpdateRoleInput) (*iam.UpdateRoleOutpu
 
 // UpdateRole indicates an expected call of UpdateRole
 func (mr *MockIAMAPIMockRecorder) UpdateRole(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateRole", reflect.TypeOf((*MockIAMAPI)(nil).UpdateRole), arg0)
 }
 
 // UpdateRoleDescription mocks base method
 func (m *MockIAMAPI) UpdateRoleDescription(arg0 *iam.UpdateRoleDescriptionInput) (*iam.UpdateRoleDescriptionOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateRoleDescription", arg0)
 	ret0, _ := ret[0].(*iam.UpdateRoleDescriptionOutput)
 	ret1, _ := ret[1].(error)
@@ -7233,13 +6370,11 @@ func (m *MockIAMAPI) UpdateRoleDescription(arg0 *iam.UpdateRoleDescriptionInput)
 
 // UpdateRoleDescription indicates an expected call of UpdateRoleDescription
 func (mr *MockIAMAPIMockRecorder) UpdateRoleDescription(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateRoleDescription", reflect.TypeOf((*MockIAMAPI)(nil).UpdateRoleDescription), arg0)
 }
 
 // UpdateRoleDescriptionRequest mocks base method
 func (m *MockIAMAPI) UpdateRoleDescriptionRequest(arg0 *iam.UpdateRoleDescriptionInput) (*request.Request, *iam.UpdateRoleDescriptionOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateRoleDescriptionRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*iam.UpdateRoleDescriptionOutput)
@@ -7248,13 +6383,11 @@ func (m *MockIAMAPI) UpdateRoleDescriptionRequest(arg0 *iam.UpdateRoleDescriptio
 
 // UpdateRoleDescriptionRequest indicates an expected call of UpdateRoleDescriptionRequest
 func (mr *MockIAMAPIMockRecorder) UpdateRoleDescriptionRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateRoleDescriptionRequest", reflect.TypeOf((*MockIAMAPI)(nil).UpdateRoleDescriptionRequest), arg0)
 }
 
 // UpdateRoleDescriptionWithContext mocks base method
 func (m *MockIAMAPI) UpdateRoleDescriptionWithContext(arg0 context.Context, arg1 *iam.UpdateRoleDescriptionInput, arg2 ...request.Option) (*iam.UpdateRoleDescriptionOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -7267,14 +6400,12 @@ func (m *MockIAMAPI) UpdateRoleDescriptionWithContext(arg0 context.Context, arg1
 
 // UpdateRoleDescriptionWithContext indicates an expected call of UpdateRoleDescriptionWithContext
 func (mr *MockIAMAPIMockRecorder) UpdateRoleDescriptionWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateRoleDescriptionWithContext", reflect.TypeOf((*MockIAMAPI)(nil).UpdateRoleDescriptionWithContext), varargs...)
 }
 
 // UpdateRoleRequest mocks base method
 func (m *MockIAMAPI) UpdateRoleRequest(arg0 *iam.UpdateRoleInput) (*request.Request, *iam.UpdateRoleOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateRoleRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*iam.UpdateRoleOutput)
@@ -7283,13 +6414,11 @@ func (m *MockIAMAPI) UpdateRoleRequest(arg0 *iam.UpdateRoleInput) (*request.Requ
 
 // UpdateRoleRequest indicates an expected call of UpdateRoleRequest
 func (mr *MockIAMAPIMockRecorder) UpdateRoleRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateRoleRequest", reflect.TypeOf((*MockIAMAPI)(nil).UpdateRoleRequest), arg0)
 }
 
 // UpdateRoleWithContext mocks base method
 func (m *MockIAMAPI) UpdateRoleWithContext(arg0 context.Context, arg1 *iam.UpdateRoleInput, arg2 ...request.Option) (*iam.UpdateRoleOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -7302,14 +6431,12 @@ func (m *MockIAMAPI) UpdateRoleWithContext(arg0 context.Context, arg1 *iam.Updat
 
 // UpdateRoleWithContext indicates an expected call of UpdateRoleWithContext
 func (mr *MockIAMAPIMockRecorder) UpdateRoleWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateRoleWithContext", reflect.TypeOf((*MockIAMAPI)(nil).UpdateRoleWithContext), varargs...)
 }
 
 // UpdateSAMLProvider mocks base method
 func (m *MockIAMAPI) UpdateSAMLProvider(arg0 *iam.UpdateSAMLProviderInput) (*iam.UpdateSAMLProviderOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateSAMLProvider", arg0)
 	ret0, _ := ret[0].(*iam.UpdateSAMLProviderOutput)
 	ret1, _ := ret[1].(error)
@@ -7318,13 +6445,11 @@ func (m *MockIAMAPI) UpdateSAMLProvider(arg0 *iam.UpdateSAMLProviderInput) (*iam
 
 // UpdateSAMLProvider indicates an expected call of UpdateSAMLProvider
 func (mr *MockIAMAPIMockRecorder) UpdateSAMLProvider(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateSAMLProvider", reflect.TypeOf((*MockIAMAPI)(nil).UpdateSAMLProvider), arg0)
 }
 
 // UpdateSAMLProviderRequest mocks base method
 func (m *MockIAMAPI) UpdateSAMLProviderRequest(arg0 *iam.UpdateSAMLProviderInput) (*request.Request, *iam.UpdateSAMLProviderOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateSAMLProviderRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*iam.UpdateSAMLProviderOutput)
@@ -7333,13 +6458,11 @@ func (m *MockIAMAPI) UpdateSAMLProviderRequest(arg0 *iam.UpdateSAMLProviderInput
 
 // UpdateSAMLProviderRequest indicates an expected call of UpdateSAMLProviderRequest
 func (mr *MockIAMAPIMockRecorder) UpdateSAMLProviderRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateSAMLProviderRequest", reflect.TypeOf((*MockIAMAPI)(nil).UpdateSAMLProviderRequest), arg0)
 }
 
 // UpdateSAMLProviderWithContext mocks base method
 func (m *MockIAMAPI) UpdateSAMLProviderWithContext(arg0 context.Context, arg1 *iam.UpdateSAMLProviderInput, arg2 ...request.Option) (*iam.UpdateSAMLProviderOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -7352,14 +6475,12 @@ func (m *MockIAMAPI) UpdateSAMLProviderWithContext(arg0 context.Context, arg1 *i
 
 // UpdateSAMLProviderWithContext indicates an expected call of UpdateSAMLProviderWithContext
 func (mr *MockIAMAPIMockRecorder) UpdateSAMLProviderWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateSAMLProviderWithContext", reflect.TypeOf((*MockIAMAPI)(nil).UpdateSAMLProviderWithContext), varargs...)
 }
 
 // UpdateSSHPublicKey mocks base method
 func (m *MockIAMAPI) UpdateSSHPublicKey(arg0 *iam.UpdateSSHPublicKeyInput) (*iam.UpdateSSHPublicKeyOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateSSHPublicKey", arg0)
 	ret0, _ := ret[0].(*iam.UpdateSSHPublicKeyOutput)
 	ret1, _ := ret[1].(error)
@@ -7368,13 +6489,11 @@ func (m *MockIAMAPI) UpdateSSHPublicKey(arg0 *iam.UpdateSSHPublicKeyInput) (*iam
 
 // UpdateSSHPublicKey indicates an expected call of UpdateSSHPublicKey
 func (mr *MockIAMAPIMockRecorder) UpdateSSHPublicKey(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateSSHPublicKey", reflect.TypeOf((*MockIAMAPI)(nil).UpdateSSHPublicKey), arg0)
 }
 
 // UpdateSSHPublicKeyRequest mocks base method
 func (m *MockIAMAPI) UpdateSSHPublicKeyRequest(arg0 *iam.UpdateSSHPublicKeyInput) (*request.Request, *iam.UpdateSSHPublicKeyOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateSSHPublicKeyRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*iam.UpdateSSHPublicKeyOutput)
@@ -7383,13 +6502,11 @@ func (m *MockIAMAPI) UpdateSSHPublicKeyRequest(arg0 *iam.UpdateSSHPublicKeyInput
 
 // UpdateSSHPublicKeyRequest indicates an expected call of UpdateSSHPublicKeyRequest
 func (mr *MockIAMAPIMockRecorder) UpdateSSHPublicKeyRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateSSHPublicKeyRequest", reflect.TypeOf((*MockIAMAPI)(nil).UpdateSSHPublicKeyRequest), arg0)
 }
 
 // UpdateSSHPublicKeyWithContext mocks base method
 func (m *MockIAMAPI) UpdateSSHPublicKeyWithContext(arg0 context.Context, arg1 *iam.UpdateSSHPublicKeyInput, arg2 ...request.Option) (*iam.UpdateSSHPublicKeyOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -7402,14 +6519,12 @@ func (m *MockIAMAPI) UpdateSSHPublicKeyWithContext(arg0 context.Context, arg1 *i
 
 // UpdateSSHPublicKeyWithContext indicates an expected call of UpdateSSHPublicKeyWithContext
 func (mr *MockIAMAPIMockRecorder) UpdateSSHPublicKeyWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateSSHPublicKeyWithContext", reflect.TypeOf((*MockIAMAPI)(nil).UpdateSSHPublicKeyWithContext), varargs...)
 }
 
 // UpdateServerCertificate mocks base method
 func (m *MockIAMAPI) UpdateServerCertificate(arg0 *iam.UpdateServerCertificateInput) (*iam.UpdateServerCertificateOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateServerCertificate", arg0)
 	ret0, _ := ret[0].(*iam.UpdateServerCertificateOutput)
 	ret1, _ := ret[1].(error)
@@ -7418,13 +6533,11 @@ func (m *MockIAMAPI) UpdateServerCertificate(arg0 *iam.UpdateServerCertificateIn
 
 // UpdateServerCertificate indicates an expected call of UpdateServerCertificate
 func (mr *MockIAMAPIMockRecorder) UpdateServerCertificate(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateServerCertificate", reflect.TypeOf((*MockIAMAPI)(nil).UpdateServerCertificate), arg0)
 }
 
 // UpdateServerCertificateRequest mocks base method
 func (m *MockIAMAPI) UpdateServerCertificateRequest(arg0 *iam.UpdateServerCertificateInput) (*request.Request, *iam.UpdateServerCertificateOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateServerCertificateRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*iam.UpdateServerCertificateOutput)
@@ -7433,13 +6546,11 @@ func (m *MockIAMAPI) UpdateServerCertificateRequest(arg0 *iam.UpdateServerCertif
 
 // UpdateServerCertificateRequest indicates an expected call of UpdateServerCertificateRequest
 func (mr *MockIAMAPIMockRecorder) UpdateServerCertificateRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateServerCertificateRequest", reflect.TypeOf((*MockIAMAPI)(nil).UpdateServerCertificateRequest), arg0)
 }
 
 // UpdateServerCertificateWithContext mocks base method
 func (m *MockIAMAPI) UpdateServerCertificateWithContext(arg0 context.Context, arg1 *iam.UpdateServerCertificateInput, arg2 ...request.Option) (*iam.UpdateServerCertificateOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -7452,14 +6563,12 @@ func (m *MockIAMAPI) UpdateServerCertificateWithContext(arg0 context.Context, ar
 
 // UpdateServerCertificateWithContext indicates an expected call of UpdateServerCertificateWithContext
 func (mr *MockIAMAPIMockRecorder) UpdateServerCertificateWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateServerCertificateWithContext", reflect.TypeOf((*MockIAMAPI)(nil).UpdateServerCertificateWithContext), varargs...)
 }
 
 // UpdateServiceSpecificCredential mocks base method
 func (m *MockIAMAPI) UpdateServiceSpecificCredential(arg0 *iam.UpdateServiceSpecificCredentialInput) (*iam.UpdateServiceSpecificCredentialOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateServiceSpecificCredential", arg0)
 	ret0, _ := ret[0].(*iam.UpdateServiceSpecificCredentialOutput)
 	ret1, _ := ret[1].(error)
@@ -7468,13 +6577,11 @@ func (m *MockIAMAPI) UpdateServiceSpecificCredential(arg0 *iam.UpdateServiceSpec
 
 // UpdateServiceSpecificCredential indicates an expected call of UpdateServiceSpecificCredential
 func (mr *MockIAMAPIMockRecorder) UpdateServiceSpecificCredential(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateServiceSpecificCredential", reflect.TypeOf((*MockIAMAPI)(nil).UpdateServiceSpecificCredential), arg0)
 }
 
 // UpdateServiceSpecificCredentialRequest mocks base method
 func (m *MockIAMAPI) UpdateServiceSpecificCredentialRequest(arg0 *iam.UpdateServiceSpecificCredentialInput) (*request.Request, *iam.UpdateServiceSpecificCredentialOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateServiceSpecificCredentialRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*iam.UpdateServiceSpecificCredentialOutput)
@@ -7483,13 +6590,11 @@ func (m *MockIAMAPI) UpdateServiceSpecificCredentialRequest(arg0 *iam.UpdateServ
 
 // UpdateServiceSpecificCredentialRequest indicates an expected call of UpdateServiceSpecificCredentialRequest
 func (mr *MockIAMAPIMockRecorder) UpdateServiceSpecificCredentialRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateServiceSpecificCredentialRequest", reflect.TypeOf((*MockIAMAPI)(nil).UpdateServiceSpecificCredentialRequest), arg0)
 }
 
 // UpdateServiceSpecificCredentialWithContext mocks base method
 func (m *MockIAMAPI) UpdateServiceSpecificCredentialWithContext(arg0 context.Context, arg1 *iam.UpdateServiceSpecificCredentialInput, arg2 ...request.Option) (*iam.UpdateServiceSpecificCredentialOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -7502,14 +6607,12 @@ func (m *MockIAMAPI) UpdateServiceSpecificCredentialWithContext(arg0 context.Con
 
 // UpdateServiceSpecificCredentialWithContext indicates an expected call of UpdateServiceSpecificCredentialWithContext
 func (mr *MockIAMAPIMockRecorder) UpdateServiceSpecificCredentialWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateServiceSpecificCredentialWithContext", reflect.TypeOf((*MockIAMAPI)(nil).UpdateServiceSpecificCredentialWithContext), varargs...)
 }
 
 // UpdateSigningCertificate mocks base method
 func (m *MockIAMAPI) UpdateSigningCertificate(arg0 *iam.UpdateSigningCertificateInput) (*iam.UpdateSigningCertificateOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateSigningCertificate", arg0)
 	ret0, _ := ret[0].(*iam.UpdateSigningCertificateOutput)
 	ret1, _ := ret[1].(error)
@@ -7518,13 +6621,11 @@ func (m *MockIAMAPI) UpdateSigningCertificate(arg0 *iam.UpdateSigningCertificate
 
 // UpdateSigningCertificate indicates an expected call of UpdateSigningCertificate
 func (mr *MockIAMAPIMockRecorder) UpdateSigningCertificate(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateSigningCertificate", reflect.TypeOf((*MockIAMAPI)(nil).UpdateSigningCertificate), arg0)
 }
 
 // UpdateSigningCertificateRequest mocks base method
 func (m *MockIAMAPI) UpdateSigningCertificateRequest(arg0 *iam.UpdateSigningCertificateInput) (*request.Request, *iam.UpdateSigningCertificateOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateSigningCertificateRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*iam.UpdateSigningCertificateOutput)
@@ -7533,13 +6634,11 @@ func (m *MockIAMAPI) UpdateSigningCertificateRequest(arg0 *iam.UpdateSigningCert
 
 // UpdateSigningCertificateRequest indicates an expected call of UpdateSigningCertificateRequest
 func (mr *MockIAMAPIMockRecorder) UpdateSigningCertificateRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateSigningCertificateRequest", reflect.TypeOf((*MockIAMAPI)(nil).UpdateSigningCertificateRequest), arg0)
 }
 
 // UpdateSigningCertificateWithContext mocks base method
 func (m *MockIAMAPI) UpdateSigningCertificateWithContext(arg0 context.Context, arg1 *iam.UpdateSigningCertificateInput, arg2 ...request.Option) (*iam.UpdateSigningCertificateOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -7552,14 +6651,12 @@ func (m *MockIAMAPI) UpdateSigningCertificateWithContext(arg0 context.Context, a
 
 // UpdateSigningCertificateWithContext indicates an expected call of UpdateSigningCertificateWithContext
 func (mr *MockIAMAPIMockRecorder) UpdateSigningCertificateWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateSigningCertificateWithContext", reflect.TypeOf((*MockIAMAPI)(nil).UpdateSigningCertificateWithContext), varargs...)
 }
 
 // UpdateUser mocks base method
 func (m *MockIAMAPI) UpdateUser(arg0 *iam.UpdateUserInput) (*iam.UpdateUserOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateUser", arg0)
 	ret0, _ := ret[0].(*iam.UpdateUserOutput)
 	ret1, _ := ret[1].(error)
@@ -7568,13 +6665,11 @@ func (m *MockIAMAPI) UpdateUser(arg0 *iam.UpdateUserInput) (*iam.UpdateUserOutpu
 
 // UpdateUser indicates an expected call of UpdateUser
 func (mr *MockIAMAPIMockRecorder) UpdateUser(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateUser", reflect.TypeOf((*MockIAMAPI)(nil).UpdateUser), arg0)
 }
 
 // UpdateUserRequest mocks base method
 func (m *MockIAMAPI) UpdateUserRequest(arg0 *iam.UpdateUserInput) (*request.Request, *iam.UpdateUserOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateUserRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*iam.UpdateUserOutput)
@@ -7583,13 +6678,11 @@ func (m *MockIAMAPI) UpdateUserRequest(arg0 *iam.UpdateUserInput) (*request.Requ
 
 // UpdateUserRequest indicates an expected call of UpdateUserRequest
 func (mr *MockIAMAPIMockRecorder) UpdateUserRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateUserRequest", reflect.TypeOf((*MockIAMAPI)(nil).UpdateUserRequest), arg0)
 }
 
 // UpdateUserWithContext mocks base method
 func (m *MockIAMAPI) UpdateUserWithContext(arg0 context.Context, arg1 *iam.UpdateUserInput, arg2 ...request.Option) (*iam.UpdateUserOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -7602,14 +6695,12 @@ func (m *MockIAMAPI) UpdateUserWithContext(arg0 context.Context, arg1 *iam.Updat
 
 // UpdateUserWithContext indicates an expected call of UpdateUserWithContext
 func (mr *MockIAMAPIMockRecorder) UpdateUserWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateUserWithContext", reflect.TypeOf((*MockIAMAPI)(nil).UpdateUserWithContext), varargs...)
 }
 
 // UploadSSHPublicKey mocks base method
 func (m *MockIAMAPI) UploadSSHPublicKey(arg0 *iam.UploadSSHPublicKeyInput) (*iam.UploadSSHPublicKeyOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UploadSSHPublicKey", arg0)
 	ret0, _ := ret[0].(*iam.UploadSSHPublicKeyOutput)
 	ret1, _ := ret[1].(error)
@@ -7618,13 +6709,11 @@ func (m *MockIAMAPI) UploadSSHPublicKey(arg0 *iam.UploadSSHPublicKeyInput) (*iam
 
 // UploadSSHPublicKey indicates an expected call of UploadSSHPublicKey
 func (mr *MockIAMAPIMockRecorder) UploadSSHPublicKey(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UploadSSHPublicKey", reflect.TypeOf((*MockIAMAPI)(nil).UploadSSHPublicKey), arg0)
 }
 
 // UploadSSHPublicKeyRequest mocks base method
 func (m *MockIAMAPI) UploadSSHPublicKeyRequest(arg0 *iam.UploadSSHPublicKeyInput) (*request.Request, *iam.UploadSSHPublicKeyOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UploadSSHPublicKeyRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*iam.UploadSSHPublicKeyOutput)
@@ -7633,13 +6722,11 @@ func (m *MockIAMAPI) UploadSSHPublicKeyRequest(arg0 *iam.UploadSSHPublicKeyInput
 
 // UploadSSHPublicKeyRequest indicates an expected call of UploadSSHPublicKeyRequest
 func (mr *MockIAMAPIMockRecorder) UploadSSHPublicKeyRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UploadSSHPublicKeyRequest", reflect.TypeOf((*MockIAMAPI)(nil).UploadSSHPublicKeyRequest), arg0)
 }
 
 // UploadSSHPublicKeyWithContext mocks base method
 func (m *MockIAMAPI) UploadSSHPublicKeyWithContext(arg0 context.Context, arg1 *iam.UploadSSHPublicKeyInput, arg2 ...request.Option) (*iam.UploadSSHPublicKeyOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -7652,14 +6739,12 @@ func (m *MockIAMAPI) UploadSSHPublicKeyWithContext(arg0 context.Context, arg1 *i
 
 // UploadSSHPublicKeyWithContext indicates an expected call of UploadSSHPublicKeyWithContext
 func (mr *MockIAMAPIMockRecorder) UploadSSHPublicKeyWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UploadSSHPublicKeyWithContext", reflect.TypeOf((*MockIAMAPI)(nil).UploadSSHPublicKeyWithContext), varargs...)
 }
 
 // UploadServerCertificate mocks base method
 func (m *MockIAMAPI) UploadServerCertificate(arg0 *iam.UploadServerCertificateInput) (*iam.UploadServerCertificateOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UploadServerCertificate", arg0)
 	ret0, _ := ret[0].(*iam.UploadServerCertificateOutput)
 	ret1, _ := ret[1].(error)
@@ -7668,13 +6753,11 @@ func (m *MockIAMAPI) UploadServerCertificate(arg0 *iam.UploadServerCertificateIn
 
 // UploadServerCertificate indicates an expected call of UploadServerCertificate
 func (mr *MockIAMAPIMockRecorder) UploadServerCertificate(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UploadServerCertificate", reflect.TypeOf((*MockIAMAPI)(nil).UploadServerCertificate), arg0)
 }
 
 // UploadServerCertificateRequest mocks base method
 func (m *MockIAMAPI) UploadServerCertificateRequest(arg0 *iam.UploadServerCertificateInput) (*request.Request, *iam.UploadServerCertificateOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UploadServerCertificateRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*iam.UploadServerCertificateOutput)
@@ -7683,13 +6766,11 @@ func (m *MockIAMAPI) UploadServerCertificateRequest(arg0 *iam.UploadServerCertif
 
 // UploadServerCertificateRequest indicates an expected call of UploadServerCertificateRequest
 func (mr *MockIAMAPIMockRecorder) UploadServerCertificateRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UploadServerCertificateRequest", reflect.TypeOf((*MockIAMAPI)(nil).UploadServerCertificateRequest), arg0)
 }
 
 // UploadServerCertificateWithContext mocks base method
 func (m *MockIAMAPI) UploadServerCertificateWithContext(arg0 context.Context, arg1 *iam.UploadServerCertificateInput, arg2 ...request.Option) (*iam.UploadServerCertificateOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -7702,14 +6783,12 @@ func (m *MockIAMAPI) UploadServerCertificateWithContext(arg0 context.Context, ar
 
 // UploadServerCertificateWithContext indicates an expected call of UploadServerCertificateWithContext
 func (mr *MockIAMAPIMockRecorder) UploadServerCertificateWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UploadServerCertificateWithContext", reflect.TypeOf((*MockIAMAPI)(nil).UploadServerCertificateWithContext), varargs...)
 }
 
 // UploadSigningCertificate mocks base method
 func (m *MockIAMAPI) UploadSigningCertificate(arg0 *iam.UploadSigningCertificateInput) (*iam.UploadSigningCertificateOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UploadSigningCertificate", arg0)
 	ret0, _ := ret[0].(*iam.UploadSigningCertificateOutput)
 	ret1, _ := ret[1].(error)
@@ -7718,13 +6797,11 @@ func (m *MockIAMAPI) UploadSigningCertificate(arg0 *iam.UploadSigningCertificate
 
 // UploadSigningCertificate indicates an expected call of UploadSigningCertificate
 func (mr *MockIAMAPIMockRecorder) UploadSigningCertificate(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UploadSigningCertificate", reflect.TypeOf((*MockIAMAPI)(nil).UploadSigningCertificate), arg0)
 }
 
 // UploadSigningCertificateRequest mocks base method
 func (m *MockIAMAPI) UploadSigningCertificateRequest(arg0 *iam.UploadSigningCertificateInput) (*request.Request, *iam.UploadSigningCertificateOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UploadSigningCertificateRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*iam.UploadSigningCertificateOutput)
@@ -7733,13 +6810,11 @@ func (m *MockIAMAPI) UploadSigningCertificateRequest(arg0 *iam.UploadSigningCert
 
 // UploadSigningCertificateRequest indicates an expected call of UploadSigningCertificateRequest
 func (mr *MockIAMAPIMockRecorder) UploadSigningCertificateRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UploadSigningCertificateRequest", reflect.TypeOf((*MockIAMAPI)(nil).UploadSigningCertificateRequest), arg0)
 }
 
 // UploadSigningCertificateWithContext mocks base method
 func (m *MockIAMAPI) UploadSigningCertificateWithContext(arg0 context.Context, arg1 *iam.UploadSigningCertificateInput, arg2 ...request.Option) (*iam.UploadSigningCertificateOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -7752,14 +6827,12 @@ func (m *MockIAMAPI) UploadSigningCertificateWithContext(arg0 context.Context, a
 
 // UploadSigningCertificateWithContext indicates an expected call of UploadSigningCertificateWithContext
 func (mr *MockIAMAPIMockRecorder) UploadSigningCertificateWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UploadSigningCertificateWithContext", reflect.TypeOf((*MockIAMAPI)(nil).UploadSigningCertificateWithContext), varargs...)
 }
 
 // WaitUntilInstanceProfileExists mocks base method
 func (m *MockIAMAPI) WaitUntilInstanceProfileExists(arg0 *iam.GetInstanceProfileInput) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WaitUntilInstanceProfileExists", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -7767,13 +6840,11 @@ func (m *MockIAMAPI) WaitUntilInstanceProfileExists(arg0 *iam.GetInstanceProfile
 
 // WaitUntilInstanceProfileExists indicates an expected call of WaitUntilInstanceProfileExists
 func (mr *MockIAMAPIMockRecorder) WaitUntilInstanceProfileExists(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitUntilInstanceProfileExists", reflect.TypeOf((*MockIAMAPI)(nil).WaitUntilInstanceProfileExists), arg0)
 }
 
 // WaitUntilInstanceProfileExistsWithContext mocks base method
 func (m *MockIAMAPI) WaitUntilInstanceProfileExistsWithContext(arg0 context.Context, arg1 *iam.GetInstanceProfileInput, arg2 ...request.WaiterOption) error {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -7785,14 +6856,12 @@ func (m *MockIAMAPI) WaitUntilInstanceProfileExistsWithContext(arg0 context.Cont
 
 // WaitUntilInstanceProfileExistsWithContext indicates an expected call of WaitUntilInstanceProfileExistsWithContext
 func (mr *MockIAMAPIMockRecorder) WaitUntilInstanceProfileExistsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitUntilInstanceProfileExistsWithContext", reflect.TypeOf((*MockIAMAPI)(nil).WaitUntilInstanceProfileExistsWithContext), varargs...)
 }
 
 // WaitUntilUserExists mocks base method
 func (m *MockIAMAPI) WaitUntilUserExists(arg0 *iam.GetUserInput) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WaitUntilUserExists", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -7800,13 +6869,11 @@ func (m *MockIAMAPI) WaitUntilUserExists(arg0 *iam.GetUserInput) error {
 
 // WaitUntilUserExists indicates an expected call of WaitUntilUserExists
 func (mr *MockIAMAPIMockRecorder) WaitUntilUserExists(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitUntilUserExists", reflect.TypeOf((*MockIAMAPI)(nil).WaitUntilUserExists), arg0)
 }
 
 // WaitUntilUserExistsWithContext mocks base method
 func (m *MockIAMAPI) WaitUntilUserExistsWithContext(arg0 context.Context, arg1 *iam.GetUserInput, arg2 ...request.WaiterOption) error {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -7818,7 +6885,6 @@ func (m *MockIAMAPI) WaitUntilUserExistsWithContext(arg0 context.Context, arg1 *
 
 // WaitUntilUserExistsWithContext indicates an expected call of WaitUntilUserExistsWithContext
 func (mr *MockIAMAPIMockRecorder) WaitUntilUserExistsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitUntilUserExistsWithContext", reflect.TypeOf((*MockIAMAPI)(nil).WaitUntilUserExistsWithContext), varargs...)
 }

--- a/ecs-cli/modules/clients/aws/kms/mock/client.go
+++ b/ecs-cli/modules/clients/aws/kms/mock/client.go
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2015-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the
@@ -49,7 +49,6 @@ func (m *MockClient) EXPECT() *MockClientMockRecorder {
 
 // DescribeKey mocks base method
 func (m *MockClient) DescribeKey(arg0 string) (*kms.DescribeKeyOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeKey", arg0)
 	ret0, _ := ret[0].(*kms.DescribeKeyOutput)
 	ret1, _ := ret[1].(error)
@@ -58,13 +57,11 @@ func (m *MockClient) DescribeKey(arg0 string) (*kms.DescribeKeyOutput, error) {
 
 // DescribeKey indicates an expected call of DescribeKey
 func (mr *MockClientMockRecorder) DescribeKey(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeKey", reflect.TypeOf((*MockClient)(nil).DescribeKey), arg0)
 }
 
 // GetValidKeyARN mocks base method
 func (m *MockClient) GetValidKeyARN(arg0 string) (string, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetValidKeyARN", arg0)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
@@ -73,6 +70,5 @@ func (m *MockClient) GetValidKeyARN(arg0 string) (string, error) {
 
 // GetValidKeyARN indicates an expected call of GetValidKeyARN
 func (mr *MockClientMockRecorder) GetValidKeyARN(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetValidKeyARN", reflect.TypeOf((*MockClient)(nil).GetValidKeyARN), arg0)
 }

--- a/ecs-cli/modules/clients/aws/kms/mock/sdk/kmsiface_mock.go
+++ b/ecs-cli/modules/clients/aws/kms/mock/sdk/kmsiface_mock.go
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2015-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the
@@ -51,7 +51,6 @@ func (m *MockKMSAPI) EXPECT() *MockKMSAPIMockRecorder {
 
 // CancelKeyDeletion mocks base method
 func (m *MockKMSAPI) CancelKeyDeletion(arg0 *kms.CancelKeyDeletionInput) (*kms.CancelKeyDeletionOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CancelKeyDeletion", arg0)
 	ret0, _ := ret[0].(*kms.CancelKeyDeletionOutput)
 	ret1, _ := ret[1].(error)
@@ -60,13 +59,11 @@ func (m *MockKMSAPI) CancelKeyDeletion(arg0 *kms.CancelKeyDeletionInput) (*kms.C
 
 // CancelKeyDeletion indicates an expected call of CancelKeyDeletion
 func (mr *MockKMSAPIMockRecorder) CancelKeyDeletion(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CancelKeyDeletion", reflect.TypeOf((*MockKMSAPI)(nil).CancelKeyDeletion), arg0)
 }
 
 // CancelKeyDeletionRequest mocks base method
 func (m *MockKMSAPI) CancelKeyDeletionRequest(arg0 *kms.CancelKeyDeletionInput) (*request.Request, *kms.CancelKeyDeletionOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CancelKeyDeletionRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*kms.CancelKeyDeletionOutput)
@@ -75,13 +72,11 @@ func (m *MockKMSAPI) CancelKeyDeletionRequest(arg0 *kms.CancelKeyDeletionInput) 
 
 // CancelKeyDeletionRequest indicates an expected call of CancelKeyDeletionRequest
 func (mr *MockKMSAPIMockRecorder) CancelKeyDeletionRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CancelKeyDeletionRequest", reflect.TypeOf((*MockKMSAPI)(nil).CancelKeyDeletionRequest), arg0)
 }
 
 // CancelKeyDeletionWithContext mocks base method
 func (m *MockKMSAPI) CancelKeyDeletionWithContext(arg0 context.Context, arg1 *kms.CancelKeyDeletionInput, arg2 ...request.Option) (*kms.CancelKeyDeletionOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -94,14 +89,12 @@ func (m *MockKMSAPI) CancelKeyDeletionWithContext(arg0 context.Context, arg1 *km
 
 // CancelKeyDeletionWithContext indicates an expected call of CancelKeyDeletionWithContext
 func (mr *MockKMSAPIMockRecorder) CancelKeyDeletionWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CancelKeyDeletionWithContext", reflect.TypeOf((*MockKMSAPI)(nil).CancelKeyDeletionWithContext), varargs...)
 }
 
 // ConnectCustomKeyStore mocks base method
 func (m *MockKMSAPI) ConnectCustomKeyStore(arg0 *kms.ConnectCustomKeyStoreInput) (*kms.ConnectCustomKeyStoreOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ConnectCustomKeyStore", arg0)
 	ret0, _ := ret[0].(*kms.ConnectCustomKeyStoreOutput)
 	ret1, _ := ret[1].(error)
@@ -110,13 +103,11 @@ func (m *MockKMSAPI) ConnectCustomKeyStore(arg0 *kms.ConnectCustomKeyStoreInput)
 
 // ConnectCustomKeyStore indicates an expected call of ConnectCustomKeyStore
 func (mr *MockKMSAPIMockRecorder) ConnectCustomKeyStore(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConnectCustomKeyStore", reflect.TypeOf((*MockKMSAPI)(nil).ConnectCustomKeyStore), arg0)
 }
 
 // ConnectCustomKeyStoreRequest mocks base method
 func (m *MockKMSAPI) ConnectCustomKeyStoreRequest(arg0 *kms.ConnectCustomKeyStoreInput) (*request.Request, *kms.ConnectCustomKeyStoreOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ConnectCustomKeyStoreRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*kms.ConnectCustomKeyStoreOutput)
@@ -125,13 +116,11 @@ func (m *MockKMSAPI) ConnectCustomKeyStoreRequest(arg0 *kms.ConnectCustomKeyStor
 
 // ConnectCustomKeyStoreRequest indicates an expected call of ConnectCustomKeyStoreRequest
 func (mr *MockKMSAPIMockRecorder) ConnectCustomKeyStoreRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConnectCustomKeyStoreRequest", reflect.TypeOf((*MockKMSAPI)(nil).ConnectCustomKeyStoreRequest), arg0)
 }
 
 // ConnectCustomKeyStoreWithContext mocks base method
 func (m *MockKMSAPI) ConnectCustomKeyStoreWithContext(arg0 context.Context, arg1 *kms.ConnectCustomKeyStoreInput, arg2 ...request.Option) (*kms.ConnectCustomKeyStoreOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -144,14 +133,12 @@ func (m *MockKMSAPI) ConnectCustomKeyStoreWithContext(arg0 context.Context, arg1
 
 // ConnectCustomKeyStoreWithContext indicates an expected call of ConnectCustomKeyStoreWithContext
 func (mr *MockKMSAPIMockRecorder) ConnectCustomKeyStoreWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConnectCustomKeyStoreWithContext", reflect.TypeOf((*MockKMSAPI)(nil).ConnectCustomKeyStoreWithContext), varargs...)
 }
 
 // CreateAlias mocks base method
 func (m *MockKMSAPI) CreateAlias(arg0 *kms.CreateAliasInput) (*kms.CreateAliasOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateAlias", arg0)
 	ret0, _ := ret[0].(*kms.CreateAliasOutput)
 	ret1, _ := ret[1].(error)
@@ -160,13 +147,11 @@ func (m *MockKMSAPI) CreateAlias(arg0 *kms.CreateAliasInput) (*kms.CreateAliasOu
 
 // CreateAlias indicates an expected call of CreateAlias
 func (mr *MockKMSAPIMockRecorder) CreateAlias(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateAlias", reflect.TypeOf((*MockKMSAPI)(nil).CreateAlias), arg0)
 }
 
 // CreateAliasRequest mocks base method
 func (m *MockKMSAPI) CreateAliasRequest(arg0 *kms.CreateAliasInput) (*request.Request, *kms.CreateAliasOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateAliasRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*kms.CreateAliasOutput)
@@ -175,13 +160,11 @@ func (m *MockKMSAPI) CreateAliasRequest(arg0 *kms.CreateAliasInput) (*request.Re
 
 // CreateAliasRequest indicates an expected call of CreateAliasRequest
 func (mr *MockKMSAPIMockRecorder) CreateAliasRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateAliasRequest", reflect.TypeOf((*MockKMSAPI)(nil).CreateAliasRequest), arg0)
 }
 
 // CreateAliasWithContext mocks base method
 func (m *MockKMSAPI) CreateAliasWithContext(arg0 context.Context, arg1 *kms.CreateAliasInput, arg2 ...request.Option) (*kms.CreateAliasOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -194,14 +177,12 @@ func (m *MockKMSAPI) CreateAliasWithContext(arg0 context.Context, arg1 *kms.Crea
 
 // CreateAliasWithContext indicates an expected call of CreateAliasWithContext
 func (mr *MockKMSAPIMockRecorder) CreateAliasWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateAliasWithContext", reflect.TypeOf((*MockKMSAPI)(nil).CreateAliasWithContext), varargs...)
 }
 
 // CreateCustomKeyStore mocks base method
 func (m *MockKMSAPI) CreateCustomKeyStore(arg0 *kms.CreateCustomKeyStoreInput) (*kms.CreateCustomKeyStoreOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateCustomKeyStore", arg0)
 	ret0, _ := ret[0].(*kms.CreateCustomKeyStoreOutput)
 	ret1, _ := ret[1].(error)
@@ -210,13 +191,11 @@ func (m *MockKMSAPI) CreateCustomKeyStore(arg0 *kms.CreateCustomKeyStoreInput) (
 
 // CreateCustomKeyStore indicates an expected call of CreateCustomKeyStore
 func (mr *MockKMSAPIMockRecorder) CreateCustomKeyStore(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateCustomKeyStore", reflect.TypeOf((*MockKMSAPI)(nil).CreateCustomKeyStore), arg0)
 }
 
 // CreateCustomKeyStoreRequest mocks base method
 func (m *MockKMSAPI) CreateCustomKeyStoreRequest(arg0 *kms.CreateCustomKeyStoreInput) (*request.Request, *kms.CreateCustomKeyStoreOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateCustomKeyStoreRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*kms.CreateCustomKeyStoreOutput)
@@ -225,13 +204,11 @@ func (m *MockKMSAPI) CreateCustomKeyStoreRequest(arg0 *kms.CreateCustomKeyStoreI
 
 // CreateCustomKeyStoreRequest indicates an expected call of CreateCustomKeyStoreRequest
 func (mr *MockKMSAPIMockRecorder) CreateCustomKeyStoreRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateCustomKeyStoreRequest", reflect.TypeOf((*MockKMSAPI)(nil).CreateCustomKeyStoreRequest), arg0)
 }
 
 // CreateCustomKeyStoreWithContext mocks base method
 func (m *MockKMSAPI) CreateCustomKeyStoreWithContext(arg0 context.Context, arg1 *kms.CreateCustomKeyStoreInput, arg2 ...request.Option) (*kms.CreateCustomKeyStoreOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -244,14 +221,12 @@ func (m *MockKMSAPI) CreateCustomKeyStoreWithContext(arg0 context.Context, arg1 
 
 // CreateCustomKeyStoreWithContext indicates an expected call of CreateCustomKeyStoreWithContext
 func (mr *MockKMSAPIMockRecorder) CreateCustomKeyStoreWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateCustomKeyStoreWithContext", reflect.TypeOf((*MockKMSAPI)(nil).CreateCustomKeyStoreWithContext), varargs...)
 }
 
 // CreateGrant mocks base method
 func (m *MockKMSAPI) CreateGrant(arg0 *kms.CreateGrantInput) (*kms.CreateGrantOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateGrant", arg0)
 	ret0, _ := ret[0].(*kms.CreateGrantOutput)
 	ret1, _ := ret[1].(error)
@@ -260,13 +235,11 @@ func (m *MockKMSAPI) CreateGrant(arg0 *kms.CreateGrantInput) (*kms.CreateGrantOu
 
 // CreateGrant indicates an expected call of CreateGrant
 func (mr *MockKMSAPIMockRecorder) CreateGrant(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateGrant", reflect.TypeOf((*MockKMSAPI)(nil).CreateGrant), arg0)
 }
 
 // CreateGrantRequest mocks base method
 func (m *MockKMSAPI) CreateGrantRequest(arg0 *kms.CreateGrantInput) (*request.Request, *kms.CreateGrantOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateGrantRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*kms.CreateGrantOutput)
@@ -275,13 +248,11 @@ func (m *MockKMSAPI) CreateGrantRequest(arg0 *kms.CreateGrantInput) (*request.Re
 
 // CreateGrantRequest indicates an expected call of CreateGrantRequest
 func (mr *MockKMSAPIMockRecorder) CreateGrantRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateGrantRequest", reflect.TypeOf((*MockKMSAPI)(nil).CreateGrantRequest), arg0)
 }
 
 // CreateGrantWithContext mocks base method
 func (m *MockKMSAPI) CreateGrantWithContext(arg0 context.Context, arg1 *kms.CreateGrantInput, arg2 ...request.Option) (*kms.CreateGrantOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -294,14 +265,12 @@ func (m *MockKMSAPI) CreateGrantWithContext(arg0 context.Context, arg1 *kms.Crea
 
 // CreateGrantWithContext indicates an expected call of CreateGrantWithContext
 func (mr *MockKMSAPIMockRecorder) CreateGrantWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateGrantWithContext", reflect.TypeOf((*MockKMSAPI)(nil).CreateGrantWithContext), varargs...)
 }
 
 // CreateKey mocks base method
 func (m *MockKMSAPI) CreateKey(arg0 *kms.CreateKeyInput) (*kms.CreateKeyOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateKey", arg0)
 	ret0, _ := ret[0].(*kms.CreateKeyOutput)
 	ret1, _ := ret[1].(error)
@@ -310,13 +279,11 @@ func (m *MockKMSAPI) CreateKey(arg0 *kms.CreateKeyInput) (*kms.CreateKeyOutput, 
 
 // CreateKey indicates an expected call of CreateKey
 func (mr *MockKMSAPIMockRecorder) CreateKey(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateKey", reflect.TypeOf((*MockKMSAPI)(nil).CreateKey), arg0)
 }
 
 // CreateKeyRequest mocks base method
 func (m *MockKMSAPI) CreateKeyRequest(arg0 *kms.CreateKeyInput) (*request.Request, *kms.CreateKeyOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateKeyRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*kms.CreateKeyOutput)
@@ -325,13 +292,11 @@ func (m *MockKMSAPI) CreateKeyRequest(arg0 *kms.CreateKeyInput) (*request.Reques
 
 // CreateKeyRequest indicates an expected call of CreateKeyRequest
 func (mr *MockKMSAPIMockRecorder) CreateKeyRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateKeyRequest", reflect.TypeOf((*MockKMSAPI)(nil).CreateKeyRequest), arg0)
 }
 
 // CreateKeyWithContext mocks base method
 func (m *MockKMSAPI) CreateKeyWithContext(arg0 context.Context, arg1 *kms.CreateKeyInput, arg2 ...request.Option) (*kms.CreateKeyOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -344,14 +309,12 @@ func (m *MockKMSAPI) CreateKeyWithContext(arg0 context.Context, arg1 *kms.Create
 
 // CreateKeyWithContext indicates an expected call of CreateKeyWithContext
 func (mr *MockKMSAPIMockRecorder) CreateKeyWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateKeyWithContext", reflect.TypeOf((*MockKMSAPI)(nil).CreateKeyWithContext), varargs...)
 }
 
 // Decrypt mocks base method
 func (m *MockKMSAPI) Decrypt(arg0 *kms.DecryptInput) (*kms.DecryptOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Decrypt", arg0)
 	ret0, _ := ret[0].(*kms.DecryptOutput)
 	ret1, _ := ret[1].(error)
@@ -360,13 +323,11 @@ func (m *MockKMSAPI) Decrypt(arg0 *kms.DecryptInput) (*kms.DecryptOutput, error)
 
 // Decrypt indicates an expected call of Decrypt
 func (mr *MockKMSAPIMockRecorder) Decrypt(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Decrypt", reflect.TypeOf((*MockKMSAPI)(nil).Decrypt), arg0)
 }
 
 // DecryptRequest mocks base method
 func (m *MockKMSAPI) DecryptRequest(arg0 *kms.DecryptInput) (*request.Request, *kms.DecryptOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DecryptRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*kms.DecryptOutput)
@@ -375,13 +336,11 @@ func (m *MockKMSAPI) DecryptRequest(arg0 *kms.DecryptInput) (*request.Request, *
 
 // DecryptRequest indicates an expected call of DecryptRequest
 func (mr *MockKMSAPIMockRecorder) DecryptRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DecryptRequest", reflect.TypeOf((*MockKMSAPI)(nil).DecryptRequest), arg0)
 }
 
 // DecryptWithContext mocks base method
 func (m *MockKMSAPI) DecryptWithContext(arg0 context.Context, arg1 *kms.DecryptInput, arg2 ...request.Option) (*kms.DecryptOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -394,14 +353,12 @@ func (m *MockKMSAPI) DecryptWithContext(arg0 context.Context, arg1 *kms.DecryptI
 
 // DecryptWithContext indicates an expected call of DecryptWithContext
 func (mr *MockKMSAPIMockRecorder) DecryptWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DecryptWithContext", reflect.TypeOf((*MockKMSAPI)(nil).DecryptWithContext), varargs...)
 }
 
 // DeleteAlias mocks base method
 func (m *MockKMSAPI) DeleteAlias(arg0 *kms.DeleteAliasInput) (*kms.DeleteAliasOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteAlias", arg0)
 	ret0, _ := ret[0].(*kms.DeleteAliasOutput)
 	ret1, _ := ret[1].(error)
@@ -410,13 +367,11 @@ func (m *MockKMSAPI) DeleteAlias(arg0 *kms.DeleteAliasInput) (*kms.DeleteAliasOu
 
 // DeleteAlias indicates an expected call of DeleteAlias
 func (mr *MockKMSAPIMockRecorder) DeleteAlias(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteAlias", reflect.TypeOf((*MockKMSAPI)(nil).DeleteAlias), arg0)
 }
 
 // DeleteAliasRequest mocks base method
 func (m *MockKMSAPI) DeleteAliasRequest(arg0 *kms.DeleteAliasInput) (*request.Request, *kms.DeleteAliasOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteAliasRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*kms.DeleteAliasOutput)
@@ -425,13 +380,11 @@ func (m *MockKMSAPI) DeleteAliasRequest(arg0 *kms.DeleteAliasInput) (*request.Re
 
 // DeleteAliasRequest indicates an expected call of DeleteAliasRequest
 func (mr *MockKMSAPIMockRecorder) DeleteAliasRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteAliasRequest", reflect.TypeOf((*MockKMSAPI)(nil).DeleteAliasRequest), arg0)
 }
 
 // DeleteAliasWithContext mocks base method
 func (m *MockKMSAPI) DeleteAliasWithContext(arg0 context.Context, arg1 *kms.DeleteAliasInput, arg2 ...request.Option) (*kms.DeleteAliasOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -444,14 +397,12 @@ func (m *MockKMSAPI) DeleteAliasWithContext(arg0 context.Context, arg1 *kms.Dele
 
 // DeleteAliasWithContext indicates an expected call of DeleteAliasWithContext
 func (mr *MockKMSAPIMockRecorder) DeleteAliasWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteAliasWithContext", reflect.TypeOf((*MockKMSAPI)(nil).DeleteAliasWithContext), varargs...)
 }
 
 // DeleteCustomKeyStore mocks base method
 func (m *MockKMSAPI) DeleteCustomKeyStore(arg0 *kms.DeleteCustomKeyStoreInput) (*kms.DeleteCustomKeyStoreOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteCustomKeyStore", arg0)
 	ret0, _ := ret[0].(*kms.DeleteCustomKeyStoreOutput)
 	ret1, _ := ret[1].(error)
@@ -460,13 +411,11 @@ func (m *MockKMSAPI) DeleteCustomKeyStore(arg0 *kms.DeleteCustomKeyStoreInput) (
 
 // DeleteCustomKeyStore indicates an expected call of DeleteCustomKeyStore
 func (mr *MockKMSAPIMockRecorder) DeleteCustomKeyStore(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteCustomKeyStore", reflect.TypeOf((*MockKMSAPI)(nil).DeleteCustomKeyStore), arg0)
 }
 
 // DeleteCustomKeyStoreRequest mocks base method
 func (m *MockKMSAPI) DeleteCustomKeyStoreRequest(arg0 *kms.DeleteCustomKeyStoreInput) (*request.Request, *kms.DeleteCustomKeyStoreOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteCustomKeyStoreRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*kms.DeleteCustomKeyStoreOutput)
@@ -475,13 +424,11 @@ func (m *MockKMSAPI) DeleteCustomKeyStoreRequest(arg0 *kms.DeleteCustomKeyStoreI
 
 // DeleteCustomKeyStoreRequest indicates an expected call of DeleteCustomKeyStoreRequest
 func (mr *MockKMSAPIMockRecorder) DeleteCustomKeyStoreRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteCustomKeyStoreRequest", reflect.TypeOf((*MockKMSAPI)(nil).DeleteCustomKeyStoreRequest), arg0)
 }
 
 // DeleteCustomKeyStoreWithContext mocks base method
 func (m *MockKMSAPI) DeleteCustomKeyStoreWithContext(arg0 context.Context, arg1 *kms.DeleteCustomKeyStoreInput, arg2 ...request.Option) (*kms.DeleteCustomKeyStoreOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -494,14 +441,12 @@ func (m *MockKMSAPI) DeleteCustomKeyStoreWithContext(arg0 context.Context, arg1 
 
 // DeleteCustomKeyStoreWithContext indicates an expected call of DeleteCustomKeyStoreWithContext
 func (mr *MockKMSAPIMockRecorder) DeleteCustomKeyStoreWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteCustomKeyStoreWithContext", reflect.TypeOf((*MockKMSAPI)(nil).DeleteCustomKeyStoreWithContext), varargs...)
 }
 
 // DeleteImportedKeyMaterial mocks base method
 func (m *MockKMSAPI) DeleteImportedKeyMaterial(arg0 *kms.DeleteImportedKeyMaterialInput) (*kms.DeleteImportedKeyMaterialOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteImportedKeyMaterial", arg0)
 	ret0, _ := ret[0].(*kms.DeleteImportedKeyMaterialOutput)
 	ret1, _ := ret[1].(error)
@@ -510,13 +455,11 @@ func (m *MockKMSAPI) DeleteImportedKeyMaterial(arg0 *kms.DeleteImportedKeyMateri
 
 // DeleteImportedKeyMaterial indicates an expected call of DeleteImportedKeyMaterial
 func (mr *MockKMSAPIMockRecorder) DeleteImportedKeyMaterial(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteImportedKeyMaterial", reflect.TypeOf((*MockKMSAPI)(nil).DeleteImportedKeyMaterial), arg0)
 }
 
 // DeleteImportedKeyMaterialRequest mocks base method
 func (m *MockKMSAPI) DeleteImportedKeyMaterialRequest(arg0 *kms.DeleteImportedKeyMaterialInput) (*request.Request, *kms.DeleteImportedKeyMaterialOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteImportedKeyMaterialRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*kms.DeleteImportedKeyMaterialOutput)
@@ -525,13 +468,11 @@ func (m *MockKMSAPI) DeleteImportedKeyMaterialRequest(arg0 *kms.DeleteImportedKe
 
 // DeleteImportedKeyMaterialRequest indicates an expected call of DeleteImportedKeyMaterialRequest
 func (mr *MockKMSAPIMockRecorder) DeleteImportedKeyMaterialRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteImportedKeyMaterialRequest", reflect.TypeOf((*MockKMSAPI)(nil).DeleteImportedKeyMaterialRequest), arg0)
 }
 
 // DeleteImportedKeyMaterialWithContext mocks base method
 func (m *MockKMSAPI) DeleteImportedKeyMaterialWithContext(arg0 context.Context, arg1 *kms.DeleteImportedKeyMaterialInput, arg2 ...request.Option) (*kms.DeleteImportedKeyMaterialOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -544,14 +485,12 @@ func (m *MockKMSAPI) DeleteImportedKeyMaterialWithContext(arg0 context.Context, 
 
 // DeleteImportedKeyMaterialWithContext indicates an expected call of DeleteImportedKeyMaterialWithContext
 func (mr *MockKMSAPIMockRecorder) DeleteImportedKeyMaterialWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteImportedKeyMaterialWithContext", reflect.TypeOf((*MockKMSAPI)(nil).DeleteImportedKeyMaterialWithContext), varargs...)
 }
 
 // DescribeCustomKeyStores mocks base method
 func (m *MockKMSAPI) DescribeCustomKeyStores(arg0 *kms.DescribeCustomKeyStoresInput) (*kms.DescribeCustomKeyStoresOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeCustomKeyStores", arg0)
 	ret0, _ := ret[0].(*kms.DescribeCustomKeyStoresOutput)
 	ret1, _ := ret[1].(error)
@@ -560,13 +499,11 @@ func (m *MockKMSAPI) DescribeCustomKeyStores(arg0 *kms.DescribeCustomKeyStoresIn
 
 // DescribeCustomKeyStores indicates an expected call of DescribeCustomKeyStores
 func (mr *MockKMSAPIMockRecorder) DescribeCustomKeyStores(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeCustomKeyStores", reflect.TypeOf((*MockKMSAPI)(nil).DescribeCustomKeyStores), arg0)
 }
 
 // DescribeCustomKeyStoresRequest mocks base method
 func (m *MockKMSAPI) DescribeCustomKeyStoresRequest(arg0 *kms.DescribeCustomKeyStoresInput) (*request.Request, *kms.DescribeCustomKeyStoresOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeCustomKeyStoresRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*kms.DescribeCustomKeyStoresOutput)
@@ -575,13 +512,11 @@ func (m *MockKMSAPI) DescribeCustomKeyStoresRequest(arg0 *kms.DescribeCustomKeyS
 
 // DescribeCustomKeyStoresRequest indicates an expected call of DescribeCustomKeyStoresRequest
 func (mr *MockKMSAPIMockRecorder) DescribeCustomKeyStoresRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeCustomKeyStoresRequest", reflect.TypeOf((*MockKMSAPI)(nil).DescribeCustomKeyStoresRequest), arg0)
 }
 
 // DescribeCustomKeyStoresWithContext mocks base method
 func (m *MockKMSAPI) DescribeCustomKeyStoresWithContext(arg0 context.Context, arg1 *kms.DescribeCustomKeyStoresInput, arg2 ...request.Option) (*kms.DescribeCustomKeyStoresOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -594,14 +529,12 @@ func (m *MockKMSAPI) DescribeCustomKeyStoresWithContext(arg0 context.Context, ar
 
 // DescribeCustomKeyStoresWithContext indicates an expected call of DescribeCustomKeyStoresWithContext
 func (mr *MockKMSAPIMockRecorder) DescribeCustomKeyStoresWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeCustomKeyStoresWithContext", reflect.TypeOf((*MockKMSAPI)(nil).DescribeCustomKeyStoresWithContext), varargs...)
 }
 
 // DescribeKey mocks base method
 func (m *MockKMSAPI) DescribeKey(arg0 *kms.DescribeKeyInput) (*kms.DescribeKeyOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeKey", arg0)
 	ret0, _ := ret[0].(*kms.DescribeKeyOutput)
 	ret1, _ := ret[1].(error)
@@ -610,13 +543,11 @@ func (m *MockKMSAPI) DescribeKey(arg0 *kms.DescribeKeyInput) (*kms.DescribeKeyOu
 
 // DescribeKey indicates an expected call of DescribeKey
 func (mr *MockKMSAPIMockRecorder) DescribeKey(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeKey", reflect.TypeOf((*MockKMSAPI)(nil).DescribeKey), arg0)
 }
 
 // DescribeKeyRequest mocks base method
 func (m *MockKMSAPI) DescribeKeyRequest(arg0 *kms.DescribeKeyInput) (*request.Request, *kms.DescribeKeyOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeKeyRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*kms.DescribeKeyOutput)
@@ -625,13 +556,11 @@ func (m *MockKMSAPI) DescribeKeyRequest(arg0 *kms.DescribeKeyInput) (*request.Re
 
 // DescribeKeyRequest indicates an expected call of DescribeKeyRequest
 func (mr *MockKMSAPIMockRecorder) DescribeKeyRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeKeyRequest", reflect.TypeOf((*MockKMSAPI)(nil).DescribeKeyRequest), arg0)
 }
 
 // DescribeKeyWithContext mocks base method
 func (m *MockKMSAPI) DescribeKeyWithContext(arg0 context.Context, arg1 *kms.DescribeKeyInput, arg2 ...request.Option) (*kms.DescribeKeyOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -644,14 +573,12 @@ func (m *MockKMSAPI) DescribeKeyWithContext(arg0 context.Context, arg1 *kms.Desc
 
 // DescribeKeyWithContext indicates an expected call of DescribeKeyWithContext
 func (mr *MockKMSAPIMockRecorder) DescribeKeyWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeKeyWithContext", reflect.TypeOf((*MockKMSAPI)(nil).DescribeKeyWithContext), varargs...)
 }
 
 // DisableKey mocks base method
 func (m *MockKMSAPI) DisableKey(arg0 *kms.DisableKeyInput) (*kms.DisableKeyOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DisableKey", arg0)
 	ret0, _ := ret[0].(*kms.DisableKeyOutput)
 	ret1, _ := ret[1].(error)
@@ -660,13 +587,11 @@ func (m *MockKMSAPI) DisableKey(arg0 *kms.DisableKeyInput) (*kms.DisableKeyOutpu
 
 // DisableKey indicates an expected call of DisableKey
 func (mr *MockKMSAPIMockRecorder) DisableKey(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DisableKey", reflect.TypeOf((*MockKMSAPI)(nil).DisableKey), arg0)
 }
 
 // DisableKeyRequest mocks base method
 func (m *MockKMSAPI) DisableKeyRequest(arg0 *kms.DisableKeyInput) (*request.Request, *kms.DisableKeyOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DisableKeyRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*kms.DisableKeyOutput)
@@ -675,13 +600,11 @@ func (m *MockKMSAPI) DisableKeyRequest(arg0 *kms.DisableKeyInput) (*request.Requ
 
 // DisableKeyRequest indicates an expected call of DisableKeyRequest
 func (mr *MockKMSAPIMockRecorder) DisableKeyRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DisableKeyRequest", reflect.TypeOf((*MockKMSAPI)(nil).DisableKeyRequest), arg0)
 }
 
 // DisableKeyRotation mocks base method
 func (m *MockKMSAPI) DisableKeyRotation(arg0 *kms.DisableKeyRotationInput) (*kms.DisableKeyRotationOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DisableKeyRotation", arg0)
 	ret0, _ := ret[0].(*kms.DisableKeyRotationOutput)
 	ret1, _ := ret[1].(error)
@@ -690,13 +613,11 @@ func (m *MockKMSAPI) DisableKeyRotation(arg0 *kms.DisableKeyRotationInput) (*kms
 
 // DisableKeyRotation indicates an expected call of DisableKeyRotation
 func (mr *MockKMSAPIMockRecorder) DisableKeyRotation(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DisableKeyRotation", reflect.TypeOf((*MockKMSAPI)(nil).DisableKeyRotation), arg0)
 }
 
 // DisableKeyRotationRequest mocks base method
 func (m *MockKMSAPI) DisableKeyRotationRequest(arg0 *kms.DisableKeyRotationInput) (*request.Request, *kms.DisableKeyRotationOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DisableKeyRotationRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*kms.DisableKeyRotationOutput)
@@ -705,13 +626,11 @@ func (m *MockKMSAPI) DisableKeyRotationRequest(arg0 *kms.DisableKeyRotationInput
 
 // DisableKeyRotationRequest indicates an expected call of DisableKeyRotationRequest
 func (mr *MockKMSAPIMockRecorder) DisableKeyRotationRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DisableKeyRotationRequest", reflect.TypeOf((*MockKMSAPI)(nil).DisableKeyRotationRequest), arg0)
 }
 
 // DisableKeyRotationWithContext mocks base method
 func (m *MockKMSAPI) DisableKeyRotationWithContext(arg0 context.Context, arg1 *kms.DisableKeyRotationInput, arg2 ...request.Option) (*kms.DisableKeyRotationOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -724,14 +643,12 @@ func (m *MockKMSAPI) DisableKeyRotationWithContext(arg0 context.Context, arg1 *k
 
 // DisableKeyRotationWithContext indicates an expected call of DisableKeyRotationWithContext
 func (mr *MockKMSAPIMockRecorder) DisableKeyRotationWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DisableKeyRotationWithContext", reflect.TypeOf((*MockKMSAPI)(nil).DisableKeyRotationWithContext), varargs...)
 }
 
 // DisableKeyWithContext mocks base method
 func (m *MockKMSAPI) DisableKeyWithContext(arg0 context.Context, arg1 *kms.DisableKeyInput, arg2 ...request.Option) (*kms.DisableKeyOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -744,14 +661,12 @@ func (m *MockKMSAPI) DisableKeyWithContext(arg0 context.Context, arg1 *kms.Disab
 
 // DisableKeyWithContext indicates an expected call of DisableKeyWithContext
 func (mr *MockKMSAPIMockRecorder) DisableKeyWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DisableKeyWithContext", reflect.TypeOf((*MockKMSAPI)(nil).DisableKeyWithContext), varargs...)
 }
 
 // DisconnectCustomKeyStore mocks base method
 func (m *MockKMSAPI) DisconnectCustomKeyStore(arg0 *kms.DisconnectCustomKeyStoreInput) (*kms.DisconnectCustomKeyStoreOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DisconnectCustomKeyStore", arg0)
 	ret0, _ := ret[0].(*kms.DisconnectCustomKeyStoreOutput)
 	ret1, _ := ret[1].(error)
@@ -760,13 +675,11 @@ func (m *MockKMSAPI) DisconnectCustomKeyStore(arg0 *kms.DisconnectCustomKeyStore
 
 // DisconnectCustomKeyStore indicates an expected call of DisconnectCustomKeyStore
 func (mr *MockKMSAPIMockRecorder) DisconnectCustomKeyStore(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DisconnectCustomKeyStore", reflect.TypeOf((*MockKMSAPI)(nil).DisconnectCustomKeyStore), arg0)
 }
 
 // DisconnectCustomKeyStoreRequest mocks base method
 func (m *MockKMSAPI) DisconnectCustomKeyStoreRequest(arg0 *kms.DisconnectCustomKeyStoreInput) (*request.Request, *kms.DisconnectCustomKeyStoreOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DisconnectCustomKeyStoreRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*kms.DisconnectCustomKeyStoreOutput)
@@ -775,13 +688,11 @@ func (m *MockKMSAPI) DisconnectCustomKeyStoreRequest(arg0 *kms.DisconnectCustomK
 
 // DisconnectCustomKeyStoreRequest indicates an expected call of DisconnectCustomKeyStoreRequest
 func (mr *MockKMSAPIMockRecorder) DisconnectCustomKeyStoreRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DisconnectCustomKeyStoreRequest", reflect.TypeOf((*MockKMSAPI)(nil).DisconnectCustomKeyStoreRequest), arg0)
 }
 
 // DisconnectCustomKeyStoreWithContext mocks base method
 func (m *MockKMSAPI) DisconnectCustomKeyStoreWithContext(arg0 context.Context, arg1 *kms.DisconnectCustomKeyStoreInput, arg2 ...request.Option) (*kms.DisconnectCustomKeyStoreOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -794,14 +705,12 @@ func (m *MockKMSAPI) DisconnectCustomKeyStoreWithContext(arg0 context.Context, a
 
 // DisconnectCustomKeyStoreWithContext indicates an expected call of DisconnectCustomKeyStoreWithContext
 func (mr *MockKMSAPIMockRecorder) DisconnectCustomKeyStoreWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DisconnectCustomKeyStoreWithContext", reflect.TypeOf((*MockKMSAPI)(nil).DisconnectCustomKeyStoreWithContext), varargs...)
 }
 
 // EnableKey mocks base method
 func (m *MockKMSAPI) EnableKey(arg0 *kms.EnableKeyInput) (*kms.EnableKeyOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "EnableKey", arg0)
 	ret0, _ := ret[0].(*kms.EnableKeyOutput)
 	ret1, _ := ret[1].(error)
@@ -810,13 +719,11 @@ func (m *MockKMSAPI) EnableKey(arg0 *kms.EnableKeyInput) (*kms.EnableKeyOutput, 
 
 // EnableKey indicates an expected call of EnableKey
 func (mr *MockKMSAPIMockRecorder) EnableKey(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnableKey", reflect.TypeOf((*MockKMSAPI)(nil).EnableKey), arg0)
 }
 
 // EnableKeyRequest mocks base method
 func (m *MockKMSAPI) EnableKeyRequest(arg0 *kms.EnableKeyInput) (*request.Request, *kms.EnableKeyOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "EnableKeyRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*kms.EnableKeyOutput)
@@ -825,13 +732,11 @@ func (m *MockKMSAPI) EnableKeyRequest(arg0 *kms.EnableKeyInput) (*request.Reques
 
 // EnableKeyRequest indicates an expected call of EnableKeyRequest
 func (mr *MockKMSAPIMockRecorder) EnableKeyRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnableKeyRequest", reflect.TypeOf((*MockKMSAPI)(nil).EnableKeyRequest), arg0)
 }
 
 // EnableKeyRotation mocks base method
 func (m *MockKMSAPI) EnableKeyRotation(arg0 *kms.EnableKeyRotationInput) (*kms.EnableKeyRotationOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "EnableKeyRotation", arg0)
 	ret0, _ := ret[0].(*kms.EnableKeyRotationOutput)
 	ret1, _ := ret[1].(error)
@@ -840,13 +745,11 @@ func (m *MockKMSAPI) EnableKeyRotation(arg0 *kms.EnableKeyRotationInput) (*kms.E
 
 // EnableKeyRotation indicates an expected call of EnableKeyRotation
 func (mr *MockKMSAPIMockRecorder) EnableKeyRotation(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnableKeyRotation", reflect.TypeOf((*MockKMSAPI)(nil).EnableKeyRotation), arg0)
 }
 
 // EnableKeyRotationRequest mocks base method
 func (m *MockKMSAPI) EnableKeyRotationRequest(arg0 *kms.EnableKeyRotationInput) (*request.Request, *kms.EnableKeyRotationOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "EnableKeyRotationRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*kms.EnableKeyRotationOutput)
@@ -855,13 +758,11 @@ func (m *MockKMSAPI) EnableKeyRotationRequest(arg0 *kms.EnableKeyRotationInput) 
 
 // EnableKeyRotationRequest indicates an expected call of EnableKeyRotationRequest
 func (mr *MockKMSAPIMockRecorder) EnableKeyRotationRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnableKeyRotationRequest", reflect.TypeOf((*MockKMSAPI)(nil).EnableKeyRotationRequest), arg0)
 }
 
 // EnableKeyRotationWithContext mocks base method
 func (m *MockKMSAPI) EnableKeyRotationWithContext(arg0 context.Context, arg1 *kms.EnableKeyRotationInput, arg2 ...request.Option) (*kms.EnableKeyRotationOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -874,14 +775,12 @@ func (m *MockKMSAPI) EnableKeyRotationWithContext(arg0 context.Context, arg1 *km
 
 // EnableKeyRotationWithContext indicates an expected call of EnableKeyRotationWithContext
 func (mr *MockKMSAPIMockRecorder) EnableKeyRotationWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnableKeyRotationWithContext", reflect.TypeOf((*MockKMSAPI)(nil).EnableKeyRotationWithContext), varargs...)
 }
 
 // EnableKeyWithContext mocks base method
 func (m *MockKMSAPI) EnableKeyWithContext(arg0 context.Context, arg1 *kms.EnableKeyInput, arg2 ...request.Option) (*kms.EnableKeyOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -894,14 +793,12 @@ func (m *MockKMSAPI) EnableKeyWithContext(arg0 context.Context, arg1 *kms.Enable
 
 // EnableKeyWithContext indicates an expected call of EnableKeyWithContext
 func (mr *MockKMSAPIMockRecorder) EnableKeyWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnableKeyWithContext", reflect.TypeOf((*MockKMSAPI)(nil).EnableKeyWithContext), varargs...)
 }
 
 // Encrypt mocks base method
 func (m *MockKMSAPI) Encrypt(arg0 *kms.EncryptInput) (*kms.EncryptOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Encrypt", arg0)
 	ret0, _ := ret[0].(*kms.EncryptOutput)
 	ret1, _ := ret[1].(error)
@@ -910,13 +807,11 @@ func (m *MockKMSAPI) Encrypt(arg0 *kms.EncryptInput) (*kms.EncryptOutput, error)
 
 // Encrypt indicates an expected call of Encrypt
 func (mr *MockKMSAPIMockRecorder) Encrypt(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Encrypt", reflect.TypeOf((*MockKMSAPI)(nil).Encrypt), arg0)
 }
 
 // EncryptRequest mocks base method
 func (m *MockKMSAPI) EncryptRequest(arg0 *kms.EncryptInput) (*request.Request, *kms.EncryptOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "EncryptRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*kms.EncryptOutput)
@@ -925,13 +820,11 @@ func (m *MockKMSAPI) EncryptRequest(arg0 *kms.EncryptInput) (*request.Request, *
 
 // EncryptRequest indicates an expected call of EncryptRequest
 func (mr *MockKMSAPIMockRecorder) EncryptRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EncryptRequest", reflect.TypeOf((*MockKMSAPI)(nil).EncryptRequest), arg0)
 }
 
 // EncryptWithContext mocks base method
 func (m *MockKMSAPI) EncryptWithContext(arg0 context.Context, arg1 *kms.EncryptInput, arg2 ...request.Option) (*kms.EncryptOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -944,14 +837,12 @@ func (m *MockKMSAPI) EncryptWithContext(arg0 context.Context, arg1 *kms.EncryptI
 
 // EncryptWithContext indicates an expected call of EncryptWithContext
 func (mr *MockKMSAPIMockRecorder) EncryptWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EncryptWithContext", reflect.TypeOf((*MockKMSAPI)(nil).EncryptWithContext), varargs...)
 }
 
 // GenerateDataKey mocks base method
 func (m *MockKMSAPI) GenerateDataKey(arg0 *kms.GenerateDataKeyInput) (*kms.GenerateDataKeyOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GenerateDataKey", arg0)
 	ret0, _ := ret[0].(*kms.GenerateDataKeyOutput)
 	ret1, _ := ret[1].(error)
@@ -960,13 +851,11 @@ func (m *MockKMSAPI) GenerateDataKey(arg0 *kms.GenerateDataKeyInput) (*kms.Gener
 
 // GenerateDataKey indicates an expected call of GenerateDataKey
 func (mr *MockKMSAPIMockRecorder) GenerateDataKey(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GenerateDataKey", reflect.TypeOf((*MockKMSAPI)(nil).GenerateDataKey), arg0)
 }
 
 // GenerateDataKeyRequest mocks base method
 func (m *MockKMSAPI) GenerateDataKeyRequest(arg0 *kms.GenerateDataKeyInput) (*request.Request, *kms.GenerateDataKeyOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GenerateDataKeyRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*kms.GenerateDataKeyOutput)
@@ -975,13 +864,11 @@ func (m *MockKMSAPI) GenerateDataKeyRequest(arg0 *kms.GenerateDataKeyInput) (*re
 
 // GenerateDataKeyRequest indicates an expected call of GenerateDataKeyRequest
 func (mr *MockKMSAPIMockRecorder) GenerateDataKeyRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GenerateDataKeyRequest", reflect.TypeOf((*MockKMSAPI)(nil).GenerateDataKeyRequest), arg0)
 }
 
 // GenerateDataKeyWithContext mocks base method
 func (m *MockKMSAPI) GenerateDataKeyWithContext(arg0 context.Context, arg1 *kms.GenerateDataKeyInput, arg2 ...request.Option) (*kms.GenerateDataKeyOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -994,14 +881,12 @@ func (m *MockKMSAPI) GenerateDataKeyWithContext(arg0 context.Context, arg1 *kms.
 
 // GenerateDataKeyWithContext indicates an expected call of GenerateDataKeyWithContext
 func (mr *MockKMSAPIMockRecorder) GenerateDataKeyWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GenerateDataKeyWithContext", reflect.TypeOf((*MockKMSAPI)(nil).GenerateDataKeyWithContext), varargs...)
 }
 
 // GenerateDataKeyWithoutPlaintext mocks base method
 func (m *MockKMSAPI) GenerateDataKeyWithoutPlaintext(arg0 *kms.GenerateDataKeyWithoutPlaintextInput) (*kms.GenerateDataKeyWithoutPlaintextOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GenerateDataKeyWithoutPlaintext", arg0)
 	ret0, _ := ret[0].(*kms.GenerateDataKeyWithoutPlaintextOutput)
 	ret1, _ := ret[1].(error)
@@ -1010,13 +895,11 @@ func (m *MockKMSAPI) GenerateDataKeyWithoutPlaintext(arg0 *kms.GenerateDataKeyWi
 
 // GenerateDataKeyWithoutPlaintext indicates an expected call of GenerateDataKeyWithoutPlaintext
 func (mr *MockKMSAPIMockRecorder) GenerateDataKeyWithoutPlaintext(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GenerateDataKeyWithoutPlaintext", reflect.TypeOf((*MockKMSAPI)(nil).GenerateDataKeyWithoutPlaintext), arg0)
 }
 
 // GenerateDataKeyWithoutPlaintextRequest mocks base method
 func (m *MockKMSAPI) GenerateDataKeyWithoutPlaintextRequest(arg0 *kms.GenerateDataKeyWithoutPlaintextInput) (*request.Request, *kms.GenerateDataKeyWithoutPlaintextOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GenerateDataKeyWithoutPlaintextRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*kms.GenerateDataKeyWithoutPlaintextOutput)
@@ -1025,13 +908,11 @@ func (m *MockKMSAPI) GenerateDataKeyWithoutPlaintextRequest(arg0 *kms.GenerateDa
 
 // GenerateDataKeyWithoutPlaintextRequest indicates an expected call of GenerateDataKeyWithoutPlaintextRequest
 func (mr *MockKMSAPIMockRecorder) GenerateDataKeyWithoutPlaintextRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GenerateDataKeyWithoutPlaintextRequest", reflect.TypeOf((*MockKMSAPI)(nil).GenerateDataKeyWithoutPlaintextRequest), arg0)
 }
 
 // GenerateDataKeyWithoutPlaintextWithContext mocks base method
 func (m *MockKMSAPI) GenerateDataKeyWithoutPlaintextWithContext(arg0 context.Context, arg1 *kms.GenerateDataKeyWithoutPlaintextInput, arg2 ...request.Option) (*kms.GenerateDataKeyWithoutPlaintextOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -1044,14 +925,12 @@ func (m *MockKMSAPI) GenerateDataKeyWithoutPlaintextWithContext(arg0 context.Con
 
 // GenerateDataKeyWithoutPlaintextWithContext indicates an expected call of GenerateDataKeyWithoutPlaintextWithContext
 func (mr *MockKMSAPIMockRecorder) GenerateDataKeyWithoutPlaintextWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GenerateDataKeyWithoutPlaintextWithContext", reflect.TypeOf((*MockKMSAPI)(nil).GenerateDataKeyWithoutPlaintextWithContext), varargs...)
 }
 
 // GenerateRandom mocks base method
 func (m *MockKMSAPI) GenerateRandom(arg0 *kms.GenerateRandomInput) (*kms.GenerateRandomOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GenerateRandom", arg0)
 	ret0, _ := ret[0].(*kms.GenerateRandomOutput)
 	ret1, _ := ret[1].(error)
@@ -1060,13 +939,11 @@ func (m *MockKMSAPI) GenerateRandom(arg0 *kms.GenerateRandomInput) (*kms.Generat
 
 // GenerateRandom indicates an expected call of GenerateRandom
 func (mr *MockKMSAPIMockRecorder) GenerateRandom(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GenerateRandom", reflect.TypeOf((*MockKMSAPI)(nil).GenerateRandom), arg0)
 }
 
 // GenerateRandomRequest mocks base method
 func (m *MockKMSAPI) GenerateRandomRequest(arg0 *kms.GenerateRandomInput) (*request.Request, *kms.GenerateRandomOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GenerateRandomRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*kms.GenerateRandomOutput)
@@ -1075,13 +952,11 @@ func (m *MockKMSAPI) GenerateRandomRequest(arg0 *kms.GenerateRandomInput) (*requ
 
 // GenerateRandomRequest indicates an expected call of GenerateRandomRequest
 func (mr *MockKMSAPIMockRecorder) GenerateRandomRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GenerateRandomRequest", reflect.TypeOf((*MockKMSAPI)(nil).GenerateRandomRequest), arg0)
 }
 
 // GenerateRandomWithContext mocks base method
 func (m *MockKMSAPI) GenerateRandomWithContext(arg0 context.Context, arg1 *kms.GenerateRandomInput, arg2 ...request.Option) (*kms.GenerateRandomOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -1094,14 +969,12 @@ func (m *MockKMSAPI) GenerateRandomWithContext(arg0 context.Context, arg1 *kms.G
 
 // GenerateRandomWithContext indicates an expected call of GenerateRandomWithContext
 func (mr *MockKMSAPIMockRecorder) GenerateRandomWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GenerateRandomWithContext", reflect.TypeOf((*MockKMSAPI)(nil).GenerateRandomWithContext), varargs...)
 }
 
 // GetKeyPolicy mocks base method
 func (m *MockKMSAPI) GetKeyPolicy(arg0 *kms.GetKeyPolicyInput) (*kms.GetKeyPolicyOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetKeyPolicy", arg0)
 	ret0, _ := ret[0].(*kms.GetKeyPolicyOutput)
 	ret1, _ := ret[1].(error)
@@ -1110,13 +983,11 @@ func (m *MockKMSAPI) GetKeyPolicy(arg0 *kms.GetKeyPolicyInput) (*kms.GetKeyPolic
 
 // GetKeyPolicy indicates an expected call of GetKeyPolicy
 func (mr *MockKMSAPIMockRecorder) GetKeyPolicy(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetKeyPolicy", reflect.TypeOf((*MockKMSAPI)(nil).GetKeyPolicy), arg0)
 }
 
 // GetKeyPolicyRequest mocks base method
 func (m *MockKMSAPI) GetKeyPolicyRequest(arg0 *kms.GetKeyPolicyInput) (*request.Request, *kms.GetKeyPolicyOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetKeyPolicyRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*kms.GetKeyPolicyOutput)
@@ -1125,13 +996,11 @@ func (m *MockKMSAPI) GetKeyPolicyRequest(arg0 *kms.GetKeyPolicyInput) (*request.
 
 // GetKeyPolicyRequest indicates an expected call of GetKeyPolicyRequest
 func (mr *MockKMSAPIMockRecorder) GetKeyPolicyRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetKeyPolicyRequest", reflect.TypeOf((*MockKMSAPI)(nil).GetKeyPolicyRequest), arg0)
 }
 
 // GetKeyPolicyWithContext mocks base method
 func (m *MockKMSAPI) GetKeyPolicyWithContext(arg0 context.Context, arg1 *kms.GetKeyPolicyInput, arg2 ...request.Option) (*kms.GetKeyPolicyOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -1144,14 +1013,12 @@ func (m *MockKMSAPI) GetKeyPolicyWithContext(arg0 context.Context, arg1 *kms.Get
 
 // GetKeyPolicyWithContext indicates an expected call of GetKeyPolicyWithContext
 func (mr *MockKMSAPIMockRecorder) GetKeyPolicyWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetKeyPolicyWithContext", reflect.TypeOf((*MockKMSAPI)(nil).GetKeyPolicyWithContext), varargs...)
 }
 
 // GetKeyRotationStatus mocks base method
 func (m *MockKMSAPI) GetKeyRotationStatus(arg0 *kms.GetKeyRotationStatusInput) (*kms.GetKeyRotationStatusOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetKeyRotationStatus", arg0)
 	ret0, _ := ret[0].(*kms.GetKeyRotationStatusOutput)
 	ret1, _ := ret[1].(error)
@@ -1160,13 +1027,11 @@ func (m *MockKMSAPI) GetKeyRotationStatus(arg0 *kms.GetKeyRotationStatusInput) (
 
 // GetKeyRotationStatus indicates an expected call of GetKeyRotationStatus
 func (mr *MockKMSAPIMockRecorder) GetKeyRotationStatus(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetKeyRotationStatus", reflect.TypeOf((*MockKMSAPI)(nil).GetKeyRotationStatus), arg0)
 }
 
 // GetKeyRotationStatusRequest mocks base method
 func (m *MockKMSAPI) GetKeyRotationStatusRequest(arg0 *kms.GetKeyRotationStatusInput) (*request.Request, *kms.GetKeyRotationStatusOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetKeyRotationStatusRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*kms.GetKeyRotationStatusOutput)
@@ -1175,13 +1040,11 @@ func (m *MockKMSAPI) GetKeyRotationStatusRequest(arg0 *kms.GetKeyRotationStatusI
 
 // GetKeyRotationStatusRequest indicates an expected call of GetKeyRotationStatusRequest
 func (mr *MockKMSAPIMockRecorder) GetKeyRotationStatusRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetKeyRotationStatusRequest", reflect.TypeOf((*MockKMSAPI)(nil).GetKeyRotationStatusRequest), arg0)
 }
 
 // GetKeyRotationStatusWithContext mocks base method
 func (m *MockKMSAPI) GetKeyRotationStatusWithContext(arg0 context.Context, arg1 *kms.GetKeyRotationStatusInput, arg2 ...request.Option) (*kms.GetKeyRotationStatusOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -1194,14 +1057,12 @@ func (m *MockKMSAPI) GetKeyRotationStatusWithContext(arg0 context.Context, arg1 
 
 // GetKeyRotationStatusWithContext indicates an expected call of GetKeyRotationStatusWithContext
 func (mr *MockKMSAPIMockRecorder) GetKeyRotationStatusWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetKeyRotationStatusWithContext", reflect.TypeOf((*MockKMSAPI)(nil).GetKeyRotationStatusWithContext), varargs...)
 }
 
 // GetParametersForImport mocks base method
 func (m *MockKMSAPI) GetParametersForImport(arg0 *kms.GetParametersForImportInput) (*kms.GetParametersForImportOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetParametersForImport", arg0)
 	ret0, _ := ret[0].(*kms.GetParametersForImportOutput)
 	ret1, _ := ret[1].(error)
@@ -1210,13 +1071,11 @@ func (m *MockKMSAPI) GetParametersForImport(arg0 *kms.GetParametersForImportInpu
 
 // GetParametersForImport indicates an expected call of GetParametersForImport
 func (mr *MockKMSAPIMockRecorder) GetParametersForImport(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetParametersForImport", reflect.TypeOf((*MockKMSAPI)(nil).GetParametersForImport), arg0)
 }
 
 // GetParametersForImportRequest mocks base method
 func (m *MockKMSAPI) GetParametersForImportRequest(arg0 *kms.GetParametersForImportInput) (*request.Request, *kms.GetParametersForImportOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetParametersForImportRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*kms.GetParametersForImportOutput)
@@ -1225,13 +1084,11 @@ func (m *MockKMSAPI) GetParametersForImportRequest(arg0 *kms.GetParametersForImp
 
 // GetParametersForImportRequest indicates an expected call of GetParametersForImportRequest
 func (mr *MockKMSAPIMockRecorder) GetParametersForImportRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetParametersForImportRequest", reflect.TypeOf((*MockKMSAPI)(nil).GetParametersForImportRequest), arg0)
 }
 
 // GetParametersForImportWithContext mocks base method
 func (m *MockKMSAPI) GetParametersForImportWithContext(arg0 context.Context, arg1 *kms.GetParametersForImportInput, arg2 ...request.Option) (*kms.GetParametersForImportOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -1244,14 +1101,12 @@ func (m *MockKMSAPI) GetParametersForImportWithContext(arg0 context.Context, arg
 
 // GetParametersForImportWithContext indicates an expected call of GetParametersForImportWithContext
 func (mr *MockKMSAPIMockRecorder) GetParametersForImportWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetParametersForImportWithContext", reflect.TypeOf((*MockKMSAPI)(nil).GetParametersForImportWithContext), varargs...)
 }
 
 // ImportKeyMaterial mocks base method
 func (m *MockKMSAPI) ImportKeyMaterial(arg0 *kms.ImportKeyMaterialInput) (*kms.ImportKeyMaterialOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ImportKeyMaterial", arg0)
 	ret0, _ := ret[0].(*kms.ImportKeyMaterialOutput)
 	ret1, _ := ret[1].(error)
@@ -1260,13 +1115,11 @@ func (m *MockKMSAPI) ImportKeyMaterial(arg0 *kms.ImportKeyMaterialInput) (*kms.I
 
 // ImportKeyMaterial indicates an expected call of ImportKeyMaterial
 func (mr *MockKMSAPIMockRecorder) ImportKeyMaterial(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ImportKeyMaterial", reflect.TypeOf((*MockKMSAPI)(nil).ImportKeyMaterial), arg0)
 }
 
 // ImportKeyMaterialRequest mocks base method
 func (m *MockKMSAPI) ImportKeyMaterialRequest(arg0 *kms.ImportKeyMaterialInput) (*request.Request, *kms.ImportKeyMaterialOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ImportKeyMaterialRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*kms.ImportKeyMaterialOutput)
@@ -1275,13 +1128,11 @@ func (m *MockKMSAPI) ImportKeyMaterialRequest(arg0 *kms.ImportKeyMaterialInput) 
 
 // ImportKeyMaterialRequest indicates an expected call of ImportKeyMaterialRequest
 func (mr *MockKMSAPIMockRecorder) ImportKeyMaterialRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ImportKeyMaterialRequest", reflect.TypeOf((*MockKMSAPI)(nil).ImportKeyMaterialRequest), arg0)
 }
 
 // ImportKeyMaterialWithContext mocks base method
 func (m *MockKMSAPI) ImportKeyMaterialWithContext(arg0 context.Context, arg1 *kms.ImportKeyMaterialInput, arg2 ...request.Option) (*kms.ImportKeyMaterialOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -1294,14 +1145,12 @@ func (m *MockKMSAPI) ImportKeyMaterialWithContext(arg0 context.Context, arg1 *km
 
 // ImportKeyMaterialWithContext indicates an expected call of ImportKeyMaterialWithContext
 func (mr *MockKMSAPIMockRecorder) ImportKeyMaterialWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ImportKeyMaterialWithContext", reflect.TypeOf((*MockKMSAPI)(nil).ImportKeyMaterialWithContext), varargs...)
 }
 
 // ListAliases mocks base method
 func (m *MockKMSAPI) ListAliases(arg0 *kms.ListAliasesInput) (*kms.ListAliasesOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListAliases", arg0)
 	ret0, _ := ret[0].(*kms.ListAliasesOutput)
 	ret1, _ := ret[1].(error)
@@ -1310,13 +1159,11 @@ func (m *MockKMSAPI) ListAliases(arg0 *kms.ListAliasesInput) (*kms.ListAliasesOu
 
 // ListAliases indicates an expected call of ListAliases
 func (mr *MockKMSAPIMockRecorder) ListAliases(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAliases", reflect.TypeOf((*MockKMSAPI)(nil).ListAliases), arg0)
 }
 
 // ListAliasesPages mocks base method
 func (m *MockKMSAPI) ListAliasesPages(arg0 *kms.ListAliasesInput, arg1 func(*kms.ListAliasesOutput, bool) bool) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListAliasesPages", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -1324,13 +1171,11 @@ func (m *MockKMSAPI) ListAliasesPages(arg0 *kms.ListAliasesInput, arg1 func(*kms
 
 // ListAliasesPages indicates an expected call of ListAliasesPages
 func (mr *MockKMSAPIMockRecorder) ListAliasesPages(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAliasesPages", reflect.TypeOf((*MockKMSAPI)(nil).ListAliasesPages), arg0, arg1)
 }
 
 // ListAliasesPagesWithContext mocks base method
 func (m *MockKMSAPI) ListAliasesPagesWithContext(arg0 context.Context, arg1 *kms.ListAliasesInput, arg2 func(*kms.ListAliasesOutput, bool) bool, arg3 ...request.Option) error {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1, arg2}
 	for _, a := range arg3 {
 		varargs = append(varargs, a)
@@ -1342,14 +1187,12 @@ func (m *MockKMSAPI) ListAliasesPagesWithContext(arg0 context.Context, arg1 *kms
 
 // ListAliasesPagesWithContext indicates an expected call of ListAliasesPagesWithContext
 func (mr *MockKMSAPIMockRecorder) ListAliasesPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAliasesPagesWithContext", reflect.TypeOf((*MockKMSAPI)(nil).ListAliasesPagesWithContext), varargs...)
 }
 
 // ListAliasesRequest mocks base method
 func (m *MockKMSAPI) ListAliasesRequest(arg0 *kms.ListAliasesInput) (*request.Request, *kms.ListAliasesOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListAliasesRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*kms.ListAliasesOutput)
@@ -1358,13 +1201,11 @@ func (m *MockKMSAPI) ListAliasesRequest(arg0 *kms.ListAliasesInput) (*request.Re
 
 // ListAliasesRequest indicates an expected call of ListAliasesRequest
 func (mr *MockKMSAPIMockRecorder) ListAliasesRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAliasesRequest", reflect.TypeOf((*MockKMSAPI)(nil).ListAliasesRequest), arg0)
 }
 
 // ListAliasesWithContext mocks base method
 func (m *MockKMSAPI) ListAliasesWithContext(arg0 context.Context, arg1 *kms.ListAliasesInput, arg2 ...request.Option) (*kms.ListAliasesOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -1377,14 +1218,12 @@ func (m *MockKMSAPI) ListAliasesWithContext(arg0 context.Context, arg1 *kms.List
 
 // ListAliasesWithContext indicates an expected call of ListAliasesWithContext
 func (mr *MockKMSAPIMockRecorder) ListAliasesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAliasesWithContext", reflect.TypeOf((*MockKMSAPI)(nil).ListAliasesWithContext), varargs...)
 }
 
 // ListGrants mocks base method
 func (m *MockKMSAPI) ListGrants(arg0 *kms.ListGrantsInput) (*kms.ListGrantsResponse, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListGrants", arg0)
 	ret0, _ := ret[0].(*kms.ListGrantsResponse)
 	ret1, _ := ret[1].(error)
@@ -1393,13 +1232,11 @@ func (m *MockKMSAPI) ListGrants(arg0 *kms.ListGrantsInput) (*kms.ListGrantsRespo
 
 // ListGrants indicates an expected call of ListGrants
 func (mr *MockKMSAPIMockRecorder) ListGrants(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListGrants", reflect.TypeOf((*MockKMSAPI)(nil).ListGrants), arg0)
 }
 
 // ListGrantsPages mocks base method
 func (m *MockKMSAPI) ListGrantsPages(arg0 *kms.ListGrantsInput, arg1 func(*kms.ListGrantsResponse, bool) bool) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListGrantsPages", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -1407,13 +1244,11 @@ func (m *MockKMSAPI) ListGrantsPages(arg0 *kms.ListGrantsInput, arg1 func(*kms.L
 
 // ListGrantsPages indicates an expected call of ListGrantsPages
 func (mr *MockKMSAPIMockRecorder) ListGrantsPages(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListGrantsPages", reflect.TypeOf((*MockKMSAPI)(nil).ListGrantsPages), arg0, arg1)
 }
 
 // ListGrantsPagesWithContext mocks base method
 func (m *MockKMSAPI) ListGrantsPagesWithContext(arg0 context.Context, arg1 *kms.ListGrantsInput, arg2 func(*kms.ListGrantsResponse, bool) bool, arg3 ...request.Option) error {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1, arg2}
 	for _, a := range arg3 {
 		varargs = append(varargs, a)
@@ -1425,14 +1260,12 @@ func (m *MockKMSAPI) ListGrantsPagesWithContext(arg0 context.Context, arg1 *kms.
 
 // ListGrantsPagesWithContext indicates an expected call of ListGrantsPagesWithContext
 func (mr *MockKMSAPIMockRecorder) ListGrantsPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListGrantsPagesWithContext", reflect.TypeOf((*MockKMSAPI)(nil).ListGrantsPagesWithContext), varargs...)
 }
 
 // ListGrantsRequest mocks base method
 func (m *MockKMSAPI) ListGrantsRequest(arg0 *kms.ListGrantsInput) (*request.Request, *kms.ListGrantsResponse) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListGrantsRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*kms.ListGrantsResponse)
@@ -1441,13 +1274,11 @@ func (m *MockKMSAPI) ListGrantsRequest(arg0 *kms.ListGrantsInput) (*request.Requ
 
 // ListGrantsRequest indicates an expected call of ListGrantsRequest
 func (mr *MockKMSAPIMockRecorder) ListGrantsRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListGrantsRequest", reflect.TypeOf((*MockKMSAPI)(nil).ListGrantsRequest), arg0)
 }
 
 // ListGrantsWithContext mocks base method
 func (m *MockKMSAPI) ListGrantsWithContext(arg0 context.Context, arg1 *kms.ListGrantsInput, arg2 ...request.Option) (*kms.ListGrantsResponse, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -1460,14 +1291,12 @@ func (m *MockKMSAPI) ListGrantsWithContext(arg0 context.Context, arg1 *kms.ListG
 
 // ListGrantsWithContext indicates an expected call of ListGrantsWithContext
 func (mr *MockKMSAPIMockRecorder) ListGrantsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListGrantsWithContext", reflect.TypeOf((*MockKMSAPI)(nil).ListGrantsWithContext), varargs...)
 }
 
 // ListKeyPolicies mocks base method
 func (m *MockKMSAPI) ListKeyPolicies(arg0 *kms.ListKeyPoliciesInput) (*kms.ListKeyPoliciesOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListKeyPolicies", arg0)
 	ret0, _ := ret[0].(*kms.ListKeyPoliciesOutput)
 	ret1, _ := ret[1].(error)
@@ -1476,13 +1305,11 @@ func (m *MockKMSAPI) ListKeyPolicies(arg0 *kms.ListKeyPoliciesInput) (*kms.ListK
 
 // ListKeyPolicies indicates an expected call of ListKeyPolicies
 func (mr *MockKMSAPIMockRecorder) ListKeyPolicies(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListKeyPolicies", reflect.TypeOf((*MockKMSAPI)(nil).ListKeyPolicies), arg0)
 }
 
 // ListKeyPoliciesPages mocks base method
 func (m *MockKMSAPI) ListKeyPoliciesPages(arg0 *kms.ListKeyPoliciesInput, arg1 func(*kms.ListKeyPoliciesOutput, bool) bool) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListKeyPoliciesPages", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -1490,13 +1317,11 @@ func (m *MockKMSAPI) ListKeyPoliciesPages(arg0 *kms.ListKeyPoliciesInput, arg1 f
 
 // ListKeyPoliciesPages indicates an expected call of ListKeyPoliciesPages
 func (mr *MockKMSAPIMockRecorder) ListKeyPoliciesPages(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListKeyPoliciesPages", reflect.TypeOf((*MockKMSAPI)(nil).ListKeyPoliciesPages), arg0, arg1)
 }
 
 // ListKeyPoliciesPagesWithContext mocks base method
 func (m *MockKMSAPI) ListKeyPoliciesPagesWithContext(arg0 context.Context, arg1 *kms.ListKeyPoliciesInput, arg2 func(*kms.ListKeyPoliciesOutput, bool) bool, arg3 ...request.Option) error {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1, arg2}
 	for _, a := range arg3 {
 		varargs = append(varargs, a)
@@ -1508,14 +1333,12 @@ func (m *MockKMSAPI) ListKeyPoliciesPagesWithContext(arg0 context.Context, arg1 
 
 // ListKeyPoliciesPagesWithContext indicates an expected call of ListKeyPoliciesPagesWithContext
 func (mr *MockKMSAPIMockRecorder) ListKeyPoliciesPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListKeyPoliciesPagesWithContext", reflect.TypeOf((*MockKMSAPI)(nil).ListKeyPoliciesPagesWithContext), varargs...)
 }
 
 // ListKeyPoliciesRequest mocks base method
 func (m *MockKMSAPI) ListKeyPoliciesRequest(arg0 *kms.ListKeyPoliciesInput) (*request.Request, *kms.ListKeyPoliciesOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListKeyPoliciesRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*kms.ListKeyPoliciesOutput)
@@ -1524,13 +1347,11 @@ func (m *MockKMSAPI) ListKeyPoliciesRequest(arg0 *kms.ListKeyPoliciesInput) (*re
 
 // ListKeyPoliciesRequest indicates an expected call of ListKeyPoliciesRequest
 func (mr *MockKMSAPIMockRecorder) ListKeyPoliciesRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListKeyPoliciesRequest", reflect.TypeOf((*MockKMSAPI)(nil).ListKeyPoliciesRequest), arg0)
 }
 
 // ListKeyPoliciesWithContext mocks base method
 func (m *MockKMSAPI) ListKeyPoliciesWithContext(arg0 context.Context, arg1 *kms.ListKeyPoliciesInput, arg2 ...request.Option) (*kms.ListKeyPoliciesOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -1543,14 +1364,12 @@ func (m *MockKMSAPI) ListKeyPoliciesWithContext(arg0 context.Context, arg1 *kms.
 
 // ListKeyPoliciesWithContext indicates an expected call of ListKeyPoliciesWithContext
 func (mr *MockKMSAPIMockRecorder) ListKeyPoliciesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListKeyPoliciesWithContext", reflect.TypeOf((*MockKMSAPI)(nil).ListKeyPoliciesWithContext), varargs...)
 }
 
 // ListKeys mocks base method
 func (m *MockKMSAPI) ListKeys(arg0 *kms.ListKeysInput) (*kms.ListKeysOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListKeys", arg0)
 	ret0, _ := ret[0].(*kms.ListKeysOutput)
 	ret1, _ := ret[1].(error)
@@ -1559,13 +1378,11 @@ func (m *MockKMSAPI) ListKeys(arg0 *kms.ListKeysInput) (*kms.ListKeysOutput, err
 
 // ListKeys indicates an expected call of ListKeys
 func (mr *MockKMSAPIMockRecorder) ListKeys(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListKeys", reflect.TypeOf((*MockKMSAPI)(nil).ListKeys), arg0)
 }
 
 // ListKeysPages mocks base method
 func (m *MockKMSAPI) ListKeysPages(arg0 *kms.ListKeysInput, arg1 func(*kms.ListKeysOutput, bool) bool) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListKeysPages", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -1573,13 +1390,11 @@ func (m *MockKMSAPI) ListKeysPages(arg0 *kms.ListKeysInput, arg1 func(*kms.ListK
 
 // ListKeysPages indicates an expected call of ListKeysPages
 func (mr *MockKMSAPIMockRecorder) ListKeysPages(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListKeysPages", reflect.TypeOf((*MockKMSAPI)(nil).ListKeysPages), arg0, arg1)
 }
 
 // ListKeysPagesWithContext mocks base method
 func (m *MockKMSAPI) ListKeysPagesWithContext(arg0 context.Context, arg1 *kms.ListKeysInput, arg2 func(*kms.ListKeysOutput, bool) bool, arg3 ...request.Option) error {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1, arg2}
 	for _, a := range arg3 {
 		varargs = append(varargs, a)
@@ -1591,14 +1406,12 @@ func (m *MockKMSAPI) ListKeysPagesWithContext(arg0 context.Context, arg1 *kms.Li
 
 // ListKeysPagesWithContext indicates an expected call of ListKeysPagesWithContext
 func (mr *MockKMSAPIMockRecorder) ListKeysPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListKeysPagesWithContext", reflect.TypeOf((*MockKMSAPI)(nil).ListKeysPagesWithContext), varargs...)
 }
 
 // ListKeysRequest mocks base method
 func (m *MockKMSAPI) ListKeysRequest(arg0 *kms.ListKeysInput) (*request.Request, *kms.ListKeysOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListKeysRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*kms.ListKeysOutput)
@@ -1607,13 +1420,11 @@ func (m *MockKMSAPI) ListKeysRequest(arg0 *kms.ListKeysInput) (*request.Request,
 
 // ListKeysRequest indicates an expected call of ListKeysRequest
 func (mr *MockKMSAPIMockRecorder) ListKeysRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListKeysRequest", reflect.TypeOf((*MockKMSAPI)(nil).ListKeysRequest), arg0)
 }
 
 // ListKeysWithContext mocks base method
 func (m *MockKMSAPI) ListKeysWithContext(arg0 context.Context, arg1 *kms.ListKeysInput, arg2 ...request.Option) (*kms.ListKeysOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -1626,14 +1437,12 @@ func (m *MockKMSAPI) ListKeysWithContext(arg0 context.Context, arg1 *kms.ListKey
 
 // ListKeysWithContext indicates an expected call of ListKeysWithContext
 func (mr *MockKMSAPIMockRecorder) ListKeysWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListKeysWithContext", reflect.TypeOf((*MockKMSAPI)(nil).ListKeysWithContext), varargs...)
 }
 
 // ListResourceTags mocks base method
 func (m *MockKMSAPI) ListResourceTags(arg0 *kms.ListResourceTagsInput) (*kms.ListResourceTagsOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListResourceTags", arg0)
 	ret0, _ := ret[0].(*kms.ListResourceTagsOutput)
 	ret1, _ := ret[1].(error)
@@ -1642,13 +1451,11 @@ func (m *MockKMSAPI) ListResourceTags(arg0 *kms.ListResourceTagsInput) (*kms.Lis
 
 // ListResourceTags indicates an expected call of ListResourceTags
 func (mr *MockKMSAPIMockRecorder) ListResourceTags(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListResourceTags", reflect.TypeOf((*MockKMSAPI)(nil).ListResourceTags), arg0)
 }
 
 // ListResourceTagsRequest mocks base method
 func (m *MockKMSAPI) ListResourceTagsRequest(arg0 *kms.ListResourceTagsInput) (*request.Request, *kms.ListResourceTagsOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListResourceTagsRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*kms.ListResourceTagsOutput)
@@ -1657,13 +1464,11 @@ func (m *MockKMSAPI) ListResourceTagsRequest(arg0 *kms.ListResourceTagsInput) (*
 
 // ListResourceTagsRequest indicates an expected call of ListResourceTagsRequest
 func (mr *MockKMSAPIMockRecorder) ListResourceTagsRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListResourceTagsRequest", reflect.TypeOf((*MockKMSAPI)(nil).ListResourceTagsRequest), arg0)
 }
 
 // ListResourceTagsWithContext mocks base method
 func (m *MockKMSAPI) ListResourceTagsWithContext(arg0 context.Context, arg1 *kms.ListResourceTagsInput, arg2 ...request.Option) (*kms.ListResourceTagsOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -1676,14 +1481,12 @@ func (m *MockKMSAPI) ListResourceTagsWithContext(arg0 context.Context, arg1 *kms
 
 // ListResourceTagsWithContext indicates an expected call of ListResourceTagsWithContext
 func (mr *MockKMSAPIMockRecorder) ListResourceTagsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListResourceTagsWithContext", reflect.TypeOf((*MockKMSAPI)(nil).ListResourceTagsWithContext), varargs...)
 }
 
 // ListRetirableGrants mocks base method
 func (m *MockKMSAPI) ListRetirableGrants(arg0 *kms.ListRetirableGrantsInput) (*kms.ListGrantsResponse, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListRetirableGrants", arg0)
 	ret0, _ := ret[0].(*kms.ListGrantsResponse)
 	ret1, _ := ret[1].(error)
@@ -1692,13 +1495,11 @@ func (m *MockKMSAPI) ListRetirableGrants(arg0 *kms.ListRetirableGrantsInput) (*k
 
 // ListRetirableGrants indicates an expected call of ListRetirableGrants
 func (mr *MockKMSAPIMockRecorder) ListRetirableGrants(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListRetirableGrants", reflect.TypeOf((*MockKMSAPI)(nil).ListRetirableGrants), arg0)
 }
 
 // ListRetirableGrantsRequest mocks base method
 func (m *MockKMSAPI) ListRetirableGrantsRequest(arg0 *kms.ListRetirableGrantsInput) (*request.Request, *kms.ListGrantsResponse) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListRetirableGrantsRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*kms.ListGrantsResponse)
@@ -1707,13 +1508,11 @@ func (m *MockKMSAPI) ListRetirableGrantsRequest(arg0 *kms.ListRetirableGrantsInp
 
 // ListRetirableGrantsRequest indicates an expected call of ListRetirableGrantsRequest
 func (mr *MockKMSAPIMockRecorder) ListRetirableGrantsRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListRetirableGrantsRequest", reflect.TypeOf((*MockKMSAPI)(nil).ListRetirableGrantsRequest), arg0)
 }
 
 // ListRetirableGrantsWithContext mocks base method
 func (m *MockKMSAPI) ListRetirableGrantsWithContext(arg0 context.Context, arg1 *kms.ListRetirableGrantsInput, arg2 ...request.Option) (*kms.ListGrantsResponse, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -1726,14 +1525,12 @@ func (m *MockKMSAPI) ListRetirableGrantsWithContext(arg0 context.Context, arg1 *
 
 // ListRetirableGrantsWithContext indicates an expected call of ListRetirableGrantsWithContext
 func (mr *MockKMSAPIMockRecorder) ListRetirableGrantsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListRetirableGrantsWithContext", reflect.TypeOf((*MockKMSAPI)(nil).ListRetirableGrantsWithContext), varargs...)
 }
 
 // PutKeyPolicy mocks base method
 func (m *MockKMSAPI) PutKeyPolicy(arg0 *kms.PutKeyPolicyInput) (*kms.PutKeyPolicyOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PutKeyPolicy", arg0)
 	ret0, _ := ret[0].(*kms.PutKeyPolicyOutput)
 	ret1, _ := ret[1].(error)
@@ -1742,13 +1539,11 @@ func (m *MockKMSAPI) PutKeyPolicy(arg0 *kms.PutKeyPolicyInput) (*kms.PutKeyPolic
 
 // PutKeyPolicy indicates an expected call of PutKeyPolicy
 func (mr *MockKMSAPIMockRecorder) PutKeyPolicy(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutKeyPolicy", reflect.TypeOf((*MockKMSAPI)(nil).PutKeyPolicy), arg0)
 }
 
 // PutKeyPolicyRequest mocks base method
 func (m *MockKMSAPI) PutKeyPolicyRequest(arg0 *kms.PutKeyPolicyInput) (*request.Request, *kms.PutKeyPolicyOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PutKeyPolicyRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*kms.PutKeyPolicyOutput)
@@ -1757,13 +1552,11 @@ func (m *MockKMSAPI) PutKeyPolicyRequest(arg0 *kms.PutKeyPolicyInput) (*request.
 
 // PutKeyPolicyRequest indicates an expected call of PutKeyPolicyRequest
 func (mr *MockKMSAPIMockRecorder) PutKeyPolicyRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutKeyPolicyRequest", reflect.TypeOf((*MockKMSAPI)(nil).PutKeyPolicyRequest), arg0)
 }
 
 // PutKeyPolicyWithContext mocks base method
 func (m *MockKMSAPI) PutKeyPolicyWithContext(arg0 context.Context, arg1 *kms.PutKeyPolicyInput, arg2 ...request.Option) (*kms.PutKeyPolicyOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -1776,14 +1569,12 @@ func (m *MockKMSAPI) PutKeyPolicyWithContext(arg0 context.Context, arg1 *kms.Put
 
 // PutKeyPolicyWithContext indicates an expected call of PutKeyPolicyWithContext
 func (mr *MockKMSAPIMockRecorder) PutKeyPolicyWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutKeyPolicyWithContext", reflect.TypeOf((*MockKMSAPI)(nil).PutKeyPolicyWithContext), varargs...)
 }
 
 // ReEncrypt mocks base method
 func (m *MockKMSAPI) ReEncrypt(arg0 *kms.ReEncryptInput) (*kms.ReEncryptOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ReEncrypt", arg0)
 	ret0, _ := ret[0].(*kms.ReEncryptOutput)
 	ret1, _ := ret[1].(error)
@@ -1792,13 +1583,11 @@ func (m *MockKMSAPI) ReEncrypt(arg0 *kms.ReEncryptInput) (*kms.ReEncryptOutput, 
 
 // ReEncrypt indicates an expected call of ReEncrypt
 func (mr *MockKMSAPIMockRecorder) ReEncrypt(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReEncrypt", reflect.TypeOf((*MockKMSAPI)(nil).ReEncrypt), arg0)
 }
 
 // ReEncryptRequest mocks base method
 func (m *MockKMSAPI) ReEncryptRequest(arg0 *kms.ReEncryptInput) (*request.Request, *kms.ReEncryptOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ReEncryptRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*kms.ReEncryptOutput)
@@ -1807,13 +1596,11 @@ func (m *MockKMSAPI) ReEncryptRequest(arg0 *kms.ReEncryptInput) (*request.Reques
 
 // ReEncryptRequest indicates an expected call of ReEncryptRequest
 func (mr *MockKMSAPIMockRecorder) ReEncryptRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReEncryptRequest", reflect.TypeOf((*MockKMSAPI)(nil).ReEncryptRequest), arg0)
 }
 
 // ReEncryptWithContext mocks base method
 func (m *MockKMSAPI) ReEncryptWithContext(arg0 context.Context, arg1 *kms.ReEncryptInput, arg2 ...request.Option) (*kms.ReEncryptOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -1826,14 +1613,12 @@ func (m *MockKMSAPI) ReEncryptWithContext(arg0 context.Context, arg1 *kms.ReEncr
 
 // ReEncryptWithContext indicates an expected call of ReEncryptWithContext
 func (mr *MockKMSAPIMockRecorder) ReEncryptWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReEncryptWithContext", reflect.TypeOf((*MockKMSAPI)(nil).ReEncryptWithContext), varargs...)
 }
 
 // RetireGrant mocks base method
 func (m *MockKMSAPI) RetireGrant(arg0 *kms.RetireGrantInput) (*kms.RetireGrantOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RetireGrant", arg0)
 	ret0, _ := ret[0].(*kms.RetireGrantOutput)
 	ret1, _ := ret[1].(error)
@@ -1842,13 +1627,11 @@ func (m *MockKMSAPI) RetireGrant(arg0 *kms.RetireGrantInput) (*kms.RetireGrantOu
 
 // RetireGrant indicates an expected call of RetireGrant
 func (mr *MockKMSAPIMockRecorder) RetireGrant(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RetireGrant", reflect.TypeOf((*MockKMSAPI)(nil).RetireGrant), arg0)
 }
 
 // RetireGrantRequest mocks base method
 func (m *MockKMSAPI) RetireGrantRequest(arg0 *kms.RetireGrantInput) (*request.Request, *kms.RetireGrantOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RetireGrantRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*kms.RetireGrantOutput)
@@ -1857,13 +1640,11 @@ func (m *MockKMSAPI) RetireGrantRequest(arg0 *kms.RetireGrantInput) (*request.Re
 
 // RetireGrantRequest indicates an expected call of RetireGrantRequest
 func (mr *MockKMSAPIMockRecorder) RetireGrantRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RetireGrantRequest", reflect.TypeOf((*MockKMSAPI)(nil).RetireGrantRequest), arg0)
 }
 
 // RetireGrantWithContext mocks base method
 func (m *MockKMSAPI) RetireGrantWithContext(arg0 context.Context, arg1 *kms.RetireGrantInput, arg2 ...request.Option) (*kms.RetireGrantOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -1876,14 +1657,12 @@ func (m *MockKMSAPI) RetireGrantWithContext(arg0 context.Context, arg1 *kms.Reti
 
 // RetireGrantWithContext indicates an expected call of RetireGrantWithContext
 func (mr *MockKMSAPIMockRecorder) RetireGrantWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RetireGrantWithContext", reflect.TypeOf((*MockKMSAPI)(nil).RetireGrantWithContext), varargs...)
 }
 
 // RevokeGrant mocks base method
 func (m *MockKMSAPI) RevokeGrant(arg0 *kms.RevokeGrantInput) (*kms.RevokeGrantOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RevokeGrant", arg0)
 	ret0, _ := ret[0].(*kms.RevokeGrantOutput)
 	ret1, _ := ret[1].(error)
@@ -1892,13 +1671,11 @@ func (m *MockKMSAPI) RevokeGrant(arg0 *kms.RevokeGrantInput) (*kms.RevokeGrantOu
 
 // RevokeGrant indicates an expected call of RevokeGrant
 func (mr *MockKMSAPIMockRecorder) RevokeGrant(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RevokeGrant", reflect.TypeOf((*MockKMSAPI)(nil).RevokeGrant), arg0)
 }
 
 // RevokeGrantRequest mocks base method
 func (m *MockKMSAPI) RevokeGrantRequest(arg0 *kms.RevokeGrantInput) (*request.Request, *kms.RevokeGrantOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RevokeGrantRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*kms.RevokeGrantOutput)
@@ -1907,13 +1684,11 @@ func (m *MockKMSAPI) RevokeGrantRequest(arg0 *kms.RevokeGrantInput) (*request.Re
 
 // RevokeGrantRequest indicates an expected call of RevokeGrantRequest
 func (mr *MockKMSAPIMockRecorder) RevokeGrantRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RevokeGrantRequest", reflect.TypeOf((*MockKMSAPI)(nil).RevokeGrantRequest), arg0)
 }
 
 // RevokeGrantWithContext mocks base method
 func (m *MockKMSAPI) RevokeGrantWithContext(arg0 context.Context, arg1 *kms.RevokeGrantInput, arg2 ...request.Option) (*kms.RevokeGrantOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -1926,14 +1701,12 @@ func (m *MockKMSAPI) RevokeGrantWithContext(arg0 context.Context, arg1 *kms.Revo
 
 // RevokeGrantWithContext indicates an expected call of RevokeGrantWithContext
 func (mr *MockKMSAPIMockRecorder) RevokeGrantWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RevokeGrantWithContext", reflect.TypeOf((*MockKMSAPI)(nil).RevokeGrantWithContext), varargs...)
 }
 
 // ScheduleKeyDeletion mocks base method
 func (m *MockKMSAPI) ScheduleKeyDeletion(arg0 *kms.ScheduleKeyDeletionInput) (*kms.ScheduleKeyDeletionOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ScheduleKeyDeletion", arg0)
 	ret0, _ := ret[0].(*kms.ScheduleKeyDeletionOutput)
 	ret1, _ := ret[1].(error)
@@ -1942,13 +1715,11 @@ func (m *MockKMSAPI) ScheduleKeyDeletion(arg0 *kms.ScheduleKeyDeletionInput) (*k
 
 // ScheduleKeyDeletion indicates an expected call of ScheduleKeyDeletion
 func (mr *MockKMSAPIMockRecorder) ScheduleKeyDeletion(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ScheduleKeyDeletion", reflect.TypeOf((*MockKMSAPI)(nil).ScheduleKeyDeletion), arg0)
 }
 
 // ScheduleKeyDeletionRequest mocks base method
 func (m *MockKMSAPI) ScheduleKeyDeletionRequest(arg0 *kms.ScheduleKeyDeletionInput) (*request.Request, *kms.ScheduleKeyDeletionOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ScheduleKeyDeletionRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*kms.ScheduleKeyDeletionOutput)
@@ -1957,13 +1728,11 @@ func (m *MockKMSAPI) ScheduleKeyDeletionRequest(arg0 *kms.ScheduleKeyDeletionInp
 
 // ScheduleKeyDeletionRequest indicates an expected call of ScheduleKeyDeletionRequest
 func (mr *MockKMSAPIMockRecorder) ScheduleKeyDeletionRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ScheduleKeyDeletionRequest", reflect.TypeOf((*MockKMSAPI)(nil).ScheduleKeyDeletionRequest), arg0)
 }
 
 // ScheduleKeyDeletionWithContext mocks base method
 func (m *MockKMSAPI) ScheduleKeyDeletionWithContext(arg0 context.Context, arg1 *kms.ScheduleKeyDeletionInput, arg2 ...request.Option) (*kms.ScheduleKeyDeletionOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -1976,14 +1745,12 @@ func (m *MockKMSAPI) ScheduleKeyDeletionWithContext(arg0 context.Context, arg1 *
 
 // ScheduleKeyDeletionWithContext indicates an expected call of ScheduleKeyDeletionWithContext
 func (mr *MockKMSAPIMockRecorder) ScheduleKeyDeletionWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ScheduleKeyDeletionWithContext", reflect.TypeOf((*MockKMSAPI)(nil).ScheduleKeyDeletionWithContext), varargs...)
 }
 
 // TagResource mocks base method
 func (m *MockKMSAPI) TagResource(arg0 *kms.TagResourceInput) (*kms.TagResourceOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "TagResource", arg0)
 	ret0, _ := ret[0].(*kms.TagResourceOutput)
 	ret1, _ := ret[1].(error)
@@ -1992,13 +1759,11 @@ func (m *MockKMSAPI) TagResource(arg0 *kms.TagResourceInput) (*kms.TagResourceOu
 
 // TagResource indicates an expected call of TagResource
 func (mr *MockKMSAPIMockRecorder) TagResource(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TagResource", reflect.TypeOf((*MockKMSAPI)(nil).TagResource), arg0)
 }
 
 // TagResourceRequest mocks base method
 func (m *MockKMSAPI) TagResourceRequest(arg0 *kms.TagResourceInput) (*request.Request, *kms.TagResourceOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "TagResourceRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*kms.TagResourceOutput)
@@ -2007,13 +1772,11 @@ func (m *MockKMSAPI) TagResourceRequest(arg0 *kms.TagResourceInput) (*request.Re
 
 // TagResourceRequest indicates an expected call of TagResourceRequest
 func (mr *MockKMSAPIMockRecorder) TagResourceRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TagResourceRequest", reflect.TypeOf((*MockKMSAPI)(nil).TagResourceRequest), arg0)
 }
 
 // TagResourceWithContext mocks base method
 func (m *MockKMSAPI) TagResourceWithContext(arg0 context.Context, arg1 *kms.TagResourceInput, arg2 ...request.Option) (*kms.TagResourceOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -2026,14 +1789,12 @@ func (m *MockKMSAPI) TagResourceWithContext(arg0 context.Context, arg1 *kms.TagR
 
 // TagResourceWithContext indicates an expected call of TagResourceWithContext
 func (mr *MockKMSAPIMockRecorder) TagResourceWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TagResourceWithContext", reflect.TypeOf((*MockKMSAPI)(nil).TagResourceWithContext), varargs...)
 }
 
 // UntagResource mocks base method
 func (m *MockKMSAPI) UntagResource(arg0 *kms.UntagResourceInput) (*kms.UntagResourceOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UntagResource", arg0)
 	ret0, _ := ret[0].(*kms.UntagResourceOutput)
 	ret1, _ := ret[1].(error)
@@ -2042,13 +1803,11 @@ func (m *MockKMSAPI) UntagResource(arg0 *kms.UntagResourceInput) (*kms.UntagReso
 
 // UntagResource indicates an expected call of UntagResource
 func (mr *MockKMSAPIMockRecorder) UntagResource(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UntagResource", reflect.TypeOf((*MockKMSAPI)(nil).UntagResource), arg0)
 }
 
 // UntagResourceRequest mocks base method
 func (m *MockKMSAPI) UntagResourceRequest(arg0 *kms.UntagResourceInput) (*request.Request, *kms.UntagResourceOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UntagResourceRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*kms.UntagResourceOutput)
@@ -2057,13 +1816,11 @@ func (m *MockKMSAPI) UntagResourceRequest(arg0 *kms.UntagResourceInput) (*reques
 
 // UntagResourceRequest indicates an expected call of UntagResourceRequest
 func (mr *MockKMSAPIMockRecorder) UntagResourceRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UntagResourceRequest", reflect.TypeOf((*MockKMSAPI)(nil).UntagResourceRequest), arg0)
 }
 
 // UntagResourceWithContext mocks base method
 func (m *MockKMSAPI) UntagResourceWithContext(arg0 context.Context, arg1 *kms.UntagResourceInput, arg2 ...request.Option) (*kms.UntagResourceOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -2076,14 +1833,12 @@ func (m *MockKMSAPI) UntagResourceWithContext(arg0 context.Context, arg1 *kms.Un
 
 // UntagResourceWithContext indicates an expected call of UntagResourceWithContext
 func (mr *MockKMSAPIMockRecorder) UntagResourceWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UntagResourceWithContext", reflect.TypeOf((*MockKMSAPI)(nil).UntagResourceWithContext), varargs...)
 }
 
 // UpdateAlias mocks base method
 func (m *MockKMSAPI) UpdateAlias(arg0 *kms.UpdateAliasInput) (*kms.UpdateAliasOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateAlias", arg0)
 	ret0, _ := ret[0].(*kms.UpdateAliasOutput)
 	ret1, _ := ret[1].(error)
@@ -2092,13 +1847,11 @@ func (m *MockKMSAPI) UpdateAlias(arg0 *kms.UpdateAliasInput) (*kms.UpdateAliasOu
 
 // UpdateAlias indicates an expected call of UpdateAlias
 func (mr *MockKMSAPIMockRecorder) UpdateAlias(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateAlias", reflect.TypeOf((*MockKMSAPI)(nil).UpdateAlias), arg0)
 }
 
 // UpdateAliasRequest mocks base method
 func (m *MockKMSAPI) UpdateAliasRequest(arg0 *kms.UpdateAliasInput) (*request.Request, *kms.UpdateAliasOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateAliasRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*kms.UpdateAliasOutput)
@@ -2107,13 +1860,11 @@ func (m *MockKMSAPI) UpdateAliasRequest(arg0 *kms.UpdateAliasInput) (*request.Re
 
 // UpdateAliasRequest indicates an expected call of UpdateAliasRequest
 func (mr *MockKMSAPIMockRecorder) UpdateAliasRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateAliasRequest", reflect.TypeOf((*MockKMSAPI)(nil).UpdateAliasRequest), arg0)
 }
 
 // UpdateAliasWithContext mocks base method
 func (m *MockKMSAPI) UpdateAliasWithContext(arg0 context.Context, arg1 *kms.UpdateAliasInput, arg2 ...request.Option) (*kms.UpdateAliasOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -2126,14 +1877,12 @@ func (m *MockKMSAPI) UpdateAliasWithContext(arg0 context.Context, arg1 *kms.Upda
 
 // UpdateAliasWithContext indicates an expected call of UpdateAliasWithContext
 func (mr *MockKMSAPIMockRecorder) UpdateAliasWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateAliasWithContext", reflect.TypeOf((*MockKMSAPI)(nil).UpdateAliasWithContext), varargs...)
 }
 
 // UpdateCustomKeyStore mocks base method
 func (m *MockKMSAPI) UpdateCustomKeyStore(arg0 *kms.UpdateCustomKeyStoreInput) (*kms.UpdateCustomKeyStoreOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateCustomKeyStore", arg0)
 	ret0, _ := ret[0].(*kms.UpdateCustomKeyStoreOutput)
 	ret1, _ := ret[1].(error)
@@ -2142,13 +1891,11 @@ func (m *MockKMSAPI) UpdateCustomKeyStore(arg0 *kms.UpdateCustomKeyStoreInput) (
 
 // UpdateCustomKeyStore indicates an expected call of UpdateCustomKeyStore
 func (mr *MockKMSAPIMockRecorder) UpdateCustomKeyStore(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateCustomKeyStore", reflect.TypeOf((*MockKMSAPI)(nil).UpdateCustomKeyStore), arg0)
 }
 
 // UpdateCustomKeyStoreRequest mocks base method
 func (m *MockKMSAPI) UpdateCustomKeyStoreRequest(arg0 *kms.UpdateCustomKeyStoreInput) (*request.Request, *kms.UpdateCustomKeyStoreOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateCustomKeyStoreRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*kms.UpdateCustomKeyStoreOutput)
@@ -2157,13 +1904,11 @@ func (m *MockKMSAPI) UpdateCustomKeyStoreRequest(arg0 *kms.UpdateCustomKeyStoreI
 
 // UpdateCustomKeyStoreRequest indicates an expected call of UpdateCustomKeyStoreRequest
 func (mr *MockKMSAPIMockRecorder) UpdateCustomKeyStoreRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateCustomKeyStoreRequest", reflect.TypeOf((*MockKMSAPI)(nil).UpdateCustomKeyStoreRequest), arg0)
 }
 
 // UpdateCustomKeyStoreWithContext mocks base method
 func (m *MockKMSAPI) UpdateCustomKeyStoreWithContext(arg0 context.Context, arg1 *kms.UpdateCustomKeyStoreInput, arg2 ...request.Option) (*kms.UpdateCustomKeyStoreOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -2176,14 +1921,12 @@ func (m *MockKMSAPI) UpdateCustomKeyStoreWithContext(arg0 context.Context, arg1 
 
 // UpdateCustomKeyStoreWithContext indicates an expected call of UpdateCustomKeyStoreWithContext
 func (mr *MockKMSAPIMockRecorder) UpdateCustomKeyStoreWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateCustomKeyStoreWithContext", reflect.TypeOf((*MockKMSAPI)(nil).UpdateCustomKeyStoreWithContext), varargs...)
 }
 
 // UpdateKeyDescription mocks base method
 func (m *MockKMSAPI) UpdateKeyDescription(arg0 *kms.UpdateKeyDescriptionInput) (*kms.UpdateKeyDescriptionOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateKeyDescription", arg0)
 	ret0, _ := ret[0].(*kms.UpdateKeyDescriptionOutput)
 	ret1, _ := ret[1].(error)
@@ -2192,13 +1935,11 @@ func (m *MockKMSAPI) UpdateKeyDescription(arg0 *kms.UpdateKeyDescriptionInput) (
 
 // UpdateKeyDescription indicates an expected call of UpdateKeyDescription
 func (mr *MockKMSAPIMockRecorder) UpdateKeyDescription(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateKeyDescription", reflect.TypeOf((*MockKMSAPI)(nil).UpdateKeyDescription), arg0)
 }
 
 // UpdateKeyDescriptionRequest mocks base method
 func (m *MockKMSAPI) UpdateKeyDescriptionRequest(arg0 *kms.UpdateKeyDescriptionInput) (*request.Request, *kms.UpdateKeyDescriptionOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateKeyDescriptionRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*kms.UpdateKeyDescriptionOutput)
@@ -2207,13 +1948,11 @@ func (m *MockKMSAPI) UpdateKeyDescriptionRequest(arg0 *kms.UpdateKeyDescriptionI
 
 // UpdateKeyDescriptionRequest indicates an expected call of UpdateKeyDescriptionRequest
 func (mr *MockKMSAPIMockRecorder) UpdateKeyDescriptionRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateKeyDescriptionRequest", reflect.TypeOf((*MockKMSAPI)(nil).UpdateKeyDescriptionRequest), arg0)
 }
 
 // UpdateKeyDescriptionWithContext mocks base method
 func (m *MockKMSAPI) UpdateKeyDescriptionWithContext(arg0 context.Context, arg1 *kms.UpdateKeyDescriptionInput, arg2 ...request.Option) (*kms.UpdateKeyDescriptionOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -2226,7 +1965,6 @@ func (m *MockKMSAPI) UpdateKeyDescriptionWithContext(arg0 context.Context, arg1 
 
 // UpdateKeyDescriptionWithContext indicates an expected call of UpdateKeyDescriptionWithContext
 func (mr *MockKMSAPIMockRecorder) UpdateKeyDescriptionWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateKeyDescriptionWithContext", reflect.TypeOf((*MockKMSAPI)(nil).UpdateKeyDescriptionWithContext), varargs...)
 }

--- a/ecs-cli/modules/clients/aws/secretsmanager/mock/client.go
+++ b/ecs-cli/modules/clients/aws/secretsmanager/mock/client.go
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2015-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the
@@ -49,7 +49,6 @@ func (m *MockSMClient) EXPECT() *MockSMClientMockRecorder {
 
 // CreateSecret mocks base method
 func (m *MockSMClient) CreateSecret(arg0 secretsmanager.CreateSecretInput) (*secretsmanager.CreateSecretOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateSecret", arg0)
 	ret0, _ := ret[0].(*secretsmanager.CreateSecretOutput)
 	ret1, _ := ret[1].(error)
@@ -58,13 +57,11 @@ func (m *MockSMClient) CreateSecret(arg0 secretsmanager.CreateSecretInput) (*sec
 
 // CreateSecret indicates an expected call of CreateSecret
 func (mr *MockSMClientMockRecorder) CreateSecret(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateSecret", reflect.TypeOf((*MockSMClient)(nil).CreateSecret), arg0)
 }
 
 // DescribeSecret mocks base method
 func (m *MockSMClient) DescribeSecret(arg0 string) (*secretsmanager.DescribeSecretOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeSecret", arg0)
 	ret0, _ := ret[0].(*secretsmanager.DescribeSecretOutput)
 	ret1, _ := ret[1].(error)
@@ -73,13 +70,11 @@ func (m *MockSMClient) DescribeSecret(arg0 string) (*secretsmanager.DescribeSecr
 
 // DescribeSecret indicates an expected call of DescribeSecret
 func (mr *MockSMClientMockRecorder) DescribeSecret(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeSecret", reflect.TypeOf((*MockSMClient)(nil).DescribeSecret), arg0)
 }
 
 // ListSecrets mocks base method
 func (m *MockSMClient) ListSecrets(arg0 *string) (*secretsmanager.ListSecretsOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListSecrets", arg0)
 	ret0, _ := ret[0].(*secretsmanager.ListSecretsOutput)
 	ret1, _ := ret[1].(error)
@@ -88,13 +83,11 @@ func (m *MockSMClient) ListSecrets(arg0 *string) (*secretsmanager.ListSecretsOut
 
 // ListSecrets indicates an expected call of ListSecrets
 func (mr *MockSMClientMockRecorder) ListSecrets(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSecrets", reflect.TypeOf((*MockSMClient)(nil).ListSecrets), arg0)
 }
 
 // PutSecretValue mocks base method
 func (m *MockSMClient) PutSecretValue(arg0 secretsmanager.PutSecretValueInput) (*secretsmanager.PutSecretValueOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PutSecretValue", arg0)
 	ret0, _ := ret[0].(*secretsmanager.PutSecretValueOutput)
 	ret1, _ := ret[1].(error)
@@ -103,6 +96,5 @@ func (m *MockSMClient) PutSecretValue(arg0 secretsmanager.PutSecretValueInput) (
 
 // PutSecretValue indicates an expected call of PutSecretValue
 func (mr *MockSMClientMockRecorder) PutSecretValue(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutSecretValue", reflect.TypeOf((*MockSMClient)(nil).PutSecretValue), arg0)
 }

--- a/ecs-cli/modules/clients/aws/secretsmanager/mock/sdk/secretsmanageriface_mock.go
+++ b/ecs-cli/modules/clients/aws/secretsmanager/mock/sdk/secretsmanageriface_mock.go
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2015-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the
@@ -51,7 +51,6 @@ func (m *MockSecretsManagerAPI) EXPECT() *MockSecretsManagerAPIMockRecorder {
 
 // CancelRotateSecret mocks base method
 func (m *MockSecretsManagerAPI) CancelRotateSecret(arg0 *secretsmanager.CancelRotateSecretInput) (*secretsmanager.CancelRotateSecretOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CancelRotateSecret", arg0)
 	ret0, _ := ret[0].(*secretsmanager.CancelRotateSecretOutput)
 	ret1, _ := ret[1].(error)
@@ -60,13 +59,11 @@ func (m *MockSecretsManagerAPI) CancelRotateSecret(arg0 *secretsmanager.CancelRo
 
 // CancelRotateSecret indicates an expected call of CancelRotateSecret
 func (mr *MockSecretsManagerAPIMockRecorder) CancelRotateSecret(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CancelRotateSecret", reflect.TypeOf((*MockSecretsManagerAPI)(nil).CancelRotateSecret), arg0)
 }
 
 // CancelRotateSecretRequest mocks base method
 func (m *MockSecretsManagerAPI) CancelRotateSecretRequest(arg0 *secretsmanager.CancelRotateSecretInput) (*request.Request, *secretsmanager.CancelRotateSecretOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CancelRotateSecretRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*secretsmanager.CancelRotateSecretOutput)
@@ -75,13 +72,11 @@ func (m *MockSecretsManagerAPI) CancelRotateSecretRequest(arg0 *secretsmanager.C
 
 // CancelRotateSecretRequest indicates an expected call of CancelRotateSecretRequest
 func (mr *MockSecretsManagerAPIMockRecorder) CancelRotateSecretRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CancelRotateSecretRequest", reflect.TypeOf((*MockSecretsManagerAPI)(nil).CancelRotateSecretRequest), arg0)
 }
 
 // CancelRotateSecretWithContext mocks base method
 func (m *MockSecretsManagerAPI) CancelRotateSecretWithContext(arg0 context.Context, arg1 *secretsmanager.CancelRotateSecretInput, arg2 ...request.Option) (*secretsmanager.CancelRotateSecretOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -94,14 +89,12 @@ func (m *MockSecretsManagerAPI) CancelRotateSecretWithContext(arg0 context.Conte
 
 // CancelRotateSecretWithContext indicates an expected call of CancelRotateSecretWithContext
 func (mr *MockSecretsManagerAPIMockRecorder) CancelRotateSecretWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CancelRotateSecretWithContext", reflect.TypeOf((*MockSecretsManagerAPI)(nil).CancelRotateSecretWithContext), varargs...)
 }
 
 // CreateSecret mocks base method
 func (m *MockSecretsManagerAPI) CreateSecret(arg0 *secretsmanager.CreateSecretInput) (*secretsmanager.CreateSecretOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateSecret", arg0)
 	ret0, _ := ret[0].(*secretsmanager.CreateSecretOutput)
 	ret1, _ := ret[1].(error)
@@ -110,13 +103,11 @@ func (m *MockSecretsManagerAPI) CreateSecret(arg0 *secretsmanager.CreateSecretIn
 
 // CreateSecret indicates an expected call of CreateSecret
 func (mr *MockSecretsManagerAPIMockRecorder) CreateSecret(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateSecret", reflect.TypeOf((*MockSecretsManagerAPI)(nil).CreateSecret), arg0)
 }
 
 // CreateSecretRequest mocks base method
 func (m *MockSecretsManagerAPI) CreateSecretRequest(arg0 *secretsmanager.CreateSecretInput) (*request.Request, *secretsmanager.CreateSecretOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateSecretRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*secretsmanager.CreateSecretOutput)
@@ -125,13 +116,11 @@ func (m *MockSecretsManagerAPI) CreateSecretRequest(arg0 *secretsmanager.CreateS
 
 // CreateSecretRequest indicates an expected call of CreateSecretRequest
 func (mr *MockSecretsManagerAPIMockRecorder) CreateSecretRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateSecretRequest", reflect.TypeOf((*MockSecretsManagerAPI)(nil).CreateSecretRequest), arg0)
 }
 
 // CreateSecretWithContext mocks base method
 func (m *MockSecretsManagerAPI) CreateSecretWithContext(arg0 context.Context, arg1 *secretsmanager.CreateSecretInput, arg2 ...request.Option) (*secretsmanager.CreateSecretOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -144,14 +133,12 @@ func (m *MockSecretsManagerAPI) CreateSecretWithContext(arg0 context.Context, ar
 
 // CreateSecretWithContext indicates an expected call of CreateSecretWithContext
 func (mr *MockSecretsManagerAPIMockRecorder) CreateSecretWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateSecretWithContext", reflect.TypeOf((*MockSecretsManagerAPI)(nil).CreateSecretWithContext), varargs...)
 }
 
 // DeleteResourcePolicy mocks base method
 func (m *MockSecretsManagerAPI) DeleteResourcePolicy(arg0 *secretsmanager.DeleteResourcePolicyInput) (*secretsmanager.DeleteResourcePolicyOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteResourcePolicy", arg0)
 	ret0, _ := ret[0].(*secretsmanager.DeleteResourcePolicyOutput)
 	ret1, _ := ret[1].(error)
@@ -160,13 +147,11 @@ func (m *MockSecretsManagerAPI) DeleteResourcePolicy(arg0 *secretsmanager.Delete
 
 // DeleteResourcePolicy indicates an expected call of DeleteResourcePolicy
 func (mr *MockSecretsManagerAPIMockRecorder) DeleteResourcePolicy(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteResourcePolicy", reflect.TypeOf((*MockSecretsManagerAPI)(nil).DeleteResourcePolicy), arg0)
 }
 
 // DeleteResourcePolicyRequest mocks base method
 func (m *MockSecretsManagerAPI) DeleteResourcePolicyRequest(arg0 *secretsmanager.DeleteResourcePolicyInput) (*request.Request, *secretsmanager.DeleteResourcePolicyOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteResourcePolicyRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*secretsmanager.DeleteResourcePolicyOutput)
@@ -175,13 +160,11 @@ func (m *MockSecretsManagerAPI) DeleteResourcePolicyRequest(arg0 *secretsmanager
 
 // DeleteResourcePolicyRequest indicates an expected call of DeleteResourcePolicyRequest
 func (mr *MockSecretsManagerAPIMockRecorder) DeleteResourcePolicyRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteResourcePolicyRequest", reflect.TypeOf((*MockSecretsManagerAPI)(nil).DeleteResourcePolicyRequest), arg0)
 }
 
 // DeleteResourcePolicyWithContext mocks base method
 func (m *MockSecretsManagerAPI) DeleteResourcePolicyWithContext(arg0 context.Context, arg1 *secretsmanager.DeleteResourcePolicyInput, arg2 ...request.Option) (*secretsmanager.DeleteResourcePolicyOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -194,14 +177,12 @@ func (m *MockSecretsManagerAPI) DeleteResourcePolicyWithContext(arg0 context.Con
 
 // DeleteResourcePolicyWithContext indicates an expected call of DeleteResourcePolicyWithContext
 func (mr *MockSecretsManagerAPIMockRecorder) DeleteResourcePolicyWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteResourcePolicyWithContext", reflect.TypeOf((*MockSecretsManagerAPI)(nil).DeleteResourcePolicyWithContext), varargs...)
 }
 
 // DeleteSecret mocks base method
 func (m *MockSecretsManagerAPI) DeleteSecret(arg0 *secretsmanager.DeleteSecretInput) (*secretsmanager.DeleteSecretOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteSecret", arg0)
 	ret0, _ := ret[0].(*secretsmanager.DeleteSecretOutput)
 	ret1, _ := ret[1].(error)
@@ -210,13 +191,11 @@ func (m *MockSecretsManagerAPI) DeleteSecret(arg0 *secretsmanager.DeleteSecretIn
 
 // DeleteSecret indicates an expected call of DeleteSecret
 func (mr *MockSecretsManagerAPIMockRecorder) DeleteSecret(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteSecret", reflect.TypeOf((*MockSecretsManagerAPI)(nil).DeleteSecret), arg0)
 }
 
 // DeleteSecretRequest mocks base method
 func (m *MockSecretsManagerAPI) DeleteSecretRequest(arg0 *secretsmanager.DeleteSecretInput) (*request.Request, *secretsmanager.DeleteSecretOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteSecretRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*secretsmanager.DeleteSecretOutput)
@@ -225,13 +204,11 @@ func (m *MockSecretsManagerAPI) DeleteSecretRequest(arg0 *secretsmanager.DeleteS
 
 // DeleteSecretRequest indicates an expected call of DeleteSecretRequest
 func (mr *MockSecretsManagerAPIMockRecorder) DeleteSecretRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteSecretRequest", reflect.TypeOf((*MockSecretsManagerAPI)(nil).DeleteSecretRequest), arg0)
 }
 
 // DeleteSecretWithContext mocks base method
 func (m *MockSecretsManagerAPI) DeleteSecretWithContext(arg0 context.Context, arg1 *secretsmanager.DeleteSecretInput, arg2 ...request.Option) (*secretsmanager.DeleteSecretOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -244,14 +221,12 @@ func (m *MockSecretsManagerAPI) DeleteSecretWithContext(arg0 context.Context, ar
 
 // DeleteSecretWithContext indicates an expected call of DeleteSecretWithContext
 func (mr *MockSecretsManagerAPIMockRecorder) DeleteSecretWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteSecretWithContext", reflect.TypeOf((*MockSecretsManagerAPI)(nil).DeleteSecretWithContext), varargs...)
 }
 
 // DescribeSecret mocks base method
 func (m *MockSecretsManagerAPI) DescribeSecret(arg0 *secretsmanager.DescribeSecretInput) (*secretsmanager.DescribeSecretOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeSecret", arg0)
 	ret0, _ := ret[0].(*secretsmanager.DescribeSecretOutput)
 	ret1, _ := ret[1].(error)
@@ -260,13 +235,11 @@ func (m *MockSecretsManagerAPI) DescribeSecret(arg0 *secretsmanager.DescribeSecr
 
 // DescribeSecret indicates an expected call of DescribeSecret
 func (mr *MockSecretsManagerAPIMockRecorder) DescribeSecret(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeSecret", reflect.TypeOf((*MockSecretsManagerAPI)(nil).DescribeSecret), arg0)
 }
 
 // DescribeSecretRequest mocks base method
 func (m *MockSecretsManagerAPI) DescribeSecretRequest(arg0 *secretsmanager.DescribeSecretInput) (*request.Request, *secretsmanager.DescribeSecretOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeSecretRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*secretsmanager.DescribeSecretOutput)
@@ -275,13 +248,11 @@ func (m *MockSecretsManagerAPI) DescribeSecretRequest(arg0 *secretsmanager.Descr
 
 // DescribeSecretRequest indicates an expected call of DescribeSecretRequest
 func (mr *MockSecretsManagerAPIMockRecorder) DescribeSecretRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeSecretRequest", reflect.TypeOf((*MockSecretsManagerAPI)(nil).DescribeSecretRequest), arg0)
 }
 
 // DescribeSecretWithContext mocks base method
 func (m *MockSecretsManagerAPI) DescribeSecretWithContext(arg0 context.Context, arg1 *secretsmanager.DescribeSecretInput, arg2 ...request.Option) (*secretsmanager.DescribeSecretOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -294,14 +265,12 @@ func (m *MockSecretsManagerAPI) DescribeSecretWithContext(arg0 context.Context, 
 
 // DescribeSecretWithContext indicates an expected call of DescribeSecretWithContext
 func (mr *MockSecretsManagerAPIMockRecorder) DescribeSecretWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeSecretWithContext", reflect.TypeOf((*MockSecretsManagerAPI)(nil).DescribeSecretWithContext), varargs...)
 }
 
 // GetRandomPassword mocks base method
 func (m *MockSecretsManagerAPI) GetRandomPassword(arg0 *secretsmanager.GetRandomPasswordInput) (*secretsmanager.GetRandomPasswordOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetRandomPassword", arg0)
 	ret0, _ := ret[0].(*secretsmanager.GetRandomPasswordOutput)
 	ret1, _ := ret[1].(error)
@@ -310,13 +279,11 @@ func (m *MockSecretsManagerAPI) GetRandomPassword(arg0 *secretsmanager.GetRandom
 
 // GetRandomPassword indicates an expected call of GetRandomPassword
 func (mr *MockSecretsManagerAPIMockRecorder) GetRandomPassword(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRandomPassword", reflect.TypeOf((*MockSecretsManagerAPI)(nil).GetRandomPassword), arg0)
 }
 
 // GetRandomPasswordRequest mocks base method
 func (m *MockSecretsManagerAPI) GetRandomPasswordRequest(arg0 *secretsmanager.GetRandomPasswordInput) (*request.Request, *secretsmanager.GetRandomPasswordOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetRandomPasswordRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*secretsmanager.GetRandomPasswordOutput)
@@ -325,13 +292,11 @@ func (m *MockSecretsManagerAPI) GetRandomPasswordRequest(arg0 *secretsmanager.Ge
 
 // GetRandomPasswordRequest indicates an expected call of GetRandomPasswordRequest
 func (mr *MockSecretsManagerAPIMockRecorder) GetRandomPasswordRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRandomPasswordRequest", reflect.TypeOf((*MockSecretsManagerAPI)(nil).GetRandomPasswordRequest), arg0)
 }
 
 // GetRandomPasswordWithContext mocks base method
 func (m *MockSecretsManagerAPI) GetRandomPasswordWithContext(arg0 context.Context, arg1 *secretsmanager.GetRandomPasswordInput, arg2 ...request.Option) (*secretsmanager.GetRandomPasswordOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -344,14 +309,12 @@ func (m *MockSecretsManagerAPI) GetRandomPasswordWithContext(arg0 context.Contex
 
 // GetRandomPasswordWithContext indicates an expected call of GetRandomPasswordWithContext
 func (mr *MockSecretsManagerAPIMockRecorder) GetRandomPasswordWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRandomPasswordWithContext", reflect.TypeOf((*MockSecretsManagerAPI)(nil).GetRandomPasswordWithContext), varargs...)
 }
 
 // GetResourcePolicy mocks base method
 func (m *MockSecretsManagerAPI) GetResourcePolicy(arg0 *secretsmanager.GetResourcePolicyInput) (*secretsmanager.GetResourcePolicyOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetResourcePolicy", arg0)
 	ret0, _ := ret[0].(*secretsmanager.GetResourcePolicyOutput)
 	ret1, _ := ret[1].(error)
@@ -360,13 +323,11 @@ func (m *MockSecretsManagerAPI) GetResourcePolicy(arg0 *secretsmanager.GetResour
 
 // GetResourcePolicy indicates an expected call of GetResourcePolicy
 func (mr *MockSecretsManagerAPIMockRecorder) GetResourcePolicy(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetResourcePolicy", reflect.TypeOf((*MockSecretsManagerAPI)(nil).GetResourcePolicy), arg0)
 }
 
 // GetResourcePolicyRequest mocks base method
 func (m *MockSecretsManagerAPI) GetResourcePolicyRequest(arg0 *secretsmanager.GetResourcePolicyInput) (*request.Request, *secretsmanager.GetResourcePolicyOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetResourcePolicyRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*secretsmanager.GetResourcePolicyOutput)
@@ -375,13 +336,11 @@ func (m *MockSecretsManagerAPI) GetResourcePolicyRequest(arg0 *secretsmanager.Ge
 
 // GetResourcePolicyRequest indicates an expected call of GetResourcePolicyRequest
 func (mr *MockSecretsManagerAPIMockRecorder) GetResourcePolicyRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetResourcePolicyRequest", reflect.TypeOf((*MockSecretsManagerAPI)(nil).GetResourcePolicyRequest), arg0)
 }
 
 // GetResourcePolicyWithContext mocks base method
 func (m *MockSecretsManagerAPI) GetResourcePolicyWithContext(arg0 context.Context, arg1 *secretsmanager.GetResourcePolicyInput, arg2 ...request.Option) (*secretsmanager.GetResourcePolicyOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -394,14 +353,12 @@ func (m *MockSecretsManagerAPI) GetResourcePolicyWithContext(arg0 context.Contex
 
 // GetResourcePolicyWithContext indicates an expected call of GetResourcePolicyWithContext
 func (mr *MockSecretsManagerAPIMockRecorder) GetResourcePolicyWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetResourcePolicyWithContext", reflect.TypeOf((*MockSecretsManagerAPI)(nil).GetResourcePolicyWithContext), varargs...)
 }
 
 // GetSecretValue mocks base method
 func (m *MockSecretsManagerAPI) GetSecretValue(arg0 *secretsmanager.GetSecretValueInput) (*secretsmanager.GetSecretValueOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetSecretValue", arg0)
 	ret0, _ := ret[0].(*secretsmanager.GetSecretValueOutput)
 	ret1, _ := ret[1].(error)
@@ -410,13 +367,11 @@ func (m *MockSecretsManagerAPI) GetSecretValue(arg0 *secretsmanager.GetSecretVal
 
 // GetSecretValue indicates an expected call of GetSecretValue
 func (mr *MockSecretsManagerAPIMockRecorder) GetSecretValue(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSecretValue", reflect.TypeOf((*MockSecretsManagerAPI)(nil).GetSecretValue), arg0)
 }
 
 // GetSecretValueRequest mocks base method
 func (m *MockSecretsManagerAPI) GetSecretValueRequest(arg0 *secretsmanager.GetSecretValueInput) (*request.Request, *secretsmanager.GetSecretValueOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetSecretValueRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*secretsmanager.GetSecretValueOutput)
@@ -425,13 +380,11 @@ func (m *MockSecretsManagerAPI) GetSecretValueRequest(arg0 *secretsmanager.GetSe
 
 // GetSecretValueRequest indicates an expected call of GetSecretValueRequest
 func (mr *MockSecretsManagerAPIMockRecorder) GetSecretValueRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSecretValueRequest", reflect.TypeOf((*MockSecretsManagerAPI)(nil).GetSecretValueRequest), arg0)
 }
 
 // GetSecretValueWithContext mocks base method
 func (m *MockSecretsManagerAPI) GetSecretValueWithContext(arg0 context.Context, arg1 *secretsmanager.GetSecretValueInput, arg2 ...request.Option) (*secretsmanager.GetSecretValueOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -444,14 +397,12 @@ func (m *MockSecretsManagerAPI) GetSecretValueWithContext(arg0 context.Context, 
 
 // GetSecretValueWithContext indicates an expected call of GetSecretValueWithContext
 func (mr *MockSecretsManagerAPIMockRecorder) GetSecretValueWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSecretValueWithContext", reflect.TypeOf((*MockSecretsManagerAPI)(nil).GetSecretValueWithContext), varargs...)
 }
 
 // ListSecretVersionIds mocks base method
 func (m *MockSecretsManagerAPI) ListSecretVersionIds(arg0 *secretsmanager.ListSecretVersionIdsInput) (*secretsmanager.ListSecretVersionIdsOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListSecretVersionIds", arg0)
 	ret0, _ := ret[0].(*secretsmanager.ListSecretVersionIdsOutput)
 	ret1, _ := ret[1].(error)
@@ -460,13 +411,11 @@ func (m *MockSecretsManagerAPI) ListSecretVersionIds(arg0 *secretsmanager.ListSe
 
 // ListSecretVersionIds indicates an expected call of ListSecretVersionIds
 func (mr *MockSecretsManagerAPIMockRecorder) ListSecretVersionIds(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSecretVersionIds", reflect.TypeOf((*MockSecretsManagerAPI)(nil).ListSecretVersionIds), arg0)
 }
 
 // ListSecretVersionIdsPages mocks base method
 func (m *MockSecretsManagerAPI) ListSecretVersionIdsPages(arg0 *secretsmanager.ListSecretVersionIdsInput, arg1 func(*secretsmanager.ListSecretVersionIdsOutput, bool) bool) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListSecretVersionIdsPages", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -474,13 +423,11 @@ func (m *MockSecretsManagerAPI) ListSecretVersionIdsPages(arg0 *secretsmanager.L
 
 // ListSecretVersionIdsPages indicates an expected call of ListSecretVersionIdsPages
 func (mr *MockSecretsManagerAPIMockRecorder) ListSecretVersionIdsPages(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSecretVersionIdsPages", reflect.TypeOf((*MockSecretsManagerAPI)(nil).ListSecretVersionIdsPages), arg0, arg1)
 }
 
 // ListSecretVersionIdsPagesWithContext mocks base method
 func (m *MockSecretsManagerAPI) ListSecretVersionIdsPagesWithContext(arg0 context.Context, arg1 *secretsmanager.ListSecretVersionIdsInput, arg2 func(*secretsmanager.ListSecretVersionIdsOutput, bool) bool, arg3 ...request.Option) error {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1, arg2}
 	for _, a := range arg3 {
 		varargs = append(varargs, a)
@@ -492,14 +439,12 @@ func (m *MockSecretsManagerAPI) ListSecretVersionIdsPagesWithContext(arg0 contex
 
 // ListSecretVersionIdsPagesWithContext indicates an expected call of ListSecretVersionIdsPagesWithContext
 func (mr *MockSecretsManagerAPIMockRecorder) ListSecretVersionIdsPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSecretVersionIdsPagesWithContext", reflect.TypeOf((*MockSecretsManagerAPI)(nil).ListSecretVersionIdsPagesWithContext), varargs...)
 }
 
 // ListSecretVersionIdsRequest mocks base method
 func (m *MockSecretsManagerAPI) ListSecretVersionIdsRequest(arg0 *secretsmanager.ListSecretVersionIdsInput) (*request.Request, *secretsmanager.ListSecretVersionIdsOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListSecretVersionIdsRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*secretsmanager.ListSecretVersionIdsOutput)
@@ -508,13 +453,11 @@ func (m *MockSecretsManagerAPI) ListSecretVersionIdsRequest(arg0 *secretsmanager
 
 // ListSecretVersionIdsRequest indicates an expected call of ListSecretVersionIdsRequest
 func (mr *MockSecretsManagerAPIMockRecorder) ListSecretVersionIdsRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSecretVersionIdsRequest", reflect.TypeOf((*MockSecretsManagerAPI)(nil).ListSecretVersionIdsRequest), arg0)
 }
 
 // ListSecretVersionIdsWithContext mocks base method
 func (m *MockSecretsManagerAPI) ListSecretVersionIdsWithContext(arg0 context.Context, arg1 *secretsmanager.ListSecretVersionIdsInput, arg2 ...request.Option) (*secretsmanager.ListSecretVersionIdsOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -527,14 +470,12 @@ func (m *MockSecretsManagerAPI) ListSecretVersionIdsWithContext(arg0 context.Con
 
 // ListSecretVersionIdsWithContext indicates an expected call of ListSecretVersionIdsWithContext
 func (mr *MockSecretsManagerAPIMockRecorder) ListSecretVersionIdsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSecretVersionIdsWithContext", reflect.TypeOf((*MockSecretsManagerAPI)(nil).ListSecretVersionIdsWithContext), varargs...)
 }
 
 // ListSecrets mocks base method
 func (m *MockSecretsManagerAPI) ListSecrets(arg0 *secretsmanager.ListSecretsInput) (*secretsmanager.ListSecretsOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListSecrets", arg0)
 	ret0, _ := ret[0].(*secretsmanager.ListSecretsOutput)
 	ret1, _ := ret[1].(error)
@@ -543,13 +484,11 @@ func (m *MockSecretsManagerAPI) ListSecrets(arg0 *secretsmanager.ListSecretsInpu
 
 // ListSecrets indicates an expected call of ListSecrets
 func (mr *MockSecretsManagerAPIMockRecorder) ListSecrets(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSecrets", reflect.TypeOf((*MockSecretsManagerAPI)(nil).ListSecrets), arg0)
 }
 
 // ListSecretsPages mocks base method
 func (m *MockSecretsManagerAPI) ListSecretsPages(arg0 *secretsmanager.ListSecretsInput, arg1 func(*secretsmanager.ListSecretsOutput, bool) bool) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListSecretsPages", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -557,13 +496,11 @@ func (m *MockSecretsManagerAPI) ListSecretsPages(arg0 *secretsmanager.ListSecret
 
 // ListSecretsPages indicates an expected call of ListSecretsPages
 func (mr *MockSecretsManagerAPIMockRecorder) ListSecretsPages(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSecretsPages", reflect.TypeOf((*MockSecretsManagerAPI)(nil).ListSecretsPages), arg0, arg1)
 }
 
 // ListSecretsPagesWithContext mocks base method
 func (m *MockSecretsManagerAPI) ListSecretsPagesWithContext(arg0 context.Context, arg1 *secretsmanager.ListSecretsInput, arg2 func(*secretsmanager.ListSecretsOutput, bool) bool, arg3 ...request.Option) error {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1, arg2}
 	for _, a := range arg3 {
 		varargs = append(varargs, a)
@@ -575,14 +512,12 @@ func (m *MockSecretsManagerAPI) ListSecretsPagesWithContext(arg0 context.Context
 
 // ListSecretsPagesWithContext indicates an expected call of ListSecretsPagesWithContext
 func (mr *MockSecretsManagerAPIMockRecorder) ListSecretsPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSecretsPagesWithContext", reflect.TypeOf((*MockSecretsManagerAPI)(nil).ListSecretsPagesWithContext), varargs...)
 }
 
 // ListSecretsRequest mocks base method
 func (m *MockSecretsManagerAPI) ListSecretsRequest(arg0 *secretsmanager.ListSecretsInput) (*request.Request, *secretsmanager.ListSecretsOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListSecretsRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*secretsmanager.ListSecretsOutput)
@@ -591,13 +526,11 @@ func (m *MockSecretsManagerAPI) ListSecretsRequest(arg0 *secretsmanager.ListSecr
 
 // ListSecretsRequest indicates an expected call of ListSecretsRequest
 func (mr *MockSecretsManagerAPIMockRecorder) ListSecretsRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSecretsRequest", reflect.TypeOf((*MockSecretsManagerAPI)(nil).ListSecretsRequest), arg0)
 }
 
 // ListSecretsWithContext mocks base method
 func (m *MockSecretsManagerAPI) ListSecretsWithContext(arg0 context.Context, arg1 *secretsmanager.ListSecretsInput, arg2 ...request.Option) (*secretsmanager.ListSecretsOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -610,14 +543,12 @@ func (m *MockSecretsManagerAPI) ListSecretsWithContext(arg0 context.Context, arg
 
 // ListSecretsWithContext indicates an expected call of ListSecretsWithContext
 func (mr *MockSecretsManagerAPIMockRecorder) ListSecretsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSecretsWithContext", reflect.TypeOf((*MockSecretsManagerAPI)(nil).ListSecretsWithContext), varargs...)
 }
 
 // PutResourcePolicy mocks base method
 func (m *MockSecretsManagerAPI) PutResourcePolicy(arg0 *secretsmanager.PutResourcePolicyInput) (*secretsmanager.PutResourcePolicyOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PutResourcePolicy", arg0)
 	ret0, _ := ret[0].(*secretsmanager.PutResourcePolicyOutput)
 	ret1, _ := ret[1].(error)
@@ -626,13 +557,11 @@ func (m *MockSecretsManagerAPI) PutResourcePolicy(arg0 *secretsmanager.PutResour
 
 // PutResourcePolicy indicates an expected call of PutResourcePolicy
 func (mr *MockSecretsManagerAPIMockRecorder) PutResourcePolicy(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutResourcePolicy", reflect.TypeOf((*MockSecretsManagerAPI)(nil).PutResourcePolicy), arg0)
 }
 
 // PutResourcePolicyRequest mocks base method
 func (m *MockSecretsManagerAPI) PutResourcePolicyRequest(arg0 *secretsmanager.PutResourcePolicyInput) (*request.Request, *secretsmanager.PutResourcePolicyOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PutResourcePolicyRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*secretsmanager.PutResourcePolicyOutput)
@@ -641,13 +570,11 @@ func (m *MockSecretsManagerAPI) PutResourcePolicyRequest(arg0 *secretsmanager.Pu
 
 // PutResourcePolicyRequest indicates an expected call of PutResourcePolicyRequest
 func (mr *MockSecretsManagerAPIMockRecorder) PutResourcePolicyRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutResourcePolicyRequest", reflect.TypeOf((*MockSecretsManagerAPI)(nil).PutResourcePolicyRequest), arg0)
 }
 
 // PutResourcePolicyWithContext mocks base method
 func (m *MockSecretsManagerAPI) PutResourcePolicyWithContext(arg0 context.Context, arg1 *secretsmanager.PutResourcePolicyInput, arg2 ...request.Option) (*secretsmanager.PutResourcePolicyOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -660,14 +587,12 @@ func (m *MockSecretsManagerAPI) PutResourcePolicyWithContext(arg0 context.Contex
 
 // PutResourcePolicyWithContext indicates an expected call of PutResourcePolicyWithContext
 func (mr *MockSecretsManagerAPIMockRecorder) PutResourcePolicyWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutResourcePolicyWithContext", reflect.TypeOf((*MockSecretsManagerAPI)(nil).PutResourcePolicyWithContext), varargs...)
 }
 
 // PutSecretValue mocks base method
 func (m *MockSecretsManagerAPI) PutSecretValue(arg0 *secretsmanager.PutSecretValueInput) (*secretsmanager.PutSecretValueOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PutSecretValue", arg0)
 	ret0, _ := ret[0].(*secretsmanager.PutSecretValueOutput)
 	ret1, _ := ret[1].(error)
@@ -676,13 +601,11 @@ func (m *MockSecretsManagerAPI) PutSecretValue(arg0 *secretsmanager.PutSecretVal
 
 // PutSecretValue indicates an expected call of PutSecretValue
 func (mr *MockSecretsManagerAPIMockRecorder) PutSecretValue(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutSecretValue", reflect.TypeOf((*MockSecretsManagerAPI)(nil).PutSecretValue), arg0)
 }
 
 // PutSecretValueRequest mocks base method
 func (m *MockSecretsManagerAPI) PutSecretValueRequest(arg0 *secretsmanager.PutSecretValueInput) (*request.Request, *secretsmanager.PutSecretValueOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PutSecretValueRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*secretsmanager.PutSecretValueOutput)
@@ -691,13 +614,11 @@ func (m *MockSecretsManagerAPI) PutSecretValueRequest(arg0 *secretsmanager.PutSe
 
 // PutSecretValueRequest indicates an expected call of PutSecretValueRequest
 func (mr *MockSecretsManagerAPIMockRecorder) PutSecretValueRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutSecretValueRequest", reflect.TypeOf((*MockSecretsManagerAPI)(nil).PutSecretValueRequest), arg0)
 }
 
 // PutSecretValueWithContext mocks base method
 func (m *MockSecretsManagerAPI) PutSecretValueWithContext(arg0 context.Context, arg1 *secretsmanager.PutSecretValueInput, arg2 ...request.Option) (*secretsmanager.PutSecretValueOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -710,14 +631,12 @@ func (m *MockSecretsManagerAPI) PutSecretValueWithContext(arg0 context.Context, 
 
 // PutSecretValueWithContext indicates an expected call of PutSecretValueWithContext
 func (mr *MockSecretsManagerAPIMockRecorder) PutSecretValueWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutSecretValueWithContext", reflect.TypeOf((*MockSecretsManagerAPI)(nil).PutSecretValueWithContext), varargs...)
 }
 
 // RestoreSecret mocks base method
 func (m *MockSecretsManagerAPI) RestoreSecret(arg0 *secretsmanager.RestoreSecretInput) (*secretsmanager.RestoreSecretOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RestoreSecret", arg0)
 	ret0, _ := ret[0].(*secretsmanager.RestoreSecretOutput)
 	ret1, _ := ret[1].(error)
@@ -726,13 +645,11 @@ func (m *MockSecretsManagerAPI) RestoreSecret(arg0 *secretsmanager.RestoreSecret
 
 // RestoreSecret indicates an expected call of RestoreSecret
 func (mr *MockSecretsManagerAPIMockRecorder) RestoreSecret(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RestoreSecret", reflect.TypeOf((*MockSecretsManagerAPI)(nil).RestoreSecret), arg0)
 }
 
 // RestoreSecretRequest mocks base method
 func (m *MockSecretsManagerAPI) RestoreSecretRequest(arg0 *secretsmanager.RestoreSecretInput) (*request.Request, *secretsmanager.RestoreSecretOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RestoreSecretRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*secretsmanager.RestoreSecretOutput)
@@ -741,13 +658,11 @@ func (m *MockSecretsManagerAPI) RestoreSecretRequest(arg0 *secretsmanager.Restor
 
 // RestoreSecretRequest indicates an expected call of RestoreSecretRequest
 func (mr *MockSecretsManagerAPIMockRecorder) RestoreSecretRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RestoreSecretRequest", reflect.TypeOf((*MockSecretsManagerAPI)(nil).RestoreSecretRequest), arg0)
 }
 
 // RestoreSecretWithContext mocks base method
 func (m *MockSecretsManagerAPI) RestoreSecretWithContext(arg0 context.Context, arg1 *secretsmanager.RestoreSecretInput, arg2 ...request.Option) (*secretsmanager.RestoreSecretOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -760,14 +675,12 @@ func (m *MockSecretsManagerAPI) RestoreSecretWithContext(arg0 context.Context, a
 
 // RestoreSecretWithContext indicates an expected call of RestoreSecretWithContext
 func (mr *MockSecretsManagerAPIMockRecorder) RestoreSecretWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RestoreSecretWithContext", reflect.TypeOf((*MockSecretsManagerAPI)(nil).RestoreSecretWithContext), varargs...)
 }
 
 // RotateSecret mocks base method
 func (m *MockSecretsManagerAPI) RotateSecret(arg0 *secretsmanager.RotateSecretInput) (*secretsmanager.RotateSecretOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RotateSecret", arg0)
 	ret0, _ := ret[0].(*secretsmanager.RotateSecretOutput)
 	ret1, _ := ret[1].(error)
@@ -776,13 +689,11 @@ func (m *MockSecretsManagerAPI) RotateSecret(arg0 *secretsmanager.RotateSecretIn
 
 // RotateSecret indicates an expected call of RotateSecret
 func (mr *MockSecretsManagerAPIMockRecorder) RotateSecret(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RotateSecret", reflect.TypeOf((*MockSecretsManagerAPI)(nil).RotateSecret), arg0)
 }
 
 // RotateSecretRequest mocks base method
 func (m *MockSecretsManagerAPI) RotateSecretRequest(arg0 *secretsmanager.RotateSecretInput) (*request.Request, *secretsmanager.RotateSecretOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RotateSecretRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*secretsmanager.RotateSecretOutput)
@@ -791,13 +702,11 @@ func (m *MockSecretsManagerAPI) RotateSecretRequest(arg0 *secretsmanager.RotateS
 
 // RotateSecretRequest indicates an expected call of RotateSecretRequest
 func (mr *MockSecretsManagerAPIMockRecorder) RotateSecretRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RotateSecretRequest", reflect.TypeOf((*MockSecretsManagerAPI)(nil).RotateSecretRequest), arg0)
 }
 
 // RotateSecretWithContext mocks base method
 func (m *MockSecretsManagerAPI) RotateSecretWithContext(arg0 context.Context, arg1 *secretsmanager.RotateSecretInput, arg2 ...request.Option) (*secretsmanager.RotateSecretOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -810,14 +719,12 @@ func (m *MockSecretsManagerAPI) RotateSecretWithContext(arg0 context.Context, ar
 
 // RotateSecretWithContext indicates an expected call of RotateSecretWithContext
 func (mr *MockSecretsManagerAPIMockRecorder) RotateSecretWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RotateSecretWithContext", reflect.TypeOf((*MockSecretsManagerAPI)(nil).RotateSecretWithContext), varargs...)
 }
 
 // TagResource mocks base method
 func (m *MockSecretsManagerAPI) TagResource(arg0 *secretsmanager.TagResourceInput) (*secretsmanager.TagResourceOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "TagResource", arg0)
 	ret0, _ := ret[0].(*secretsmanager.TagResourceOutput)
 	ret1, _ := ret[1].(error)
@@ -826,13 +733,11 @@ func (m *MockSecretsManagerAPI) TagResource(arg0 *secretsmanager.TagResourceInpu
 
 // TagResource indicates an expected call of TagResource
 func (mr *MockSecretsManagerAPIMockRecorder) TagResource(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TagResource", reflect.TypeOf((*MockSecretsManagerAPI)(nil).TagResource), arg0)
 }
 
 // TagResourceRequest mocks base method
 func (m *MockSecretsManagerAPI) TagResourceRequest(arg0 *secretsmanager.TagResourceInput) (*request.Request, *secretsmanager.TagResourceOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "TagResourceRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*secretsmanager.TagResourceOutput)
@@ -841,13 +746,11 @@ func (m *MockSecretsManagerAPI) TagResourceRequest(arg0 *secretsmanager.TagResou
 
 // TagResourceRequest indicates an expected call of TagResourceRequest
 func (mr *MockSecretsManagerAPIMockRecorder) TagResourceRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TagResourceRequest", reflect.TypeOf((*MockSecretsManagerAPI)(nil).TagResourceRequest), arg0)
 }
 
 // TagResourceWithContext mocks base method
 func (m *MockSecretsManagerAPI) TagResourceWithContext(arg0 context.Context, arg1 *secretsmanager.TagResourceInput, arg2 ...request.Option) (*secretsmanager.TagResourceOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -860,14 +763,12 @@ func (m *MockSecretsManagerAPI) TagResourceWithContext(arg0 context.Context, arg
 
 // TagResourceWithContext indicates an expected call of TagResourceWithContext
 func (mr *MockSecretsManagerAPIMockRecorder) TagResourceWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TagResourceWithContext", reflect.TypeOf((*MockSecretsManagerAPI)(nil).TagResourceWithContext), varargs...)
 }
 
 // UntagResource mocks base method
 func (m *MockSecretsManagerAPI) UntagResource(arg0 *secretsmanager.UntagResourceInput) (*secretsmanager.UntagResourceOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UntagResource", arg0)
 	ret0, _ := ret[0].(*secretsmanager.UntagResourceOutput)
 	ret1, _ := ret[1].(error)
@@ -876,13 +777,11 @@ func (m *MockSecretsManagerAPI) UntagResource(arg0 *secretsmanager.UntagResource
 
 // UntagResource indicates an expected call of UntagResource
 func (mr *MockSecretsManagerAPIMockRecorder) UntagResource(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UntagResource", reflect.TypeOf((*MockSecretsManagerAPI)(nil).UntagResource), arg0)
 }
 
 // UntagResourceRequest mocks base method
 func (m *MockSecretsManagerAPI) UntagResourceRequest(arg0 *secretsmanager.UntagResourceInput) (*request.Request, *secretsmanager.UntagResourceOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UntagResourceRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*secretsmanager.UntagResourceOutput)
@@ -891,13 +790,11 @@ func (m *MockSecretsManagerAPI) UntagResourceRequest(arg0 *secretsmanager.UntagR
 
 // UntagResourceRequest indicates an expected call of UntagResourceRequest
 func (mr *MockSecretsManagerAPIMockRecorder) UntagResourceRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UntagResourceRequest", reflect.TypeOf((*MockSecretsManagerAPI)(nil).UntagResourceRequest), arg0)
 }
 
 // UntagResourceWithContext mocks base method
 func (m *MockSecretsManagerAPI) UntagResourceWithContext(arg0 context.Context, arg1 *secretsmanager.UntagResourceInput, arg2 ...request.Option) (*secretsmanager.UntagResourceOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -910,14 +807,12 @@ func (m *MockSecretsManagerAPI) UntagResourceWithContext(arg0 context.Context, a
 
 // UntagResourceWithContext indicates an expected call of UntagResourceWithContext
 func (mr *MockSecretsManagerAPIMockRecorder) UntagResourceWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UntagResourceWithContext", reflect.TypeOf((*MockSecretsManagerAPI)(nil).UntagResourceWithContext), varargs...)
 }
 
 // UpdateSecret mocks base method
 func (m *MockSecretsManagerAPI) UpdateSecret(arg0 *secretsmanager.UpdateSecretInput) (*secretsmanager.UpdateSecretOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateSecret", arg0)
 	ret0, _ := ret[0].(*secretsmanager.UpdateSecretOutput)
 	ret1, _ := ret[1].(error)
@@ -926,13 +821,11 @@ func (m *MockSecretsManagerAPI) UpdateSecret(arg0 *secretsmanager.UpdateSecretIn
 
 // UpdateSecret indicates an expected call of UpdateSecret
 func (mr *MockSecretsManagerAPIMockRecorder) UpdateSecret(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateSecret", reflect.TypeOf((*MockSecretsManagerAPI)(nil).UpdateSecret), arg0)
 }
 
 // UpdateSecretRequest mocks base method
 func (m *MockSecretsManagerAPI) UpdateSecretRequest(arg0 *secretsmanager.UpdateSecretInput) (*request.Request, *secretsmanager.UpdateSecretOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateSecretRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*secretsmanager.UpdateSecretOutput)
@@ -941,13 +834,11 @@ func (m *MockSecretsManagerAPI) UpdateSecretRequest(arg0 *secretsmanager.UpdateS
 
 // UpdateSecretRequest indicates an expected call of UpdateSecretRequest
 func (mr *MockSecretsManagerAPIMockRecorder) UpdateSecretRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateSecretRequest", reflect.TypeOf((*MockSecretsManagerAPI)(nil).UpdateSecretRequest), arg0)
 }
 
 // UpdateSecretVersionStage mocks base method
 func (m *MockSecretsManagerAPI) UpdateSecretVersionStage(arg0 *secretsmanager.UpdateSecretVersionStageInput) (*secretsmanager.UpdateSecretVersionStageOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateSecretVersionStage", arg0)
 	ret0, _ := ret[0].(*secretsmanager.UpdateSecretVersionStageOutput)
 	ret1, _ := ret[1].(error)
@@ -956,13 +847,11 @@ func (m *MockSecretsManagerAPI) UpdateSecretVersionStage(arg0 *secretsmanager.Up
 
 // UpdateSecretVersionStage indicates an expected call of UpdateSecretVersionStage
 func (mr *MockSecretsManagerAPIMockRecorder) UpdateSecretVersionStage(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateSecretVersionStage", reflect.TypeOf((*MockSecretsManagerAPI)(nil).UpdateSecretVersionStage), arg0)
 }
 
 // UpdateSecretVersionStageRequest mocks base method
 func (m *MockSecretsManagerAPI) UpdateSecretVersionStageRequest(arg0 *secretsmanager.UpdateSecretVersionStageInput) (*request.Request, *secretsmanager.UpdateSecretVersionStageOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateSecretVersionStageRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*secretsmanager.UpdateSecretVersionStageOutput)
@@ -971,13 +860,11 @@ func (m *MockSecretsManagerAPI) UpdateSecretVersionStageRequest(arg0 *secretsman
 
 // UpdateSecretVersionStageRequest indicates an expected call of UpdateSecretVersionStageRequest
 func (mr *MockSecretsManagerAPIMockRecorder) UpdateSecretVersionStageRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateSecretVersionStageRequest", reflect.TypeOf((*MockSecretsManagerAPI)(nil).UpdateSecretVersionStageRequest), arg0)
 }
 
 // UpdateSecretVersionStageWithContext mocks base method
 func (m *MockSecretsManagerAPI) UpdateSecretVersionStageWithContext(arg0 context.Context, arg1 *secretsmanager.UpdateSecretVersionStageInput, arg2 ...request.Option) (*secretsmanager.UpdateSecretVersionStageOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -990,14 +877,12 @@ func (m *MockSecretsManagerAPI) UpdateSecretVersionStageWithContext(arg0 context
 
 // UpdateSecretVersionStageWithContext indicates an expected call of UpdateSecretVersionStageWithContext
 func (mr *MockSecretsManagerAPIMockRecorder) UpdateSecretVersionStageWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateSecretVersionStageWithContext", reflect.TypeOf((*MockSecretsManagerAPI)(nil).UpdateSecretVersionStageWithContext), varargs...)
 }
 
 // UpdateSecretWithContext mocks base method
 func (m *MockSecretsManagerAPI) UpdateSecretWithContext(arg0 context.Context, arg1 *secretsmanager.UpdateSecretInput, arg2 ...request.Option) (*secretsmanager.UpdateSecretOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -1010,7 +895,6 @@ func (m *MockSecretsManagerAPI) UpdateSecretWithContext(arg0 context.Context, ar
 
 // UpdateSecretWithContext indicates an expected call of UpdateSecretWithContext
 func (mr *MockSecretsManagerAPIMockRecorder) UpdateSecretWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateSecretWithContext", reflect.TypeOf((*MockSecretsManagerAPI)(nil).UpdateSecretWithContext), varargs...)
 }

--- a/ecs-cli/modules/clients/aws/sts/mock/client.go
+++ b/ecs-cli/modules/clients/aws/sts/mock/client.go
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2015-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the
@@ -48,7 +48,6 @@ func (m *MockClient) EXPECT() *MockClientMockRecorder {
 
 // GetAWSAccountID mocks base method
 func (m *MockClient) GetAWSAccountID() (string, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetAWSAccountID")
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
@@ -57,6 +56,5 @@ func (m *MockClient) GetAWSAccountID() (string, error) {
 
 // GetAWSAccountID indicates an expected call of GetAWSAccountID
 func (mr *MockClientMockRecorder) GetAWSAccountID() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAWSAccountID", reflect.TypeOf((*MockClient)(nil).GetAWSAccountID))
 }

--- a/ecs-cli/modules/clients/aws/sts/mock/sdk/stsiface_mock.go
+++ b/ecs-cli/modules/clients/aws/sts/mock/sdk/stsiface_mock.go
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2015-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the
@@ -51,7 +51,6 @@ func (m *MockSTSAPI) EXPECT() *MockSTSAPIMockRecorder {
 
 // AssumeRole mocks base method
 func (m *MockSTSAPI) AssumeRole(arg0 *sts.AssumeRoleInput) (*sts.AssumeRoleOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AssumeRole", arg0)
 	ret0, _ := ret[0].(*sts.AssumeRoleOutput)
 	ret1, _ := ret[1].(error)
@@ -60,13 +59,11 @@ func (m *MockSTSAPI) AssumeRole(arg0 *sts.AssumeRoleInput) (*sts.AssumeRoleOutpu
 
 // AssumeRole indicates an expected call of AssumeRole
 func (mr *MockSTSAPIMockRecorder) AssumeRole(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AssumeRole", reflect.TypeOf((*MockSTSAPI)(nil).AssumeRole), arg0)
 }
 
 // AssumeRoleRequest mocks base method
 func (m *MockSTSAPI) AssumeRoleRequest(arg0 *sts.AssumeRoleInput) (*request.Request, *sts.AssumeRoleOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AssumeRoleRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*sts.AssumeRoleOutput)
@@ -75,13 +72,11 @@ func (m *MockSTSAPI) AssumeRoleRequest(arg0 *sts.AssumeRoleInput) (*request.Requ
 
 // AssumeRoleRequest indicates an expected call of AssumeRoleRequest
 func (mr *MockSTSAPIMockRecorder) AssumeRoleRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AssumeRoleRequest", reflect.TypeOf((*MockSTSAPI)(nil).AssumeRoleRequest), arg0)
 }
 
 // AssumeRoleWithContext mocks base method
 func (m *MockSTSAPI) AssumeRoleWithContext(arg0 context.Context, arg1 *sts.AssumeRoleInput, arg2 ...request.Option) (*sts.AssumeRoleOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -94,14 +89,12 @@ func (m *MockSTSAPI) AssumeRoleWithContext(arg0 context.Context, arg1 *sts.Assum
 
 // AssumeRoleWithContext indicates an expected call of AssumeRoleWithContext
 func (mr *MockSTSAPIMockRecorder) AssumeRoleWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AssumeRoleWithContext", reflect.TypeOf((*MockSTSAPI)(nil).AssumeRoleWithContext), varargs...)
 }
 
 // AssumeRoleWithSAML mocks base method
 func (m *MockSTSAPI) AssumeRoleWithSAML(arg0 *sts.AssumeRoleWithSAMLInput) (*sts.AssumeRoleWithSAMLOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AssumeRoleWithSAML", arg0)
 	ret0, _ := ret[0].(*sts.AssumeRoleWithSAMLOutput)
 	ret1, _ := ret[1].(error)
@@ -110,13 +103,11 @@ func (m *MockSTSAPI) AssumeRoleWithSAML(arg0 *sts.AssumeRoleWithSAMLInput) (*sts
 
 // AssumeRoleWithSAML indicates an expected call of AssumeRoleWithSAML
 func (mr *MockSTSAPIMockRecorder) AssumeRoleWithSAML(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AssumeRoleWithSAML", reflect.TypeOf((*MockSTSAPI)(nil).AssumeRoleWithSAML), arg0)
 }
 
 // AssumeRoleWithSAMLRequest mocks base method
 func (m *MockSTSAPI) AssumeRoleWithSAMLRequest(arg0 *sts.AssumeRoleWithSAMLInput) (*request.Request, *sts.AssumeRoleWithSAMLOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AssumeRoleWithSAMLRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*sts.AssumeRoleWithSAMLOutput)
@@ -125,13 +116,11 @@ func (m *MockSTSAPI) AssumeRoleWithSAMLRequest(arg0 *sts.AssumeRoleWithSAMLInput
 
 // AssumeRoleWithSAMLRequest indicates an expected call of AssumeRoleWithSAMLRequest
 func (mr *MockSTSAPIMockRecorder) AssumeRoleWithSAMLRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AssumeRoleWithSAMLRequest", reflect.TypeOf((*MockSTSAPI)(nil).AssumeRoleWithSAMLRequest), arg0)
 }
 
 // AssumeRoleWithSAMLWithContext mocks base method
 func (m *MockSTSAPI) AssumeRoleWithSAMLWithContext(arg0 context.Context, arg1 *sts.AssumeRoleWithSAMLInput, arg2 ...request.Option) (*sts.AssumeRoleWithSAMLOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -144,14 +133,12 @@ func (m *MockSTSAPI) AssumeRoleWithSAMLWithContext(arg0 context.Context, arg1 *s
 
 // AssumeRoleWithSAMLWithContext indicates an expected call of AssumeRoleWithSAMLWithContext
 func (mr *MockSTSAPIMockRecorder) AssumeRoleWithSAMLWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AssumeRoleWithSAMLWithContext", reflect.TypeOf((*MockSTSAPI)(nil).AssumeRoleWithSAMLWithContext), varargs...)
 }
 
 // AssumeRoleWithWebIdentity mocks base method
 func (m *MockSTSAPI) AssumeRoleWithWebIdentity(arg0 *sts.AssumeRoleWithWebIdentityInput) (*sts.AssumeRoleWithWebIdentityOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AssumeRoleWithWebIdentity", arg0)
 	ret0, _ := ret[0].(*sts.AssumeRoleWithWebIdentityOutput)
 	ret1, _ := ret[1].(error)
@@ -160,13 +147,11 @@ func (m *MockSTSAPI) AssumeRoleWithWebIdentity(arg0 *sts.AssumeRoleWithWebIdenti
 
 // AssumeRoleWithWebIdentity indicates an expected call of AssumeRoleWithWebIdentity
 func (mr *MockSTSAPIMockRecorder) AssumeRoleWithWebIdentity(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AssumeRoleWithWebIdentity", reflect.TypeOf((*MockSTSAPI)(nil).AssumeRoleWithWebIdentity), arg0)
 }
 
 // AssumeRoleWithWebIdentityRequest mocks base method
 func (m *MockSTSAPI) AssumeRoleWithWebIdentityRequest(arg0 *sts.AssumeRoleWithWebIdentityInput) (*request.Request, *sts.AssumeRoleWithWebIdentityOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AssumeRoleWithWebIdentityRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*sts.AssumeRoleWithWebIdentityOutput)
@@ -175,13 +160,11 @@ func (m *MockSTSAPI) AssumeRoleWithWebIdentityRequest(arg0 *sts.AssumeRoleWithWe
 
 // AssumeRoleWithWebIdentityRequest indicates an expected call of AssumeRoleWithWebIdentityRequest
 func (mr *MockSTSAPIMockRecorder) AssumeRoleWithWebIdentityRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AssumeRoleWithWebIdentityRequest", reflect.TypeOf((*MockSTSAPI)(nil).AssumeRoleWithWebIdentityRequest), arg0)
 }
 
 // AssumeRoleWithWebIdentityWithContext mocks base method
 func (m *MockSTSAPI) AssumeRoleWithWebIdentityWithContext(arg0 context.Context, arg1 *sts.AssumeRoleWithWebIdentityInput, arg2 ...request.Option) (*sts.AssumeRoleWithWebIdentityOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -194,14 +177,12 @@ func (m *MockSTSAPI) AssumeRoleWithWebIdentityWithContext(arg0 context.Context, 
 
 // AssumeRoleWithWebIdentityWithContext indicates an expected call of AssumeRoleWithWebIdentityWithContext
 func (mr *MockSTSAPIMockRecorder) AssumeRoleWithWebIdentityWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AssumeRoleWithWebIdentityWithContext", reflect.TypeOf((*MockSTSAPI)(nil).AssumeRoleWithWebIdentityWithContext), varargs...)
 }
 
 // DecodeAuthorizationMessage mocks base method
 func (m *MockSTSAPI) DecodeAuthorizationMessage(arg0 *sts.DecodeAuthorizationMessageInput) (*sts.DecodeAuthorizationMessageOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DecodeAuthorizationMessage", arg0)
 	ret0, _ := ret[0].(*sts.DecodeAuthorizationMessageOutput)
 	ret1, _ := ret[1].(error)
@@ -210,13 +191,11 @@ func (m *MockSTSAPI) DecodeAuthorizationMessage(arg0 *sts.DecodeAuthorizationMes
 
 // DecodeAuthorizationMessage indicates an expected call of DecodeAuthorizationMessage
 func (mr *MockSTSAPIMockRecorder) DecodeAuthorizationMessage(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DecodeAuthorizationMessage", reflect.TypeOf((*MockSTSAPI)(nil).DecodeAuthorizationMessage), arg0)
 }
 
 // DecodeAuthorizationMessageRequest mocks base method
 func (m *MockSTSAPI) DecodeAuthorizationMessageRequest(arg0 *sts.DecodeAuthorizationMessageInput) (*request.Request, *sts.DecodeAuthorizationMessageOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DecodeAuthorizationMessageRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*sts.DecodeAuthorizationMessageOutput)
@@ -225,13 +204,11 @@ func (m *MockSTSAPI) DecodeAuthorizationMessageRequest(arg0 *sts.DecodeAuthoriza
 
 // DecodeAuthorizationMessageRequest indicates an expected call of DecodeAuthorizationMessageRequest
 func (mr *MockSTSAPIMockRecorder) DecodeAuthorizationMessageRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DecodeAuthorizationMessageRequest", reflect.TypeOf((*MockSTSAPI)(nil).DecodeAuthorizationMessageRequest), arg0)
 }
 
 // DecodeAuthorizationMessageWithContext mocks base method
 func (m *MockSTSAPI) DecodeAuthorizationMessageWithContext(arg0 context.Context, arg1 *sts.DecodeAuthorizationMessageInput, arg2 ...request.Option) (*sts.DecodeAuthorizationMessageOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -244,14 +221,12 @@ func (m *MockSTSAPI) DecodeAuthorizationMessageWithContext(arg0 context.Context,
 
 // DecodeAuthorizationMessageWithContext indicates an expected call of DecodeAuthorizationMessageWithContext
 func (mr *MockSTSAPIMockRecorder) DecodeAuthorizationMessageWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DecodeAuthorizationMessageWithContext", reflect.TypeOf((*MockSTSAPI)(nil).DecodeAuthorizationMessageWithContext), varargs...)
 }
 
 // GetCallerIdentity mocks base method
 func (m *MockSTSAPI) GetCallerIdentity(arg0 *sts.GetCallerIdentityInput) (*sts.GetCallerIdentityOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetCallerIdentity", arg0)
 	ret0, _ := ret[0].(*sts.GetCallerIdentityOutput)
 	ret1, _ := ret[1].(error)
@@ -260,13 +235,11 @@ func (m *MockSTSAPI) GetCallerIdentity(arg0 *sts.GetCallerIdentityInput) (*sts.G
 
 // GetCallerIdentity indicates an expected call of GetCallerIdentity
 func (mr *MockSTSAPIMockRecorder) GetCallerIdentity(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCallerIdentity", reflect.TypeOf((*MockSTSAPI)(nil).GetCallerIdentity), arg0)
 }
 
 // GetCallerIdentityRequest mocks base method
 func (m *MockSTSAPI) GetCallerIdentityRequest(arg0 *sts.GetCallerIdentityInput) (*request.Request, *sts.GetCallerIdentityOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetCallerIdentityRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*sts.GetCallerIdentityOutput)
@@ -275,13 +248,11 @@ func (m *MockSTSAPI) GetCallerIdentityRequest(arg0 *sts.GetCallerIdentityInput) 
 
 // GetCallerIdentityRequest indicates an expected call of GetCallerIdentityRequest
 func (mr *MockSTSAPIMockRecorder) GetCallerIdentityRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCallerIdentityRequest", reflect.TypeOf((*MockSTSAPI)(nil).GetCallerIdentityRequest), arg0)
 }
 
 // GetCallerIdentityWithContext mocks base method
 func (m *MockSTSAPI) GetCallerIdentityWithContext(arg0 context.Context, arg1 *sts.GetCallerIdentityInput, arg2 ...request.Option) (*sts.GetCallerIdentityOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -294,14 +265,12 @@ func (m *MockSTSAPI) GetCallerIdentityWithContext(arg0 context.Context, arg1 *st
 
 // GetCallerIdentityWithContext indicates an expected call of GetCallerIdentityWithContext
 func (mr *MockSTSAPIMockRecorder) GetCallerIdentityWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCallerIdentityWithContext", reflect.TypeOf((*MockSTSAPI)(nil).GetCallerIdentityWithContext), varargs...)
 }
 
 // GetFederationToken mocks base method
 func (m *MockSTSAPI) GetFederationToken(arg0 *sts.GetFederationTokenInput) (*sts.GetFederationTokenOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetFederationToken", arg0)
 	ret0, _ := ret[0].(*sts.GetFederationTokenOutput)
 	ret1, _ := ret[1].(error)
@@ -310,13 +279,11 @@ func (m *MockSTSAPI) GetFederationToken(arg0 *sts.GetFederationTokenInput) (*sts
 
 // GetFederationToken indicates an expected call of GetFederationToken
 func (mr *MockSTSAPIMockRecorder) GetFederationToken(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFederationToken", reflect.TypeOf((*MockSTSAPI)(nil).GetFederationToken), arg0)
 }
 
 // GetFederationTokenRequest mocks base method
 func (m *MockSTSAPI) GetFederationTokenRequest(arg0 *sts.GetFederationTokenInput) (*request.Request, *sts.GetFederationTokenOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetFederationTokenRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*sts.GetFederationTokenOutput)
@@ -325,13 +292,11 @@ func (m *MockSTSAPI) GetFederationTokenRequest(arg0 *sts.GetFederationTokenInput
 
 // GetFederationTokenRequest indicates an expected call of GetFederationTokenRequest
 func (mr *MockSTSAPIMockRecorder) GetFederationTokenRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFederationTokenRequest", reflect.TypeOf((*MockSTSAPI)(nil).GetFederationTokenRequest), arg0)
 }
 
 // GetFederationTokenWithContext mocks base method
 func (m *MockSTSAPI) GetFederationTokenWithContext(arg0 context.Context, arg1 *sts.GetFederationTokenInput, arg2 ...request.Option) (*sts.GetFederationTokenOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -344,14 +309,12 @@ func (m *MockSTSAPI) GetFederationTokenWithContext(arg0 context.Context, arg1 *s
 
 // GetFederationTokenWithContext indicates an expected call of GetFederationTokenWithContext
 func (mr *MockSTSAPIMockRecorder) GetFederationTokenWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFederationTokenWithContext", reflect.TypeOf((*MockSTSAPI)(nil).GetFederationTokenWithContext), varargs...)
 }
 
 // GetSessionToken mocks base method
 func (m *MockSTSAPI) GetSessionToken(arg0 *sts.GetSessionTokenInput) (*sts.GetSessionTokenOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetSessionToken", arg0)
 	ret0, _ := ret[0].(*sts.GetSessionTokenOutput)
 	ret1, _ := ret[1].(error)
@@ -360,13 +323,11 @@ func (m *MockSTSAPI) GetSessionToken(arg0 *sts.GetSessionTokenInput) (*sts.GetSe
 
 // GetSessionToken indicates an expected call of GetSessionToken
 func (mr *MockSTSAPIMockRecorder) GetSessionToken(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSessionToken", reflect.TypeOf((*MockSTSAPI)(nil).GetSessionToken), arg0)
 }
 
 // GetSessionTokenRequest mocks base method
 func (m *MockSTSAPI) GetSessionTokenRequest(arg0 *sts.GetSessionTokenInput) (*request.Request, *sts.GetSessionTokenOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetSessionTokenRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*sts.GetSessionTokenOutput)
@@ -375,13 +336,11 @@ func (m *MockSTSAPI) GetSessionTokenRequest(arg0 *sts.GetSessionTokenInput) (*re
 
 // GetSessionTokenRequest indicates an expected call of GetSessionTokenRequest
 func (mr *MockSTSAPIMockRecorder) GetSessionTokenRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSessionTokenRequest", reflect.TypeOf((*MockSTSAPI)(nil).GetSessionTokenRequest), arg0)
 }
 
 // GetSessionTokenWithContext mocks base method
 func (m *MockSTSAPI) GetSessionTokenWithContext(arg0 context.Context, arg1 *sts.GetSessionTokenInput, arg2 ...request.Option) (*sts.GetSessionTokenOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -394,7 +353,6 @@ func (m *MockSTSAPI) GetSessionTokenWithContext(arg0 context.Context, arg1 *sts.
 
 // GetSessionTokenWithContext indicates an expected call of GetSessionTokenWithContext
 func (mr *MockSTSAPIMockRecorder) GetSessionTokenWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSessionTokenWithContext", reflect.TypeOf((*MockSTSAPI)(nil).GetSessionTokenWithContext), varargs...)
 }

--- a/ecs-cli/modules/clients/aws/tagging/mock/client.go
+++ b/ecs-cli/modules/clients/aws/tagging/mock/client.go
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2015-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the
@@ -49,7 +49,6 @@ func (m *MockClient) EXPECT() *MockClientMockRecorder {
 
 // TagResources mocks base method
 func (m *MockClient) TagResources(arg0 *resourcegroupstaggingapi.TagResourcesInput) (*resourcegroupstaggingapi.TagResourcesOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "TagResources", arg0)
 	ret0, _ := ret[0].(*resourcegroupstaggingapi.TagResourcesOutput)
 	ret1, _ := ret[1].(error)
@@ -58,6 +57,5 @@ func (m *MockClient) TagResources(arg0 *resourcegroupstaggingapi.TagResourcesInp
 
 // TagResources indicates an expected call of TagResources
 func (mr *MockClientMockRecorder) TagResources(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TagResources", reflect.TypeOf((*MockClient)(nil).TagResources), arg0)
 }

--- a/ecs-cli/modules/clients/aws/tagging/mock/sdk/resourcegroupstaggingapiiface.go
+++ b/ecs-cli/modules/clients/aws/tagging/mock/sdk/resourcegroupstaggingapiiface.go
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2015-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the
@@ -51,7 +51,6 @@ func (m *MockResourceGroupsTaggingAPIAPI) EXPECT() *MockResourceGroupsTaggingAPI
 
 // GetResources mocks base method
 func (m *MockResourceGroupsTaggingAPIAPI) GetResources(arg0 *resourcegroupstaggingapi.GetResourcesInput) (*resourcegroupstaggingapi.GetResourcesOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetResources", arg0)
 	ret0, _ := ret[0].(*resourcegroupstaggingapi.GetResourcesOutput)
 	ret1, _ := ret[1].(error)
@@ -60,13 +59,11 @@ func (m *MockResourceGroupsTaggingAPIAPI) GetResources(arg0 *resourcegroupstaggi
 
 // GetResources indicates an expected call of GetResources
 func (mr *MockResourceGroupsTaggingAPIAPIMockRecorder) GetResources(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetResources", reflect.TypeOf((*MockResourceGroupsTaggingAPIAPI)(nil).GetResources), arg0)
 }
 
 // GetResourcesPages mocks base method
 func (m *MockResourceGroupsTaggingAPIAPI) GetResourcesPages(arg0 *resourcegroupstaggingapi.GetResourcesInput, arg1 func(*resourcegroupstaggingapi.GetResourcesOutput, bool) bool) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetResourcesPages", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -74,13 +71,11 @@ func (m *MockResourceGroupsTaggingAPIAPI) GetResourcesPages(arg0 *resourcegroups
 
 // GetResourcesPages indicates an expected call of GetResourcesPages
 func (mr *MockResourceGroupsTaggingAPIAPIMockRecorder) GetResourcesPages(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetResourcesPages", reflect.TypeOf((*MockResourceGroupsTaggingAPIAPI)(nil).GetResourcesPages), arg0, arg1)
 }
 
 // GetResourcesPagesWithContext mocks base method
 func (m *MockResourceGroupsTaggingAPIAPI) GetResourcesPagesWithContext(arg0 context.Context, arg1 *resourcegroupstaggingapi.GetResourcesInput, arg2 func(*resourcegroupstaggingapi.GetResourcesOutput, bool) bool, arg3 ...request.Option) error {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1, arg2}
 	for _, a := range arg3 {
 		varargs = append(varargs, a)
@@ -92,14 +87,12 @@ func (m *MockResourceGroupsTaggingAPIAPI) GetResourcesPagesWithContext(arg0 cont
 
 // GetResourcesPagesWithContext indicates an expected call of GetResourcesPagesWithContext
 func (mr *MockResourceGroupsTaggingAPIAPIMockRecorder) GetResourcesPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetResourcesPagesWithContext", reflect.TypeOf((*MockResourceGroupsTaggingAPIAPI)(nil).GetResourcesPagesWithContext), varargs...)
 }
 
 // GetResourcesRequest mocks base method
 func (m *MockResourceGroupsTaggingAPIAPI) GetResourcesRequest(arg0 *resourcegroupstaggingapi.GetResourcesInput) (*request.Request, *resourcegroupstaggingapi.GetResourcesOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetResourcesRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*resourcegroupstaggingapi.GetResourcesOutput)
@@ -108,13 +101,11 @@ func (m *MockResourceGroupsTaggingAPIAPI) GetResourcesRequest(arg0 *resourcegrou
 
 // GetResourcesRequest indicates an expected call of GetResourcesRequest
 func (mr *MockResourceGroupsTaggingAPIAPIMockRecorder) GetResourcesRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetResourcesRequest", reflect.TypeOf((*MockResourceGroupsTaggingAPIAPI)(nil).GetResourcesRequest), arg0)
 }
 
 // GetResourcesWithContext mocks base method
 func (m *MockResourceGroupsTaggingAPIAPI) GetResourcesWithContext(arg0 context.Context, arg1 *resourcegroupstaggingapi.GetResourcesInput, arg2 ...request.Option) (*resourcegroupstaggingapi.GetResourcesOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -127,14 +118,12 @@ func (m *MockResourceGroupsTaggingAPIAPI) GetResourcesWithContext(arg0 context.C
 
 // GetResourcesWithContext indicates an expected call of GetResourcesWithContext
 func (mr *MockResourceGroupsTaggingAPIAPIMockRecorder) GetResourcesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetResourcesWithContext", reflect.TypeOf((*MockResourceGroupsTaggingAPIAPI)(nil).GetResourcesWithContext), varargs...)
 }
 
 // GetTagKeys mocks base method
 func (m *MockResourceGroupsTaggingAPIAPI) GetTagKeys(arg0 *resourcegroupstaggingapi.GetTagKeysInput) (*resourcegroupstaggingapi.GetTagKeysOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetTagKeys", arg0)
 	ret0, _ := ret[0].(*resourcegroupstaggingapi.GetTagKeysOutput)
 	ret1, _ := ret[1].(error)
@@ -143,13 +132,11 @@ func (m *MockResourceGroupsTaggingAPIAPI) GetTagKeys(arg0 *resourcegroupstagging
 
 // GetTagKeys indicates an expected call of GetTagKeys
 func (mr *MockResourceGroupsTaggingAPIAPIMockRecorder) GetTagKeys(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTagKeys", reflect.TypeOf((*MockResourceGroupsTaggingAPIAPI)(nil).GetTagKeys), arg0)
 }
 
 // GetTagKeysPages mocks base method
 func (m *MockResourceGroupsTaggingAPIAPI) GetTagKeysPages(arg0 *resourcegroupstaggingapi.GetTagKeysInput, arg1 func(*resourcegroupstaggingapi.GetTagKeysOutput, bool) bool) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetTagKeysPages", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -157,13 +144,11 @@ func (m *MockResourceGroupsTaggingAPIAPI) GetTagKeysPages(arg0 *resourcegroupsta
 
 // GetTagKeysPages indicates an expected call of GetTagKeysPages
 func (mr *MockResourceGroupsTaggingAPIAPIMockRecorder) GetTagKeysPages(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTagKeysPages", reflect.TypeOf((*MockResourceGroupsTaggingAPIAPI)(nil).GetTagKeysPages), arg0, arg1)
 }
 
 // GetTagKeysPagesWithContext mocks base method
 func (m *MockResourceGroupsTaggingAPIAPI) GetTagKeysPagesWithContext(arg0 context.Context, arg1 *resourcegroupstaggingapi.GetTagKeysInput, arg2 func(*resourcegroupstaggingapi.GetTagKeysOutput, bool) bool, arg3 ...request.Option) error {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1, arg2}
 	for _, a := range arg3 {
 		varargs = append(varargs, a)
@@ -175,14 +160,12 @@ func (m *MockResourceGroupsTaggingAPIAPI) GetTagKeysPagesWithContext(arg0 contex
 
 // GetTagKeysPagesWithContext indicates an expected call of GetTagKeysPagesWithContext
 func (mr *MockResourceGroupsTaggingAPIAPIMockRecorder) GetTagKeysPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTagKeysPagesWithContext", reflect.TypeOf((*MockResourceGroupsTaggingAPIAPI)(nil).GetTagKeysPagesWithContext), varargs...)
 }
 
 // GetTagKeysRequest mocks base method
 func (m *MockResourceGroupsTaggingAPIAPI) GetTagKeysRequest(arg0 *resourcegroupstaggingapi.GetTagKeysInput) (*request.Request, *resourcegroupstaggingapi.GetTagKeysOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetTagKeysRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*resourcegroupstaggingapi.GetTagKeysOutput)
@@ -191,13 +174,11 @@ func (m *MockResourceGroupsTaggingAPIAPI) GetTagKeysRequest(arg0 *resourcegroups
 
 // GetTagKeysRequest indicates an expected call of GetTagKeysRequest
 func (mr *MockResourceGroupsTaggingAPIAPIMockRecorder) GetTagKeysRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTagKeysRequest", reflect.TypeOf((*MockResourceGroupsTaggingAPIAPI)(nil).GetTagKeysRequest), arg0)
 }
 
 // GetTagKeysWithContext mocks base method
 func (m *MockResourceGroupsTaggingAPIAPI) GetTagKeysWithContext(arg0 context.Context, arg1 *resourcegroupstaggingapi.GetTagKeysInput, arg2 ...request.Option) (*resourcegroupstaggingapi.GetTagKeysOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -210,14 +191,12 @@ func (m *MockResourceGroupsTaggingAPIAPI) GetTagKeysWithContext(arg0 context.Con
 
 // GetTagKeysWithContext indicates an expected call of GetTagKeysWithContext
 func (mr *MockResourceGroupsTaggingAPIAPIMockRecorder) GetTagKeysWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTagKeysWithContext", reflect.TypeOf((*MockResourceGroupsTaggingAPIAPI)(nil).GetTagKeysWithContext), varargs...)
 }
 
 // GetTagValues mocks base method
 func (m *MockResourceGroupsTaggingAPIAPI) GetTagValues(arg0 *resourcegroupstaggingapi.GetTagValuesInput) (*resourcegroupstaggingapi.GetTagValuesOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetTagValues", arg0)
 	ret0, _ := ret[0].(*resourcegroupstaggingapi.GetTagValuesOutput)
 	ret1, _ := ret[1].(error)
@@ -226,13 +205,11 @@ func (m *MockResourceGroupsTaggingAPIAPI) GetTagValues(arg0 *resourcegroupstaggi
 
 // GetTagValues indicates an expected call of GetTagValues
 func (mr *MockResourceGroupsTaggingAPIAPIMockRecorder) GetTagValues(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTagValues", reflect.TypeOf((*MockResourceGroupsTaggingAPIAPI)(nil).GetTagValues), arg0)
 }
 
 // GetTagValuesPages mocks base method
 func (m *MockResourceGroupsTaggingAPIAPI) GetTagValuesPages(arg0 *resourcegroupstaggingapi.GetTagValuesInput, arg1 func(*resourcegroupstaggingapi.GetTagValuesOutput, bool) bool) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetTagValuesPages", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -240,13 +217,11 @@ func (m *MockResourceGroupsTaggingAPIAPI) GetTagValuesPages(arg0 *resourcegroups
 
 // GetTagValuesPages indicates an expected call of GetTagValuesPages
 func (mr *MockResourceGroupsTaggingAPIAPIMockRecorder) GetTagValuesPages(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTagValuesPages", reflect.TypeOf((*MockResourceGroupsTaggingAPIAPI)(nil).GetTagValuesPages), arg0, arg1)
 }
 
 // GetTagValuesPagesWithContext mocks base method
 func (m *MockResourceGroupsTaggingAPIAPI) GetTagValuesPagesWithContext(arg0 context.Context, arg1 *resourcegroupstaggingapi.GetTagValuesInput, arg2 func(*resourcegroupstaggingapi.GetTagValuesOutput, bool) bool, arg3 ...request.Option) error {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1, arg2}
 	for _, a := range arg3 {
 		varargs = append(varargs, a)
@@ -258,14 +233,12 @@ func (m *MockResourceGroupsTaggingAPIAPI) GetTagValuesPagesWithContext(arg0 cont
 
 // GetTagValuesPagesWithContext indicates an expected call of GetTagValuesPagesWithContext
 func (mr *MockResourceGroupsTaggingAPIAPIMockRecorder) GetTagValuesPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTagValuesPagesWithContext", reflect.TypeOf((*MockResourceGroupsTaggingAPIAPI)(nil).GetTagValuesPagesWithContext), varargs...)
 }
 
 // GetTagValuesRequest mocks base method
 func (m *MockResourceGroupsTaggingAPIAPI) GetTagValuesRequest(arg0 *resourcegroupstaggingapi.GetTagValuesInput) (*request.Request, *resourcegroupstaggingapi.GetTagValuesOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetTagValuesRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*resourcegroupstaggingapi.GetTagValuesOutput)
@@ -274,13 +247,11 @@ func (m *MockResourceGroupsTaggingAPIAPI) GetTagValuesRequest(arg0 *resourcegrou
 
 // GetTagValuesRequest indicates an expected call of GetTagValuesRequest
 func (mr *MockResourceGroupsTaggingAPIAPIMockRecorder) GetTagValuesRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTagValuesRequest", reflect.TypeOf((*MockResourceGroupsTaggingAPIAPI)(nil).GetTagValuesRequest), arg0)
 }
 
 // GetTagValuesWithContext mocks base method
 func (m *MockResourceGroupsTaggingAPIAPI) GetTagValuesWithContext(arg0 context.Context, arg1 *resourcegroupstaggingapi.GetTagValuesInput, arg2 ...request.Option) (*resourcegroupstaggingapi.GetTagValuesOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -293,14 +264,12 @@ func (m *MockResourceGroupsTaggingAPIAPI) GetTagValuesWithContext(arg0 context.C
 
 // GetTagValuesWithContext indicates an expected call of GetTagValuesWithContext
 func (mr *MockResourceGroupsTaggingAPIAPIMockRecorder) GetTagValuesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTagValuesWithContext", reflect.TypeOf((*MockResourceGroupsTaggingAPIAPI)(nil).GetTagValuesWithContext), varargs...)
 }
 
 // TagResources mocks base method
 func (m *MockResourceGroupsTaggingAPIAPI) TagResources(arg0 *resourcegroupstaggingapi.TagResourcesInput) (*resourcegroupstaggingapi.TagResourcesOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "TagResources", arg0)
 	ret0, _ := ret[0].(*resourcegroupstaggingapi.TagResourcesOutput)
 	ret1, _ := ret[1].(error)
@@ -309,13 +278,11 @@ func (m *MockResourceGroupsTaggingAPIAPI) TagResources(arg0 *resourcegroupstaggi
 
 // TagResources indicates an expected call of TagResources
 func (mr *MockResourceGroupsTaggingAPIAPIMockRecorder) TagResources(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TagResources", reflect.TypeOf((*MockResourceGroupsTaggingAPIAPI)(nil).TagResources), arg0)
 }
 
 // TagResourcesRequest mocks base method
 func (m *MockResourceGroupsTaggingAPIAPI) TagResourcesRequest(arg0 *resourcegroupstaggingapi.TagResourcesInput) (*request.Request, *resourcegroupstaggingapi.TagResourcesOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "TagResourcesRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*resourcegroupstaggingapi.TagResourcesOutput)
@@ -324,13 +291,11 @@ func (m *MockResourceGroupsTaggingAPIAPI) TagResourcesRequest(arg0 *resourcegrou
 
 // TagResourcesRequest indicates an expected call of TagResourcesRequest
 func (mr *MockResourceGroupsTaggingAPIAPIMockRecorder) TagResourcesRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TagResourcesRequest", reflect.TypeOf((*MockResourceGroupsTaggingAPIAPI)(nil).TagResourcesRequest), arg0)
 }
 
 // TagResourcesWithContext mocks base method
 func (m *MockResourceGroupsTaggingAPIAPI) TagResourcesWithContext(arg0 context.Context, arg1 *resourcegroupstaggingapi.TagResourcesInput, arg2 ...request.Option) (*resourcegroupstaggingapi.TagResourcesOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -343,14 +308,12 @@ func (m *MockResourceGroupsTaggingAPIAPI) TagResourcesWithContext(arg0 context.C
 
 // TagResourcesWithContext indicates an expected call of TagResourcesWithContext
 func (mr *MockResourceGroupsTaggingAPIAPIMockRecorder) TagResourcesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TagResourcesWithContext", reflect.TypeOf((*MockResourceGroupsTaggingAPIAPI)(nil).TagResourcesWithContext), varargs...)
 }
 
 // UntagResources mocks base method
 func (m *MockResourceGroupsTaggingAPIAPI) UntagResources(arg0 *resourcegroupstaggingapi.UntagResourcesInput) (*resourcegroupstaggingapi.UntagResourcesOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UntagResources", arg0)
 	ret0, _ := ret[0].(*resourcegroupstaggingapi.UntagResourcesOutput)
 	ret1, _ := ret[1].(error)
@@ -359,13 +322,11 @@ func (m *MockResourceGroupsTaggingAPIAPI) UntagResources(arg0 *resourcegroupstag
 
 // UntagResources indicates an expected call of UntagResources
 func (mr *MockResourceGroupsTaggingAPIAPIMockRecorder) UntagResources(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UntagResources", reflect.TypeOf((*MockResourceGroupsTaggingAPIAPI)(nil).UntagResources), arg0)
 }
 
 // UntagResourcesRequest mocks base method
 func (m *MockResourceGroupsTaggingAPIAPI) UntagResourcesRequest(arg0 *resourcegroupstaggingapi.UntagResourcesInput) (*request.Request, *resourcegroupstaggingapi.UntagResourcesOutput) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UntagResourcesRequest", arg0)
 	ret0, _ := ret[0].(*request.Request)
 	ret1, _ := ret[1].(*resourcegroupstaggingapi.UntagResourcesOutput)
@@ -374,13 +335,11 @@ func (m *MockResourceGroupsTaggingAPIAPI) UntagResourcesRequest(arg0 *resourcegr
 
 // UntagResourcesRequest indicates an expected call of UntagResourcesRequest
 func (mr *MockResourceGroupsTaggingAPIAPIMockRecorder) UntagResourcesRequest(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UntagResourcesRequest", reflect.TypeOf((*MockResourceGroupsTaggingAPIAPI)(nil).UntagResourcesRequest), arg0)
 }
 
 // UntagResourcesWithContext mocks base method
 func (m *MockResourceGroupsTaggingAPIAPI) UntagResourcesWithContext(arg0 context.Context, arg1 *resourcegroupstaggingapi.UntagResourcesInput, arg2 ...request.Option) (*resourcegroupstaggingapi.UntagResourcesOutput, error) {
-	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
@@ -393,7 +352,6 @@ func (m *MockResourceGroupsTaggingAPIAPI) UntagResourcesWithContext(arg0 context
 
 // UntagResourcesWithContext indicates an expected call of UntagResourcesWithContext
 func (mr *MockResourceGroupsTaggingAPIAPIMockRecorder) UntagResourcesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UntagResourcesWithContext", reflect.TypeOf((*MockResourceGroupsTaggingAPIAPI)(nil).UntagResourcesWithContext), varargs...)
 }

--- a/ecs-cli/modules/clients/docker/dockeriface/mock/dockeriface_mock.go
+++ b/ecs-cli/modules/clients/docker/dockeriface/mock/dockeriface_mock.go
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2015-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the
@@ -49,7 +49,6 @@ func (m *MockDockerAPI) EXPECT() *MockDockerAPIMockRecorder {
 
 // PullImage mocks base method
 func (m *MockDockerAPI) PullImage(arg0 go_dockerclient.PullImageOptions, arg1 go_dockerclient.AuthConfiguration) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PullImage", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -57,13 +56,11 @@ func (m *MockDockerAPI) PullImage(arg0 go_dockerclient.PullImageOptions, arg1 go
 
 // PullImage indicates an expected call of PullImage
 func (mr *MockDockerAPIMockRecorder) PullImage(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PullImage", reflect.TypeOf((*MockDockerAPI)(nil).PullImage), arg0, arg1)
 }
 
 // PushImage mocks base method
 func (m *MockDockerAPI) PushImage(arg0 go_dockerclient.PushImageOptions, arg1 go_dockerclient.AuthConfiguration) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PushImage", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -71,13 +68,11 @@ func (m *MockDockerAPI) PushImage(arg0 go_dockerclient.PushImageOptions, arg1 go
 
 // PushImage indicates an expected call of PushImage
 func (mr *MockDockerAPIMockRecorder) PushImage(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PushImage", reflect.TypeOf((*MockDockerAPI)(nil).PushImage), arg0, arg1)
 }
 
 // TagImage mocks base method
 func (m *MockDockerAPI) TagImage(arg0 string, arg1 go_dockerclient.TagImageOptions) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "TagImage", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -85,6 +80,5 @@ func (m *MockDockerAPI) TagImage(arg0 string, arg1 go_dockerclient.TagImageOptio
 
 // TagImage indicates an expected call of TagImage
 func (mr *MockDockerAPIMockRecorder) TagImage(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TagImage", reflect.TypeOf((*MockDockerAPI)(nil).TagImage), arg0, arg1)
 }

--- a/ecs-cli/modules/clients/docker/mock/client.go
+++ b/ecs-cli/modules/clients/docker/mock/client.go
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2015-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the
@@ -49,7 +49,6 @@ func (m *MockClient) EXPECT() *MockClientMockRecorder {
 
 // PullImage mocks base method
 func (m *MockClient) PullImage(arg0, arg1 string, arg2 go_dockerclient.AuthConfiguration) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PullImage", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -57,13 +56,11 @@ func (m *MockClient) PullImage(arg0, arg1 string, arg2 go_dockerclient.AuthConfi
 
 // PullImage indicates an expected call of PullImage
 func (mr *MockClientMockRecorder) PullImage(arg0, arg1, arg2 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PullImage", reflect.TypeOf((*MockClient)(nil).PullImage), arg0, arg1, arg2)
 }
 
 // PushImage mocks base method
 func (m *MockClient) PushImage(arg0, arg1, arg2 string, arg3 go_dockerclient.AuthConfiguration) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PushImage", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -71,13 +68,11 @@ func (m *MockClient) PushImage(arg0, arg1, arg2 string, arg3 go_dockerclient.Aut
 
 // PushImage indicates an expected call of PushImage
 func (mr *MockClientMockRecorder) PushImage(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PushImage", reflect.TypeOf((*MockClient)(nil).PushImage), arg0, arg1, arg2, arg3)
 }
 
 // TagImage mocks base method
 func (m *MockClient) TagImage(arg0, arg1, arg2 string) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "TagImage", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -85,6 +80,5 @@ func (m *MockClient) TagImage(arg0, arg1, arg2 string) error {
 
 // TagImage indicates an expected call of TagImage
 func (mr *MockClientMockRecorder) TagImage(arg0, arg1, arg2 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TagImage", reflect.TypeOf((*MockClient)(nil).TagImage), arg0, arg1, arg2)
 }

--- a/ecs-cli/modules/utils/cache/mocks/cache.go
+++ b/ecs-cli/modules/utils/cache/mocks/cache.go
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2015-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the
@@ -48,7 +48,6 @@ func (m *MockCache) EXPECT() *MockCacheMockRecorder {
 
 // Get mocks base method
 func (m *MockCache) Get(arg0 string, arg1 interface{}) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Get", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -56,13 +55,11 @@ func (m *MockCache) Get(arg0 string, arg1 interface{}) error {
 
 // Get indicates an expected call of Get
 func (mr *MockCacheMockRecorder) Get(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockCache)(nil).Get), arg0, arg1)
 }
 
 // Put mocks base method
 func (m *MockCache) Put(arg0 string, arg1 interface{}) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Put", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -70,6 +67,5 @@ func (m *MockCache) Put(arg0 string, arg1 interface{}) error {
 
 // Put indicates an expected call of Put
 func (mr *MockCacheMockRecorder) Put(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Put", reflect.TypeOf((*MockCache)(nil).Put), arg0, arg1)
 }

--- a/scripts/mockgen.sh
+++ b/scripts/mockgen.sh
@@ -25,7 +25,7 @@ export PATH="${GOPATH//://bin:}/bin:$PATH"
 
 data=$(
 cat << EOF
-// Copyright 2015-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2015-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the


### PR DESCRIPTION
Our mocks shall no longer be stuck in 2017.

References:
- https://www.youtube.com/watch?v=sT8646Nx2C0
- https://www.youtube.com/watch?v=c1f7eZ8cHpM

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
