### PR TITLE
Generate coverage statistics for integration tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,8 +52,7 @@ integ-test-build:
 .PHONY: integ-test-run
 integ-test-run:
 	@echo "Running integration tests..."
-	go test -timeout 60m -tags integ ./ecs-cli/integ/e2e/...
-
+	go test -timeout 60m -tags integ -v ./ecs-cli/integ/e2e/...
 
 # Run `integ-test-run` and merge each coverage file from our e2e tests to one file and calculate the total coverage.
 .PHONY: integ-test-run-with-coverage

--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,8 @@ test:
 .PHONY: integ-test
 integ-test: integ-test-build integ-test-run-with-coverage
 
+# Builds the ecs-cli.test binary.
+# This binary is the same as regular ecs-cli but it additionally gives coverage stats to stdout after each execution.
 .PHONY: integ-test-build
 integ-test-build:
 	@echo "Installing dependencies..."
@@ -46,15 +48,16 @@ integ-test-build:
 	env -i PATH=$$PATH GOPATH=$$GOPATH GOROOT=$$GOROOT GOCACHE=$$GOCACHE \
 	go test -coverpkg ./ecs-cli/modules/... -c -tags testrunmain -o ./bin/local/ecs-cli.test ./ecs-cli
 
+# Run our integration tests using the ecs-cli.test binary.
 .PHONY: integ-test-run
 integ-test-run:
 	@echo "Running integration tests..."
 	go test -timeout 60m -tags integ ./ecs-cli/integ/e2e/...
 
+
+# Run `integ-test-run` and merge each coverage file from our e2e tests to one file and calculate the total coverage.
 .PHONY: integ-test-run-with-coverage
 integ-test-run-with-coverage: integ-test-run
-	# Our integration tests generate a separate coverage file for each CLI command.
-	# We merge them together into a single file so that we can get our overall line coverage.
 	@echo "Code coverage"
 	gocovmerge $$TMPDIR/coverage* > $$TMPDIR/all.out
 	go tool cover -func=$$TMPDIR/all.out

--- a/Makefile
+++ b/Makefile
@@ -35,13 +35,30 @@ $(LOCAL_BINARY): $(SOURCES)
 test:
 	env -i PATH=$$PATH GOPATH=$$GOPATH GOROOT=$$GOROOT GOCACHE=$$GOCACHE go test -timeout=120s -v -cover ./ecs-cli/modules/...
 
-
 .PHONY: integ-test
-integ-test:
-	@echo "Building ecs-cli..."
-	./scripts/build_binary.sh ./bin/local
+integ-test: integ-test-build integ-test-run-with-coverage
+
+.PHONY: integ-test-build
+integ-test-build:
+	@echo "Installing dependencies..."
+	go get github.com/wadey/gocovmerge
+	@echo "Building ecs-cli.test..."
+	env -i PATH=$$PATH GOPATH=$$GOPATH GOROOT=$$GOROOT GOCACHE=$$GOCACHE \
+	go test -coverpkg ./ecs-cli/modules/... -c -tags testrunmain -o ./bin/local/ecs-cli.test ./ecs-cli
+
+.PHONY: integ-test-run
+integ-test-run:
 	@echo "Running integration tests..."
-	go test -timeout 60m -tags integ -v ./ecs-cli/integ/e2e/...
+	go test -timeout 60m -tags integ ./ecs-cli/integ/e2e/...
+
+.PHONY: integ-test-run-with-coverage
+integ-test-run-with-coverage: integ-test-run
+	# Our integration tests generate a separate coverage file for each CLI command.
+	# We merge them together into a single file so that we can get our overall line coverage.
+	@echo "Code coverage"
+	gocovmerge $$TMPDIR/coverage* > $$TMPDIR/all.out
+	go tool cover -func=$$TMPDIR/all.out
+	rm $$TMPDIR/coverage* $$TMPDIR/all.out
 
 .PHONY: generate
 generate: $(SOURCES)

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -4,4 +4,4 @@ phases:
   build:
     commands:
       - make integ-test
-      - ./bin/local/ecs-cli --version
+      - ./bin/local/ecs-cli.test

--- a/ecs-cli/integ/README.md
+++ b/ecs-cli/integ/README.md
@@ -6,13 +6,20 @@ You may be charged for the AWS resources utilized while running these tests. It'
 
 ## Local test setup
 
-1. Set the following environment variables:
+1. Set the following mandatory environment variables:
     ```bash
     # hardcode the CodeBuild ID since we're not using codebuild to run the tests
     export CODEBUILD_BUILD_ID="local-integ-test"
     # change this to the region you'd like to run the tests in
     export AWS_REGION="us-east-1"
     ```
+2. If your OS doesn't support the `TMPDIR` environment variable, then set it:
+    ```bash
+    # If your OS sets TMPDIR, you should get an output like /var/folders/13/y9bcvw7557d5bvlvrj8jz0k04gs5dl/T/
+    echo $TMPDIR
+    # Otherwise set the environment to a location of your choice
+    export $TMPDIR="/tmp"
+    ```   
 
 
 ## Running the tests

--- a/ecs-cli/integ/cmd/compose.go
+++ b/ecs-cli/integ/cmd/compose.go
@@ -16,7 +16,6 @@ package cmd
 import (
 	"fmt"
 	"strconv"
-	"strings"
 	"testing"
 	"time"
 
@@ -257,8 +256,7 @@ func testServiceHasAllRunningContainers(t *testing.T, p *Project, wantedNumOfCon
 	}
 
 	// Then
-	lines := strings.Split(string(out), "\n")
-	lines = lines[:len(lines)-3] // remove coverage metadata
+	lines := stdout.Stdout(out).Lines()
 	if len(lines) < 2 {
 		t.Logf("No running containers yet, out = %v", lines)
 		return false

--- a/ecs-cli/integ/cmd/compose.go
+++ b/ecs-cli/integ/cmd/compose.go
@@ -258,6 +258,7 @@ func testServiceHasAllRunningContainers(t *testing.T, p *Project, wantedNumOfCon
 
 	// Then
 	lines := strings.Split(string(out), "\n")
+	lines = lines[:len(lines)-3] // remove coverage metadata
 	if len(lines) < 2 {
 		t.Logf("No running containers yet, out = %v", lines)
 		return false

--- a/ecs-cli/integ/cmd/ps.go
+++ b/ecs-cli/integ/cmd/ps.go
@@ -18,6 +18,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/aws/amazon-ecs-cli/ecs-cli/integ/stdout"
+
 	"github.com/aws/amazon-ecs-cli/ecs-cli/integ"
 	"github.com/stretchr/testify/require"
 )
@@ -51,7 +53,7 @@ func testClusterHasAllRunningContainers(t *testing.T, p *Project, wantedNumOfCon
 	}
 
 	// Then
-	lines := strings.Split(string(out), "\n")
+	lines := stdout.Stdout(out).Lines()
 	if len(lines) < 2 {
 		t.Logf("No running containers yet, out = %v", lines)
 		return false

--- a/ecs-cli/integ/stdout/stdout.go
+++ b/ecs-cli/integ/stdout/stdout.go
@@ -16,6 +16,7 @@
 package stdout
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -24,9 +25,22 @@ import (
 // Stdout is the standard output content from running a test.
 type Stdout []byte
 
+// Lines returns a slice of lines in stdout without the coverage statistics from the ecs-cli.test binary.
+func (b Stdout) Lines() []string {
+	// Each command against the ecs-cli.test binary produces an output like:
+	// > PASS
+	// > coverage: 2.3% of statements in ./ecs-cli/modules/...
+	// >
+	// We need to remove these lines from stdout.
+	coverageLineCount := 3
+
+	lines := strings.Split(string(b), "\n")
+	return lines[:len(lines)-coverageLineCount]
+}
+
 // TestHasAllSubstrings returns true if stdout contains each snippet in wantedSnippets, false otherwise.
 func (b Stdout) TestHasAllSubstrings(t *testing.T, wantedSubstrings []string) {
-	s := string(b)
+	s := strings.Join(b.Lines(), "\n")
 	for _, substring := range wantedSubstrings {
 		require.Contains(t, s, substring)
 	}

--- a/ecs-cli/main.go
+++ b/ecs-cli/main.go
@@ -15,22 +15,44 @@ package main
 
 import (
 	"os"
+	"strings"
+
+	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/commands/flags"
 
 	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/cli/compose/factory"
-	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/commands/cluster"
-	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/commands/compose"
-	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/commands/configure"
-	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/commands/flags"
-	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/commands/image"
-	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/commands/license"
-	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/commands/log"
-	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/commands/regcreds"
+	attributecheckercommand "github.com/aws/amazon-ecs-cli/ecs-cli/modules/commands/attributechecker"
+	clusterCommand "github.com/aws/amazon-ecs-cli/ecs-cli/modules/commands/cluster"
+	composeCommand "github.com/aws/amazon-ecs-cli/ecs-cli/modules/commands/compose"
+	configureCommand "github.com/aws/amazon-ecs-cli/ecs-cli/modules/commands/configure"
+	imageCommand "github.com/aws/amazon-ecs-cli/ecs-cli/modules/commands/image"
+	licenseCommand "github.com/aws/amazon-ecs-cli/ecs-cli/modules/commands/license"
+	logsCommand "github.com/aws/amazon-ecs-cli/ecs-cli/modules/commands/log"
+	regcredsCommand "github.com/aws/amazon-ecs-cli/ecs-cli/modules/commands/regcreds"
 	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/utils/logger"
 	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/version"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
-	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/commands/attributechecker"
 )
+
+// cliArgsWithoutTestFlags returns command-line arguments without "go test" testflags.
+func cliArgsWithoutTestFlags() []string {
+	if !strings.HasSuffix(os.Args[0], "ecs-cli.test") {
+		return os.Args
+	}
+	var args []string
+	for _, arg := range os.Args {
+		// Don't pass test flags used by Go to the ECS CLI. Otherwise, the ECS CLI will try to parse these
+		// flags that are not defined and error.
+		//
+		// Example flag: -test.coverprofile=coverage.out
+		// See "go help testflag" for full list.
+		if strings.HasPrefix(arg, "-test.") {
+			continue
+		}
+		args = append(args, arg)
+	}
+	return args
+}
 
 func main() {
 	// Setup logrus for amazon-ecr-credential-helper
@@ -67,7 +89,7 @@ func main() {
 		},
 	}
 
-	err := app.Run(os.Args)
+	err := app.Run(cliArgsWithoutTestFlags())
 	if err != nil {
 		logrus.Fatal(err)
 	}

--- a/ecs-cli/main.go
+++ b/ecs-cli/main.go
@@ -1,4 +1,4 @@
-// Copyright 2015-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2015-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the

--- a/ecs-cli/main_test.go
+++ b/ecs-cli/main_test.go
@@ -1,0 +1,28 @@
+// +build testrunmain
+
+// Copyright 2015-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package main
+
+import (
+	"testing"
+)
+
+// TestRunMain is a mandatory test to generate the binary ecs-cli.test that's used by our integration tests.
+// It creates a wrapper test binary that's the same as the ecs-cli that also outputs the line coverage
+// after each execution.
+// See https://www.elastic.co/blog/code-coverage-for-your-golang-system-tests for further details.
+func TestRunMain(t *testing.T) {
+	main()
+}

--- a/ecs-cli/main_test.go
+++ b/ecs-cli/main_test.go
@@ -1,6 +1,6 @@
 // +build testrunmain
 
-// Copyright 2015-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2015-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"). You may
 // not use this file except in compliance with the License. A copy of the


### PR DESCRIPTION
**Description of changes**: `make integ-test` now outputs our code coverage. For example, the fargate tutorial e2e test covers 29.2% of our statements.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**  
- [x] Unit tests passed
- [x] Integration tests passed
- [N/A] Unit tests added for new functionality
- [x] Listed manual checks and their outputs in the comments ([example](https://github.com/aws/amazon-ecs-cli/pull/750#issuecomment-472623042))
- [N/A] Link to issue or PR for the integration tests: 

**Documentation**  
- [N/A] Contacted our doc writer
- [N/A] Updated our README
----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
