### PR TITLE
 Allow init_process_enabled bool from ecs_params

### DIFF
--- a/ecs-cli/modules/cli/compose/adapter/containerconfig.go
+++ b/ecs-cli/modules/cli/compose/adapter/containerconfig.go
@@ -21,6 +21,7 @@ type ContainerConfig struct {
 	HealthCheck           *ecs.HealthCheck
 	Hostname              string
 	Image                 string
+	InitProcessEnabled    bool
 	Links                 []string
 	LogConfiguration      *ecs.LogConfiguration
 	Memory                int64

--- a/ecs-cli/modules/utils/compose/convert_task_definition_test.go
+++ b/ecs-cli/modules/utils/compose/convert_task_definition_test.go
@@ -459,6 +459,7 @@ task_definition:
   services:
     mysql:
       essential: false
+      init_process_enabled: true
       repository_credentials:
         credentials_parameter: arn:aws:secretsmanager:1234567890:secret:test-secret
   task_size:
@@ -497,6 +498,7 @@ task_definition:
 		assert.Equal(t, "5Gb", aws.StringValue(taskDefinition.Memory), "Expected CPU to match")
 		assert.True(t, aws.BoolValue(wordpress.Essential), "Expected container with name: '%v' to be true", *wordpress.Name)
 		assert.Equal(t, "arn:aws:secretsmanager:1234567890:secret:test-secret", aws.StringValue(mysql.RepositoryCredentials.CredentialsParameter), "Expected CredentialsParameter to match")
+		assert.Equal(t, true, aws.BoolValue(mysql.LinuxParameters.InitProcessEnabled), "Expected container def initProcessEnabled to match")
 	}
 }
 

--- a/ecs-cli/modules/utils/compose/ecs_params_reader.go
+++ b/ecs-cli/modules/utils/compose/ecs_params_reader.go
@@ -59,6 +59,7 @@ type ContainerDefs map[string]ContainerDef
 // ContainerDef holds fields for an ECS Container Definition that are not supplied by docker-compose
 type ContainerDef struct {
 	Essential             bool                  `yaml:"essential"`
+	InitProcessEnabled    bool                  `yaml:"init_process_enabled"`
 	RepositoryCredentials RepositoryCredentials `yaml:"repository_credentials"`
 	// resource field yaml names correspond to equivalent docker-compose field
 	Cpu               int64                  `yaml:"cpu_shares"`

--- a/ecs-cli/modules/utils/compose/reconcile_container_def.go
+++ b/ecs-cli/modules/utils/compose/reconcile_container_def.go
@@ -75,6 +75,9 @@ func reconcileContainerDef(inputCfg *adapter.ContainerConfig, ecsConDef *Contain
 	if inputCfg.Devices != nil {
 		outputContDef.LinuxParameters.SetDevices(inputCfg.Devices)
 	}
+	if ecsConDef.InitProcessEnabled != false {
+		outputContDef.LinuxParameters.SetInitProcessEnabled(ecsConDef.InitProcessEnabled)
+	}
 
 	// Only set shmSize if specified. Docker will by default allocate 64M
 	// for shared memory if shmSize is null.


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/amazon-ecs-cli/issues/716

*Description of changes:*
Allow appending `init_process_enabled: <bool>` to services defined in ecs-params.yml to toggle init flag for services in task definitions.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
