### PR TITLE
Use the ECS CLI's default region and cache the SSM clients per region

### DIFF
--- a/ecs-cli/modules/cli/local/secrets/clients/clients.go
+++ b/ecs-cli/modules/cli/local/secrets/clients/clients.go
@@ -17,22 +17,32 @@ package clients
 import (
 	"strings"
 
+	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/config"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/secretsmanager"
+	"github.com/aws/aws-sdk-go/service/secretsmanager/secretsmanageriface"
 	"github.com/aws/aws-sdk-go/service/ssm"
+	"github.com/aws/aws-sdk-go/service/ssm/ssmiface"
 	"github.com/pkg/errors"
 )
 
+// region represents an AWS region.
+type region string
+
 // SSMDecrypter represents a SSM client that implements the secrets.SecretDecrypter interface.
 type SSMDecrypter struct {
-	*ssm.SSM
+	ssmiface.SSMAPI
+
+	// clients holds regional SSM clients.
+	// The region "default" is always present and points to the same session as the user's default region.
+	clients map[region]ssmiface.SSMAPI
 }
 
 // SecretsManagerDecrypter represents a SecretsManager client that implements the secrets.SecretDecrypter interface.
 type SecretsManagerDecrypter struct {
-	*secretsmanager.SecretsManager
+	secretsmanageriface.SecretsManagerAPI
 }
 
 // DecryptSecret returns the decrypted parameter value from SSM.
@@ -42,7 +52,7 @@ type SecretsManagerDecrypter struct {
 func (d *SSMDecrypter) DecryptSecret(arnOrName string) (string, error) {
 	defer func() {
 		// Reset the region of the client in case another SSM secret uses only the param name instead of full ARN.
-		d.SSM = ssm.New(session.Must(session.NewSessionWithOptions(session.Options{})))
+		d.SSMAPI = d.getClient("default")
 	}()
 
 	// If the value is an ARN we need to retrieve the parameter name and update the region of the client.
@@ -50,9 +60,7 @@ func (d *SSMDecrypter) DecryptSecret(arnOrName string) (string, error) {
 	if parsedARN, err := arn.Parse(arnOrName); err == nil {
 		resource := strings.Split(parsedARN.Resource, "/") // Resource is formatted as parameter/{paramName}.
 		paramName = strings.Join(resource[1:], "")
-		d.SSM = ssm.New(session.Must(session.NewSessionWithOptions(session.Options{
-			Config: aws.Config{Region: aws.String(parsedARN.Region)},
-		})))
+		d.SSMAPI = d.getClient(region(parsedARN.Region))
 	}
 
 	val, err := d.GetParameter(&ssm.GetParameterInput{
@@ -63,6 +71,19 @@ func (d *SSMDecrypter) DecryptSecret(arnOrName string) (string, error) {
 		return "", errors.Wrapf(err, "Failed to retrieve decrypted secret from %s due to %v", arnOrName, err)
 	}
 	return *val.Parameter.Value, nil
+}
+
+// getClient returns the SSM client for a given region.
+// If there is no client available for that region, then creates and caches it.
+func (d *SSMDecrypter) getClient(r region) ssmiface.SSMAPI {
+	if c, ok := d.clients[r]; ok {
+		return c
+	}
+	c := ssm.New(session.Must(session.NewSessionWithOptions(session.Options{
+		Config: aws.Config{Region: aws.String(string(r))},
+	})))
+	d.clients[r] = c
+	return c
 }
 
 // DecryptSecret returns the decrypted secret value from Secrets Manager.
@@ -76,24 +97,44 @@ func (d *SecretsManagerDecrypter) DecryptSecret(arn string) (string, error) {
 	return *val.SecretString, nil
 }
 
-// NewSSMDecrypter returns a new SSMDecrypter using the default region.
+// NewSSMDecrypter returns a new SSMDecrypter using the ECS CLI's default region.
 func NewSSMDecrypter() (*SSMDecrypter, error) {
-	sess, err := session.NewSession()
+	sess, err := getDefaultSession()
 	if err != nil {
 		return nil, errors.Wrapf(err, "Failed to create a new AWS session due to %v", err)
 	}
+	defaultClient := ssm.New(sess)
+
+	clients := make(map[region]ssmiface.SSMAPI)
+	clients["default"] = defaultClient
+	clients[region(aws.StringValue(sess.Config.Region))] = defaultClient
 	return &SSMDecrypter{
-		ssm.New(sess),
+		SSMAPI:  defaultClient,
+		clients: clients,
 	}, nil
 }
 
-// NewSecretsManagerDecrypter returns a new SecretsManagerDecrypter using the default region.
+// NewSecretsManagerDecrypter returns a new SecretsManagerDecrypter using the ECS CLI's default region.
 func NewSecretsManagerDecrypter() (*SecretsManagerDecrypter, error) {
-	sess, err := session.NewSession()
+	sess, err := getDefaultSession()
 	if err != nil {
 		return nil, errors.Wrapf(err, "Failed to create a new AWS session due to %v", err)
 	}
 	return &SecretsManagerDecrypter{
 		secretsmanager.New(sess),
 	}, nil
+}
+
+// getDefaultSession returns a session for AWS clients where the region is set to the ECS CLI's default region.
+// See https://github.com/aws/amazon-ecs-cli/blob/master/README.md#order-of-resolution-for-region
+func getDefaultSession() (*session.Session, error) {
+	rdwr, err := config.NewReadWriter()
+	if err != nil {
+		return nil, err
+	}
+	cmdConf, err := config.NewCommandConfig(nil, rdwr)
+	if err != nil {
+		return nil, err
+	}
+	return cmdConf.Session, nil
 }

--- a/ecs-cli/modules/cli/local/secrets/clients/clients_test.go
+++ b/ecs-cli/modules/cli/local/secrets/clients/clients_test.go
@@ -1,0 +1,186 @@
+// Copyright 2015-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package clients
+
+import (
+	"testing"
+
+	mock_ssmiface "github.com/aws/amazon-ecs-cli/ecs-cli/modules/clients/aws/amimetadata/mock/sdk"
+	mock_secretsmanageriface "github.com/aws/amazon-ecs-cli/ecs-cli/modules/clients/aws/secretsmanager/mock/sdk"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/secretsmanager"
+	"github.com/aws/aws-sdk-go/service/ssm"
+	"github.com/aws/aws-sdk-go/service/ssm/ssmiface"
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSSMDecrypter_DecryptSecret(t *testing.T) {
+	testCases := map[string]struct {
+		input          string
+		wantedSecret   string
+		setupDecrypter func(ctrl *gomock.Controller) *SSMDecrypter
+	}{
+		"with ARN in default region": {
+			input:        "arn:aws:ssm:us-east-1:11111111111:parameter/TEST_DB_PASSWORD",
+			wantedSecret: "1234",
+			setupDecrypter: func(ctrl *gomock.Controller) *SSMDecrypter {
+				defaultClient := mock_ssmiface.NewMockSSMAPI(ctrl)
+
+				m := make(map[region]ssmiface.SSMAPI)
+				m["default"] = defaultClient
+				m["us-east-1"] = defaultClient
+
+				gomock.InOrder(
+					defaultClient.EXPECT().GetParameter(&ssm.GetParameterInput{
+						Name:           aws.String("TEST_DB_PASSWORD"),
+						WithDecryption: aws.Bool(true),
+					}).Return(&ssm.GetParameterOutput{
+						Parameter: &ssm.Parameter{
+							Value: aws.String("1234"),
+						},
+					}, nil),
+				)
+
+				return &SSMDecrypter{
+					SSMAPI:  defaultClient,
+					clients: m,
+				}
+			},
+		},
+		"with ARN in different region": {
+			input:        "arn:aws:ssm:us-west-2:11111111111:parameter/TEST_DB_PASSWORD",
+			wantedSecret: "what??",
+			setupDecrypter: func(ctrl *gomock.Controller) *SSMDecrypter {
+				iadClient := mock_ssmiface.NewMockSSMAPI(ctrl)
+				pdxClient := mock_ssmiface.NewMockSSMAPI(ctrl)
+
+				m := make(map[region]ssmiface.SSMAPI)
+				m["default"] = iadClient
+				m["us-east-1"] = iadClient
+				m["us-west-2"] = pdxClient
+
+				gomock.InOrder(
+					pdxClient.EXPECT().GetParameter(&ssm.GetParameterInput{
+						Name:           aws.String("TEST_DB_PASSWORD"),
+						WithDecryption: aws.Bool(true),
+					}).Return(&ssm.GetParameterOutput{
+						Parameter: &ssm.Parameter{
+							Value: aws.String("what??"),
+						},
+					}, nil),
+
+					iadClient.EXPECT().GetParameter(gomock.Any()).Times(0), // Should not have called IAD
+				)
+
+				return &SSMDecrypter{
+					SSMAPI:  iadClient,
+					clients: m,
+				}
+			},
+		},
+		"without ARN": {
+			input:        "TEST_DB_PASSWORD",
+			wantedSecret: "hello",
+			setupDecrypter: func(ctrl *gomock.Controller) *SSMDecrypter {
+				iadClient := mock_ssmiface.NewMockSSMAPI(ctrl)
+				pdxClient := mock_ssmiface.NewMockSSMAPI(ctrl)
+
+				m := make(map[region]ssmiface.SSMAPI)
+				m["default"] = iadClient
+				m["us-east-1"] = iadClient
+				m["us-west-2"] = pdxClient
+
+				gomock.InOrder(
+					iadClient.EXPECT().GetParameter(&ssm.GetParameterInput{
+						Name:           aws.String("TEST_DB_PASSWORD"),
+						WithDecryption: aws.Bool(true),
+					}).Return(&ssm.GetParameterOutput{
+						Parameter: &ssm.Parameter{
+							Value: aws.String("hello"),
+						},
+					}, nil),
+
+					pdxClient.EXPECT().GetParameter(gomock.Any()).Times(0), // Should not have called PDX
+				)
+
+				return &SSMDecrypter{
+					SSMAPI:  iadClient,
+					clients: m,
+				}
+			},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			// Given
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+			decrypter := tc.setupDecrypter(ctrl)
+
+			// When
+			got, err := decrypter.DecryptSecret(tc.input)
+
+			// Then
+			require.Equal(t, tc.wantedSecret, got)
+			require.NoError(t, err)
+			require.Equal(t, decrypter.clients["default"], decrypter.SSMAPI, "Expected DecryptSecret() to reset the client after each call")
+		})
+	}
+}
+
+func TestSecretsManagerDecrypter_DecryptSecret(t *testing.T) {
+	testCases := map[string]struct {
+		input          string
+		wantedSecret   string
+		setupDecrypter func(ctrl *gomock.Controller) *SecretsManagerDecrypter
+	}{
+		"with ARN": {
+			input:        "arn:aws:secretsmanager:us-east-1:11111111111:secret:alpha/efe/local-j0gCbT",
+			wantedSecret: "verysafe",
+			setupDecrypter: func(ctrl *gomock.Controller) *SecretsManagerDecrypter {
+				client := mock_secretsmanageriface.NewMockSecretsManagerAPI(ctrl)
+
+				gomock.InOrder(
+					client.EXPECT().GetSecretValue(&secretsmanager.GetSecretValueInput{
+						SecretId: aws.String("arn:aws:secretsmanager:us-east-1:11111111111:secret:alpha/efe/local-j0gCbT"),
+					}).Return(&secretsmanager.GetSecretValueOutput{
+						SecretString: aws.String("verysafe"),
+					}, nil),
+				)
+
+				return &SecretsManagerDecrypter{
+					SecretsManagerAPI: client,
+				}
+			},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			// Given
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+			decrypter := tc.setupDecrypter(ctrl)
+
+			// When
+			got, err := decrypter.DecryptSecret(tc.input)
+
+			// Then
+			require.Equal(t, tc.wantedSecret, got)
+			require.NoError(t, err)
+		})
+	}
+}


### PR DESCRIPTION
**Issue #, if available**: https://github.com/aws/amazon-ecs-cli/issues/822

**Description of changes**:
The `secrets/clients` previously used only `session.NewSession()` which ignores the `~/.aws/config` file and reads only from `$AWS_REGION`. This change leverages the `NewCommandConfig()` method to create a session that respect ECS CLI's order resolution for the region.

Furthermore, to follow best practices for sessions (https://docs.aws.amazon.com/sdk-for-go/api/aws/session/) we are caching them in the SSM client instead of re-creating them multiple times.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**  
- [x] Unit tests passed
- [x] Integration tests passed
- [x] Unit tests added for new functionality
- [x] Listed manual checks and their outputs in the comments ([example](https://github.com/aws/amazon-ecs-cli/pull/750#issuecomment-472623042))
- [ ] Link to issue or PR for the integration tests: 

**Documentation**  
- [N/A] Contacted our doc writer
- [N/A] Updated our README
----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
