### PR TITLE
Support "local down" to stop a running local task

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -1,6 +1,9 @@
 version: 0.2
 
 phases:
+  install:  # TODO remove this step after supporting pulling the image part of "ecs-cli local up". See ECS-8445.
+    commands:
+      - docker pull amazon/amazon-ecs-local-container-endpoints
   build:
     commands:
       - make integ-test

--- a/ecs-cli/integ/e2e/local_test.go
+++ b/ecs-cli/integ/e2e/local_test.go
@@ -70,6 +70,31 @@ func TestECSLocal(t *testing.T) {
 				},
 			},
 		},
+		"run a single local ECS task": {
+			sequence: []commandTest{
+				{
+					args: []string{"local", "up"},
+					execute: func(t *testing.T, args []string) {
+						stdout := integ.RunCmd(t, args)
+						stdout.TestHasAllSubstrings(t, []string{
+							"Created network ecs-local-network",
+							"Created the amazon-ecs-local-container-endpoints container",
+						})
+					},
+				},
+				{
+					args: []string{"local", "down"},
+					execute: func(t *testing.T, args []string) {
+						stdout := integ.RunCmd(t, args)
+						stdout.TestHasAllSubstrings(t, []string{
+							"Stopped container with name amazon-ecs-local-container-endpoints",
+							"Removed container with name amazon-ecs-local-container-endpoints",
+							"Removed network with name ecs-local-network",
+						})
+					},
+				},
+			},
+		},
 	}
 
 	for name, tc := range tests {

--- a/ecs-cli/integ/e2e/local_test.go
+++ b/ecs-cli/integ/e2e/local_test.go
@@ -16,11 +16,9 @@
 package e2e
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/aws/amazon-ecs-cli/ecs-cli/integ"
-	"github.com/aws/amazon-ecs-cli/ecs-cli/integ/stdout"
 	"github.com/stretchr/testify/require"
 )
 
@@ -40,15 +38,7 @@ func TestECSLocal(t *testing.T) {
 				{
 					args: []string{"local", "ps"},
 					execute: func(t *testing.T, args []string) {
-						// Given
-						cmd := integ.GetCommand(args)
-
-						// When
-						out, err := cmd.Output()
-						require.NoErrorf(t, err, "Failed local ps", fmt.Sprintf("args=%v, stdout=%s, err=%v", args, string(out), err))
-
-						// Then
-						stdout := stdout.Stdout(out)
+						stdout := integ.RunCmd(t, args)
 						require.Equal(t, 1, len(stdout.Lines()), "Expected only the table header")
 						stdout.TestHasAllSubstrings(t, []string{
 							"CONTAINER ID",
@@ -64,16 +54,18 @@ func TestECSLocal(t *testing.T) {
 				{
 					args: []string{"local", "ps", "--json"},
 					execute: func(t *testing.T, args []string) {
-						// Given
-						cmd := integ.GetCommand(args)
-
-						// When
-						out, err := cmd.Output()
-						require.NoErrorf(t, err, "Failed local ps", fmt.Sprintf("args=%v, stdout=%s, err=%v", args, string(out), err))
-
-						// Then
-						stdout := stdout.Stdout(out)
+						stdout := integ.RunCmd(t, args)
 						stdout.TestHasAllSubstrings(t, []string{"[]"})
+					},
+				},
+				{
+					args: []string{"local", "down"},
+					execute: func(t *testing.T, args []string) {
+						stdout := integ.RunCmd(t, args)
+						stdout.TestHasAllSubstrings(t, []string{
+							"docker-compose.local.yml does not exist",
+							"ecs-local-network not found",
+						})
 					},
 				},
 			},

--- a/ecs-cli/integ/runner.go
+++ b/ecs-cli/integ/runner.go
@@ -24,6 +24,9 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/aws/amazon-ecs-cli/ecs-cli/integ/stdout"
+	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -44,6 +47,16 @@ func GetCommand(args []string) *exec.Cmd {
 	}
 	args = append([]string{fmt.Sprintf("-test.coverprofile=%s", fname)}, args...)
 	return exec.Command(cmdPath, args...)
+}
+
+// RunCmd runs a command with args and returns its Stdout.
+func RunCmd(t *testing.T, args []string) stdout.Stdout {
+	cmd := GetCommand(args)
+
+	out, err := cmd.Output()
+	require.NoErrorf(t, err, "Failed running command", fmt.Sprintf("args=%v, stdout=%s, err=%v", args, string(out), err))
+
+	return stdout.Stdout(out)
 }
 
 // createTempCoverageFile creates a coverage file for a CLI command under $TMPDIR.

--- a/ecs-cli/modules/cli/local/docker/docker.go
+++ b/ecs-cli/modules/cli/local/docker/docker.go
@@ -33,8 +33,8 @@ const (
 	minDockerAPIVersion = "1.27"
 )
 
-// NewDockerClient returns an object to communicate with the Docker Engine API.
-func NewDockerClient() *client.Client {
+// NewClient returns an object to communicate with the Docker Engine API.
+func NewClient() *client.Client {
 	if os.Getenv("DOCKER_API_VERSION") == "" {
 		// If the user does not explicitly set the API version, then the SDK can choose
 		// an API version that's too new for the user's Docker engine.

--- a/ecs-cli/modules/cli/local/docker/docker.go
+++ b/ecs-cli/modules/cli/local/docker/docker.go
@@ -11,13 +11,19 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-package local
+package docker
 
 import (
 	"os"
+	"time"
 
 	"github.com/docker/docker/client"
 	"github.com/sirupsen/logrus"
+)
+
+const (
+	// TimeoutInS is the wait duration for a response from the Docker daemon before returning an error to the user.
+	TimeoutInS = 30 * time.Second
 )
 
 const (
@@ -27,7 +33,8 @@ const (
 	minDockerAPIVersion = "1.27"
 )
 
-func newDockerClient() *client.Client {
+// NewDockerClient returns an object to communicate with the Docker Engine API.
+func NewDockerClient() *client.Client {
 	if os.Getenv("DOCKER_API_VERSION") == "" {
 		// If the user does not explicitly set the API version, then the SDK can choose
 		// an API version that's too new for the user's Docker engine.

--- a/ecs-cli/modules/cli/local/down_app.go
+++ b/ecs-cli/modules/cli/local/down_app.go
@@ -39,7 +39,7 @@ const (
 // If the user stops the last running task in the local network then also remove the network.
 func Down(c *cli.Context) error {
 	defer func() {
-		client := docker.NewDockerClient()
+		client := docker.NewClient()
 		network.Teardown(client)
 	}()
 
@@ -87,7 +87,7 @@ func handleDownWithCompose() error {
 }
 
 func handleDownWithFilters(args filters.Args) error {
-	client := docker.NewDockerClient()
+	client := docker.NewClient()
 	ctx, cancel := context.WithTimeout(context.Background(), docker.TimeoutInS)
 	defer cancel()
 

--- a/ecs-cli/modules/cli/local/down_app.go
+++ b/ecs-cli/modules/cli/local/down_app.go
@@ -45,6 +45,7 @@ func Down(c *cli.Context) error {
 	taskPath := c.String(flags.TaskDefinitionFileFlag)
 	taskARN := c.String(flags.TaskDefinitionArnFlag)
 
+	// TaskDefinitionFileFlag flag has priority over TaskDefinitionArnFlag if both are present
 	if taskPath != "" {
 		return handleDownWithFile(taskPath)
 	}

--- a/ecs-cli/modules/cli/local/down_app.go
+++ b/ecs-cli/modules/cli/local/down_app.go
@@ -18,10 +18,9 @@ import (
 	"github.com/urfave/cli"
 )
 
-// Stop stops a running local ECS task.
-//
+// Down stops and removes a running local ECS task.
 // If the user stops the last running task in the local network then also remove the network.
-func Stop(c *cli.Context) {
+func Down(c *cli.Context) {
 	docker := newDockerClient()
 	defer network.Teardown(docker)
 }

--- a/ecs-cli/modules/cli/local/network/setup.go
+++ b/ecs-cli/modules/cli/local/network/setup.go
@@ -18,8 +18,8 @@ import (
 	"fmt"
 	"os"
 	"strings"
-	"time"
 
+	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/cli/local/docker"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/filters"
@@ -70,12 +70,6 @@ const (
 	localEndpointsContainerName = "amazon-ecs-local-container-endpoints"
 )
 
-// Configuration for Docker requests
-const (
-	// Wait duration for a response from the Docker daemon before returning an error to the user.
-	dockerTimeout = 30 * time.Second
-)
-
 // Setup creates a user-defined bridge network with a running Local Container Endpoints container. If the network
 // already exists or the container is already running then this function does nothing.
 //
@@ -94,7 +88,7 @@ func setupLocalNetwork(dockerClient networkCreator) {
 }
 
 func localNetworkExists(dockerClient networkCreator) bool {
-	ctx, cancel := context.WithTimeout(context.Background(), dockerTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), docker.TimeoutInS)
 	defer cancel()
 
 	_, err := dockerClient.NetworkInspect(ctx, EcsLocalNetworkName, types.NetworkInspectOptions{})
@@ -109,7 +103,7 @@ func localNetworkExists(dockerClient networkCreator) bool {
 }
 
 func createLocalNetwork(dockerClient networkCreator) {
-	ctx, cancel := context.WithTimeout(context.Background(), dockerTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), docker.TimeoutInS)
 	defer cancel()
 
 	logrus.Infof("Creating network: %s...", EcsLocalNetworkName)
@@ -136,7 +130,7 @@ func setupLocalEndpointsContainer(docker containerStarter) {
 // createLocalEndpointsContainer returns the ID of the newly created container.
 // If the container already exists, returns the ID of the existing container.
 func createLocalEndpointsContainer(dockerClient containerStarter) string {
-	ctx, cancel := context.WithTimeout(context.Background(), dockerTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), docker.TimeoutInS)
 	defer cancel()
 
 	// See First Scenario in https://aws.amazon.com/blogs/compute/a-guide-to-locally-testing-containers-with-amazon-ecs-local-endpoints-and-docker-compose/
@@ -182,7 +176,7 @@ func createLocalEndpointsContainer(dockerClient containerStarter) string {
 }
 
 func localEndpointsContainerID(dockerClient containerStarter) string {
-	ctx, cancel := context.WithTimeout(context.Background(), dockerTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), docker.TimeoutInS)
 	defer cancel()
 
 	resp, err := dockerClient.ContainerList(ctx, types.ContainerListOptions{
@@ -201,7 +195,7 @@ func localEndpointsContainerID(dockerClient containerStarter) string {
 }
 
 func startContainer(dockerClient containerStarter, containerID string) {
-	ctx, cancel := context.WithTimeout(context.Background(), dockerTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), docker.TimeoutInS)
 	defer cancel()
 
 	// If the container is already running, Docker does not return an error response.

--- a/ecs-cli/modules/cli/local/network/teardown.go
+++ b/ecs-cli/modules/cli/local/network/teardown.go
@@ -105,7 +105,7 @@ func stopEndpointsContainer(d containerStopper) {
 		}
 		logrus.Fatalf("Failed to stop %s container due to %v", localEndpointsContainerName, err)
 	}
-	logrus.Infof("Stopped the %s container successfully, removing it...", localEndpointsContainerName)
+	logrus.Infof("Stopped container with name %s", localEndpointsContainerName)
 }
 
 // removeEndpointsContainer removes the endpoints container.
@@ -128,8 +128,7 @@ func removeEndpointsContainer(d containerRemover) {
 		}
 		logrus.Fatalf("Failed to remove %s container due to %v", localEndpointsContainerName, err)
 	}
-	logrus.Infof("Removed the %s container successfully, removing the %s network...",
-		localEndpointsContainerName, EcsLocalNetworkName)
+	logrus.Infof("Removed container with name %s", localEndpointsContainerName)
 }
 
 func removeLocalNetwork(d networkRemover) {
@@ -144,5 +143,5 @@ func removeLocalNetwork(d networkRemover) {
 		}
 		logrus.Fatalf("Failed to remove %s network due to %v", EcsLocalNetworkName, err)
 	}
-	logrus.Infof("Removed the %s network successfully", EcsLocalNetworkName)
+	logrus.Infof("Removed network with name %s", EcsLocalNetworkName)
 }

--- a/ecs-cli/modules/cli/local/network/teardown.go
+++ b/ecs-cli/modules/cli/local/network/teardown.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/cli/local/docker"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/client"
 	"github.com/sirupsen/logrus"
@@ -64,7 +65,7 @@ func Teardown(dockerClient LocalEndpointsStopper) {
 
 // shouldSkipTeardown returns false if the network exists and there is no local task running, otherwise return true.
 func shouldSkipTeardown(d networkInspector) bool {
-	ctx, cancel := context.WithTimeout(context.Background(), dockerTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), docker.TimeoutInS)
 	defer cancel()
 
 	resp, err := d.NetworkInspect(ctx, EcsLocalNetworkName, types.NetworkInspectOptions{})
@@ -98,7 +99,7 @@ func shouldSkipTeardown(d networkInspector) bool {
 }
 
 func stopEndpointsContainer(d containerStopper) {
-	ctx, cancel := context.WithTimeout(context.Background(), dockerTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), docker.TimeoutInS)
 	defer cancel()
 
 	err := d.ContainerStop(ctx, localEndpointsContainerName, nil)
@@ -121,7 +122,7 @@ func stopEndpointsContainer(d containerStopper) {
 // 3) User runs "local up" again and creates a new local network but re-starts the old endpoints container.
 // The old endpoints container tries to connect to the network created in step 1) and fails.
 func removeEndpointsContainer(d containerRemover) {
-	ctx, cancel := context.WithTimeout(context.Background(), dockerTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), docker.TimeoutInS)
 	defer cancel()
 
 	err := d.ContainerRemove(ctx, localEndpointsContainerName, types.ContainerRemoveOptions{})
@@ -136,7 +137,7 @@ func removeEndpointsContainer(d containerRemover) {
 }
 
 func removeLocalNetwork(d networkRemover) {
-	ctx, cancel := context.WithTimeout(context.Background(), dockerTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), docker.TimeoutInS)
 	defer cancel()
 
 	err := d.NetworkRemove(ctx, EcsLocalNetworkName)

--- a/ecs-cli/modules/cli/local/network/teardown.go
+++ b/ecs-cli/modules/cli/local/network/teardown.go
@@ -79,8 +79,8 @@ func shouldSkipTeardown(d networkInspector) bool {
 	}
 
 	if len(resp.Containers) > 1 {
-		// Has other containers running in the network, skip teardown.
-		logrus.Infof("%d other task(s) running locally, skipping network removal", len(resp.Containers)-1)
+		// Don't count the endpoints container part of the running containers
+		logrus.Infof("%d other task container(s) running locally, skipping network removal", len(resp.Containers)-1)
 		return true
 	}
 

--- a/ecs-cli/modules/cli/local/network/teardown_test.go
+++ b/ecs-cli/modules/cli/local/network/teardown_test.go
@@ -103,6 +103,21 @@ func TestTeardown(t *testing.T) {
 				return mock
 			},
 		},
+		"no network": {
+			configureCalls: func(mock *mock_network.MockLocalEndpointsStopper) *mock_network.MockLocalEndpointsStopper {
+				gomock.InOrder(
+					mock.EXPECT().NetworkInspect(gomock.Any(), gomock.Eq(EcsLocalNetworkName), gomock.Any()).Return(
+						types.NetworkResource{},
+						notFoundErr{},
+					),
+					// Should not be invoked
+					mock.EXPECT().ContainerStop(gomock.Any(), gomock.Any(), gomock.Any()).Times(0),
+					mock.EXPECT().ContainerRemove(gomock.Any(), gomock.Any(), gomock.Any()).Times(0),
+					mock.EXPECT().NetworkRemove(gomock.Any(), gomock.Any()).Times(0),
+				)
+				return mock
+			},
+		},
 	}
 
 	for name, tc := range tests {

--- a/ecs-cli/modules/cli/local/ps_app.go
+++ b/ecs-cli/modules/cli/local/ps_app.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 	"text/tabwriter"
 
+	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/cli/local/docker"
 	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/commands/flags"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
@@ -65,9 +66,9 @@ const (
 // Defaults to listing the container metadata in a table format to stdout. If the --json flag is provided,
 // then output the content as JSON instead.
 func Ps(c *cli.Context) {
-	docker := newDockerClient()
+	client := docker.NewDockerClient()
 
-	containers := listECSLocalContainers(docker)
+	containers := listECSLocalContainers(client)
 	if c.Bool(flags.JsonFlag) {
 		displayAsJSON(containers)
 	} else {
@@ -75,9 +76,12 @@ func Ps(c *cli.Context) {
 	}
 }
 
-func listECSLocalContainers(docker *client.Client) []types.Container {
+func listECSLocalContainers(client *client.Client) []types.Container {
+	ctx, cancel := context.WithTimeout(context.Background(), docker.TimeoutInS)
+	defer cancel()
+
 	// ECS Task containers running locally all have an ECS local label
-	containers, err := docker.ContainerList(context.Background(), types.ContainerListOptions{
+	containers, err := client.ContainerList(ctx, types.ContainerListOptions{
 		Filters: filters.NewArgs(
 			filters.Arg("label", ecsLocalLabelKey),
 		),

--- a/ecs-cli/modules/cli/local/ps_app.go
+++ b/ecs-cli/modules/cli/local/ps_app.go
@@ -66,7 +66,7 @@ const (
 // Defaults to listing the container metadata in a table format to stdout. If the --json flag is provided,
 // then output the content as JSON instead.
 func Ps(c *cli.Context) {
-	client := docker.NewDockerClient()
+	client := docker.NewClient()
 
 	containers := listECSLocalContainers(client)
 	if c.Bool(flags.JsonFlag) {

--- a/ecs-cli/modules/cli/local/up_app.go
+++ b/ecs-cli/modules/cli/local/up_app.go
@@ -14,6 +14,7 @@
 package local
 
 import (
+	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/cli/local/docker"
 	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/cli/local/network"
 	"github.com/urfave/cli"
 )
@@ -25,6 +26,6 @@ import (
 // If the container is not running, this command creates a new network for all local ECS tasks to join
 // and communicate with the Amazon ECS Local Endpoints container.
 func Up(c *cli.Context) {
-	docker := newDockerClient()
-	network.Setup(docker)
+	client := docker.NewDockerClient()
+	network.Setup(client)
 }

--- a/ecs-cli/modules/cli/local/up_app.go
+++ b/ecs-cli/modules/cli/local/up_app.go
@@ -26,6 +26,6 @@ import (
 // If the container is not running, this command creates a new network for all local ECS tasks to join
 // and communicate with the Amazon ECS Local Endpoints container.
 func Up(c *cli.Context) {
-	client := docker.NewDockerClient()
+	client := docker.NewClient()
 	network.Setup(client)
 }

--- a/ecs-cli/modules/commands/flags/flags.go
+++ b/ecs-cli/modules/commands/flags/flags.go
@@ -152,6 +152,7 @@ const (
 	TaskDefinitionArnFlag  = "arn"
 	LocalOutputFlag        = "output"
 	JsonFlag               = "json"
+	AllFlag                = "all"
 )
 
 // OptionalRegionAndProfileFlags provides these flags:

--- a/ecs-cli/modules/commands/local/local_command.go
+++ b/ecs-cli/modules/commands/local/local_command.go
@@ -32,7 +32,7 @@ func LocalCommand() cli.Command {
 		Subcommands: []cli.Command{
 			createCommand(),
 			upCommand(),
-			stopCommand(),
+			downCommand(),
 			psCommand(),
 		},
 	}
@@ -57,12 +57,24 @@ func upCommand() cli.Command {
 	}
 }
 
-// TODO This is a placeholder function used to test the teardown of the ECS local network.
-func stopCommand() cli.Command {
+func downCommand() cli.Command {
 	return cli.Command{
-		Name:   "stop",
-		Usage:  "Stop a running local ECS task.",
-		Action: local.Stop,
+		Name:   "down",
+		Usage:  "Stop and remove a locally running ECS task.",
+		Action: local.Down,
+		Description: `By default, stop and remove containers defined in "docker-compose.local.yml". 
+   If an option is provided, find, stop, and remove containers matching the option. 
+   When there are no more running local ECS tasks then also teardown the network created with "local up".`,
+		Flags: []cli.Flag{
+			cli.StringFlag{
+				Name:  flags.TaskDefinitionFileFlag + ",f",
+				Usage: "The file `path` of the task definition to stop.",
+			},
+			cli.StringFlag{
+				Name:  flags.TaskDefinitionArnFlag + ",a",
+				Usage: "The ARN of the task definition to stop.",
+			},
+		},
 	}
 }
 

--- a/ecs-cli/modules/commands/local/local_command.go
+++ b/ecs-cli/modules/commands/local/local_command.go
@@ -60,19 +60,12 @@ func upCommand() cli.Command {
 func downCommand() cli.Command {
 	return cli.Command{
 		Name:   "down",
-		Usage:  "Stop and remove a locally running ECS task.",
+		Usage:  "Stop and remove a running local ECS task.",
 		Action: local.Down,
-		Description: `By default, stop and remove containers defined in "docker-compose.local.yml". 
-   If an option is provided, find, stop, and remove containers matching the option. 
-   When there are no more running local ECS tasks then also teardown the network created with "local up".`,
 		Flags: []cli.Flag{
-			cli.StringFlag{
-				Name:  flags.TaskDefinitionFileFlag + ",f",
-				Usage: "The file `path` of the task definition to stop.",
-			},
-			cli.StringFlag{
-				Name:  flags.TaskDefinitionArnFlag + ",a",
-				Usage: "The ARN of the task definition to stop.",
+			cli.BoolFlag{
+				Name:  flags.AllFlag,
+				Usage: "Stop and remove all running local ECS tasks.",
 			},
 		},
 	}


### PR DESCRIPTION
**Description of changes**: `ecs-cli local down` stops a running local task. If the stopped task is the last running ECS local task, then also teardown the network.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**  
- [x] Unit tests passed
- [x] Integration tests passed
- [x] Unit tests added for new functionality
- [x] Listed manual checks and their outputs in the comments ([example](https://github.com/aws/amazon-ecs-cli/pull/750#issuecomment-472623042))
- [x] Added an additional integ test 

**Documentation**  
- [N/A] Contacted our doc writer
- [N/A] Updated our README
----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
