### PR TITLE
[local] fix swallowing error log details when ecs-cli local up/ps/down

### DIFF
--- a/ecs-cli/modules/cli/local/down_app.go
+++ b/ecs-cli/modules/cli/local/down_app.go
@@ -75,7 +75,7 @@ func downComposeLocalContainers() error {
 	cmd := exec.Command("docker-compose", "-f", localproject.LocalOutDefaultFileName, "down")
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		logrus.Fatalf("Failed to run docker-compose down due to %v: %v", err, string(out))
+		logrus.Fatalf("Failed to run docker-compose down due to %v: %s", err, string(out))
 	}
 
 	logrus.Info("Stopped and removed containers successfully")

--- a/ecs-cli/modules/cli/local/down_app.go
+++ b/ecs-cli/modules/cli/local/down_app.go
@@ -75,7 +75,7 @@ func downComposeLocalContainers() error {
 	cmd := exec.Command("docker-compose", "-f", localproject.LocalOutDefaultFileName, "down")
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		logrus.Fatalf("Failed to run docker-compose down due to %v: %s", err, string(out))
+		logrus.Fatalf("Failed to run docker-compose down due to \n%v: %s", err, string(out))
 	}
 
 	logrus.Info("Stopped and removed containers successfully")
@@ -91,7 +91,7 @@ func downLocalContainersWithFilters(args filters.Args) error {
 		All:     true,
 	})
 	if err != nil {
-		logrus.Fatalf("Failed to list containers with filters %v due to %v", args, err)
+		logrus.Fatalf("Failed to list containers with filters %v due to \n%v", args, err)
 	}
 	cancel()
 
@@ -104,12 +104,12 @@ func downLocalContainersWithFilters(args filters.Args) error {
 	for _, container := range containers {
 		ctx, cancel = context.WithTimeout(context.Background(), docker.TimeoutInS)
 		if err = client.ContainerStop(ctx, container.ID, nil); err != nil {
-			logrus.Fatalf("Failed to stop container %s due to %v", container.ID[:maxContainerIDLength], err)
+			logrus.Fatalf("Failed to stop container %s due to \n%v", container.ID[:maxContainerIDLength], err)
 		}
 		logrus.Infof("Stopped container with id %s", container.ID[:maxContainerIDLength])
 
 		if err = client.ContainerRemove(ctx, container.ID, types.ContainerRemoveOptions{}); err != nil {
-			logrus.Fatalf("Failed to remove container %s due to %v", container.ID[:maxContainerIDLength], err)
+			logrus.Fatalf("Failed to remove container %s due to \n%v", container.ID[:maxContainerIDLength], err)
 		}
 		logrus.Infof("Removed container with id %s", container.ID[:maxContainerIDLength])
 		cancel()

--- a/ecs-cli/modules/cli/local/down_app.go
+++ b/ecs-cli/modules/cli/local/down_app.go
@@ -73,9 +73,9 @@ func downComposeLocalContainers() error {
 
 	logrus.Infof("Running Compose down on %s", localproject.LocalOutDefaultFileName)
 	cmd := exec.Command("docker-compose", "-f", localproject.LocalOutDefaultFileName, "down")
-	_, err := cmd.CombinedOutput()
+	out, err := cmd.CombinedOutput()
 	if err != nil {
-		logrus.Fatalf("Failed to run docker-compose down due to %v", err)
+		logrus.Fatalf("Failed to run docker-compose down due to %v: %v", err, string(out))
 	}
 
 	logrus.Info("Stopped and removed containers successfully")

--- a/ecs-cli/modules/cli/local/ps_app.go
+++ b/ecs-cli/modules/cli/local/ps_app.go
@@ -96,7 +96,7 @@ func listLocalComposeContainers() []types.Container {
 	cmd := exec.Command("docker-compose", "-f", localproject.LocalOutDefaultFileName, "ps", "-q")
 	composeOut, err := cmd.CombinedOutput()
 	if err != nil {
-		logrus.Fatalf("Failed to run docker-compose ps due to %v: %s", err, string(composeOut))
+		logrus.Fatalf("Failed to run docker-compose ps due to \n%v: %s", err, string(composeOut))
 	}
 
 	containerIDs := strings.Split(string(composeOut), "\n")
@@ -120,7 +120,7 @@ func listContainersWithFilters(args filters.Args) []types.Container {
 		Filters: args,
 	})
 	if err != nil {
-		logrus.Fatalf("Failed to list containers with args=%v due to %v", args, err)
+		logrus.Fatalf("Failed to list containers with args=%v due to \n%v", args, err)
 	}
 	return containers
 }
@@ -136,7 +136,7 @@ func displayContainers(c *cli.Context, containers []types.Container) {
 func displayAsJSON(containers []types.Container) {
 	data, err := json.MarshalIndent(containers, jsonPrefix, jsonIndent)
 	if err != nil {
-		logrus.Fatalf("Failed to marshal containers to JSON due to %v", err)
+		logrus.Fatalf("Failed to marshal containers to JSON due to \n%v", err)
 	}
 	fmt.Fprintln(os.Stdout, string(data))
 }

--- a/ecs-cli/modules/cli/local/ps_app.go
+++ b/ecs-cli/modules/cli/local/ps_app.go
@@ -96,7 +96,7 @@ func listLocalComposeContainers() []types.Container {
 	cmd := exec.Command("docker-compose", "-f", localproject.LocalOutDefaultFileName, "ps", "-q")
 	composeOut, err := cmd.CombinedOutput()
 	if err != nil {
-		logrus.Fatalf("Failed to run docker-compose ps due to %v: %v", err, string(composeOut))
+		logrus.Fatalf("Failed to run docker-compose ps due to %v: %s", err, string(composeOut))
 	}
 
 	containerIDs := strings.Split(string(composeOut), "\n")

--- a/ecs-cli/modules/cli/local/ps_app.go
+++ b/ecs-cli/modules/cli/local/ps_app.go
@@ -94,9 +94,9 @@ func listLocalComposeContainers() []types.Container {
 
 	// The -q flag displays the ID of the containers instead of the default "Name, Command, State, Ports" metadata.
 	cmd := exec.Command("docker-compose", "-f", localproject.LocalOutDefaultFileName, "ps", "-q")
-	composeOut, err := cmd.Output()
+	composeOut, err := cmd.CombinedOutput()
 	if err != nil {
-		logrus.Fatalf("Failed to run docker-compose ps due to %v", err)
+		logrus.Fatalf("Failed to run docker-compose ps due to %v: %v", err, string(composeOut))
 	}
 
 	containerIDs := strings.Split(string(composeOut), "\n")

--- a/ecs-cli/modules/cli/local/up_app.go
+++ b/ecs-cli/modules/cli/local/up_app.go
@@ -124,7 +124,7 @@ func upComposeFile(config *composeV3.Config, envVars map[string]string) {
 
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		logrus.Fatalf("Failed to run docker-compose up due to %v: %v", err, string(out))
+		logrus.Fatalf("Failed to run docker-compose up due to %v: %s", err, string(out))
 	}
 	fmt.Printf("Compose out: %s\n", string(out))
 }

--- a/ecs-cli/modules/cli/local/up_app.go
+++ b/ecs-cli/modules/cli/local/up_app.go
@@ -59,7 +59,7 @@ func readComposeFile(c *cli.Context) *composeV3.Config {
 	}
 	config, err := converter.UnmarshalComposeFile(filename)
 	if err != nil {
-		logrus.Fatalf("Failed to unmarshal Compose file %s due to %v", filename, err)
+		logrus.Fatalf("Failed to unmarshal Compose file %s due to \n%v", filename, err)
 	}
 	return config
 }
@@ -84,14 +84,14 @@ func decryptSecrets(containerSecrets []*secrets.ContainerSecret) (envVars map[st
 	ssmClient, err := clients.NewSSMDecrypter()
 	secretsManagerClient, err := clients.NewSecretsManagerDecrypter()
 	if err != nil {
-		logrus.Fatalf("Failed to create clients to decrypt secrets due to %v", err)
+		logrus.Fatalf("Failed to create clients to decrypt secrets due to \n%v", err)
 	}
 
 	envVars = make(map[string]string)
 	for _, containerSecret := range containerSecrets {
 		service, err := containerSecret.ServiceName()
 		if err != nil {
-			logrus.Fatalf("Failed to retrieve the service of the secret due to %v", err)
+			logrus.Fatalf("Failed to retrieve the service of the secret due to \n%v", err)
 		}
 
 		decrypted := ""
@@ -105,7 +105,7 @@ func decryptSecrets(containerSecrets []*secrets.ContainerSecret) (envVars map[st
 			err = errors.New(fmt.Sprintf("can't decrypt secret from service %s", service))
 		}
 		if err != nil {
-			logrus.Fatalf("Failed to decrypt secret due to %v", err)
+			logrus.Fatalf("Failed to decrypt secret due to \n%v", err)
 		}
 		envVars[containerSecret.Name()] = decrypted
 	}
@@ -124,7 +124,7 @@ func upComposeFile(config *composeV3.Config, envVars map[string]string) {
 
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		logrus.Fatalf("Failed to run docker-compose up due to %v: %s", err, string(out))
+		logrus.Fatalf("Failed to run docker-compose up due to \n%v: %s", err, string(out))
 	}
 	fmt.Printf("Compose out: %s\n", string(out))
 }

--- a/ecs-cli/modules/cli/local/up_app.go
+++ b/ecs-cli/modules/cli/local/up_app.go
@@ -124,7 +124,7 @@ func upComposeFile(config *composeV3.Config, envVars map[string]string) {
 
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		logrus.Fatalf("Failed to run docker-compose up due to %v", err)
+		logrus.Fatalf("Failed to run docker-compose up due to %v: %v", err, string(out))
 	}
 	fmt.Printf("Compose out: %s\n", string(out))
 }


### PR DESCRIPTION
## Issue #, if available:
#817 (#823)
## Description of changes:
Fixed the issue of swallowing error log details when ecs-cli local up/ps/down. Also #823 has the same problem resulting the difficulty for debugging.

**Testing**  
- [x] Unit tests passed
- [x] Integration tests passed
- [N/A] Unit tests added for new functionality
- [x] Listed manual checks and their outputs in the comments ([example](https://github.com/aws/amazon-ecs-cli/pull/750#issuecomment-472623042))
- [N/A] Link to issue or PR for the integration tests: 

**Documentation**  
- [N/A] Contacted our doc writer
- [N/A] Updated our README
----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
