### PR TITLE
Added support for the `StopTimeout` field in `ContainerDefinition`

### DIFF
--- a/ecs-cli/integ/e2e/ec2_task_test.go
+++ b/ecs-cli/integ/e2e/ec2_task_test.go
@@ -77,6 +77,7 @@ services:
       - "80:80"
     links:
       - mysql
+    stop_grace_period: "1m30s"
   mysql:
     image: mysql:5.7
     cpu_shares: 100

--- a/ecs-cli/integ/e2e/fargate_service_test.go
+++ b/ecs-cli/integ/e2e/fargate_service_test.go
@@ -63,11 +63,12 @@ version: '3'
 services:
   wordpress:
     image: wordpress
+    stop_grace_period: "1m30s"
     ports:
       - "80:80"
     logging:
       driver: awslogs
-      options: 
+      options:
         awslogs-group: tutorial
         awslogs-region: us-east-1
         awslogs-stream-prefix: wordpress`

--- a/ecs-cli/modules/cli/compose/adapter/containerconfig.go
+++ b/ecs-cli/modules/cli/compose/adapter/containerconfig.go
@@ -32,10 +32,16 @@ type ContainerConfig struct {
 	PseudoTerminal        bool
 	ReadOnly              bool
 	ShmSize               int64
-	StopTimeout           *int64
-	Tmpfs                 []*ecs.Tmpfs
-	Ulimits               []*ecs.Ulimit
-	VolumesFrom           []*ecs.VolumeFrom
-	User                  string
-	WorkingDirectory      string
+
+	// `ContainerConfig` contains the union of
+	// all fields supported by Docker Compose v1~v3 and some of the
+	// fields did not exist prior to certain version, so we need to
+	// to use pointer type for these field in order to distinguish
+	// between "not set" and cases like: "customer explicitly set it to 0".
+	StopTimeout      *int64
+	Tmpfs            []*ecs.Tmpfs
+	Ulimits          []*ecs.Ulimit
+	VolumesFrom      []*ecs.VolumeFrom
+	User             string
+	WorkingDirectory string
 }

--- a/ecs-cli/modules/cli/compose/adapter/containerconfig.go
+++ b/ecs-cli/modules/cli/compose/adapter/containerconfig.go
@@ -32,6 +32,7 @@ type ContainerConfig struct {
 	PseudoTerminal        bool
 	ReadOnly              bool
 	ShmSize               int64
+	StopTimeout           *int64
 	Tmpfs                 []*ecs.Tmpfs
 	Ulimits               []*ecs.Ulimit
 	VolumesFrom           []*ecs.VolumeFrom

--- a/ecs-cli/modules/cli/compose/adapter/convert.go
+++ b/ecs-cli/modules/cli/compose/adapter/convert.go
@@ -222,6 +222,20 @@ func ConvertToTimeInSeconds(d *time.Duration) *int64 {
 	return &val
 }
 
+func ConvertDurationStrToSeconds(d string) (*int64, error) {
+	// if not set (i.e. ""), which is a valid case, then simply return
+	// nil to indicate the fact.
+	if d == "" {
+		return nil, nil
+	}
+	duration, err := time.ParseDuration(d)
+	if err != nil {
+		return nil, err
+	}
+	result := (int64)(duration.Seconds())
+	return &result, nil
+}
+
 // ConvertToMountPoints transforms the yml volumes slice to ecs compatible MountPoints slice
 // It also uses the hostPath from volumes if present, else adds one to it
 func ConvertToMountPoints(cfgVolumes *yaml.Volumes, volumes *Volumes) ([]*ecs.MountPoint, error) {

--- a/ecs-cli/modules/cli/compose/adapter/convert.go
+++ b/ecs-cli/modules/cli/compose/adapter/convert.go
@@ -222,6 +222,9 @@ func ConvertToTimeInSeconds(d *time.Duration) *int64 {
 	return &val
 }
 
+// ConvertDurationStrToSeconds converts a duration string to an int64 number of seconds
+// In case of an empty string, instead of returning error like time.ParseDuration(),
+// it returns nil as the conversion result and a nil error.
 func ConvertDurationStrToSeconds(d string) (*int64, error) {
 	// if not set (i.e. ""), which is a valid case, then simply return
 	// nil to indicate the fact.

--- a/ecs-cli/modules/cli/compose/adapter/convert_test.go
+++ b/ecs-cli/modules/cli/compose/adapter/convert_test.go
@@ -685,3 +685,20 @@ func TestConvertToHealthCheck(t *testing.T) {
 	assert.Equal(t, aws.Int64(3), output.Retries)
 	assert.Equal(t, aws.Int64(120), output.StartPeriod)
 }
+
+func TestConvertDurationStrToSecondsEmptyString(t *testing.T) {
+	res, err := ConvertDurationStrToSeconds("")
+	assert.NoError(t, err, "empty string should not result in conversion error")
+	assert.Nil(t, res, "conversion result should be nil to indicate that the input duration string is empty")
+}
+
+func TestConvertDurationStrToSeconds(t *testing.T) {
+	res, err := ConvertDurationStrToSeconds("1m15s")
+	assert.NoError(t, err, "valid duration string should not result in conversion error")
+	assert.Equal(t, int64(75), *res)
+}
+
+func TestConvertDurationStrToSecondsInvalidDurationStr(t *testing.T) {
+	_, err := ConvertDurationStrToSeconds("chickenWings")
+	assert.Error(t, err, "invalid duration string should result in conversion error")
+}

--- a/ecs-cli/modules/cli/compose/logger/logger.go
+++ b/ecs-cli/modules/cli/compose/logger/logger.go
@@ -26,6 +26,9 @@ import (
 )
 
 // supported fields/options from compose 1/2 YAML file
+// Ideally, we should have separate slices for Docker Compose v1 and v2 for more explicit warnings
+// because certain fields were introduced after v1. However, due to the lack of popularity of v1,
+// for now we combine the 2 versions.
 var supportedComposeV1V2YamlOptions = []string{
 	"cap_add",
 	"cap_drop",
@@ -53,6 +56,7 @@ var supportedComposeV1V2YamlOptions = []string{
 	"read_only",
 	"security_opt",
 	"shm_size",
+	"stop_grace_period", // v2 and above
 	"tmpfs",
 	"tty",
 	"ulimits",
@@ -64,33 +68,34 @@ var supportedComposeV1V2YamlOptions = []string{
 
 // supported fields/options from compose 3 YAML file
 var supportedFieldsInV3 = map[string]bool{
-	"CapAdd":      true,
-	"CapDrop":     true,
-	"Command":     true,
-	"Devices":     true,
-	"DNS":         true,
-	"DNSSearch":   true,
-	"Entrypoint":  true,
-	"Environment": true,
-	"EnvFile":     true,
-	"ExtraHosts":  true,
-	"Hostname":    true,
-	"HealthCheck": true,
-	"Image":       true,
-	"Labels":      true,
-	"Links":       true,
-	"Logging":     true,
-	"Name":        true,
-	"Ports":       true,
-	"Privileged":  true,
-	"ReadOnly":    true,
-	"SecurityOpt": true,
-	"Tmpfs":       true,
-	"Tty":         true,
-	"Ulimits":     true,
-	"User":        true,
-	"Volumes":     true,
-	"WorkingDir":  true,
+	"CapAdd":          true,
+	"CapDrop":         true,
+	"Command":         true,
+	"Devices":         true,
+	"DNS":             true,
+	"DNSSearch":       true,
+	"Entrypoint":      true,
+	"Environment":     true,
+	"EnvFile":         true,
+	"ExtraHosts":      true,
+	"Hostname":        true,
+	"HealthCheck":     true,
+	"Image":           true,
+	"Labels":          true,
+	"Links":           true,
+	"Logging":         true,
+	"Name":            true,
+	"Ports":           true,
+	"Privileged":      true,
+	"ReadOnly":        true,
+	"SecurityOpt":     true,
+	"StopGracePeriod": true,
+	"Tmpfs":           true,
+	"Tty":             true,
+	"Ulimits":         true,
+	"User":            true,
+	"Volumes":         true,
+	"WorkingDir":      true,
 }
 
 var supportedComposeV1V2YamlOptionsMap = getSupportedComposeV1V2YamlOptionsMap()

--- a/ecs-cli/modules/cli/compose/project/project_parseV1V2.go
+++ b/ecs-cli/modules/cli/compose/project/project_parseV1V2.go
@@ -107,6 +107,11 @@ func convertV1V2ToContainerConfig(context *project.Context, serviceName string, 
 		return nil, err
 	}
 
+	stopTimeout, err := adapter.ConvertDurationStrToSeconds(service.StopGracePeriod)
+	if err != nil {
+		return nil, err
+	}
+
 	outputConfig := &adapter.ContainerConfig{
 		Name:                  serviceName,
 		CapAdd:                service.CapAdd,
@@ -133,6 +138,7 @@ func convertV1V2ToContainerConfig(context *project.Context, serviceName string, 
 		Privileged:            service.Privileged,
 		ReadOnly:              service.ReadOnly,
 		ShmSize:               shmSize,
+		StopTimeout:           stopTimeout,
 		Tmpfs:                 tmpfs,
 		Ulimits:               ulimits,
 		VolumesFrom:           volumesFrom,

--- a/ecs-cli/modules/cli/compose/project/project_parseV1V2_test.go
+++ b/ecs-cli/modules/cli/compose/project/project_parseV1V2_test.go
@@ -282,6 +282,8 @@ func TestParseV1V2_Version2Files(t *testing.T) {
 		},
 	}
 	shmSize := int64(1024) // 1 gb = 1024 miB
+	stg := int64(60)
+	stopGracePeriod := &stg
 	tmpfs := []*ecs.Tmpfs{
 		{
 			ContainerPath: aws.String("/run"),
@@ -317,6 +319,7 @@ services:
     mem_reservation: 500000000
     mem_limit: 512M
     shm_size: 1gb
+    stop_grace_period: "1m"
     tmpfs:
       - /run:size=1gb
       - /tmp:size=65536k,ro,rw
@@ -371,6 +374,7 @@ volumes:
 	assert.Equal(t, memory, wordpress.Memory, "Expected Memory to match")
 	assert.Equal(t, ports, wordpress.PortMappings, "Expected ports to match")
 	assert.Equal(t, shmSize, wordpress.ShmSize, "Expected shmSize to match")
+	assert.Equal(t, stopGracePeriod, wordpress.StopTimeout, "Expected StopTimeout to match")
 	assert.ElementsMatch(t, tmpfs, wordpress.Tmpfs, "Expected tmpfs to match")
 	assert.Equal(t, volumesFrom, wordpress.VolumesFrom, "Expected VolumesFrom to match")
 

--- a/ecs-cli/modules/cli/compose/project/project_parseV3.go
+++ b/ecs-cli/modules/cli/compose/project/project_parseV3.go
@@ -92,6 +92,12 @@ func convertToContainerConfig(serviceConfig types.ServiceConfig, serviceVols *ad
 	logger.LogUnsupportedV3ServiceConfigFields(serviceConfig)
 	logWarningForDeployFields(serviceConfig.Deploy, serviceConfig.Name)
 
+	var stopTimeout *int64
+	if serviceConfig.StopGracePeriod != nil {
+		st := (int64)(serviceConfig.StopGracePeriod.Seconds())
+		stopTimeout = &st
+	}
+
 	c := &adapter.ContainerConfig{
 		CapAdd:                serviceConfig.CapAdd,
 		CapDrop:               serviceConfig.CapDrop,
@@ -105,6 +111,7 @@ func convertToContainerConfig(serviceConfig types.ServiceConfig, serviceVols *ad
 		Privileged:            serviceConfig.Privileged,
 		PseudoTerminal:        serviceConfig.Tty,
 		ReadOnly:              serviceConfig.ReadOnly,
+		StopTimeout:           stopTimeout,
 		User:                  serviceConfig.User,
 		WorkingDirectory:      serviceConfig.WorkingDir,
 	}

--- a/ecs-cli/modules/cli/compose/project/project_parseV3_test.go
+++ b/ecs-cli/modules/cli/compose/project/project_parseV3_test.go
@@ -83,6 +83,8 @@ func TestParseV3WithOneFile(t *testing.T) {
 	wordpressCon.Privileged = true
 	wordpressCon.ReadOnly = true
 	wordpressCon.PseudoTerminal = true
+	stg := int64(60)
+	wordpressCon.StopTimeout = &stg
 	wordpressCon.DockerSecurityOptions = []string{"label:role:ROLE", "label:user:USER"}
 	wordpressCon.Ulimits = []*ecs.Ulimit{
 		{
@@ -169,6 +171,7 @@ services:
       - label:user:USER
     working_dir: /wrdprsdir
     privileged: true
+    stop_grace_period: "1m"
     ulimits:
       rss: 65535
       nofile:
@@ -749,6 +752,7 @@ func verifyContainerConfig(t *testing.T, expected, actual adapter.ContainerConfi
 	assert.Equal(t, expected.ReadOnly, actual.ReadOnly, "Expected ReadOnly to match")
 	assert.ElementsMatch(t, expected.Tmpfs, actual.Tmpfs, "Expected Tmpfs to match")
 	assert.Equal(t, expected.PseudoTerminal, actual.PseudoTerminal, "Expected PseuoTerminal to match")
+	assert.Equal(t, expected.StopTimeout, actual.StopTimeout, "Expected StopTimeout to match")
 	assert.ElementsMatch(t, expected.Ulimits, actual.Ulimits, "Expected Ulimits to match")
 	assert.Equal(t, expected.User, actual.User, "Expected User to match")
 	assert.Equal(t, expected.WorkingDirectory, actual.WorkingDirectory, "Expected WorkingDirectory to match")

--- a/ecs-cli/modules/utils/compose/reconcile_container_def.go
+++ b/ecs-cli/modules/utils/compose/reconcile_container_def.go
@@ -15,6 +15,7 @@ package utils
 
 import (
 	"errors"
+
 	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/cli/compose/adapter"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ecs"
@@ -83,6 +84,11 @@ func reconcileContainerDef(inputCfg *adapter.ContainerConfig, ecsConDef *Contain
 	// for shared memory if shmSize is null.
 	if inputCfg.ShmSize != 0 {
 		outputContDef.LinuxParameters.SetSharedMemorySize(inputCfg.ShmSize)
+	}
+
+	// Only set stopTimeout if specified
+	if inputCfg.StopTimeout != nil {
+		outputContDef.SetStopTimeout(*inputCfg.StopTimeout)
 	}
 
 	// Only set tmpfs if tmpfs mounts are specified.

--- a/ecs-cli/modules/utils/compose/reconcile_container_def.go
+++ b/ecs-cli/modules/utils/compose/reconcile_container_def.go
@@ -86,7 +86,6 @@ func reconcileContainerDef(inputCfg *adapter.ContainerConfig, ecsConDef *Contain
 		outputContDef.LinuxParameters.SetSharedMemorySize(inputCfg.ShmSize)
 	}
 
-	// Only set stopTimeout if specified
 	if inputCfg.StopTimeout != nil {
 		outputContDef.SetStopTimeout(*inputCfg.StopTimeout)
 	}


### PR DESCRIPTION
**Issue #, if available**:
Closes #787 

**Description of changes**:
Added the support for the `StopTimeout` field, which maps to the `stop_grace_period` in Docker compose.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**  
- [X] Unit tests passed
- [X] Integration tests passed
- [X] Unit tests added for new functionality
- [X] Listed manual checks and their outputs in the comments ([example](https://github.com/aws/amazon-ecs-cli/pull/750#issuecomment-472623042))
- [X] Link to issue or PR for the integration tests: 

**Documentation**  
- [N/A] Contacted our doc writer
- [N/A] Updated our README

**Manual Testing**
Before code change
```
# Docker compose v2
$ cat docker-compose.yml
version: '2'
services:
  web:
    image: amazon/amazon-ecs-sample
    ports:
      - "80:80"
    stop_grace_period: 1m15s

$ ./ecs-cli compose up --cluster chicken
WARN[0000] Skipping unsupported YAML option for service...  option name=stop_grace_period service name=web
INFO[0000] Using ECS task definition                     TaskDefinition="ecs-cli-tutorial:1"
INFO[0000] Starting container...                         container=d4769bf3-4a84-4603-af6d-f8ac54560854/web
INFO[0000] Describe ECS container status                 container=d4769bf3-4a84-4603-af6d-f8ac54560854/web desiredStatus=RUNNING lastStatus=PROVISIONING taskDefinition="ecs-cli-tutorial:1"
INFO[0012] Describe ECS container status                 container=d4769bf3-4a84-4603-af6d-f8ac54560854/web desiredStatus=RUNNING lastStatus=PROVISIONING taskDefinition="ecs-cli-tutorial:1"
INFO[0024] Describe ECS container status                 container=d4769bf3-4a84-4603-af6d-f8ac54560854/web desiredStatus=RUNNING lastStatus=PENDING taskDefinition="ecs-cli-tutorial:1"
INFO[0037] Started container...                          container=d4769bf3-4a84-4603-af6d-f8ac54560854/web desiredStatus=RUNNING lastStatus=RUNNING taskDefinition="ecs-cli-tutorial:1"

$ aws ecs describe-task-definition --task-definition ecs-cli-tutorial:1 --region us-west-2
{
    "taskDefinition": {
        "taskDefinitionArn": "arn:aws:ecs:us-west-2:620297136107:task-definition/ecs-cli-tutorial:1",
        "containerDefinitions": [
            {
                "name": "web",
                "image": "amazon/amazon-ecs-sample",
                "cpu": 0,
                "links": [],
                "portMappings": [
                    {
                        "containerPort": 80,
                        "hostPort": 80,
                        "protocol": "tcp"
                    }
                ],
                "essential": true,
                "entryPoint": [],
                "command": [],
                "environment": [],
                "mountPoints": [],
                "volumesFrom": [],
                "linuxParameters": {
                    "capabilities": {},
                    "devices": []
                },
                "privileged": false,
                "readonlyRootFilesystem": false,
                "dnsServers": [],
                "dnsSearchDomains": [],
                "extraHosts": [],
                "dockerSecurityOptions": [],
                "pseudoTerminal": false,
                "dockerLabels": {},
                "ulimits": []
            }
        ],
        "family": "ecs-cli-tutorial",
        "executionRoleArn": "arn:aws:iam::620297136107:role/ecsTaskExecutionRole",
        "networkMode": "awsvpc",
        "revision": 1,
        "volumes": [],
        "status": "ACTIVE",
        "requiresAttributes": [
            {
                "name": "com.amazonaws.ecs.capability.docker-remote-api.1.17"
            },
            {
                "name": "com.amazonaws.ecs.capability.docker-remote-api.1.18"
            },
            {
                "name": "ecs.capability.task-eni"
            }
        ],
        "placementConstraints": [],
        "compatibilities": [
            "EC2",
            "FARGATE"
        ],
        "requiresCompatibilities": [
            "EC2"
        ],
        "cpu": "256",
        "memory": "512"
    }
}
```
After the code change:
```
# Docker Compose v2. After the change, stop_grace_period not set
$ cat docker-compose.yml
version: '2'
services:
  web:
    image: amazon/amazon-ecs-sample
    ports:
      - "80:80"
#    stop_grace_period: 1m15s

$ ./ecs-cli compose up --cluster chicken
INFO[0000] Using ECS task definition                     TaskDefinition="ecs-cli-tutorial:1"
INFO[0000] Found existing ECS tasks for project          CountOfTasks=1 ProjectName=ecs-cli-tutorial
INFO[0000] Updating to new task definition               taskDefinition="arn:aws:ecs:us-west-2:620297136107:task-definition/ecs-cli-tutorial:1"
INFO[0000] Describe ECS container status                 container=3263c5ff-3447-4a07-aeec-dd3c5b958ec0/web desiredStatus=STOPPED lastStatus=RUNNING taskDefinition="ecs-cli-tutorial:5"
INFO[0000] Describe ECS container status                 container=cd01c5d0-480a-4aad-9bc7-1f696fac98fe/web desiredStatus=RUNNING lastStatus=PROVISIONING taskDefinition="ecs-cli-tutorial:1"
INFO[0013] Describe ECS container status                 container=3263c5ff-3447-4a07-aeec-dd3c5b958ec0/web desiredStatus=STOPPED lastStatus=DEPROVISIONING taskDefinition="ecs-cli-tutorial:5"
INFO[0013] Describe ECS container status                 container=cd01c5d0-480a-4aad-9bc7-1f696fac98fe/web desiredStatus=RUNNING lastStatus=PROVISIONING taskDefinition="ecs-cli-tutorial:1"
INFO[0025] Stopped container...                          container=3263c5ff-3447-4a07-aeec-dd3c5b958ec0/web desiredStatus=STOPPED lastStatus=STOPPED taskDefinition="ecs-cli-tutorial:5"
INFO[0025] Describe ECS container status                 container=cd01c5d0-480a-4aad-9bc7-1f696fac98fe/web desiredStatus=RUNNING lastStatus=PENDING taskDefinition="ecs-cli-tutorial:1"
INFO[0037] Started container...                          container=cd01c5d0-480a-4aad-9bc7-1f696fac98fe/web desiredStatus=RUNNING lastStatus=RUNNING taskDefinition="ecs-cli-tutorial:1"

$ aws ecs describe-task-definition --task-definition ecs-cli-tutorial:1 --region us-west-2
{
    "taskDefinition": {
        "taskDefinitionArn": "arn:aws:ecs:us-west-2:620297136107:task-definition/ecs-cli-tutorial:1",
        "containerDefinitions": [
            {
                "name": "web",
                "image": "amazon/amazon-ecs-sample",
                "cpu": 0,
                "links": [],
                "portMappings": [
                    {
                        "containerPort": 80,
                        "hostPort": 80,
                        "protocol": "tcp"
                    }
                ],
                "essential": true,
                "entryPoint": [],
                "command": [],
                "environment": [],
                "mountPoints": [],
                "volumesFrom": [],
                "linuxParameters": {
                    "capabilities": {},
                    "devices": []
                },
                "privileged": false,
                "readonlyRootFilesystem": false,
                "dnsServers": [],
                "dnsSearchDomains": [],
                "extraHosts": [],
                "dockerSecurityOptions": [],
                "pseudoTerminal": false,
                "dockerLabels": {},
                "ulimits": []
            }
        ],
        "family": "ecs-cli-tutorial",
        "executionRoleArn": "arn:aws:iam::620297136107:role/ecsTaskExecutionRole",
        "networkMode": "awsvpc",
        "revision": 1,
        "volumes": [],
        "status": "ACTIVE",
        "requiresAttributes": [
            {
                "name": "com.amazonaws.ecs.capability.docker-remote-api.1.17"
            },
            {
                "name": "com.amazonaws.ecs.capability.docker-remote-api.1.18"
            },
            {
                "name": "ecs.capability.task-eni"
            }
        ],
        "placementConstraints": [],
        "compatibilities": [
            "EC2",
            "FARGATE"
        ],
        "requiresCompatibilities": [
            "EC2"
        ],
        "cpu": "256",
        "memory": "512"
    }
}

# Docker compose v2, stop_grace_period set
$ cat docker-compose.yml
version: '2'
services:
  web:
    image: amazon/amazon-ecs-sample
    ports:
      - "80:80"
    stop_grace_period: 1m15s

$ ./ecs-cli compose up --cluster chicken
INFO[0000] Using ECS task definition                     TaskDefinition="ecs-cli-tutorial:3"
INFO[0000] Found existing ECS tasks for project          CountOfTasks=1 ProjectName=ecs-cli-tutorial
INFO[0000] Updating to new task definition               taskDefinition="arn:aws:ecs:us-west-2:620297136107:task-definition/ecs-cli-tutorial:3"
INFO[0000] Describe ECS container status                 container=cd01c5d0-480a-4aad-9bc7-1f696fac98fe/web desiredStatus=STOPPED lastStatus=RUNNING taskDefinition="ecs-cli-tutorial:1"
INFO[0000] Describe ECS container status                 container=c84e36ae-a812-49b1-b34b-f51b477ae309/web desiredStatus=RUNNING lastStatus=PROVISIONING taskDefinition="ecs-cli-tutorial:3"
INFO[0012] Describe ECS container status                 container=c84e36ae-a812-49b1-b34b-f51b477ae309/web desiredStatus=RUNNING lastStatus=PROVISIONING taskDefinition="ecs-cli-tutorial:3"
INFO[0012] Describe ECS container status                 container=cd01c5d0-480a-4aad-9bc7-1f696fac98fe/web desiredStatus=STOPPED lastStatus=DEPROVISIONING taskDefinition="ecs-cli-tutorial:1"
INFO[0025] Describe ECS container status                 container=cd01c5d0-480a-4aad-9bc7-1f696fac98fe/web desiredStatus=STOPPED lastStatus=DEPROVISIONING taskDefinition="ecs-cli-tutorial:1"
INFO[0025] Describe ECS container status                 container=c84e36ae-a812-49b1-b34b-f51b477ae309/web desiredStatus=RUNNING lastStatus=PROVISIONING taskDefinition="ecs-cli-tutorial:3"
INFO[0037] Stopped container...                          container=cd01c5d0-480a-4aad-9bc7-1f696fac98fe/web desiredStatus=STOPPED lastStatus=STOPPED taskDefinition="ecs-cli-tutorial:1"
INFO[0037] Describe ECS container status                 container=c84e36ae-a812-49b1-b34b-f51b477ae309/web desiredStatus=RUNNING lastStatus=PENDING taskDefinition="ecs-cli-tutorial:3"
INFO[0043] Started container...                          container=c84e36ae-a812-49b1-b34b-f51b477ae309/web desiredStatus=RUNNING lastStatus=RUNNING taskDefinition="ecs-cli-tutorial:3"

$ aws ecs describe-task-definition --task-definition ecs-cli-tutorial:3 --region us-west-2
{
    "taskDefinition": {
        "taskDefinitionArn": "arn:aws:ecs:us-west-2:620297136107:task-definition/ecs-cli-tutorial:3",
        "containerDefinitions": [
            {
                "name": "web",
                "image": "amazon/amazon-ecs-sample",
                "cpu": 0,
                "links": [],
                "portMappings": [
                    {
                        "containerPort": 80,
                        "hostPort": 80,
                        "protocol": "tcp"
                    }
                ],
                "essential": true,
                "entryPoint": [],
                "command": [],
                "environment": [],
                "mountPoints": [],
                "volumesFrom": [],
                "linuxParameters": {
                    "capabilities": {},
                    "devices": []
                },
                "stopTimeout": 75,
                "privileged": false,
                "readonlyRootFilesystem": false,
                "dnsServers": [],
                "dnsSearchDomains": [],
                "extraHosts": [],
                "dockerSecurityOptions": [],
                "pseudoTerminal": false,
                "dockerLabels": {},
                "ulimits": []
            }
        ],
        "family": "ecs-cli-tutorial",
        "executionRoleArn": "arn:aws:iam::620297136107:role/ecsTaskExecutionRole",
        "networkMode": "awsvpc",
        "revision": 3,
        "volumes": [],
        "status": "ACTIVE",
        "requiresAttributes": [
            {
                "name": "com.amazonaws.ecs.capability.docker-remote-api.1.17"
            },
            {
                "name": "ecs.capability.container-ordering"
            },
            {
                "name": "com.amazonaws.ecs.capability.docker-remote-api.1.18"
            },
            {
                "name": "ecs.capability.task-eni"
            }
        ],
        "placementConstraints": [],
        "compatibilities": [
            "EC2",
            "FARGATE"
        ],
        "requiresCompatibilities": [
            "EC2"
        ],
        "cpu": "256",
        "memory": "512"
    }
}

# Docker compose v3, stop_grace_period not set
$ cat docker-compose.yml
version: '3'
services:
  web:
    image: amazon/amazon-ecs-sample
    ports:
      - "80:80"
#    stop_grace_period: 1m15s

$ ./ecs-cli compose up --cluster chicken
INFO[0000] Using ECS task definition                     TaskDefinition="ecs-cli-tutorial:5"
INFO[0000] Found existing ECS tasks for project          CountOfTasks=1 ProjectName=ecs-cli-tutorial
INFO[0000] Updating to new task definition               taskDefinition="arn:aws:ecs:us-west-2:620297136107:task-definition/ecs-cli-tutorial:5"
INFO[0001] Describe ECS container status                 container=c84e36ae-a812-49b1-b34b-f51b477ae309/web desiredStatus=STOPPED lastStatus=RUNNING taskDefinition="ecs-cli-tutorial:3"
INFO[0001] Describe ECS container status                 container=1f70eec1-1492-4ca4-b164-28c4974f80ca/web desiredStatus=RUNNING lastStatus=PROVISIONING taskDefinition="ecs-cli-tutorial:5"
INFO[0013] Describe ECS container status                 container=c84e36ae-a812-49b1-b34b-f51b477ae309/web desiredStatus=STOPPED lastStatus=DEPROVISIONING taskDefinition="ecs-cli-tutorial:3"
INFO[0013] Describe ECS container status                 container=1f70eec1-1492-4ca4-b164-28c4974f80ca/web desiredStatus=RUNNING lastStatus=PROVISIONING taskDefinition="ecs-cli-tutorial:5"
INFO[0019] Started container...                          container=1f70eec1-1492-4ca4-b164-28c4974f80ca/web desiredStatus=RUNNING lastStatus=RUNNING taskDefinition="ecs-cli-tutorial:5"
INFO[0025] Describe ECS container status                 container=c84e36ae-a812-49b1-b34b-f51b477ae309/web desiredStatus=STOPPED lastStatus=DEPROVISIONING taskDefinition="ecs-cli-tutorial:3"
INFO[0037] Describe ECS container status                 container=c84e36ae-a812-49b1-b34b-f51b477ae309/web desiredStatus=STOPPED lastStatus=DEPROVISIONING taskDefinition="ecs-cli-tutorial:3"
INFO[0049] Stopped container...                          container=c84e36ae-a812-49b1-b34b-f51b477ae309/web desiredStatus=STOPPED lastStatus=STOPPED taskDefinition="ecs-cli-tutorial:3

$ aws ecs describe-task-definition --task-definition ecs-cli-tutorial:5 --region us-west-2
{
    "taskDefinition": {
        "taskDefinitionArn": "arn:aws:ecs:us-west-2:620297136107:task-definition/ecs-cli-tutorial:5",
        "containerDefinitions": [
            {
                "name": "web",
                "image": "amazon/amazon-ecs-sample",
                "cpu": 0,
                "links": [],
                "portMappings": [
                    {
                        "containerPort": 80,
                        "hostPort": 80,
                        "protocol": "tcp"
                    }
                ],
                "essential": true,
                "entryPoint": [],
                "command": [],
                "environment": [],
                "mountPoints": [],
                "volumesFrom": [],
                "linuxParameters": {
                    "capabilities": {},
                    "devices": []
                },
                "privileged": false,
                "readonlyRootFilesystem": false,
                "dnsServers": [],
                "dnsSearchDomains": [],
                "extraHosts": [],
                "dockerSecurityOptions": [],
                "pseudoTerminal": false
            }
        ],
        "family": "ecs-cli-tutorial",
        "executionRoleArn": "arn:aws:iam::620297136107:role/ecsTaskExecutionRole",
        "networkMode": "awsvpc",
        "revision": 5,
        "volumes": [],
        "status": "ACTIVE",
        "requiresAttributes": [
            {
                "name": "com.amazonaws.ecs.capability.docker-remote-api.1.17"
            },
            {
                "name": "com.amazonaws.ecs.capability.docker-remote-api.1.18"
            },
            {
                "name": "ecs.capability.task-eni"
            }
        ],
        "placementConstraints": [],
        "compatibilities": [
            "EC2",
            "FARGATE"
        ],
        "requiresCompatibilities": [
            "EC2"
        ],
        "cpu": "256",
        "memory": "512"
    }
}

# Docker compose v3, stop_grace_period set
$ cat docker-compose.yml
version: '3'
services:
  web:
    image: amazon/amazon-ecs-sample
    ports:
      - "80:80"
    stop_grace_period: 1m15s

$ ./ecs-cli compose up --cluster chicken
INFO[0000] Using ECS task definition                     TaskDefinition="ecs-cli-tutorial:4"
INFO[0000] Found existing ECS tasks for project          CountOfTasks=1 ProjectName=ecs-cli-tutorial
INFO[0000] Updating to new task definition               taskDefinition="arn:aws:ecs:us-west-2:620297136107:task-definition/ecs-cli-tutorial:4"
INFO[0000] Describe ECS container status                 container=1f70eec1-1492-4ca4-b164-28c4974f80ca/web desiredStatus=STOPPED lastStatus=RUNNING taskDefinition="ecs-cli-tutorial:5"
INFO[0000] Describe ECS container status                 container=e906f98a-4777-413b-a5b3-5091c185a68e/web desiredStatus=RUNNING lastStatus=PROVISIONING taskDefinition="ecs-cli-tutorial:4"
INFO[0013] Describe ECS container status                 container=1f70eec1-1492-4ca4-b164-28c4974f80ca/web desiredStatus=STOPPED lastStatus=DEPROVISIONING taskDefinition="ecs-cli-tutorial:5"
INFO[0013] Describe ECS container status                 container=e906f98a-4777-413b-a5b3-5091c185a68e/web desiredStatus=RUNNING lastStatus=PROVISIONING taskDefinition="ecs-cli-tutorial:4"
INFO[0019] Started container...                          container=e906f98a-4777-413b-a5b3-5091c185a68e/web desiredStatus=RUNNING lastStatus=RUNNING taskDefinition="ecs-cli-tutorial:4"
INFO[0025] Describe ECS container status                 container=1f70eec1-1492-4ca4-b164-28c4974f80ca/web desiredStatus=STOPPED lastStatus=DEPROVISIONING taskDefinition="ecs-cli-tutorial:5"
INFO[0037] Describe ECS container status                 container=1f70eec1-1492-4ca4-b164-28c4974f80ca/web desiredStatus=STOPPED lastStatus=DEPROVISIONING taskDefinition="ecs-cli-tutorial:5"
INFO[0049] Stopped container...                          container=1f70eec1-1492-4ca4-b164-28c4974f80ca/web desiredStatus=STOPPED lastStatus=STOPPED taskDefinition="ecs-cli-tutorial:5"

$ aws ecs describe-task-definition --task-definition ecs-cli-tutorial:4 --region us-west-2
{
    "taskDefinition": {
        "taskDefinitionArn": "arn:aws:ecs:us-west-2:620297136107:task-definition/ecs-cli-tutorial:4",
        "containerDefinitions": [
            {
                "name": "web",
                "image": "amazon/amazon-ecs-sample",
                "cpu": 0,
                "links": [],
                "portMappings": [
                    {
                        "containerPort": 80,
                        "hostPort": 80,
                        "protocol": "tcp"
                    }
                ],
                "essential": true,
                "entryPoint": [],
                "command": [],
                "environment": [],
                "mountPoints": [],
                "volumesFrom": [],
                "linuxParameters": {
                    "capabilities": {},
                    "devices": []
                },
                "stopTimeout": 75,
                "privileged": false,
                "readonlyRootFilesystem": false,
                "dnsServers": [],
                "dnsSearchDomains": [],
                "extraHosts": [],
                "dockerSecurityOptions": [],
                "pseudoTerminal": false
            }
        ],
        "family": "ecs-cli-tutorial",
        "executionRoleArn": "arn:aws:iam::620297136107:role/ecsTaskExecutionRole",
        "networkMode": "awsvpc",
        "revision": 4,
        "volumes": [],
        "status": "ACTIVE",
        "requiresAttributes": [
            {
                "name": "com.amazonaws.ecs.capability.docker-remote-api.1.17"
            },
            {
                "name": "ecs.capability.container-ordering"
            },
            {
                "name": "com.amazonaws.ecs.capability.docker-remote-api.1.18"
            },
            {
                "name": "ecs.capability.task-eni"
            }
        ],
        "placementConstraints": [],
        "compatibilities": [
            "EC2",
            "FARGATE"
        ],
        "requiresCompatibilities": [
            "EC2"
        ],
        "cpu": "256",
        "memory": "512"
    }
}
```
----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
