### PR TITLE
Restructure local commands and flags

### DIFF
--- a/ecs-cli/modules/cli/local/create_app.go
+++ b/ecs-cli/modules/cli/local/create_app.go
@@ -61,9 +61,9 @@ func createLocal(project localproject.LocalProject) error {
 }
 
 func validateOptions(c *cli.Context) error {
-	if (c.String(flags.TaskDefinitionFileFlag) != "") && (c.String(flags.TaskDefinitionTaskFlag) != "") {
+	if (c.String(flags.TaskDefinitionFileFlag) != "") && (c.String(flags.TaskDefinitionTaskRemote) != "") {
 		return fmt.Errorf("%s and %s can not be used together",
-			flags.TaskDefinitionTaskFlag, flags.TaskDefinitionFileFlag)
+			flags.TaskDefinitionTaskRemote, flags.TaskDefinitionFileFlag)
 	}
 	return nil
 }

--- a/ecs-cli/modules/cli/local/create_app.go
+++ b/ecs-cli/modules/cli/local/create_app.go
@@ -19,8 +19,6 @@ import (
 	"fmt"
 
 	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/cli/local/localproject"
-	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/commands/flags"
-
 	log "github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 )
@@ -57,13 +55,5 @@ func createLocal(project localproject.LocalProject) error {
 		return err
 	}
 
-	return nil
-}
-
-func validateOptions(c *cli.Context) error {
-	if (c.String(flags.TaskDefinitionFileFlag) != "") && (c.String(flags.TaskDefinitionTaskRemote) != "") {
-		return fmt.Errorf("%s and %s can not be used together",
-			flags.TaskDefinitionTaskRemote, flags.TaskDefinitionFileFlag)
-	}
 	return nil
 }

--- a/ecs-cli/modules/cli/local/down_app.go
+++ b/ecs-cli/modules/cli/local/down_app.go
@@ -14,19 +14,10 @@
 package local
 
 import (
-	"fmt"
-	"os"
-	"os/exec"
-	"path/filepath"
-
-	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/cli/local/converter"
 	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/cli/local/docker"
-	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/cli/local/localproject"
 	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/cli/local/network"
 	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/cli/local/options"
-	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/commands/flags"
 	"github.com/docker/docker/api/types"
-	"github.com/docker/docker/api/types/filters"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 	"golang.org/x/net/context"
@@ -34,7 +25,7 @@ import (
 
 // Down stops and removes running local ECS tasks.
 // If the user stops the last running task in the local network then also remove the network.
-func Down(c *cli.Context) error {
+func Down(c *cli.Context) {
 	defer func() {
 		client := docker.NewClient()
 		network.Teardown(client)
@@ -43,77 +34,31 @@ func Down(c *cli.Context) error {
 	if err := options.ValidateCombinations(c); err != nil {
 		logrus.Fatal(err.Error())
 	}
-
-	if c.String(flags.TaskDefinitionFile) != "" {
-		return downLocalContainersWithFilters(filters.NewArgs(
-			filters.Arg("label", fmt.Sprintf("%s=%s", converter.TaskDefinitionLabelValue,
-				c.String(flags.TaskDefinitionFile))),
-			filters.Arg("label", fmt.Sprintf("%s=%s", converter.TaskDefinitionLabelType, localproject.LocalTaskDefType)),
-		))
+	containers, err := listContainers(c)
+	if err != nil {
+		logrus.Fatalf("Failed to list containers due to:\n%v", err)
 	}
-	if c.String(flags.TaskDefinitionRemote) != "" {
-		return downLocalContainersWithFilters(filters.NewArgs(
-			filters.Arg("label", fmt.Sprintf("%s=%s", converter.TaskDefinitionLabelValue,
-				c.String(flags.TaskDefinitionRemote))),
-			filters.Arg("label", fmt.Sprintf("%s=%s", converter.TaskDefinitionLabelType, localproject.RemoteTaskDefType)),
-		))
-	}
-	if c.Bool(flags.All) {
-		return downLocalContainersWithFilters(filters.NewArgs(
-			filters.Arg("label", converter.TaskDefinitionLabelValue),
-		))
-	}
-	return downComposeLocalContainers()
+	downContainers(containers)
 }
 
-func downComposeLocalContainers() error {
-	wd, _ := os.Getwd()
-	if _, err := os.Stat(filepath.Join(wd, localproject.LocalOutDefaultFileName)); os.IsNotExist(err) {
-		logrus.Fatalf("Compose file %s does not exist in current directory", localproject.LocalOutDefaultFileName)
-	}
-
-	logrus.Infof("Running Compose down on %s", localproject.LocalOutDefaultFileName)
-	cmd := exec.Command("docker-compose", "-f", localproject.LocalOutDefaultFileName, "down")
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		logrus.Fatalf("Failed to run docker-compose down due to \n%v: %s", err, string(out))
-	}
-
-	logrus.Info("Stopped and removed containers successfully")
-	return nil
-}
-
-func downLocalContainersWithFilters(args filters.Args) error {
-	ctx, cancel := context.WithTimeout(context.Background(), docker.TimeoutInS)
-
-	client := docker.NewClient()
-	containers, err := client.ContainerList(ctx, types.ContainerListOptions{
-		Filters: args,
-		All:     true,
-	})
-	if err != nil {
-		logrus.Fatalf("Failed to list containers with filters %v due to \n%v", args, err)
-	}
-	cancel()
-
+func downContainers(containers []types.Container) {
 	if len(containers) == 0 {
 		logrus.Warn("No running ECS local tasks found")
-		return nil
+		return
 	}
-
+	client := docker.NewClient()
 	logrus.Infof("Stop and remove %d container(s)", len(containers))
 	for _, container := range containers {
-		ctx, cancel = context.WithTimeout(context.Background(), docker.TimeoutInS)
-		if err = client.ContainerStop(ctx, container.ID, nil); err != nil {
-			logrus.Fatalf("Failed to stop container %s due to \n%v", container.ID[:maxContainerIDLength], err)
+		ctx, cancel := context.WithTimeout(context.Background(), docker.TimeoutInS)
+		if err := client.ContainerStop(ctx, container.ID, nil); err != nil {
+			logrus.Fatalf("Failed to stop container %s due to:\n%v", container.ID[:maxContainerIDLength], err)
 		}
 		logrus.Infof("Stopped container with id %s", container.ID[:maxContainerIDLength])
 
-		if err = client.ContainerRemove(ctx, container.ID, types.ContainerRemoveOptions{}); err != nil {
-			logrus.Fatalf("Failed to remove container %s due to \n%v", container.ID[:maxContainerIDLength], err)
+		if err := client.ContainerRemove(ctx, container.ID, types.ContainerRemoveOptions{}); err != nil {
+			logrus.Fatalf("Failed to remove container %s due to:\n%v", container.ID[:maxContainerIDLength], err)
 		}
 		logrus.Infof("Removed container with id %s", container.ID[:maxContainerIDLength])
 		cancel()
 	}
-	return nil
 }

--- a/ecs-cli/modules/cli/local/down_app.go
+++ b/ecs-cli/modules/cli/local/down_app.go
@@ -50,10 +50,10 @@ func Down(c *cli.Context) error {
 			filters.Arg("label", fmt.Sprintf("%s=%s", converter.TaskDefinitionLabelType, localproject.LocalTaskDefType)),
 		))
 	}
-	if c.String(flags.TaskDefinitionTaskFlag) != "" {
+	if c.String(flags.TaskDefinitionTaskRemote) != "" {
 		return downLocalContainersWithFilters(filters.NewArgs(
 			filters.Arg("label", fmt.Sprintf("%s=%s", converter.TaskDefinitionLabelValue,
-				c.String(flags.TaskDefinitionTaskFlag))),
+				c.String(flags.TaskDefinitionTaskRemote))),
 			filters.Arg("label", fmt.Sprintf("%s=%s", converter.TaskDefinitionLabelType, localproject.RemoteTaskDefType)),
 		))
 	}

--- a/ecs-cli/modules/cli/local/down_app.go
+++ b/ecs-cli/modules/cli/local/down_app.go
@@ -44,21 +44,21 @@ func Down(c *cli.Context) error {
 		logrus.Fatal(err.Error())
 	}
 
-	if c.String(flags.TaskDefinitionFileFlag) != "" {
+	if c.String(flags.TaskDefinitionFile) != "" {
 		return downLocalContainersWithFilters(filters.NewArgs(
 			filters.Arg("label", fmt.Sprintf("%s=%s", converter.TaskDefinitionLabelValue,
-				c.String(flags.TaskDefinitionFileFlag))),
+				c.String(flags.TaskDefinitionFile))),
 			filters.Arg("label", fmt.Sprintf("%s=%s", converter.TaskDefinitionLabelType, localproject.LocalTaskDefType)),
 		))
 	}
-	if c.String(flags.TaskDefinitionTaskRemote) != "" {
+	if c.String(flags.TaskDefinitionRemote) != "" {
 		return downLocalContainersWithFilters(filters.NewArgs(
 			filters.Arg("label", fmt.Sprintf("%s=%s", converter.TaskDefinitionLabelValue,
-				c.String(flags.TaskDefinitionTaskRemote))),
+				c.String(flags.TaskDefinitionRemote))),
 			filters.Arg("label", fmt.Sprintf("%s=%s", converter.TaskDefinitionLabelType, localproject.RemoteTaskDefType)),
 		))
 	}
-	if c.Bool(flags.AllFlag) {
+	if c.Bool(flags.All) {
 		return downLocalContainersWithFilters(filters.NewArgs(
 			filters.Arg("label", converter.TaskDefinitionLabelValue),
 		))

--- a/ecs-cli/modules/cli/local/down_app.go
+++ b/ecs-cli/modules/cli/local/down_app.go
@@ -31,7 +31,7 @@ func Down(c *cli.Context) {
 		network.Teardown(client)
 	}()
 
-	if err := options.ValidateCombinations(c); err != nil {
+	if err := options.ValidateFlagPairs(c); err != nil {
 		logrus.Fatal(err.Error())
 	}
 	containers, err := listContainers(c)

--- a/ecs-cli/modules/cli/local/down_app.go
+++ b/ecs-cli/modules/cli/local/down_app.go
@@ -23,6 +23,7 @@ import (
 	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/cli/local/docker"
 	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/cli/local/localproject"
 	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/cli/local/network"
+	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/cli/local/options"
 	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/commands/flags"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
@@ -39,7 +40,7 @@ func Down(c *cli.Context) error {
 		network.Teardown(client)
 	}()
 
-	if err := validateOptions(c); err != nil {
+	if err := options.ValidateCombinations(c); err != nil {
 		logrus.Fatal(err.Error())
 	}
 

--- a/ecs-cli/modules/cli/local/localproject/project.go
+++ b/ecs-cli/modules/cli/local/localproject/project.go
@@ -95,11 +95,11 @@ func (p *localProject) InputMetadata() *converter.LocalCreateMetadata {
 // ReadTaskDefinition reads an ECS Task Definition either from a local file
 // or from retrieving one from ECS and stores it on the local project
 func (p *localProject) ReadTaskDefinition() error {
-	remote := p.context.String(flags.TaskDefinitionTaskFlag)
+	remote := p.context.String(flags.TaskDefinitionTaskRemote)
 	filename := p.context.String(flags.TaskDefinitionFileFlag)
 
 	if remote != "" && filename != "" {
-		return fmt.Errorf("cannot specify both --%s and --%s flags", flags.TaskDefinitionTaskFlag, flags.TaskDefinitionFileFlag)
+		return fmt.Errorf("cannot specify both --%s and --%s flags", flags.TaskDefinitionTaskRemote, flags.TaskDefinitionFileFlag)
 	}
 
 	var taskDefinition *ecs.TaskDefinition

--- a/ecs-cli/modules/cli/local/localproject/project.go
+++ b/ecs-cli/modules/cli/local/localproject/project.go
@@ -95,11 +95,11 @@ func (p *localProject) InputMetadata() *converter.LocalCreateMetadata {
 // ReadTaskDefinition reads an ECS Task Definition either from a local file
 // or from retrieving one from ECS and stores it on the local project
 func (p *localProject) ReadTaskDefinition() error {
-	remote := p.context.String(flags.TaskDefinitionTaskRemote)
-	filename := p.context.String(flags.TaskDefinitionFileFlag)
+	remote := p.context.String(flags.TaskDefinitionRemote)
+	filename := p.context.String(flags.TaskDefinitionFile)
 
 	if remote != "" && filename != "" {
-		return fmt.Errorf("cannot specify both --%s and --%s flags", flags.TaskDefinitionTaskRemote, flags.TaskDefinitionFileFlag)
+		return fmt.Errorf("cannot specify both --%s and --%s flags", flags.TaskDefinitionRemote, flags.TaskDefinitionFile)
 	}
 
 	var taskDefinition *ecs.TaskDefinition
@@ -217,7 +217,7 @@ func (p *localProject) Write() error {
 	// Will error if the file already exists, otherwise create
 	p.localOutFileName = LocalOutDefaultFileName
 
-	if fileName := p.context.String(flags.LocalOutputFlag); fileName != "" {
+	if fileName := p.context.String(flags.Output); fileName != "" {
 		p.localOutFileName = fileName
 	}
 

--- a/ecs-cli/modules/cli/local/localproject/project_test.go
+++ b/ecs-cli/modules/cli/local/localproject/project_test.go
@@ -43,7 +43,7 @@ func TestReadTaskDefinition_FromRemote(t *testing.T) {
 	// GIVEN
 	taskDefName := "myTaskDef"
 	flagSet := flag.NewFlagSet("ecs-cli", 0)
-	flagSet.String(flags.TaskDefinitionTaskFlag, taskDefName, "")
+	flagSet.String(flags.TaskDefinitionTaskRemote, taskDefName, "")
 	context := cli.NewContext(nil, flagSet, nil)
 	project := New(context)
 
@@ -135,7 +135,7 @@ func TestReadTaskDefinition_ErrorIfTwoInputsSpecified(t *testing.T) {
 	taskDefName := "myTaskDef"
 	taskDefFile := "some-file.json"
 	flagSet := flag.NewFlagSet("ecs-cli", 0)
-	flagSet.String(flags.TaskDefinitionTaskFlag, taskDefName, "")
+	flagSet.String(flags.TaskDefinitionTaskRemote, taskDefName, "")
 	flagSet.String(flags.TaskDefinitionFileFlag, taskDefFile, "")
 	context := cli.NewContext(nil, flagSet, nil)
 	project := New(context)

--- a/ecs-cli/modules/cli/local/localproject/project_test.go
+++ b/ecs-cli/modules/cli/local/localproject/project_test.go
@@ -43,7 +43,7 @@ func TestReadTaskDefinition_FromRemote(t *testing.T) {
 	// GIVEN
 	taskDefName := "myTaskDef"
 	flagSet := flag.NewFlagSet("ecs-cli", 0)
-	flagSet.String(flags.TaskDefinitionTaskRemote, taskDefName, "")
+	flagSet.String(flags.TaskDefinitionRemote, taskDefName, "")
 	context := cli.NewContext(nil, flagSet, nil)
 	project := New(context)
 
@@ -72,7 +72,7 @@ func TestReadTaskDefinition_FromLocal(t *testing.T) {
 	// GIVEN
 	taskDefFile := "some-file.json"
 	flagSet := flag.NewFlagSet("ecs-cli", 0)
-	flagSet.String(flags.TaskDefinitionFileFlag, taskDefFile, "")
+	flagSet.String(flags.TaskDefinitionFile, taskDefFile, "")
 	context := cli.NewContext(nil, flagSet, nil)
 	project := New(context)
 
@@ -135,8 +135,8 @@ func TestReadTaskDefinition_ErrorIfTwoInputsSpecified(t *testing.T) {
 	taskDefName := "myTaskDef"
 	taskDefFile := "some-file.json"
 	flagSet := flag.NewFlagSet("ecs-cli", 0)
-	flagSet.String(flags.TaskDefinitionTaskRemote, taskDefName, "")
-	flagSet.String(flags.TaskDefinitionFileFlag, taskDefFile, "")
+	flagSet.String(flags.TaskDefinitionRemote, taskDefName, "")
+	flagSet.String(flags.TaskDefinitionFile, taskDefFile, "")
 	context := cli.NewContext(nil, flagSet, nil)
 	project := New(context)
 
@@ -175,7 +175,7 @@ func TestWrite_WithOutputFlag(t *testing.T) {
 	// GIVEN
 	expectedOutputFile := "foo.yml"
 	flagSet := flag.NewFlagSet("ecs-cli", 0)
-	flagSet.String(flags.LocalOutputFlag, expectedOutputFile, "")
+	flagSet.String(flags.Output, expectedOutputFile, "")
 	context := cli.NewContext(nil, flagSet, nil)
 	project := New(context)
 

--- a/ecs-cli/modules/cli/local/options/options.go
+++ b/ecs-cli/modules/cli/local/options/options.go
@@ -26,8 +26,8 @@ type flagPair struct {
 	second string
 }
 
-// ValidateCombinations returns an error if two flags can not be used together.
-func ValidateCombinations(c *cli.Context) error {
+// ValidateFlagPairs returns an error if two flags can not be used together.
+func ValidateFlagPairs(c *cli.Context) error {
 	invalid := []flagPair{
 		{
 			flags.TaskDefinitionFile,

--- a/ecs-cli/modules/cli/local/options/options.go
+++ b/ecs-cli/modules/cli/local/options/options.go
@@ -30,20 +30,20 @@ type flagPair struct {
 func ValidateCombinations(c *cli.Context) error {
 	notTogether := []flagPair{
 		{
-			flags.TaskDefinitionFileFlag,
-			flags.TaskDefinitionTaskRemote,
+			flags.TaskDefinitionFile,
+			flags.TaskDefinitionRemote,
 		},
 		{
-			flags.TaskDefinitionFileFlag,
-			flags.TaskDefinitionComposeFlag,
+			flags.TaskDefinitionFile,
+			flags.TaskDefinitionCompose,
 		},
 		{
-			flags.TaskDefinitionTaskRemote,
-			flags.TaskDefinitionComposeFlag,
+			flags.TaskDefinitionRemote,
+			flags.TaskDefinitionCompose,
 		},
 		{
-			flags.LocalOutputFlag,
-			flags.TaskDefinitionComposeFlag,
+			flags.Output,
+			flags.TaskDefinitionCompose,
 		},
 	}
 
@@ -57,13 +57,13 @@ func ValidateCombinations(c *cli.Context) error {
 
 // HasTaskDefInputFlag returns true if any --task-def-* flag was set, false otherwise.
 func HasTaskDefInputFlag(c *cli.Context) bool {
-	if c.String(flags.TaskDefinitionFileFlag) != "" {
+	if c.String(flags.TaskDefinitionFile) != "" {
 		return true
 	}
-	if c.String(flags.TaskDefinitionTaskRemote) != "" {
+	if c.String(flags.TaskDefinitionRemote) != "" {
 		return true
 	}
-	if c.String(flags.TaskDefinitionComposeFlag) != "" {
+	if c.String(flags.TaskDefinitionCompose) != "" {
 		return true
 	}
 	return false

--- a/ecs-cli/modules/cli/local/options/options.go
+++ b/ecs-cli/modules/cli/local/options/options.go
@@ -1,0 +1,70 @@
+// Copyright 2015-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+// Package options implements utility functions around ECS local flags.
+package options
+
+import (
+	"fmt"
+
+	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/commands/flags"
+	"github.com/urfave/cli"
+)
+
+type flagPair struct {
+	first  string
+	second string
+}
+
+// ValidateCombinations returns an error if two flags can not be used together.
+func ValidateCombinations(c *cli.Context) error {
+	notTogether := []flagPair{
+		{
+			flags.TaskDefinitionFileFlag,
+			flags.TaskDefinitionTaskRemote,
+		},
+		{
+			flags.TaskDefinitionFileFlag,
+			flags.TaskDefinitionComposeFlag,
+		},
+		{
+			flags.TaskDefinitionTaskRemote,
+			flags.TaskDefinitionComposeFlag,
+		},
+		{
+			flags.LocalOutputFlag,
+			flags.TaskDefinitionComposeFlag,
+		},
+	}
+
+	for _, pair := range notTogether {
+		if c.String(pair.first) != "" && c.String(pair.second) != "" {
+			return fmt.Errorf("%s and %s can not be used together", pair.first, pair.second)
+		}
+	}
+	return nil
+}
+
+// HasTaskDefInputFlag returns true if any --task-def-* flag was set, false otherwise.
+func HasTaskDefInputFlag(c *cli.Context) bool {
+	if c.String(flags.TaskDefinitionFileFlag) != "" {
+		return true
+	}
+	if c.String(flags.TaskDefinitionTaskRemote) != "" {
+		return true
+	}
+	if c.String(flags.TaskDefinitionComposeFlag) != "" {
+		return true
+	}
+	return false
+}

--- a/ecs-cli/modules/cli/local/options/options.go
+++ b/ecs-cli/modules/cli/local/options/options.go
@@ -28,7 +28,7 @@ type flagPair struct {
 
 // ValidateCombinations returns an error if two flags can not be used together.
 func ValidateCombinations(c *cli.Context) error {
-	notTogether := []flagPair{
+	invalid := []flagPair{
 		{
 			flags.TaskDefinitionFile,
 			flags.TaskDefinitionRemote,
@@ -47,24 +47,10 @@ func ValidateCombinations(c *cli.Context) error {
 		},
 	}
 
-	for _, pair := range notTogether {
+	for _, pair := range invalid {
 		if c.String(pair.first) != "" && c.String(pair.second) != "" {
 			return fmt.Errorf("%s and %s can not be used together", pair.first, pair.second)
 		}
 	}
 	return nil
-}
-
-// HasTaskDefInputFlag returns true if any --task-def-* flag was set, false otherwise.
-func HasTaskDefInputFlag(c *cli.Context) bool {
-	if c.String(flags.TaskDefinitionFile) != "" {
-		return true
-	}
-	if c.String(flags.TaskDefinitionRemote) != "" {
-		return true
-	}
-	if c.String(flags.TaskDefinitionCompose) != "" {
-		return true
-	}
-	return false
 }

--- a/ecs-cli/modules/cli/local/ps_app.go
+++ b/ecs-cli/modules/cli/local/ps_app.go
@@ -71,10 +71,10 @@ func listContainers(c *cli.Context) []types.Container {
 			filters.Arg("label", fmt.Sprintf("%s=%s", converter.TaskDefinitionLabelType, localproject.LocalTaskDefType)),
 		))
 	}
-	if c.String(flags.TaskDefinitionTaskFlag) != "" {
+	if c.String(flags.TaskDefinitionTaskRemote) != "" {
 		return listContainersWithFilters(filters.NewArgs(
 			filters.Arg("label", fmt.Sprintf("%s=%s", converter.TaskDefinitionLabelValue,
-				c.String(flags.TaskDefinitionTaskFlag))),
+				c.String(flags.TaskDefinitionTaskRemote))),
 			filters.Arg("label", fmt.Sprintf("%s=%s", converter.TaskDefinitionLabelType, localproject.RemoteTaskDefType)),
 		))
 	}

--- a/ecs-cli/modules/cli/local/ps_app.go
+++ b/ecs-cli/modules/cli/local/ps_app.go
@@ -65,21 +65,21 @@ func Ps(c *cli.Context) {
 }
 
 func listContainers(c *cli.Context) []types.Container {
-	if c.String(flags.TaskDefinitionFileFlag) != "" {
+	if c.String(flags.TaskDefinitionFile) != "" {
 		return listContainersWithFilters(filters.NewArgs(
 			filters.Arg("label", fmt.Sprintf("%s=%s", converter.TaskDefinitionLabelValue,
-				c.String(flags.TaskDefinitionFileFlag))),
+				c.String(flags.TaskDefinitionFile))),
 			filters.Arg("label", fmt.Sprintf("%s=%s", converter.TaskDefinitionLabelType, localproject.LocalTaskDefType)),
 		))
 	}
-	if c.String(flags.TaskDefinitionTaskRemote) != "" {
+	if c.String(flags.TaskDefinitionRemote) != "" {
 		return listContainersWithFilters(filters.NewArgs(
 			filters.Arg("label", fmt.Sprintf("%s=%s", converter.TaskDefinitionLabelValue,
-				c.String(flags.TaskDefinitionTaskRemote))),
+				c.String(flags.TaskDefinitionRemote))),
 			filters.Arg("label", fmt.Sprintf("%s=%s", converter.TaskDefinitionLabelType, localproject.RemoteTaskDefType)),
 		))
 	}
-	if c.Bool(flags.AllFlag) {
+	if c.Bool(flags.All) {
 		return listContainersWithFilters(filters.NewArgs(
 			filters.Arg("label", converter.TaskDefinitionLabelValue),
 		))
@@ -127,7 +127,7 @@ func listContainersWithFilters(args filters.Args) []types.Container {
 }
 
 func displayContainers(c *cli.Context, containers []types.Container) {
-	if c.Bool(flags.JsonFlag) {
+	if c.Bool(flags.JSON) {
 		displayAsJSON(containers)
 	} else {
 		displayAsTable(containers)

--- a/ecs-cli/modules/cli/local/ps_app.go
+++ b/ecs-cli/modules/cli/local/ps_app.go
@@ -25,6 +25,7 @@ import (
 	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/cli/local/converter"
 	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/cli/local/docker"
 	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/cli/local/localproject"
+	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/cli/local/options"
 	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/commands/flags"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
@@ -56,7 +57,7 @@ const (
 // If the --all flag is provided, then list all local ECS task containers.
 // If the --json flag is provided, then output the format as JSON instead.
 func Ps(c *cli.Context) {
-	if err := validateOptions(c); err != nil {
+	if err := options.ValidateCombinations(c); err != nil {
 		logrus.Fatal(err.Error())
 	}
 	containers := listContainers(c)

--- a/ecs-cli/modules/cli/local/ps_app.go
+++ b/ecs-cli/modules/cli/local/ps_app.go
@@ -58,7 +58,7 @@ const (
 // If the --all flag is provided, then list all local ECS task containers.
 // If the --json flag is provided, then output the format as JSON instead.
 func Ps(c *cli.Context) {
-	if err := options.ValidateCombinations(c); err != nil {
+	if err := options.ValidateFlagPairs(c); err != nil {
 		logrus.Fatal(err.Error())
 	}
 	containers, err := listContainers(c)
@@ -71,21 +71,21 @@ func Ps(c *cli.Context) {
 }
 
 func listContainers(c *cli.Context) ([]types.Container, error) {
-	if name := c.String(flags.TaskDefinitionCompose); name != "" {
-		path, err := filepath.Abs(name)
+	if c.IsSet(flags.TaskDefinitionCompose) {
+		path, err := filepath.Abs(c.String(flags.TaskDefinitionCompose))
 		if err != nil {
-			return nil, errors.Wrapf(err, "failed to get absolute path of %s", name)
+			return nil, errors.Wrapf(err, "failed to get absolute path of %s", c.String(flags.TaskDefinitionCompose))
 		}
 		return listLocalComposeContainers(path)
 	}
-	if c.String(flags.TaskDefinitionFile) != "" {
+	if c.IsSet(flags.TaskDefinitionFile) {
 		return listContainersWithFilters(filters.NewArgs(
 			filters.Arg("label", fmt.Sprintf("%s=%s", converter.TaskDefinitionLabelValue,
 				c.String(flags.TaskDefinitionFile))),
 			filters.Arg("label", fmt.Sprintf("%s=%s", converter.TaskDefinitionLabelType, localproject.LocalTaskDefType)),
 		))
 	}
-	if c.String(flags.TaskDefinitionRemote) != "" {
+	if c.IsSet(flags.TaskDefinitionRemote) {
 		return listContainersWithFilters(filters.NewArgs(
 			filters.Arg("label", fmt.Sprintf("%s=%s", converter.TaskDefinitionLabelValue,
 				c.String(flags.TaskDefinitionRemote))),

--- a/ecs-cli/modules/cli/local/up_app.go
+++ b/ecs-cli/modules/cli/local/up_app.go
@@ -56,7 +56,7 @@ func Up(c *cli.Context) {
 }
 
 func createComposeFile(c *cli.Context) (string, error) {
-	if name := c.String(flags.TaskDefinitionComposeFlag); name != "" {
+	if name := c.String(flags.TaskDefinitionCompose); name != "" {
 		return filepath.Abs(name)
 	}
 	if shouldUseDefaultComposeFile(c) {

--- a/ecs-cli/modules/commands/flags/flags.go
+++ b/ecs-cli/modules/commands/flags/flags.go
@@ -148,11 +148,12 @@ const (
 	DisableECSManagedTagsFlag = "disable-ecs-managed-tags"
 
 	// Local
-	TaskDefinitionFileFlag = "file"
-	TaskDefinitionTaskFlag = "task-def"
-	LocalOutputFlag        = "output"
-	JsonFlag               = "json"
-	AllFlag                = "all"
+	TaskDefinitionFileFlag    = "task-def-file"
+	TaskDefinitionTaskRemote  = "task-def-remote"
+	TaskDefinitionComposeFlag = "task-def-compose"
+	LocalOutputFlag           = "output"
+	JsonFlag                  = "json"
+	AllFlag                   = "all"
 )
 
 // OptionalRegionAndProfileFlags provides these flags:

--- a/ecs-cli/modules/commands/flags/flags.go
+++ b/ecs-cli/modules/commands/flags/flags.go
@@ -148,12 +148,12 @@ const (
 	DisableECSManagedTagsFlag = "disable-ecs-managed-tags"
 
 	// Local
-	TaskDefinitionFileFlag    = "task-def-file"
-	TaskDefinitionTaskRemote  = "task-def-remote"
-	TaskDefinitionComposeFlag = "task-def-compose"
-	LocalOutputFlag           = "output"
-	JsonFlag                  = "json"
-	AllFlag                   = "all"
+	TaskDefinitionFile    = "task-def-file"
+	TaskDefinitionRemote  = "task-def-remote"
+	TaskDefinitionCompose = "task-def-compose"
+	Output                = "output"
+	JSON                  = "json"
+	All                   = "all"
 )
 
 // OptionalRegionAndProfileFlags provides these flags:

--- a/ecs-cli/modules/commands/local/local_command.go
+++ b/ecs-cli/modules/commands/local/local_command.go
@@ -92,17 +92,21 @@ func downCommand() cli.Command {
 		Usage:  "Stop and remove a running ECS task.",
 		Action: local.Down,
 		Flags: []cli.Flag{
-			cli.BoolFlag{
-				Name:  flags.All,
-				Usage: "Stops and removes all running containers.",
+			cli.StringFlag{
+				Name:  flags.TaskDefinitionCompose + ",c",
+				Usage: "Stop and remove containers from the Compose file `name`.",
 			},
 			cli.StringFlag{
 				Name:  flags.TaskDefinitionFile + ",f",
-				Usage: "Stops and removes all running containers matching the task definition file path",
+				Usage: "Stop and remove all running containers matching the task definition file `name`.",
 			},
 			cli.StringFlag{
-				Name:  flags.TaskDefinitionRemote + ",t",
-				Usage: "Stops and removes all running containers matching the task family or ARN",
+				Name:  flags.TaskDefinitionRemote + ",r",
+				Usage: "Stop and remove all running containers matching the task definition `arnOrFamily`.",
+			},
+			cli.BoolFlag{
+				Name:  flags.All,
+				Usage: "Stop and remove all running containers.",
 			},
 		},
 	}
@@ -120,11 +124,11 @@ func psCommand() cli.Command {
 			},
 			cli.StringFlag{
 				Name:  flags.TaskDefinitionFile + ",f",
-				Usage: "Lists all running containers matching the task definition file path.",
+				Usage: "List all running containers matching the task definition file `name`.",
 			},
 			cli.StringFlag{
 				Name:  flags.TaskDefinitionRemote + ",r",
-				Usage: "Lists all running containers matching the task definition `arnOrFamily`.",
+				Usage: "List all running containers matching the task definition `arnOrFamily`.",
 			},
 			cli.BoolFlag{
 				Name:  flags.All,

--- a/ecs-cli/modules/commands/local/local_command.go
+++ b/ecs-cli/modules/commands/local/local_command.go
@@ -43,7 +43,20 @@ func createCommand() cli.Command {
 		Usage:  "Create a Compose file from an ECS task definition.",
 		Before: app.BeforeApp,
 		Action: local.Create,
-		Flags:  createFlags(),
+		Flags: []cli.Flag{
+			cli.StringFlag{
+				Name:  flags.TaskDefinitionFileFlag + ",f",
+				Usage: "The file `name` of a task definition json to convert. If not specified, defaults to task-definition.json.",
+			},
+			cli.StringFlag{
+				Name:  flags.TaskDefinitionTaskRemote + ",r",
+				Usage: "The `arnOrFamily` of a task definition to convert.",
+			},
+			cli.StringFlag{
+				Name:  flags.LocalOutputFlag + ",o",
+				Usage: "The Compose file `name` to write to. If not specified, defaults to docker-compose.local.yml.",
+			},
+		},
 	}
 }
 
@@ -52,19 +65,36 @@ func upCommand() cli.Command {
 		Name:   "up",
 		Usage:  "Create a Compose file from an ECS task definition and run it.",
 		Action: local.Up,
-		Flags:  createFlags(),
+		Flags: []cli.Flag{
+			cli.StringFlag{
+				Name:  flags.TaskDefinitionFileFlag + ",f",
+				Usage: "The file `name` of a task definition json to convert and run. If not specified, defaults to task-definition.json.",
+			},
+			cli.StringFlag{
+				Name:  flags.TaskDefinitionTaskRemote + ",r",
+				Usage: "The `arnOrFamily` of a task definition to convert and run.",
+			},
+			cli.StringFlag{
+				Name:  flags.TaskDefinitionComposeFlag + ",c",
+				Usage: "The Compose file `name` of a task definition to run.",
+			},
+			cli.StringFlag{
+				Name:  flags.LocalOutputFlag + ",o",
+				Usage: "The Compose file `name` to write to. If not specified, defaults to docker-compose.local.yml.",
+			},
+		},
 	}
 }
 
 func downCommand() cli.Command {
 	return cli.Command{
 		Name:   "down",
-		Usage:  "Stop and remove a running ECS task container.",
+		Usage:  "Stop and remove a running ECS task.",
 		Action: local.Down,
 		Flags: []cli.Flag{
 			cli.BoolFlag{
 				Name:  flags.AllFlag,
-				Usage: "Stops and removes all running containers",
+				Usage: "Stops and removes all running containers.",
 			},
 			cli.StringFlag{
 				Name:  flags.TaskDefinitionFileFlag + ",f",
@@ -100,23 +130,6 @@ func psCommand() cli.Command {
 				Name:  flags.JsonFlag,
 				Usage: "Output in JSON format.",
 			},
-		},
-	}
-}
-
-func createFlags() []cli.Flag {
-	return []cli.Flag{
-		cli.StringFlag{
-			Name:  flags.TaskDefinitionFileFlag + ",f",
-			Usage: "The file `name` of the task definition json to convert.",
-		},
-		cli.StringFlag{
-			Name:  flags.TaskDefinitionTaskRemote + ",r",
-			Usage: "The `arnOrFamily` of the task definition to convert.",
-		},
-		cli.StringFlag{
-			Name:  flags.LocalOutputFlag + ",o",
-			Usage: "The `name` of the file to write to. If not specified, defaults to docker-compose.local.yml.",
 		},
 	}
 }

--- a/ecs-cli/modules/commands/local/local_command.go
+++ b/ecs-cli/modules/commands/local/local_command.go
@@ -28,7 +28,6 @@ func LocalCommand() cli.Command {
 		Name:   "local",
 		Usage:  "Run your ECS tasks locally.",
 		Before: app.BeforeApp,
-		Flags:  flags.OptionalRegionAndProfileFlags(),
 		Subcommands: []cli.Command{
 			createCommand(),
 			upCommand(),
@@ -72,7 +71,7 @@ func downCommand() cli.Command {
 				Usage: "Stops and removes all running containers matching the task definition file path",
 			},
 			cli.StringFlag{
-				Name:  flags.TaskDefinitionTaskFlag + ",t",
+				Name:  flags.TaskDefinitionTaskRemote + ",t",
 				Usage: "Stops and removes all running containers matching the task family or ARN",
 			},
 		},
@@ -94,7 +93,7 @@ func psCommand() cli.Command {
 				Usage: "Lists all running containers matching the task definition file path",
 			},
 			cli.StringFlag{
-				Name:  flags.TaskDefinitionTaskFlag + ",t",
+				Name:  flags.TaskDefinitionTaskRemote + ",t",
 				Usage: "Lists all running containers matching the task family or ARN",
 			},
 			cli.BoolFlag{
@@ -109,15 +108,15 @@ func createFlags() []cli.Flag {
 	return []cli.Flag{
 		cli.StringFlag{
 			Name:  flags.TaskDefinitionFileFlag + ",f",
-			Usage: "The file name of the task definition to convert",
+			Usage: "The file `name` of the task definition json to convert.",
 		},
 		cli.StringFlag{
-			Name:  flags.TaskDefinitionTaskFlag + ",t",
-			Usage: "The family or ARN of the task definition to convert",
+			Name:  flags.TaskDefinitionTaskRemote + ",r",
+			Usage: "The `arnOrFamily` of the task definition to convert.",
 		},
 		cli.StringFlag{
 			Name:  flags.LocalOutputFlag + ",o",
-			Usage: "The name of the file to write to. If not specified, defaults to docker-compose.local.yml",
+			Usage: "The `name` of the file to write to. If not specified, defaults to docker-compose.local.yml.",
 		},
 	}
 }

--- a/ecs-cli/modules/commands/local/local_command.go
+++ b/ecs-cli/modules/commands/local/local_command.go
@@ -67,16 +67,16 @@ func upCommand() cli.Command {
 		Action: local.Up,
 		Flags: []cli.Flag{
 			cli.StringFlag{
+				Name:  flags.TaskDefinitionCompose + ",c",
+				Usage: "The Compose file `name` of a task definition to run.",
+			},
+			cli.StringFlag{
 				Name:  flags.TaskDefinitionFile + ",f",
 				Usage: "The file `name` of a task definition json to convert and run. If not specified, defaults to task-definition.json.",
 			},
 			cli.StringFlag{
 				Name:  flags.TaskDefinitionRemote + ",r",
 				Usage: "The `arnOrFamily` of a task definition to convert and run.",
-			},
-			cli.StringFlag{
-				Name:  flags.TaskDefinitionCompose + ",c",
-				Usage: "The Compose file `name` of a task definition to run.",
 			},
 			cli.StringFlag{
 				Name:  flags.Output + ",o",
@@ -114,17 +114,21 @@ func psCommand() cli.Command {
 		Usage:  "List locally running ECS task containers.",
 		Action: local.Ps,
 		Flags: []cli.Flag{
-			cli.BoolFlag{
-				Name:  flags.All,
-				Usage: "Lists all running local ECS tasks.",
+			cli.StringFlag{
+				Name:  flags.TaskDefinitionCompose + ",c",
+				Usage: "List containers created from the Compose file `name`.",
 			},
 			cli.StringFlag{
 				Name:  flags.TaskDefinitionFile + ",f",
-				Usage: "Lists all running containers matching the task definition file path",
+				Usage: "Lists all running containers matching the task definition file path.",
 			},
 			cli.StringFlag{
-				Name:  flags.TaskDefinitionRemote + ",t",
-				Usage: "Lists all running containers matching the task family or ARN",
+				Name:  flags.TaskDefinitionRemote + ",r",
+				Usage: "Lists all running containers matching the task definition `arnOrFamily`.",
+			},
+			cli.BoolFlag{
+				Name:  flags.All,
+				Usage: "List all running local ECS task containers.",
 			},
 			cli.BoolFlag{
 				Name:  flags.JSON,

--- a/ecs-cli/modules/commands/local/local_command.go
+++ b/ecs-cli/modules/commands/local/local_command.go
@@ -21,6 +21,13 @@ import (
 	"github.com/urfave/cli"
 )
 
+const (
+	createCmdName = "create"
+	upCmdName     = "up"
+	psCmdName     = "ps"
+	downCmdName   = "down"
+)
+
 // LocalCommand provides a list of commands that operate on a task-definition
 // file (accepted formats: JSON, YAML, CloudFormation).
 func LocalCommand() cli.Command {
@@ -39,22 +46,22 @@ func LocalCommand() cli.Command {
 
 func createCommand() cli.Command {
 	return cli.Command{
-		Name:   "create",
+		Name:   createCmdName,
 		Usage:  "Create a Compose file from an ECS task definition.",
 		Before: app.BeforeApp,
 		Action: local.Create,
 		Flags: []cli.Flag{
 			cli.StringFlag{
-				Name:  flags.TaskDefinitionFile + ",f",
-				Usage: "The file `name` of a task definition json to convert. If not specified, defaults to task-definition.json.",
+				Name:  flagName(flags.TaskDefinitionFile),
+				Usage: flagDescription(flags.TaskDefinitionFile, createCmdName),
 			},
 			cli.StringFlag{
-				Name:  flags.TaskDefinitionRemote + ",r",
-				Usage: "The `arnOrFamily` of a task definition to convert.",
+				Name:  flagName(flags.TaskDefinitionRemote),
+				Usage: flagDescription(flags.TaskDefinitionRemote, createCmdName),
 			},
 			cli.StringFlag{
-				Name:  flags.Output + ",o",
-				Usage: "The Compose file `name` to write to. If not specified, defaults to docker-compose.local.yml.",
+				Name:  flagName(flags.Output),
+				Usage: flagDescription(flags.Output, createCmdName),
 			},
 		},
 	}
@@ -62,51 +69,25 @@ func createCommand() cli.Command {
 
 func upCommand() cli.Command {
 	return cli.Command{
-		Name:   "up",
+		Name:   upCmdName,
 		Usage:  "Create a Compose file from an ECS task definition and run it.",
 		Action: local.Up,
 		Flags: []cli.Flag{
 			cli.StringFlag{
-				Name:  flags.TaskDefinitionCompose + ",c",
-				Usage: "The Compose file `name` of a task definition to run.",
+				Name:  flagName(flags.TaskDefinitionCompose),
+				Usage: flagDescription(flags.TaskDefinitionCompose, upCmdName),
 			},
 			cli.StringFlag{
-				Name:  flags.TaskDefinitionFile + ",f",
-				Usage: "The file `name` of a task definition json to convert and run. If not specified, defaults to task-definition.json.",
+				Name:  flagName(flags.TaskDefinitionFile),
+				Usage: flagDescription(flags.TaskDefinitionFile, upCmdName),
 			},
 			cli.StringFlag{
-				Name:  flags.TaskDefinitionRemote + ",r",
-				Usage: "The `arnOrFamily` of a task definition to convert and run.",
+				Name:  flagName(flags.TaskDefinitionRemote),
+				Usage: flagDescription(flags.TaskDefinitionRemote, upCmdName),
 			},
 			cli.StringFlag{
-				Name:  flags.Output + ",o",
-				Usage: "The Compose file `name` to write to. If not specified, defaults to docker-compose.local.yml.",
-			},
-		},
-	}
-}
-
-func downCommand() cli.Command {
-	return cli.Command{
-		Name:   "down",
-		Usage:  "Stop and remove a running ECS task.",
-		Action: local.Down,
-		Flags: []cli.Flag{
-			cli.StringFlag{
-				Name:  flags.TaskDefinitionCompose + ",c",
-				Usage: "Stop and remove containers from the Compose file `name`.",
-			},
-			cli.StringFlag{
-				Name:  flags.TaskDefinitionFile + ",f",
-				Usage: "Stop and remove all running containers matching the task definition file `name`.",
-			},
-			cli.StringFlag{
-				Name:  flags.TaskDefinitionRemote + ",r",
-				Usage: "Stop and remove all running containers matching the task definition `arnOrFamily`.",
-			},
-			cli.BoolFlag{
-				Name:  flags.All,
-				Usage: "Stop and remove all running containers.",
+				Name:  flagName(flags.Output),
+				Usage: flagDescription(flags.Output, upCmdName),
 			},
 		},
 	}
@@ -114,30 +95,102 @@ func downCommand() cli.Command {
 
 func psCommand() cli.Command {
 	return cli.Command{
-		Name:   "ps",
+		Name:   psCmdName,
 		Usage:  "List locally running ECS task containers.",
 		Action: local.Ps,
 		Flags: []cli.Flag{
 			cli.StringFlag{
-				Name:  flags.TaskDefinitionCompose + ",c",
-				Usage: "List containers created from the Compose file `name`.",
+				Name:  flagName(flags.TaskDefinitionCompose),
+				Usage: flagDescription(flags.TaskDefinitionCompose, psCmdName),
 			},
 			cli.StringFlag{
-				Name:  flags.TaskDefinitionFile + ",f",
-				Usage: "List all running containers matching the task definition file `name`.",
+				Name:  flagName(flags.TaskDefinitionFile),
+				Usage: flagDescription(flags.TaskDefinitionFile, psCmdName),
 			},
 			cli.StringFlag{
-				Name:  flags.TaskDefinitionRemote + ",r",
-				Usage: "List all running containers matching the task definition `arnOrFamily`.",
+				Name:  flagName(flags.TaskDefinitionRemote),
+				Usage: flagDescription(flags.TaskDefinitionRemote, psCmdName),
 			},
 			cli.BoolFlag{
-				Name:  flags.All,
-				Usage: "List all running local ECS task containers.",
+				Name:  flagName(flags.All),
+				Usage: flagDescription(flags.All, psCmdName),
 			},
 			cli.BoolFlag{
-				Name:  flags.JSON,
-				Usage: "Output in JSON format.",
+				Name:  flagName(flags.JSON),
+				Usage: flagDescription(flags.JSON, psCmdName),
 			},
 		},
 	}
+}
+
+func downCommand() cli.Command {
+	return cli.Command{
+		Name:   downCmdName,
+		Usage:  "Stop and remove a running ECS task.",
+		Action: local.Down,
+		Flags: []cli.Flag{
+			cli.StringFlag{
+				Name:  flagName(flags.TaskDefinitionCompose),
+				Usage: flagDescription(flags.TaskDefinitionCompose, downCmdName),
+			},
+			cli.StringFlag{
+				Name:  flagName(flags.TaskDefinitionFile),
+				Usage: flagDescription(flags.TaskDefinitionFile, downCmdName),
+			},
+			cli.StringFlag{
+				Name:  flagName(flags.TaskDefinitionRemote),
+				Usage: flagDescription(flags.TaskDefinitionRemote, downCmdName),
+			},
+			cli.BoolFlag{
+				Name:  flagName(flags.All),
+				Usage: flagDescription(flags.All, downCmdName),
+			},
+		},
+	}
+}
+
+func flagName(longName string) string {
+	m := map[string]string{
+		flags.TaskDefinitionCompose: flags.TaskDefinitionCompose + ",c",
+		flags.TaskDefinitionFile:    flags.TaskDefinitionFile + ",f",
+		flags.TaskDefinitionRemote:  flags.TaskDefinitionRemote + ",r",
+		flags.Output:                flags.Output + ",o",
+		flags.JSON:                  flags.JSON,
+		flags.All:                   flags.All,
+	}
+	return m[longName]
+}
+
+func flagDescription(longName, cmdName string) string {
+	m := map[string]map[string]string{
+		flags.TaskDefinitionCompose: {
+			upCmdName:   "The Compose file `name` of a task definition to run.",
+			psCmdName:   "List containers created from the Compose file `name`.",
+			downCmdName: "Stop and remove containers from the Compose file `name`.",
+		},
+		flags.TaskDefinitionFile: {
+			createCmdName: "The file `name` of a task definition json to convert. If not specified, defaults to task-definition.json.",
+			upCmdName:     "The file `name` of a task definition json to convert and run. If not specified, defaults to task-definition.json.",
+			psCmdName:     "List all running containers matching the task definition file `name`.",
+			downCmdName:   "Stop and remove all running containers matching the task definition file `name`.",
+		},
+		flags.TaskDefinitionRemote: {
+			createCmdName: "The `arnOrFamily` of a task definition to convert.",
+			upCmdName:     "The `arnOrFamily` of a task definition to convert and run.",
+			psCmdName:     "List all running containers matching the task definition `arnOrFamily`.",
+			downCmdName:   "Stop and remove all running containers matching the task definition `arnOrFamily`.",
+		},
+		flags.Output: {
+			createCmdName: "The Compose file `name` to write to. If not specified, defaults to docker-compose.local.yml.",
+			upCmdName:     "The Compose file `name` to write to. If not specified, defaults to docker-compose.local.yml.",
+		},
+		flags.JSON: {
+			psCmdName: "Output in JSON format.",
+		},
+		flags.All: {
+			psCmdName:   "List all running local ECS task containers.",
+			downCmdName: "Stop and remove all running containers.",
+		},
+	}
+	return m[longName][cmdName]
 }

--- a/ecs-cli/modules/commands/local/local_command.go
+++ b/ecs-cli/modules/commands/local/local_command.go
@@ -45,15 +45,15 @@ func createCommand() cli.Command {
 		Action: local.Create,
 		Flags: []cli.Flag{
 			cli.StringFlag{
-				Name:  flags.TaskDefinitionFileFlag + ",f",
+				Name:  flags.TaskDefinitionFile + ",f",
 				Usage: "The file `name` of a task definition json to convert. If not specified, defaults to task-definition.json.",
 			},
 			cli.StringFlag{
-				Name:  flags.TaskDefinitionTaskRemote + ",r",
+				Name:  flags.TaskDefinitionRemote + ",r",
 				Usage: "The `arnOrFamily` of a task definition to convert.",
 			},
 			cli.StringFlag{
-				Name:  flags.LocalOutputFlag + ",o",
+				Name:  flags.Output + ",o",
 				Usage: "The Compose file `name` to write to. If not specified, defaults to docker-compose.local.yml.",
 			},
 		},
@@ -67,19 +67,19 @@ func upCommand() cli.Command {
 		Action: local.Up,
 		Flags: []cli.Flag{
 			cli.StringFlag{
-				Name:  flags.TaskDefinitionFileFlag + ",f",
+				Name:  flags.TaskDefinitionFile + ",f",
 				Usage: "The file `name` of a task definition json to convert and run. If not specified, defaults to task-definition.json.",
 			},
 			cli.StringFlag{
-				Name:  flags.TaskDefinitionTaskRemote + ",r",
+				Name:  flags.TaskDefinitionRemote + ",r",
 				Usage: "The `arnOrFamily` of a task definition to convert and run.",
 			},
 			cli.StringFlag{
-				Name:  flags.TaskDefinitionComposeFlag + ",c",
+				Name:  flags.TaskDefinitionCompose + ",c",
 				Usage: "The Compose file `name` of a task definition to run.",
 			},
 			cli.StringFlag{
-				Name:  flags.LocalOutputFlag + ",o",
+				Name:  flags.Output + ",o",
 				Usage: "The Compose file `name` to write to. If not specified, defaults to docker-compose.local.yml.",
 			},
 		},
@@ -93,15 +93,15 @@ func downCommand() cli.Command {
 		Action: local.Down,
 		Flags: []cli.Flag{
 			cli.BoolFlag{
-				Name:  flags.AllFlag,
+				Name:  flags.All,
 				Usage: "Stops and removes all running containers.",
 			},
 			cli.StringFlag{
-				Name:  flags.TaskDefinitionFileFlag + ",f",
+				Name:  flags.TaskDefinitionFile + ",f",
 				Usage: "Stops and removes all running containers matching the task definition file path",
 			},
 			cli.StringFlag{
-				Name:  flags.TaskDefinitionTaskRemote + ",t",
+				Name:  flags.TaskDefinitionRemote + ",t",
 				Usage: "Stops and removes all running containers matching the task family or ARN",
 			},
 		},
@@ -115,19 +115,19 @@ func psCommand() cli.Command {
 		Action: local.Ps,
 		Flags: []cli.Flag{
 			cli.BoolFlag{
-				Name:  flags.AllFlag,
+				Name:  flags.All,
 				Usage: "Lists all running local ECS tasks.",
 			},
 			cli.StringFlag{
-				Name:  flags.TaskDefinitionFileFlag + ",f",
+				Name:  flags.TaskDefinitionFile + ",f",
 				Usage: "Lists all running containers matching the task definition file path",
 			},
 			cli.StringFlag{
-				Name:  flags.TaskDefinitionTaskRemote + ",t",
+				Name:  flags.TaskDefinitionRemote + ",t",
 				Usage: "Lists all running containers matching the task family or ARN",
 			},
 			cli.BoolFlag{
-				Name:  flags.JsonFlag,
+				Name:  flags.JSON,
 				Usage: "Output in JSON format.",
 			},
 		},


### PR DESCRIPTION
Add the `--task-def-compose` flag to `up`, `create`, and `down`.

Fixes https://github.com/aws/amazon-ecs-cli/issues/809



----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**  
- [x] Unit tests passed
- [x] Integration tests passed
- [ ] Unit tests added for new functionality
- [x] Listed manual checks and their outputs in the comments ([example](https://github.com/aws/amazon-ecs-cli/pull/750#issuecomment-472623042))
- [ ] Link to issue or PR for the integration tests: 

**Documentation**  
- [ ] Contacted our doc writer
- [ ] Updated our README
----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
