### PR TITLE
Add `local create` metadata to local Compose file

### DIFF
--- a/ecs-cli/modules/cli/local/converter/converter.go
+++ b/ecs-cli/modules/cli/local/converter/converter.go
@@ -27,6 +27,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/ecs"
 	composeV3 "github.com/docker/cli/cli/compose/types"
 	"github.com/docker/go-units"
+	yaml "gopkg.in/yaml.v2"
 )
 
 // LinuxParams is a shim between members of ecs.LinuxParamters and their
@@ -45,8 +46,17 @@ type LinuxParams struct {
 // See https://github.com/aws/amazon-ecs-cli/issues/797
 const SecretLabelPrefix = "ecs-local.secret"
 
+const (
+	// taskDefinitionLabelType represents the type of option used to
+	// transform a task definition to a compose file e.g. remoteFile, localFile.
+	// taskDefinitionLabelValue represents the value of the option
+	// e.g. file path, arn, family.
+	taskDefinitionLabelType  = "ecs-local.task.type"
+	taskDefinitionLabelValue = "ecs-local.task.value"
+)
+
 // ConvertToDockerCompose creates the payload from an ECS Task Definition to be written as a docker compose file
-func ConvertToDockerCompose(taskDefinition *ecs.TaskDefinition) ([]composeV3.ServiceConfig, error) {
+func ConvertToDockerCompose(taskDefinition *ecs.TaskDefinition, localTaskType, localTaskValue string) ([]byte, error) {
 	services := []composeV3.ServiceConfig{}
 	for _, containerDefinition := range taskDefinition.ContainerDefinitions {
 		service, err := convertToComposeService(containerDefinition)
@@ -56,7 +66,22 @@ func ConvertToDockerCompose(taskDefinition *ecs.TaskDefinition) ([]composeV3.Ser
 		services = append(services, service)
 	}
 
-	return services, nil
+	for _, service := range services {
+		service.Labels[taskDefinitionLabelType] = localTaskType
+		service.Labels[taskDefinitionLabelValue] = localTaskValue
+	}
+
+	data, err := yaml.Marshal(&composeV3.Config{
+		Filename: "docker-compose.local.yml",
+		Version:  "3.0",
+		Services: services,
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return data, nil
 }
 
 // TODO convert top level volumes

--- a/ecs-cli/modules/cli/local/create_app.go
+++ b/ecs-cli/modules/cli/local/create_app.go
@@ -81,7 +81,7 @@ func createLocal(project localproject.LocalProject) error {
 func validateOptions(c *cli.Context) error {
 	if (c.String(flags.TaskDefinitionFileFlag) != "") && (c.String(flags.TaskDefinitionTaskFlag) != "") {
 		return fmt.Errorf("%s and %s can not be used together",
-		flags.TaskDefinitionTaskFlag, flags.TaskDefinitionFileFlag)
+			flags.TaskDefinitionTaskFlag, flags.TaskDefinitionFileFlag)
 	}
 	return nil
 }


### PR DESCRIPTION
Added `local create` metadata to local Compose file. Metadata `ecsLocalTaskDefType` and `ecsLocalTaskDefVal` are added.

Fixed #801 

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**  
- [x] Unit tests passed
- [x] Integration tests passed
- [ ] Unit tests added for new functionality
- [x] Listed manual checks and their outputs in the comments ([example](https://github.com/aws/amazon-ecs-cli/pull/750#issuecomment-472623042))
- [N/A] Link to issue or PR for the integration tests: 

**Documentation**  
- [N/A] Contacted our doc writer
- [N/A] Updated our README
----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
