### PR TITLE
added print out task definition revision

### DIFF
--- a/ecs-cli/modules/cli/local/localproject/project.go
+++ b/ecs-cli/modules/cli/local/localproject/project.go
@@ -29,6 +29,7 @@ import (
 	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/config"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ecs"
+	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 )
 
@@ -106,7 +107,7 @@ func (p *localProject) ReadTaskDefinition() error {
 
 	if remote != "" {
 		taskDefinition, err = p.readTaskDefinitionFromRemote(remote)
-		fmt.Printf("Reading task definition from %s:%v\n", aws.StringValue(taskDefinition.Family), aws.Int64Value(taskDefinition.Revision))
+		logrus.Infof("Reading task definition from %s:%v\n", aws.StringValue(taskDefinition.Family), aws.Int64Value(taskDefinition.Revision))
 		if err != nil {
 			return err
 		}

--- a/ecs-cli/modules/cli/local/localproject/project.go
+++ b/ecs-cli/modules/cli/local/localproject/project.go
@@ -27,6 +27,7 @@ import (
 	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/clients/aws/secretsmanager"
 	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/commands/flags"
 	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/config"
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ecs"
 	"github.com/urfave/cli"
 )
@@ -105,6 +106,7 @@ func (p *localProject) ReadTaskDefinition() error {
 
 	if remote != "" {
 		taskDefinition, err = p.readTaskDefinitionFromRemote(remote)
+		fmt.Printf("Reading task definition from %s:%v\n", aws.StringValue(taskDefinition.Family), aws.Int64Value(taskDefinition.Revision))
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Issue #, if available:
#818 
Description of changes:
When running ecs-cli local create/up using a family name, it will print out which exact task definition revision is being used to generate local Docker compose file.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**  
- [x] Unit tests passed
- [x] Integration tests passed
- [ ] Unit tests added for new functionality
- [ ] Listed manual checks and their outputs in the comments ([example](https://github.com/aws/amazon-ecs-cli/pull/750#issuecomment-472623042))
- [ ] Link to issue or PR for the integration tests: 

**Documentation**  
- [ ] Contacted our doc writer
- [ ] Updated our README
----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
