### PR TITLE
Update "local ps" to default to compose project

### DIFF
--- a/ecs-cli/integ/e2e/local_test.go
+++ b/ecs-cli/integ/e2e/local_test.go
@@ -57,7 +57,6 @@ func TestECSLocal(t *testing.T) {
 							"PORTS",
 							"NAMES",
 							"TASKDEFINITION",
-							"TASKFILEPATH",
 						})
 					},
 				},

--- a/ecs-cli/integ/e2e/local_test.go
+++ b/ecs-cli/integ/e2e/local_test.go
@@ -38,33 +38,46 @@ func TestECSLocal(t *testing.T) {
 				{
 					args: []string{"local", "ps"},
 					execute: func(t *testing.T, args []string) {
-						stdout := integ.RunCmd(t, args)
-						require.Equal(t, 1, len(stdout.Lines()), "Expected only the table header")
+						stdout, err := integ.RunCmd(t, args)
+						require.Error(t, err, "expected args=%v to fail", args)
+						stdout.TestHasAllSubstrings(t, []string{
+							"docker-compose.local.yml does not exist",
+						})
+					},
+				},
+				{
+					args: []string{"local", "ps", "--all"},
+					execute: func(t *testing.T, args []string) {
+						stdout, err := integ.RunCmd(t, args)
+						require.NoError(t, err)
 						stdout.TestHasAllSubstrings(t, []string{
 							"CONTAINER ID",
 							"IMAGE",
 							"STATUS",
 							"PORTS",
 							"NAMES",
-							"TASKDEFINITIONARN",
+							"TASKDEFINITION",
 							"TASKFILEPATH",
 						})
 					},
 				},
 				{
-					args: []string{"local", "ps", "--json"},
+					args: []string{"local", "ps", "--all", "--json"},
 					execute: func(t *testing.T, args []string) {
-						stdout := integ.RunCmd(t, args)
-						stdout.TestHasAllSubstrings(t, []string{"[]"})
+						stdout, err := integ.RunCmd(t, args)
+						require.NoError(t, err)
+						stdout.TestHasAllSubstrings(t, []string{
+							"[]",
+						})
 					},
 				},
 				{
 					args: []string{"local", "down"},
 					execute: func(t *testing.T, args []string) {
-						stdout := integ.RunCmd(t, args)
+						stdout, err := integ.RunCmd(t, args)
+						require.Error(t, err, "expected args=%v to fail", args)
 						stdout.TestHasAllSubstrings(t, []string{
 							"docker-compose.local.yml does not exist",
-							"ecs-local-network not found",
 						})
 					},
 				},
@@ -75,7 +88,8 @@ func TestECSLocal(t *testing.T) {
 				{
 					args: []string{"local", "up"},
 					execute: func(t *testing.T, args []string) {
-						stdout := integ.RunCmd(t, args)
+						stdout, err := integ.RunCmd(t, args)
+						require.NoError(t, err)
 						stdout.TestHasAllSubstrings(t, []string{
 							"Created network ecs-local-network",
 							"Created the amazon-ecs-local-container-endpoints container",
@@ -83,9 +97,10 @@ func TestECSLocal(t *testing.T) {
 					},
 				},
 				{
-					args: []string{"local", "down"},
+					args: []string{"local", "down", "--all"},
 					execute: func(t *testing.T, args []string) {
-						stdout := integ.RunCmd(t, args)
+						stdout, err := integ.RunCmd(t, args)
+						require.NoError(t, err)
 						stdout.TestHasAllSubstrings(t, []string{
 							"Stopped container with name amazon-ecs-local-container-endpoints",
 							"Removed container with name amazon-ecs-local-container-endpoints",

--- a/ecs-cli/integ/runner.go
+++ b/ecs-cli/integ/runner.go
@@ -26,7 +26,6 @@ import (
 	"time"
 
 	"github.com/aws/amazon-ecs-cli/ecs-cli/integ/stdout"
-	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -50,13 +49,10 @@ func GetCommand(args []string) *exec.Cmd {
 }
 
 // RunCmd runs a command with args and returns its Stdout.
-func RunCmd(t *testing.T, args []string) stdout.Stdout {
+func RunCmd(t *testing.T, args []string) (stdout.Stdout, error) {
 	cmd := GetCommand(args)
-
-	out, err := cmd.Output()
-	require.NoErrorf(t, err, "Failed running command", fmt.Sprintf("args=%v, stdout=%s, err=%v", args, string(out), err))
-
-	return stdout.Stdout(out)
+	out, err := cmd.CombinedOutput()
+	return stdout.Stdout(out), err
 }
 
 // createTempCoverageFile creates a coverage file for a CLI command under $TMPDIR.

--- a/ecs-cli/integ/stdout/stdout.go
+++ b/ecs-cli/integ/stdout/stdout.go
@@ -13,6 +13,7 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
+// Package stdout implements testing wrappers on the standard output stream.
 package stdout
 
 import (
@@ -40,7 +41,7 @@ func (b Stdout) Lines() []string {
 
 // TestHasAllSubstrings returns true if stdout contains each snippet in wantedSnippets, false otherwise.
 func (b Stdout) TestHasAllSubstrings(t *testing.T, wantedSubstrings []string) {
-	s := strings.Join(b.Lines(), "\n")
+	s := string(b)
 	for _, substring := range wantedSubstrings {
 		require.Contains(t, s, substring)
 	}

--- a/ecs-cli/modules/cli/local/down_app.go
+++ b/ecs-cli/modules/cli/local/down_app.go
@@ -72,12 +72,12 @@ func downAllLocalContainers() error {
 	client := docker.NewClient()
 	containers, err := client.ContainerList(ctx, types.ContainerListOptions{
 		Filters: filters.NewArgs(
-			filters.Arg("label", ecsLocalLabelKey),
+			filters.Arg("label", taskDefinitionLabelKey),
 		),
 		All: true,
 	})
 	if err != nil {
-		logrus.Fatalf("Failed to list containers with label=%s due to %v", ecsLocalLabelKey, err)
+		logrus.Fatalf("Failed to list containers with label=%s due to %v", taskDefinitionLabelKey, err)
 	}
 	if len(containers) == 0 {
 		logrus.Warn("No running ECS local tasks found")

--- a/ecs-cli/modules/cli/local/down_app.go
+++ b/ecs-cli/modules/cli/local/down_app.go
@@ -51,8 +51,7 @@ func Down(c *cli.Context) error {
 func downComposeLocalContainers() error {
 	wd, _ := os.Getwd()
 	if _, err := os.Stat(filepath.Join(wd, ecsLocalDockerComposeFileName)); os.IsNotExist(err) {
-		logrus.Warnf("Compose file %s does not exist in current directory", ecsLocalDockerComposeFileName)
-		return nil
+		logrus.Fatalf("Compose file %s does not exist in current directory", ecsLocalDockerComposeFileName)
 	}
 
 	logrus.Infof("Running Compose down on %s", ecsLocalDockerComposeFileName)

--- a/ecs-cli/modules/cli/local/ps_app.go
+++ b/ecs-cli/modules/cli/local/ps_app.go
@@ -17,6 +17,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"os/exec"
+	"path/filepath"
 	"strings"
 	"text/tabwriter"
 
@@ -24,7 +26,6 @@ import (
 	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/commands/flags"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
-	"github.com/docker/docker/client"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 	"golang.org/x/net/context"
@@ -34,13 +35,13 @@ import (
 // Refactor to import these constants instead of re-defining them here.
 const (
 	// ecsLocalLabelKey is the Docker object label associated with containers created with "ecs-cli local".
-	ecsLocalLabelKey = "ECSLocalTask"
+	ecsLocalLabelKey = "ecsLocalTask"
 
-	// taskDefinitionARNLabelKey is the Docker object label present if the container was created with a task def ARN.
-	taskDefinitionARNLabelKey = "taskDefinitionARN"
+	// taskDefinitionLabelKey is the Docker object label present if the container was created with an ARN or task family.
+	taskDefinitionLabelKey = "ecsTaskDefinition"
 
 	// taskFilePathLabelKey is the Docker object label present if the container was created from a file.
-	taskFilePathLabelKey = "taskFilePath"
+	taskFilePathLabelKey = "ecsTaskFilePath"
 )
 
 // Table formatting settings used by the Docker CLI.
@@ -51,8 +52,7 @@ const (
 	cellPaddingInSpaces       = 3
 	paddingCharacter          = ' '
 	noFormatting              = 0
-
-	maxContainerIDLength = 12
+	maxContainerIDLength      = 12
 )
 
 // JSON formatting settings.
@@ -61,35 +61,71 @@ const (
 	jsonIndent = "  "
 )
 
-// Ps lists the status of the ECS task containers running locally.
+// Ps lists the status of the ECS task containers running locally as a table.
 //
-// Defaults to listing the container metadata in a table format to stdout. If the --json flag is provided,
-// then output the content as JSON instead.
+// Defaults to listing containers from the local Compose file.
+// If the --all flag is provided, then list all local ECS task containers.
+// If the --json flag is provided, then output the format as JSON instead.
 func Ps(c *cli.Context) {
-	client := docker.NewClient()
+	containers := listContainers(c)
+	displayContainers(c, containers)
+}
 
-	containers := listECSLocalContainers(client)
+func listContainers(c *cli.Context) []types.Container {
+	if !c.Bool(flags.AllFlag) {
+		return listLocalComposeContainers()
+	}
+	// Task containers running locally all have a local label
+	return listContainersWithFilters(filters.NewArgs(
+		filters.Arg("label", ecsLocalLabelKey),
+	))
+}
+
+func listLocalComposeContainers() []types.Container {
+	wd, _ := os.Getwd()
+	if _, err := os.Stat(filepath.Join(wd, ecsLocalDockerComposeFileName)); os.IsNotExist(err) {
+		logrus.Fatalf("Compose file %s does not exist in current directory", ecsLocalDockerComposeFileName)
+	}
+
+	// The -q flag displays the ID of the containers instead of the default "Name, Command, State, Ports" metadata.
+	cmd := exec.Command("docker-compose", "-f", ecsLocalDockerComposeFileName, "ps", "-q")
+	composeOut, err := cmd.Output()
+	if err != nil {
+		logrus.Fatalf("Failed to run docker-compose ps due to %v", err)
+	}
+
+	containerIDs := strings.Split(string(composeOut), "\n")
+	if len(containerIDs) == 0 {
+		return []types.Container{}
+	}
+
+	var args []filters.KeyValuePair
+	for _, containerID := range containerIDs {
+		args = append(args, filters.Arg("id", containerID))
+	}
+	return listContainersWithFilters(filters.NewArgs(args...))
+}
+
+func listContainersWithFilters(args filters.Args) []types.Container {
+	ctx, cancel := context.WithTimeout(context.Background(), docker.TimeoutInS)
+	defer cancel()
+
+	cl := docker.NewClient()
+	containers, err := cl.ContainerList(ctx, types.ContainerListOptions{
+		Filters: args,
+	})
+	if err != nil {
+		logrus.Fatalf("Failed to list containers with args=%v due to %v", args, err)
+	}
+	return containers
+}
+
+func displayContainers(c *cli.Context, containers []types.Container) {
 	if c.Bool(flags.JsonFlag) {
 		displayAsJSON(containers)
 	} else {
 		displayAsTable(containers)
 	}
-}
-
-func listECSLocalContainers(client *client.Client) []types.Container {
-	ctx, cancel := context.WithTimeout(context.Background(), docker.TimeoutInS)
-	defer cancel()
-
-	// ECS Task containers running locally all have an ECS local label
-	containers, err := client.ContainerList(ctx, types.ContainerListOptions{
-		Filters: filters.NewArgs(
-			filters.Arg("label", ecsLocalLabelKey),
-		),
-	})
-	if err != nil {
-		logrus.Fatalf("Failed to list containers with label=%s due to %v", ecsLocalLabelKey, err)
-	}
-	return containers
 }
 
 func displayAsJSON(containers []types.Container) {
@@ -104,7 +140,7 @@ func displayAsTable(containers []types.Container) {
 	w := new(tabwriter.Writer)
 
 	w.Init(os.Stdout, cellWidthInSpaces, widthBetweenCellsInSpaces, cellPaddingInSpaces, paddingCharacter, noFormatting)
-	fmt.Fprintln(w, "CONTAINER ID\tIMAGE\tSTATUS\tPORTS\tNAMES\tTASKDEFINITIONARN\tTASKFILEPATH")
+	fmt.Fprintln(w, "CONTAINER ID\tIMAGE\tSTATUS\tPORTS\tNAMES\tTASKDEFINITION\tTASKFILEPATH")
 	for _, container := range containers {
 		row := fmt.Sprintf("%s\t%s\t%s\t%s\t%s\t%s\t%s",
 			container.ID[:maxContainerIDLength],
@@ -112,7 +148,7 @@ func displayAsTable(containers []types.Container) {
 			container.Status,
 			prettifyPorts(container.Ports),
 			prettifyNames(container.Names),
-			container.Labels[taskDefinitionARNLabelKey],
+			container.Labels[taskDefinitionLabelKey],
 			container.Labels[taskFilePathLabelKey])
 		fmt.Fprintln(w, row)
 	}

--- a/ecs-cli/modules/cli/local/ps_app.go
+++ b/ecs-cli/modules/cli/local/ps_app.go
@@ -140,16 +140,21 @@ func displayAsTable(containers []types.Container) {
 	w := new(tabwriter.Writer)
 
 	w.Init(os.Stdout, cellWidthInSpaces, widthBetweenCellsInSpaces, cellPaddingInSpaces, paddingCharacter, noFormatting)
-	fmt.Fprintln(w, "CONTAINER ID\tIMAGE\tSTATUS\tPORTS\tNAMES\tTASKDEFINITION\tTASKFILEPATH")
+	fmt.Fprintln(w, "CONTAINER ID\tIMAGE\tSTATUS\tPORTS\tNAMES\tTASKDEFINITION")
 	for _, container := range containers {
-		row := fmt.Sprintf("%s\t%s\t%s\t%s\t%s\t%s\t%s",
+		// The ARN/Family and FilePath labels are mutually exclusive
+		taskDef := container.Labels[taskDefinitionLabelKey]
+		if container.Labels[taskFilePathLabelKey] != "" {
+			taskDef = container.Labels[taskFilePathLabelKey]
+		}
+
+		row := fmt.Sprintf("%s\t%s\t%s\t%s\t%s\t%s",
 			container.ID[:maxContainerIDLength],
 			container.Image,
 			container.Status,
 			prettifyPorts(container.Ports),
 			prettifyNames(container.Names),
-			container.Labels[taskDefinitionLabelKey],
-			container.Labels[taskFilePathLabelKey])
+			taskDef)
 		fmt.Fprintln(w, row)
 	}
 	w.Flush()

--- a/ecs-cli/modules/commands/local/local_command.go
+++ b/ecs-cli/modules/commands/local/local_command.go
@@ -78,6 +78,10 @@ func psCommand() cli.Command {
 		Action: local.Ps,
 		Flags: []cli.Flag{
 			cli.BoolFlag{
+				Name:  flags.AllFlag,
+				Usage: "Lists all running local ECS tasks.",
+			},
+			cli.BoolFlag{
 				Name:  flags.JsonFlag,
 				Usage: "Output in JSON format.",
 			},


### PR DESCRIPTION
**Description of changes**: The command `local ps` will by default output the containers in the `docker-compose.local.yml` file.   
If the `--all` flag is provided, then all local ECS task containers are printed.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**  
- [x] Unit tests passed
- [x] Integration tests passed
- [N/A] Unit tests added for new functionality
- [x] Listed manual checks and their outputs in the comments
- [x] Added integration tests instead 

**Documentation**  
- [N/A] Contacted our doc writer
- [N/A] Updated our README
----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
