### PR TITLE
Enabled race detector during the execution of unit tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ $(LOCAL_BINARY): $(SOURCES)
 
 .PHONY: test
 test:
-	env -i PATH=$$PATH GOPATH=$$GOPATH GOROOT=$$GOROOT GOCACHE=$$GOCACHE go test -timeout=120s -v -cover ./ecs-cli/modules/...
+	env -i PATH=$$PATH GOPATH=$$GOPATH GOROOT=$$GOROOT GOCACHE=$$GOCACHE go test -race -timeout=120s -v -cover ./ecs-cli/modules/...
 
 .PHONY: integ-test
 integ-test: integ-test-build integ-test-run-with-coverage


### PR DESCRIPTION
**Description of changes**:
Enabled the race detector when `make test` is executed.

And just for fun, I timed the `make test` command before and after this code change, there's essentially no difference:

```
Before:
real    1m14.350s
user    2m24.599s
sys     0m31.100s

After:
real    1m15.237s
user    2m29.455s
sys     0m31.182s
```



**Testing**  
- [Y] Unit tests passed
- [N/A] Integration tests passed
- [N/A] Unit tests added for new functionality
- [N/A] Listed manual checks and their outputs in the comments ([example](https://github.com/aws/amazon-ecs-cli/pull/750#issuecomment-472623042))
- [N/A] Link to issue or PR for the integration tests: 

**Documentation**  
- [N/A] Contacted our doc writer
- [N/A] Updated our README
----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
