### PR TITLE
Add integration tests that follow our EC2 tutorial

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ integ-test:
 	@echo "Building ecs-cli..."
 	./scripts/build_binary.sh ./bin/local
 	@echo "Running integration tests..."
-	go test -tags integ -v ./ecs-cli/integ/e2e/...
+	go test -timeout 60m -tags integ -v ./ecs-cli/integ/e2e/...
 
 .PHONY: generate
 generate: $(SOURCES)

--- a/ecs-cli/integ/cfn/cfn.go
+++ b/ecs-cli/integ/cfn/cfn.go
@@ -60,7 +60,7 @@ func TestNoStackName(t *testing.T, stackName string) {
 
 func newClient(t *testing.T) *cloudformation.CloudFormation {
 	sess, err := session.NewSession()
-	require.NoError(t, err, "failed to create new session for upTest clients")
+	require.NoError(t, err, "failed to create new session for CloudFormation")
 	conf := aws.NewConfig()
 	return cloudformation.New(sess, conf)
 }

--- a/ecs-cli/integ/cmd/compose.go
+++ b/ecs-cli/integ/cmd/compose.go
@@ -168,7 +168,6 @@ func TestServiceScale(t *testing.T, p *Project, scale int) {
 	stdout.Stdout(out).TestHasAllSubstrings(t, []string{
 		"ECS Service has reached a stable state",
 		fmt.Sprintf("desiredCount=%d", scale),
-		fmt.Sprintf("runningCount=%d", scale),
 		"serviceName=" + p.Name,
 	})
 	t.Logf("Scaled the service %s to %d tasks", p.Name, scale)
@@ -228,7 +227,6 @@ func TestServiceDown(t *testing.T, p *Project) {
 		"Deleted ECS service",
 		"ECS Service has reached a stable state",
 		"desiredCount=0",
-		"runningCount=0",
 		"serviceName=" + p.Name,
 	})
 	t.Logf("Deleted service %s", p.Name)

--- a/ecs-cli/integ/cmd/compose.go
+++ b/ecs-cli/integ/cmd/compose.go
@@ -43,6 +43,34 @@ func NewProject(name string, configName string) *Project {
 	}
 }
 
+// TestTaskUp runs `ecs-cli compose up` for a project.
+func TestTaskUp(t *testing.T, p *Project) {
+	// Given
+	args := []string{
+		"compose",
+		"--file",
+		p.ComposeFileName,
+		"--ecs-params",
+		p.ECSParamsFileName,
+		"--project-name",
+		p.Name,
+		"up",
+		"--cluster-config",
+		p.ConfigName,
+	}
+	cmd := integ.GetCommand(args)
+
+	// When
+	out, err := cmd.Output()
+	require.NoErrorf(t, err, "Failed to create task definition", "error %v, running %v, out: %s", err, args, string(out))
+
+	// Then
+	stdout.Stdout(out).TestHasAllSubstrings(t, []string{
+		"Started container",
+	})
+	t.Logf("Created containers for %s", p.Name)
+}
+
 // TestServiceUp runs `ecs-cli compose service up` for a project.
 func TestServiceUp(t *testing.T, p *Project) {
 	// Given
@@ -85,6 +113,34 @@ func TestServicePs(t *testing.T, p *Project, wantedNumOfContainers int) {
 	t.Logf("Project %s has %d running containers", p.Name, wantedNumOfContainers)
 }
 
+// TestTaskScale runs `ecs-cli compose scale` for a project.
+func TestTaskScale(t *testing.T, p *Project, scale int) {
+	args := []string{
+		"compose",
+		"--file",
+		p.ComposeFileName,
+		"--ecs-params",
+		p.ECSParamsFileName,
+		"--project-name",
+		p.Name,
+		"scale",
+		strconv.Itoa(scale),
+		"--cluster-config",
+		p.ConfigName,
+	}
+	cmd := integ.GetCommand(args)
+
+	// When
+	out, err := cmd.Output()
+	require.NoErrorf(t, err, "Failed to scale task", "error %v, running %v, out: %s", err, args, string(out))
+
+	// Then
+	stdout.Stdout(out).TestHasAllSubstrings(t, []string{
+		"Started container",
+	})
+	t.Logf("Scaled the task %s to %d", p.Name, scale)
+}
+
 // TestServiceScale runs `ecs-cli compose service scale` for a project.
 func TestServiceScale(t *testing.T, p *Project, scale int) {
 	// Given
@@ -116,6 +172,33 @@ func TestServiceScale(t *testing.T, p *Project, scale int) {
 		"serviceName=" + p.Name,
 	})
 	t.Logf("Scaled the service %s to %d tasks", p.Name, scale)
+}
+
+// TestTaskDown runs `ecs-cli compose down` for a project.
+func TestTaskDown(t *testing.T, p *Project) {
+	args := []string{
+		"compose",
+		"--file",
+		p.ComposeFileName,
+		"--ecs-params",
+		p.ECSParamsFileName,
+		"--project-name",
+		p.Name,
+		"down",
+		"--cluster-config",
+		p.ConfigName,
+	}
+	cmd := integ.GetCommand(args)
+
+	// When
+	out, err := cmd.Output()
+	require.NoErrorf(t, err, "Failed to delete task", "error %v, running %v, out: %s", err, args, string(out))
+
+	// Then
+	stdout.Stdout(out).TestHasAllSubstrings(t, []string{
+		"Stopped container",
+	})
+	t.Logf("Deleted task %s", p.Name)
 }
 
 // TestServiceDown runs `ecs-cli compose service down` for a project.

--- a/ecs-cli/integ/cmd/configure.go
+++ b/ecs-cli/integ/cmd/configure.go
@@ -32,13 +32,24 @@ type CLIConfig struct {
 	ConfigName  string
 }
 
-// TestFargateConfig runs `ecs-cli configure` with a FARGATE launch type.
-func TestFargateConfig(t *testing.T) *CLIConfig {
+// TestFargateTutorialConfig runs `ecs-cli configure` with a FARGATE launch type.
+func TestFargateTutorialConfig(t *testing.T) *CLIConfig {
 	conf := CLIConfig{
-		ClusterName: integ.SuggestedResourceName("fargate", "cluster"),
-		ConfigName:  integ.SuggestedResourceName("fargate", "config"),
+		ClusterName: integ.SuggestedResourceName("fargate-tutorial", "cluster"),
+		ConfigName:  integ.SuggestedResourceName("fargate-tutorial", "config"),
 	}
 	testConfig(t, conf.ClusterName, "FARGATE", conf.ConfigName)
+	t.Logf("Created config %s", conf.ConfigName)
+	return &conf
+}
+
+// TestEC2TutorialConfig runs `ecs-cli configure` with a EC2 launch type.
+func TestEC2TutorialConfig(t *testing.T) *CLIConfig {
+	conf := CLIConfig{
+		ClusterName: integ.SuggestedResourceName("ec2-tutorial", "cluster"),
+		ConfigName:  integ.SuggestedResourceName("ec2-tutorial", "config"),
+	}
+	testConfig(t, conf.ClusterName, "EC2", conf.ConfigName)
 	t.Logf("Created config %s", conf.ConfigName)
 	return &conf
 }

--- a/ecs-cli/integ/cmd/ps.go
+++ b/ecs-cli/integ/cmd/ps.go
@@ -1,0 +1,76 @@
+// Copyright 2015-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package cmd
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aws/amazon-ecs-cli/ecs-cli/integ"
+	"github.com/stretchr/testify/require"
+)
+
+// TestPsRunning runs `ecs-cli ps` for a project and validates that the
+// number of running containers is equal to the wanted number of containers.
+func TestPsRunning(t *testing.T, p *Project, wantedNumOfContainers int) {
+	f := func(t *testing.T) bool {
+		return testClusterHasAllRunningContainers(t, p, wantedNumOfContainers)
+	}
+	timeoutInS := 120 * time.Second // 2 mins
+	sleepInS := 15 * time.Second
+	require.True(t, integ.RetryUntilTimeout(t, f, timeoutInS, sleepInS), "Failed to get RUNNING containers")
+	t.Logf("Project %s has %d running containers", p.Name, wantedNumOfContainers)
+}
+
+func testClusterHasAllRunningContainers(t *testing.T, p *Project, wantedNumOfContainers int) bool {
+	// Given
+	args := []string{
+		"ps",
+		"--cluster-config",
+		p.ConfigName,
+	}
+	cmd := integ.GetCommand(args)
+
+	// When
+	out, err := cmd.Output()
+	if err != nil {
+		t.Logf("Failed to list containers for cluster %v", args)
+		return false
+	}
+
+	// Then
+	lines := strings.Split(string(out), "\n")
+	if len(lines) < 2 {
+		t.Logf("No running containers yet, out = %v", lines)
+		return false
+	}
+	if lines[len(lines)-1] == "" {
+		lines = lines[:len(lines)-1] // Drop the last new line
+	}
+	containers := lines[1:] // Drop the headers
+	numActiveContainers := 0
+	for _, container := range containers {
+		status := integ.GetRowValues(container)[1]
+		if status == "RUNNING" {
+			numActiveContainers++
+		}
+	}
+	if wantedNumOfContainers != numActiveContainers {
+		t.Logf("Wanted = %d, got = %d running containers", wantedNumOfContainers, numActiveContainers)
+		t.Logf("Containers = %s", strings.Join(containers, "\n"))
+		return false
+	}
+	return true
+}

--- a/ecs-cli/integ/e2e/ec2_task_test.go
+++ b/ecs-cli/integ/e2e/ec2_task_test.go
@@ -49,12 +49,12 @@ func TestCreateClusterWithEC2Task(t *testing.T) {
 	defer os.Remove(project.ComposeFileName)
 	defer os.Remove(project.ECSParamsFileName)
 
-	// Create a new task
+	// Create a new task with 2 containers.
 	cmd.TestTaskUp(t, project)
 	ecs.TestListTasks(t, conf.ClusterName, 1)
 	cmd.TestPsRunning(t, project, 2)
 
-	// Increase the number of running tasks
+	// Add an additional task to the cluster, so we expect 4 running containers.
 	cmd.TestTaskScale(t, project, 2)
 	ecs.TestListTasks(t, conf.ClusterName, 2)
 	cmd.TestPsRunning(t, project, 4)

--- a/ecs-cli/integ/e2e/ec2_task_test.go
+++ b/ecs-cli/integ/e2e/ec2_task_test.go
@@ -30,6 +30,8 @@ import (
 // TestCreateClusterWithEC2Task runs the sequence of ecs-cli commands from
 // the EC2 tutorial: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-cli-tutorial-ec2.html
 func TestCreateClusterWithEC2Task(t *testing.T) {
+	t.Parallel()
+
 	// Create the cluster
 	conf := cmd.TestEC2TutorialConfig(t)
 	cmd.TestUp(t,

--- a/ecs-cli/integ/e2e/ec2_task_test.go
+++ b/ecs-cli/integ/e2e/ec2_task_test.go
@@ -45,9 +45,7 @@ func TestCreateClusterWithEC2Task(t *testing.T) {
 	// Create the files for a task definition
 	project := cmd.NewProject("e2e-ec2-tutorial-taskdef", conf.ConfigName)
 	project.ComposeFileName = createEC2TutorialComposeFile(t)
-	project.ECSParamsFileName = createEC2TutorialECSParamsFile(t)
 	defer os.Remove(project.ComposeFileName)
-	defer os.Remove(project.ECSParamsFileName)
 
 	// Create a new task with 2 containers.
 	cmd.TestTaskUp(t, project)
@@ -69,45 +67,25 @@ func TestCreateClusterWithEC2Task(t *testing.T) {
 
 func createEC2TutorialComposeFile(t *testing.T) string {
 	content := `
-version: '3'
+version: '2'
 services:
   wordpress:
     image: wordpress
+    cpu_shares: 100
+    mem_limit: 524288000
     ports:
       - "80:80"
     links:
       - mysql
   mysql:
     image: mysql:5.7
+    cpu_shares: 100
+    mem_limit: 524288000
     environment:
       MYSQL_ROOT_PASSWORD: password`
 
 	tmpfile, err := ioutil.TempFile("", "docker-compose-*.yml")
 	require.NoError(t, err, "Failed to create docker-compose.yml")
-
-	_, err = tmpfile.Write([]byte(content))
-	require.NoErrorf(t, err, "Failed to write to %s", tmpfile.Name())
-
-	err = tmpfile.Close()
-	require.NoErrorf(t, err, "Failed to close %s", tmpfile.Name())
-
-	t.Logf("Created %s successfully", tmpfile.Name())
-	return tmpfile.Name()
-}
-
-func createEC2TutorialECSParamsFile(t *testing.T) string {
-	content := `
-version: 1
-task_definition:
-  services:
-    wordpress:
-      cpu_shares: 100
-      mem_limit: 524288000
-    mysql:
-      cpu_shares: 100
-      mem_limit: 524288000`
-	tmpfile, err := ioutil.TempFile("", "ecs-params-*.yml")
-	require.NoError(t, err, "Failed to create ecs-params.yml")
 
 	_, err = tmpfile.Write([]byte(content))
 	require.NoErrorf(t, err, "Failed to write to %s", tmpfile.Name())

--- a/ecs-cli/integ/e2e/fargate_service_test.go
+++ b/ecs-cli/integ/e2e/fargate_service_test.go
@@ -29,6 +29,8 @@ import (
 // TestCreateClusterWithFargateService runs the sequence of ecs-cli commands from
 // the Fargate tutorial: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-cli-tutorial-fargate.html
 func TestCreateClusterWithFargateService(t *testing.T) {
+	t.Parallel()
+
 	// Create the cluster
 	conf := cmd.TestFargateTutorialConfig(t)
 	vpc := cmd.TestUp(t, conf)

--- a/ecs-cli/integ/ecs/ecs.go
+++ b/ecs-cli/integ/ecs/ecs.go
@@ -1,0 +1,83 @@
+// Copyright 2015-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+// Package ecs contains validation functions against resources in ECS.
+package ecs
+
+import (
+	"testing"
+	"time"
+
+	"github.com/aws/amazon-ecs-cli/ecs-cli/integ"
+
+	"github.com/aws/aws-sdk-go/service/ecs"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/stretchr/testify/require"
+)
+
+// TestClusterSize validates that a cluster has the expected number of
+// instances by periodically querying against ECS.
+func TestClusterSize(t *testing.T, clusterName string, wantedSize int) {
+	client := newClient(t)
+	f := func(t *testing.T) bool {
+		resp, err := client.ListContainerInstances(&ecs.ListContainerInstancesInput{
+			Cluster: aws.String(clusterName),
+		})
+		if err != nil {
+			t.Logf("Unexpected error: %v while listing container instances for %s", err, clusterName)
+			return false
+		}
+		if len(resp.ContainerInstanceArns) != wantedSize {
+			t.Logf("Number of container instances mismatch, wanted = %d, got = %d", wantedSize, len(resp.ContainerInstanceArns))
+			return false
+		}
+		return true
+	}
+	timeoutInS := 600 * time.Second // 10 mins
+	sleepInS := 15 * time.Second
+	require.True(t, integ.RetryUntilTimeout(t, f, timeoutInS, sleepInS), "Failed to list container instances")
+	t.Logf("Cluster %s has %d instances", clusterName, wantedSize)
+}
+
+// TestListTasks validates that a cluster has the expected number of
+// tasks by periodically querying against ECS.
+func TestListTasks(t *testing.T, clusterName string, wantedSize int) {
+	client := newClient(t)
+	f := func(t *testing.T) bool {
+		resp, err := client.ListTasks(&ecs.ListTasksInput{
+			Cluster: aws.String(clusterName),
+		})
+		if err != nil {
+			t.Logf("Unexpected error: %v while listing tasks for %s", err, clusterName)
+			return false
+		}
+		if len(resp.TaskArns) != wantedSize {
+			t.Logf("Number of tasks mismatch, wanted = %d, got = %d", wantedSize, len(resp.TaskArns))
+			return false
+		}
+		return true
+	}
+	timeoutInS := 180 * time.Second // 3 mins
+	sleepInS := 15 * time.Second
+	require.True(t, integ.RetryUntilTimeout(t, f, timeoutInS, sleepInS), "Failed to list tasks")
+	t.Logf("Cluster %s has %d tasks", clusterName, wantedSize)
+}
+
+func newClient(t *testing.T) *ecs.ECS {
+	sess, err := session.NewSession()
+	require.NoError(t, err, "failed to create new session for ecs")
+	conf := aws.NewConfig()
+	return ecs.New(sess, conf)
+}

--- a/ecs-cli/integ/runner.go
+++ b/ecs-cli/integ/runner.go
@@ -67,8 +67,8 @@ func RetryUntilTimeout(t *testing.T, f func(t *testing.T) bool, timeoutInS time.
 		if ok := f(t); ok {
 			return true
 		}
-		t.Logf("Sleeping for %v", sleepInS)
-		time.Sleep(sleepInS * time.Second)
+		t.Logf("Current timestamp=%v, sleeping for %v", time.Now(), sleepInS)
+		time.Sleep(sleepInS)
 	}
 	return false
 }


### PR DESCRIPTION
**Description of changes**: Add integration tests that follow our EC2 tutorial (https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-cli-tutorial-ec2.html)

----
**Testing**  
- [x] Unit tests passed
- [x] Integration tests passed
- [N/A] Unit tests added for new functionality
- [x] Listed manual checks and their outputs in the comments ([example](https://github.com/aws/amazon-ecs-cli/pull/750#issuecomment-472623042))
- [N/A] Link to issue or PR for the integration tests: 

**Documentation**  
- [N/A] Contacted our doc writer
- [N/A] Updated our README
----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
