### PR TITLE
Change network of local containers to "ecs-local-network"

### DIFF
--- a/ecs-cli/modules/cli/local/converter/converter.go
+++ b/ecs-cli/modules/cli/local/converter/converter.go
@@ -111,7 +111,9 @@ func convertToComposeService(containerDefinition *ecs.ContainerDefinition) (comp
 	volumes := convertToVolumes(containerDefinition.MountPoints)
 	ports := convertToPorts(containerDefinition.PortMappings)
 	sysctls := convertToSysctls(containerDefinition.SystemControls)
-	networks := convertToNetworks()
+	networks := map[string]*composeV3.ServiceNetworkConfig{
+		network.EcsLocalNetworkName: nil,
+	}
 
 	service := composeV3.ServiceConfig{
 		Name:        aws.StringValue(containerDefinition.Name),
@@ -148,19 +150,6 @@ func convertToComposeService(containerDefinition *ecs.ContainerDefinition) (comp
 	}
 
 	return service, nil
-}
-
-func convertToNetworks() map[string]*composeV3.ServiceNetworkConfig {
-	out := make(map[string]*composeV3.ServiceNetworkConfig)
-	aliases := []string{}
-	aliases = append(aliases, network.EcsLocalNetworkName)
-	out[network.EcsLocalNetworkName] = &composeV3.ServiceNetworkConfig{
-		Aliases:     aliases,
-		Ipv4Address: "",
-		Ipv6Address: "",
-	}
-
-	return out
 }
 
 func convertToSysctls(systemControls []*ecs.SystemControl) []string {

--- a/ecs-cli/modules/cli/local/converter/converter_test.go
+++ b/ecs-cli/modules/cli/local/converter/converter_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/cli/local/network"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ecs"
 	composeV3 "github.com/docker/cli/cli/compose/types"
@@ -79,6 +80,9 @@ func TestConvertToComposeService(t *testing.T) {
 			Source:   "volume-1",
 			ReadOnly: true,
 		},
+	}
+	expectedNetworks := map[string]*composeV3.ServiceNetworkConfig{
+		network.EcsLocalNetworkName: nil,
 	}
 	expectedPorts := []composeV3.ServicePortConfig{
 		{
@@ -224,6 +228,7 @@ func TestConvertToComposeService(t *testing.T) {
 	assert.Equal(t, expectedLabels, service.Labels, "Expected Labels to match")
 	assert.Equal(t, expectedLogging, service.Logging, "Expected Logging to match")
 	assert.Equal(t, expectedVolumes, service.Volumes, "Expected Volumes to match")
+	assert.Equal(t, expectedNetworks, service.Networks, "Expected Networks to match")
 	assert.Equal(t, expectedPorts, service.Ports, "Expected Ports to match")
 	assert.Equal(t, composeV3.StringList(expectedSysctls), service.Sysctls, "Expected Sysctls to match")
 


### PR DESCRIPTION
Changed the networks of local containers, so that the networks of local containers are set to external `ecs-local-network`, and can talk with the `LocalEndpointsContainer`.

Fixed #802 

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**  
- [x] Unit tests passed
- [x] Integration tests passed
- [N/A] Unit tests added for new functionality
- [x] Listed manual checks and their outputs in the comments ([example](https://github.com/aws/amazon-ecs-cli/pull/750#issuecomment-472623042))
- [N/A] Link to issue or PR for the integration tests: 

**Documentation**  
- [N/A] Contacted our doc writer
- [N/A] Updated our README
----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
