### PR TITLE
Add env vars to retrieve creds and metadata from Endpoints container

### DIFF
--- a/ecs-cli/modules/cli/local/converter/converter_test.go
+++ b/ecs-cli/modules/cli/local/converter/converter_test.go
@@ -59,9 +59,11 @@ func TestConvertToComposeService(t *testing.T) {
 	expectedCapAdd := []string{"NET_ADMIN", "MKNOD"}
 	expectedCapDrop := []string{"KILL"}
 	expectedEnvironment := map[string]*string{
-		"rails_env":   aws.String("development"),
-		"DB_PASSWORD": aws.String("${web_DB_PASSWORD}"),
-		"API_KEY":     aws.String("${web_API_KEY}"),
+		"rails_env":             aws.String("development"),
+		"DB_PASSWORD":           aws.String("${web_DB_PASSWORD}"),
+		"API_KEY":               aws.String("${web_API_KEY}"),
+		ecsCredsProviderEnvName: aws.String(endpointsTempCredsPath),
+		ecsMetadataURIEnvName:   aws.String(endpointsMetadataV3URI),
 	}
 	expectedExtraHosts := []string{"somehost:162.242.195.82", "otherhost:50.31.209.229"}
 	expectedHealthCheck := &composeV3.HealthCheckConfig{
@@ -220,8 +222,8 @@ func TestConvertToComposeService(t *testing.T) {
 	containerDef := taskDefinition.ContainerDefinitions[0]
 
 	commonValues := &CommonContainerValues{
-		Ipc:         expectedIpc,
-		Pid:         expectedPid,
+		Ipc: expectedIpc,
+		Pid: expectedPid,
 	}
 
 	// WHEN


### PR DESCRIPTION
Previously the containers lacked a way of retrieving credentials and metadata information from the Endpoints container. This change stores the information as environment variables on the container.

Addresses #810 

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**  
- [x] Unit tests passed
- [x] Integration tests passed
- [x] Unit tests added for new functionality
- [x] Listed manual checks and their outputs in the comments ([example](https://github.com/aws/amazon-ecs-cli/pull/750#issuecomment-472623042))
- [ ] Link to issue or PR for the integration tests: 

**Documentation**  
- [ ] Contacted our doc writer
- [ ] Updated our README
----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
