### PR TITLE
Pull Endpoints image if it doesn't exist

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -1,9 +1,6 @@
 version: 0.2
 
 phases:
-  install:  # TODO remove this step after supporting pulling the image part of "ecs-cli local up". See ECS-8445.
-    commands:
-      - docker pull amazon/amazon-ecs-local-container-endpoints
   build:
     commands:
       - make integ-test

--- a/ecs-cli/modules/cli/local/docker/docker.go
+++ b/ecs-cli/modules/cli/local/docker/docker.go
@@ -21,9 +21,13 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+// Wait durations for a response from the Docker daemon before returning an error to the caller.
 const (
-	// TimeoutInS is the wait duration for a response from the Docker daemon before returning an error to the user.
+	// TimeoutInS is the wait duration for common operations.
 	TimeoutInS = 30 * time.Second
+
+	// LongTimeoutInS is the wait duration for long operations such as PullImage.
+	LongTimeoutInS = 120 * time.Second
 )
 
 const (

--- a/ecs-cli/modules/cli/local/network/mock_network/setup.go
+++ b/ecs-cli/modules/cli/local/network/mock_network/setup.go
@@ -18,6 +18,7 @@
 package mock_network
 
 import (
+	io "io"
 	reflect "reflect"
 
 	types "github.com/docker/docker/api/types"
@@ -92,6 +93,36 @@ func (m *MockLocalEndpointsStarter) ContainerStart(arg0 context.Context, arg1 st
 func (mr *MockLocalEndpointsStarterMockRecorder) ContainerStart(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContainerStart", reflect.TypeOf((*MockLocalEndpointsStarter)(nil).ContainerStart), arg0, arg1, arg2)
+}
+
+// ImageList mocks base method
+func (m *MockLocalEndpointsStarter) ImageList(arg0 context.Context, arg1 types.ImageListOptions) ([]types.ImageSummary, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ImageList", arg0, arg1)
+	ret0, _ := ret[0].([]types.ImageSummary)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ImageList indicates an expected call of ImageList
+func (mr *MockLocalEndpointsStarterMockRecorder) ImageList(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ImageList", reflect.TypeOf((*MockLocalEndpointsStarter)(nil).ImageList), arg0, arg1)
+}
+
+// ImagePull mocks base method
+func (m *MockLocalEndpointsStarter) ImagePull(arg0 context.Context, arg1 string, arg2 types.ImagePullOptions) (io.ReadCloser, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ImagePull", arg0, arg1, arg2)
+	ret0, _ := ret[0].(io.ReadCloser)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ImagePull indicates an expected call of ImagePull
+func (mr *MockLocalEndpointsStarterMockRecorder) ImagePull(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ImagePull", reflect.TypeOf((*MockLocalEndpointsStarter)(nil).ImagePull), arg0, arg1, arg2)
 }
 
 // NetworkCreate mocks base method


### PR DESCRIPTION
**Description of changes**:  
As a user that's running `ecs-cli local up` and doesn't have the [amazon/amazon-ecs-local-container-endpoints](https://hub.docker.com/r/amazon/amazon-ecs-local-container-endpoints) downloaded locally.  
I want `ecs-cli local up` to pull the image for me.  
So that I don't have to pull the image myself.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**  
- [x] Unit tests passed
- [x] Integration tests passed
- [x] Unit tests added for new functionality
- [x] Listed manual checks and their outputs in the comments ([example](https://github.com/aws/amazon-ecs-cli/pull/750#issuecomment-472623042))
- [N/A] ~~Link to issue or PR for the integration tests:~~ The integ tests need to pull the image to pass.

**Documentation**  
- [ ] Contacted our doc writer
- [ ] Updated our README
----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
