### PR TITLE
Remove redundant environment lookup for Compose v1, v2

### DIFF
--- a/ecs-cli/modules/cli/compose/factory/factory.go
+++ b/ecs-cli/modules/cli/compose/factory/factory.go
@@ -92,12 +92,6 @@ func (projectFactory projectFactory) populateContext(ecsContext *context.ECSCont
 
 // populateLibcomposeContext sets the required Libcompose lookup utilities on the ECS context
 func (projectFactory projectFactory) populateLibcomposeContext(ecsContext *context.ECSContext) error {
-	envLookup, err := utils.GetDefaultEnvironmentLookup()
-	if err != nil {
-		return err
-	}
-	ecsContext.EnvironmentLookup = envLookup
-
 	resourceLookup, err := utils.GetDefaultResourceLookup()
 	if err != nil {
 		return err

--- a/ecs-cli/modules/cli/compose/project/project_test.go
+++ b/ecs-cli/modules/cli/compose/project/project_test.go
@@ -329,8 +329,8 @@ func setupTestProjectWithECSRegistryCreds(t *testing.T, ecsParamsFileName, credF
 	}
 }
 
-// This function mimics the implementation of `project.NewProject()` used in
-// parseV1V2() and is only used for unit testing
+// This function mimics the implementation inside `project.NewProject()` for .env file lookup.
+// The following function is only used for unit tests.
 func getDefaultEnvironmentLookup() (*lookup.ComposableEnvLookup, error) {
 	cwd, err := os.Getwd()
 	if err != nil {

--- a/ecs-cli/modules/cli/compose/project/project_test.go
+++ b/ecs-cli/modules/cli/compose/project/project_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/commands/flags"
 	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/utils/compose"
 	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/utils/regcredio"
-	lConfig "github.com/docker/libcompose/config"
+	"github.com/docker/libcompose/config"
 	"github.com/docker/libcompose/lookup"
 	"github.com/stretchr/testify/assert"
 	"github.com/urfave/cli"
@@ -304,7 +304,7 @@ func setupTestProjectWithEcsParams(t *testing.T, ecsParamsFileName string) *ecsP
 
 // TODO: refactor into all-purpose 'setupTestProject' func
 func setupTestProjectWithECSRegistryCreds(t *testing.T, ecsParamsFileName, credFileName string) *ecsProject {
-	envLookup, err := getDefaultEnvironmentLookup()
+	envLookup, err := mockGetDefaultEnvironment()
 	assert.NoError(t, err, "Unexpected error setting up environment lookup")
 
 	resourceLookup, err := utils.GetDefaultResourceLookup()
@@ -331,13 +331,13 @@ func setupTestProjectWithECSRegistryCreds(t *testing.T, ecsParamsFileName, credF
 
 // This function mimics the implementation inside `project.NewProject()` for .env file lookup.
 // The following function is only used for unit tests.
-func getDefaultEnvironmentLookup() (*lookup.ComposableEnvLookup, error) {
+func mockGetDefaultEnvironment() (*lookup.ComposableEnvLookup, error) {
 	cwd, err := os.Getwd()
 	if err != nil {
 		return nil, err
 	}
 	return &lookup.ComposableEnvLookup{
-		Lookups: []lConfig.EnvironmentLookup{
+		Lookups: []config.EnvironmentLookup{
 			&lookup.EnvfileLookup{
 				Path: filepath.Join(cwd, ".env"),
 			},

--- a/ecs-cli/modules/utils/compose/lookup.go
+++ b/ecs-cli/modules/utils/compose/lookup.go
@@ -14,32 +14,8 @@
 package utils
 
 import (
-	"os"
-	"path/filepath"
-
-	lConfig "github.com/docker/libcompose/config"
 	"github.com/docker/libcompose/lookup"
 )
-
-// GetDefaultEnvironmentLookup returns the default Lookup mechanism for environment variables.
-// Order of resolution:
-// 1. Environment values specified (in the form of 'key=value') in a '.env' file in the current working directory.
-// 2. Environment values specified in the shell (using os.Getenv). If the os environment variable does not exists,
-//    the slice is empty, and the environment variable is skipped.
-func GetDefaultEnvironmentLookup() (*lookup.ComposableEnvLookup, error) {
-	cwd, err := os.Getwd()
-	if err != nil {
-		return nil, err
-	}
-	return &lookup.ComposableEnvLookup{
-		Lookups: []lConfig.EnvironmentLookup{
-			&lookup.EnvfileLookup{
-				Path: filepath.Join(cwd, ".env"),
-			},
-			&lookup.OsEnvLookup{},
-		},
-	}, nil
-}
 
 // GetDefaultResourceLookup returns the default Lookup mechanism for resources.
 // This implements a function to load a file relative to a given path. This is used to load


### PR DESCRIPTION
EnvironmentLookup is already implemented by the `project.NewProject()` in the libcompose library, which is called in `parseV1V2()`. In addition, as of 06/28/19, `.env` does not work with Compose V3 (#726) so this change should not affect any v3 feature.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**  
- [X] Unit tests passed
- [X] Integration tests passed
- [N/A] Unit tests added for new functionality
- [X] Listed manual checks and their outputs in the comments ([example](https://github.com/aws/amazon-ecs-cli/pull/750#issuecomment-472623042))
- [N/A] Link to issue or PR for the integration tests: 

**Documentation**  
- [N/A] Contacted our doc writer
- [N/A] Updated our README
----
**Manual Testing**

Rebuilt `ecs-cli` with my change.

```
$ cat docker-compose.yml
version: '2'
services:
  web:
    image: amazon/amazon-ecs-sample:$TAG
    ports:
      - "80:80"
    stop_grace_period: 1m15s
```

```
$ cat .env
TAG=1
```

You can see the `TAG` environment variable is still correctly resolved for V2 Compose.
```
aws ecs describe-task-definition --task-definition ecs-cli-tutorial:6 --region us-west-2
{
    "taskDefinition": {
        "taskDefinitionArn": "arn:aws:ecs:us-west-2:620297136107:task-definition/ecs-cli-tutorial:6",
        "containerDefinitions": [
            {
                "name": "web",
                "image": "amazon/amazon-ecs-sample:1",
                "cpu": 0,
                "links": [],
                "portMappings": [
                    {
                        "containerPort": 80,
                        "hostPort": 80,
                        "protocol": "tcp"
                    }
                ],
                "essential": true,
                "entryPoint": [],
                "command": [],
                "environment": [],
                "mountPoints": [],
                "volumesFrom": [],
                "linuxParameters": {
                    "capabilities": {},
                    "devices": []
                },
                "stopTimeout": 75,
                "privileged": false,
                "readonlyRootFilesystem": false,
                "dnsServers": [],
                "dnsSearchDomains": [],
                "extraHosts": [],
                "dockerSecurityOptions": [],
                "pseudoTerminal": false,
                "dockerLabels": {},
                "ulimits": []
            }
        ],
        "family": "ecs-cli-tutorial",
        "executionRoleArn": "arn:aws:iam::620297136107:role/ecsTaskExecutionRole",
        "networkMode": "awsvpc",
        "revision": 6,
        "volumes": [],
        "status": "ACTIVE",
        "requiresAttributes": [
            {
                "name": "com.amazonaws.ecs.capability.docker-remote-api.1.17"
            },
            {
                "name": "ecs.capability.container-ordering"
            },
            {
                "name": "com.amazonaws.ecs.capability.docker-remote-api.1.18"
            },
            {
                "name": "ecs.capability.task-eni"
            }
        ],
        "placementConstraints": [],
        "compatibilities": [
            "EC2",
            "FARGATE"
        ],
        "requiresCompatibilities": [
            "EC2"
        ],
        "cpu": "256",
        "memory": "512"
    }
}
```

If I switched the Compose version to 3, then `.env` does not work, which is expected due to #726:
```
$ aws ecs describe-task-definition --task-definition ecs-cli-tutorial:7 --region us-west-2
{
    "taskDefinition": {
        "taskDefinitionArn": "arn:aws:ecs:us-west-2:620297136107:task-definition/ecs-cli-tutorial:7",
        "containerDefinitions": [
            {
                "name": "web",
                "image": "amazon/amazon-ecs-sample:",
                "cpu": 0,
                "links": [],
                "portMappings": [
                    {
                        "containerPort": 80,
                        "hostPort": 80,
                        "protocol": "tcp"
                    }
                ],
                "essential": true,
                "entryPoint": [],
                "command": [],
                "environment": [],
                "mountPoints": [],
                "volumesFrom": [],
                "linuxParameters": {
                    "capabilities": {},
                    "devices": []
                },
                "stopTimeout": 75,
                "privileged": false,
                "readonlyRootFilesystem": false,
                "dnsServers": [],
                "dnsSearchDomains": [],
                "extraHosts": [],
                "dockerSecurityOptions": [],
                "pseudoTerminal": false
            }
        ],
        "family": "ecs-cli-tutorial",
        "executionRoleArn": "arn:aws:iam::620297136107:role/ecsTaskExecutionRole",
        "networkMode": "awsvpc",
        "revision": 7,
        "volumes": [],
        "status": "ACTIVE",
        "requiresAttributes": [
            {
                "name": "com.amazonaws.ecs.capability.docker-remote-api.1.17"
            },
            {
                "name": "ecs.capability.container-ordering"
            },
            {
                "name": "com.amazonaws.ecs.capability.docker-remote-api.1.18"
            },
            {
                "name": "ecs.capability.task-eni"
            }
        ],
        "placementConstraints": [],
        "compatibilities": [
            "EC2",
            "FARGATE"
        ],
        "requiresCompatibilities": [
            "EC2"
        ],
        "cpu": "256",
        "memory": "512"
    }
}
```

----
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.