### PR TITLE
Support container instance tagging via tags in user data ✈ 

### DIFF
--- a/ecs-cli/modules/config/command_config_test.go
+++ b/ecs-cli/modules/config/command_config_test.go
@@ -84,9 +84,7 @@ func TestNewCommandConfigFromEnvVarsWithRegionNotSpecified(t *testing.T) {
 	context, rdwr := setupTest(t)
 
 	_, err := NewCommandConfig(context, rdwr)
-	if err == nil {
-		t.Errorf("Expected error when region not specified")
-	}
+	assert.Error(t, err, "Expected error when region is not specified")
 }
 
 func TestNewCommandConfigFromEnvVarsWithRegionSpecifiedAsEnvVariable(t *testing.T) {


### PR DESCRIPTION
The previous way of doing tagging wasn't very robust; the ECS Agent can fail to uptake tags from the EC2 instance. So we're doing this instead.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Related to: https://github.com/aws/amazon-ecs-agent/issues/1935