### PR TITLE
Ecs local add filter v1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ ecs-cli/vendor/pkg
 ecs-cli/.vscode/*
 ecs-cli/.idea
 .idea/*
+*.DS_Store
+*.yml
+Dockerfile

--- a/ecs-cli/modules/cli/local/down_app.go
+++ b/ecs-cli/modules/cli/local/down_app.go
@@ -53,11 +53,13 @@ func Down(c *cli.Context) error {
 	if c.String(flags.TaskDefinitionFileFlag) != "" {
 		return downLocalContainersWithFilters(filters.NewArgs(
 			filters.Arg("label", taskDefinitionLabelValue+"="+c.String(flags.TaskDefinitionFileFlag)),
+			filters.Arg("label", taskDefinitionLabelType+"="+"localFile"),
 		))
 	}
 	if c.String(flags.TaskDefinitionTaskFlag) != "" {
 		return downLocalContainersWithFilters(filters.NewArgs(
 			filters.Arg("label", taskDefinitionLabelValue+"="+c.String(flags.TaskDefinitionTaskFlag)),
+			filters.Arg("label", taskDefinitionLabelType+"="+"remoteFile"),
 		))
 	}
 	if c.Bool(flags.AllFlag) {

--- a/ecs-cli/modules/cli/local/down_app.go
+++ b/ecs-cli/modules/cli/local/down_app.go
@@ -42,7 +42,7 @@ func Down(c *cli.Context) error {
 		network.Teardown(client)
 	}()
 
-	if err := psOptionsPreCheck(c); err != nil {
+	if err := optionsPreCheck(c); err != nil {
 		logrus.Fatalf("Tasks can be either created by local files or remote files")
 	}
 	// if c.Bool(flags.AllFlag) {
@@ -94,6 +94,7 @@ func downLocalContainersWithFilters(args filters.Args) error {
 	client := docker.NewClient()
 	containers, err := client.ContainerList(ctx, types.ContainerListOptions{
 		Filters: args,
+		All:     true,
 	})
 	if err != nil {
 		logrus.Fatalf("Failed to list containers with label=%s due to %v", taskDefinitionLabelValue, err)

--- a/ecs-cli/modules/cli/local/ps_app.go
+++ b/ecs-cli/modules/cli/local/ps_app.go
@@ -68,14 +68,14 @@ const (
 // If the --all flag is provided, then list all local ECS task containers.
 // If the --json flag is provided, then output the format as JSON instead.
 func Ps(c *cli.Context) {
-	if err := psOptionsPreCheck(c); err != nil {
+	if err := optionsPreCheck(c); err != nil {
 		logrus.Fatalf("Tasks can be either created by local files or remote files")
 	}
 	containers := listContainers(c)
 	displayContainers(c, containers)
 }
 
-func psOptionsPreCheck(c *cli.Context) error {
+func optionsPreCheck(c *cli.Context) error {
 	if (c.String(flags.TaskDefinitionFileFlag) != "") && (c.String(flags.TaskDefinitionTaskFlag) != "") {
 		return errors.New("Tasks can be either created by local files or remote files")
 	}

--- a/ecs-cli/modules/cli/local/ps_app.go
+++ b/ecs-cli/modules/cli/local/ps_app.go
@@ -86,11 +86,13 @@ func listContainers(c *cli.Context) []types.Container {
 	if c.String(flags.TaskDefinitionFileFlag) != "" {
 		return listContainersWithFilters(filters.NewArgs(
 			filters.Arg("label", taskDefinitionLabelValue+"="+c.String(flags.TaskDefinitionFileFlag)),
+			filters.Arg("label", taskDefinitionLabelType+"="+"localFile"),
 		))
 	}
 	if c.String(flags.TaskDefinitionTaskFlag) != "" {
 		return listContainersWithFilters(filters.NewArgs(
 			filters.Arg("label", taskDefinitionLabelValue+"="+c.String(flags.TaskDefinitionTaskFlag)),
+			filters.Arg("label", taskDefinitionLabelType+"="+"remoteFile"),
 		))
 	}
 	if c.Bool(flags.AllFlag) {

--- a/ecs-cli/modules/commands/flags/flags.go
+++ b/ecs-cli/modules/commands/flags/flags.go
@@ -150,6 +150,7 @@ const (
 	// Local
 	TaskDefinitionFileFlag = "file"
 	TaskDefinitionArnFlag  = "arn"
+	TaskDefinitionTaskFlag = "task-def"
 	LocalOutputFlag        = "output"
 	JsonFlag               = "json"
 	AllFlag                = "all"

--- a/ecs-cli/modules/commands/local/local_command.go
+++ b/ecs-cli/modules/commands/local/local_command.go
@@ -60,12 +60,20 @@ func upCommand() cli.Command {
 func downCommand() cli.Command {
 	return cli.Command{
 		Name:   "down",
-		Usage:  "Stop and remove a running local ECS task.",
+		Usage:  "Stop and remove a running ECS task container.",
 		Action: local.Down,
 		Flags: []cli.Flag{
 			cli.BoolFlag{
 				Name:  flags.AllFlag,
-				Usage: "Stop and remove all running local ECS tasks.",
+				Usage: "Stops and removes all running containers",
+			},
+			cli.StringFlag{
+				Name:  flags.TaskDefinitionTaskFlag,
+				Usage: "Stops and removes all running containers matching the task family or ARN",
+			},
+			cli.StringFlag{
+				Name:  flags.TaskDefinitionFileFlag,
+				Usage: "Stops and removes all running containers matching the path",
 			},
 		},
 	}
@@ -80,6 +88,14 @@ func psCommand() cli.Command {
 			cli.BoolFlag{
 				Name:  flags.AllFlag,
 				Usage: "Lists all running local ECS tasks.",
+			},
+			cli.StringFlag{
+				Name:  flags.TaskDefinitionTaskFlag,
+				Usage: "Lists all running containers matching the task family or ARN",
+			},
+			cli.StringFlag{
+				Name:  flags.TaskDefinitionFileFlag,
+				Usage: "Lists all running containers matching the path",
 			},
 			cli.BoolFlag{
 				Name:  flags.JsonFlag,


### PR DESCRIPTION
**Issue #, if available**:

**Description of changes**:
Added the "--task-def" and "--file" flags to "local ps/down", so that users can filter to show the running containers or to down them.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**  
- [ ] Unit tests passed
- [ ] Integration tests passed
- [ ] Unit tests added for new functionality
- [ ] Listed manual checks and their outputs in the comments ([example](https://github.com/aws/amazon-ecs-cli/pull/750#issuecomment-472623042))
- [ ] Link to issue or PR for the integration tests: 

**Documentation**  
- [ ] Contacted our doc writer
- [ ] Updated our README
----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
