### PR TITLE
fix `TestCreateClusterWithFargateService` integration test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ integ-test-run:
 .PHONY: integ-test-run-with-coverage
 integ-test-run-with-coverage: integ-test-run
 	@echo "Code coverage"
-	gocovmerge $$TMPDIR/coverage* > $$TMPDIR/all.out
+	$$GOPATH/bin/gocovmerge $$TMPDIR/coverage* > $$TMPDIR/all.out
 	go tool cover -func=$$TMPDIR/all.out
 	rm $$TMPDIR/coverage* $$TMPDIR/all.out
 

--- a/ecs-cli/integ/cmd/compose.go
+++ b/ecs-cli/integ/cmd/compose.go
@@ -85,6 +85,7 @@ func TestServiceUp(t *testing.T, p *Project) {
 		"up",
 		"--cluster-config",
 		p.ConfigName,
+		"--create-log-groups",
 	}
 	cmd := integ.GetCommand(args)
 

--- a/ecs-cli/integ/cmd/up.go
+++ b/ecs-cli/integ/cmd/up.go
@@ -42,6 +42,11 @@ func TestUp(t *testing.T, conf *CLIConfig, options ...func([]string) []string) *
 		"--cluster-config",
 		conf.ConfigName,
 	}
+
+	// forces the recreation of any existing resources that match current configuration
+	// in case of a previously failed integ test
+	args = append(args, "--force")
+
 	for _, option := range options {
 		args = option(args)
 	}


### PR DESCRIPTION
**Issue #, if available**:
N/A

**Description of changes**:
This change brings a fix (https://github.com/aws/amazon-ecs-cli/pull/789/commits/520d17719be12bec1cf797dcabb677d48f47761d) that was already merged on the `ecs-local` branch to the `dev` branch. The main reason behind the change is because I want to be able to run integ tests on some new changes I'm adding to the `dev` branch.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**  
- [N/A] Unit tests passed
- [X] Integration tests passed
- [N/A] Unit tests added for new functionality
- [N/A] Listed manual checks and their outputs in the comments ([example](https://github.com/aws/amazon-ecs-cli/pull/750#issuecomment-472623042))
- [N/A] Link to issue or PR for the integration tests: 

**Documentation**  
- [N/A] Contacted our doc writer
- [N/A] Updated our README
----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
