### PR TITLE
Update amazon-ecr-credential-helper

### DIFF
--- a/ecs-cli/Gopkg.lock
+++ b/ecs-cli/Gopkg.lock
@@ -91,8 +91,8 @@
     "ecr-login/config",
     "ecr-login/version"
   ]
-  revision = "b9fd5a88b82e749a5227a31409fea58f91bdd489"
-  version = "v0.2.0"
+  revision = "798bf2536dbe8a8d297e0b9ce5d61a8ef3df7775"
+  version = "v0.3.0"
 
 [[projects]]
   name = "github.com/containerd/continuity"
@@ -330,6 +330,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "2c5ab6ee696b39b2da9dba2cd47d69c3d2f04b1196cba92e3a04a58fb0cb8c25"
+  inputs-digest = "7b6e16cdffbc1c5f428b7bfaf4ce872385176e969728bf5b23c76eb065915f64"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/ecs-cli/Gopkg.toml
+++ b/ecs-cli/Gopkg.toml
@@ -29,7 +29,7 @@
 
 [[constraint]]
   name = "github.com/awslabs/amazon-ecr-credential-helper"
-  version = "0.2.0"
+  version = "0.3.0"
 
 [[constraint]]
   name = "github.com/docker/go-units"

--- a/ecs-cli/vendor/github.com/awslabs/amazon-ecr-credential-helper/ecr-login/api/factory.go
+++ b/ecs-cli/vendor/github.com/awslabs/amazon-ecr-credential-helper/ecr-login/api/factory.go
@@ -35,7 +35,7 @@ type ClientFactory interface {
 	NewClient(awsSession *session.Session, awsConfig *aws.Config) Client
 	NewClientWithOptions(opts Options) Client
 	NewClientFromRegion(region string) Client
-	NewClientWithFipsEndpoint(region string) Client
+	NewClientWithFipsEndpoint(region string) (Client, error)
 	NewClientWithDefaults() Client
 }
 
@@ -59,18 +59,20 @@ func (defaultClientFactory DefaultClientFactory) NewClientWithDefaults() Client 
 }
 
 // NewClientWithFipsEndpoint overrides the default ECR service endpoint in a given region to use the FIPS endpoint
-func (defaultClientFactory DefaultClientFactory) NewClientWithFipsEndpoint(region string) Client {
+func (defaultClientFactory DefaultClientFactory) NewClientWithFipsEndpoint(region string) (Client, error) {
 	awsSession := session.New()
 	awsSession.Handlers.Build.PushBackNamed(userAgentHandler)
 
-	// UnknownServiceError is expected for "ecr-fips", but resolver should still generate correct FIPs endpoint
-	endpoint, _ := getServiceEndpoint("ecr-fips", region)
+	endpoint, err := getServiceEndpoint("ecr-fips", region)
+	if err != nil {
+		return nil, err
+	}
 
 	awsConfig := awsSession.Config.WithEndpoint(endpoint).WithRegion(region)
 	return defaultClientFactory.NewClientWithOptions(Options{
 		Session: awsSession,
 		Config:  awsConfig,
-	})
+	}), nil
 }
 
 // NewClientFromRegion uses the region to create the client
@@ -102,6 +104,8 @@ func (defaultClientFactory DefaultClientFactory) NewClientWithOptions(opts Optio
 
 func getServiceEndpoint(service, region string) (string, error) {
 	resolver := endpoints.DefaultResolver()
-	endpoint, err := resolver.EndpointFor(service, region)
+	endpoint, err := resolver.EndpointFor(service, region, func(opts *endpoints.Options) {
+		opts.ResolveUnknownService = true
+	})
 	return endpoint.URL, err
 }

--- a/ecs-cli/vendor/github.com/docker/docker/integration-cli/fixtures/https/ca.pem
+++ b/ecs-cli/vendor/github.com/docker/docker/integration-cli/fixtures/https/ca.pem
@@ -1,1 +1,0 @@
-../../../integration/testdata/https/ca.pem

--- a/ecs-cli/vendor/github.com/docker/docker/integration-cli/fixtures/https/client-cert.pem
+++ b/ecs-cli/vendor/github.com/docker/docker/integration-cli/fixtures/https/client-cert.pem
@@ -1,1 +1,0 @@
-../../../integration/testdata/https/client-cert.pem

--- a/ecs-cli/vendor/github.com/docker/docker/integration-cli/fixtures/https/client-key.pem
+++ b/ecs-cli/vendor/github.com/docker/docker/integration-cli/fixtures/https/client-key.pem
@@ -1,1 +1,0 @@
-../../../integration/testdata/https/client-key.pem

--- a/ecs-cli/vendor/github.com/docker/docker/integration-cli/fixtures/https/server-cert.pem
+++ b/ecs-cli/vendor/github.com/docker/docker/integration-cli/fixtures/https/server-cert.pem
@@ -1,1 +1,0 @@
-../../../integration/testdata/https/server-cert.pem

--- a/ecs-cli/vendor/github.com/docker/docker/integration-cli/fixtures/https/server-key.pem
+++ b/ecs-cli/vendor/github.com/docker/docker/integration-cli/fixtures/https/server-key.pem
@@ -1,1 +1,0 @@
-../../../integration/testdata/https/server-key.pem

--- a/ecs-cli/vendor/github.com/docker/docker/project/CONTRIBUTING.md
+++ b/ecs-cli/vendor/github.com/docker/docker/project/CONTRIBUTING.md
@@ -1,1 +1,0 @@
-../CONTRIBUTING.md


### PR DESCRIPTION
Update to latest release of `amazon-ecr-credential-helper`.

### Test output / verification things still work:

push cmd
```
PS ~\GO\src\github.com\aws\amazon-ecs-cli> ./bin/local/ecs-cli.exe push httpd
INFO[0000] Getting AWS account ID...
INFO[0000] Tagging image                                 image=httpd repository=##########.dkr.ecr.us-west-2.amazonaws.com/httpd tag=
INFO[0000] Image tagged
INFO[0000] Pushing image                                 repository=##########.dkr.ecr.us-west-2.amazonaws.com/httpd tag=
INFO[0018] Image pushed
```

pull cmd
```
PS ~\GO\src\github.com\aws\amazon-ecs-cli> ./bin/local/ecs-cli.exe pull python
INFO[0000] Getting AWS account ID...
INFO[0000] Pulling image                                 repository=#########.dkr.ecr.us-west-2.amazonaws.com/python tag=
INFO[0058] Image pulled
```

push w/ FIPs
```
PS ~\GO\src\github.com\aws\amazon-ecs-cli> ./bin/local/ecs-cli.exe push busybox --use-fips
INFO[0000] Getting AWS account ID...
INFO[0000] Tagging image                                 image=busybox repository=##########.dkr.ecr-fips.us-west-2.amazonaws.com/busybox tag=
INFO[0000] Image tagged
INFO[0000] Creating repository                           repository=busybox
INFO[0000] Repository created
INFO[0000] Pushing image                                 repository=##########.dkr.ecr-fips.us-west-2.amazonaws.com/busybox tag=
INFO[0002] Image pushed
```

pull w/ FIPs
```
PS ~\GO\src\github.com\aws\amazon-ecs-cli> ./bin/local/ecs-cli.exe pull aspnetapp:latest --use-fips
INFO[0000] Getting AWS account ID...
INFO[0000] Pulling image                                 repository=##########.dkr.ecr-fips.us-west-2.amazonaws.com/aspnetapp tag=latest
INFO[0015] Image pulled
```


--
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
