### PR TITLE
Read arn region

### DIFF
--- a/ecs-cli/modules/cli/logs/logs_app.go
+++ b/ecs-cli/modules/cli/logs/logs_app.go
@@ -121,7 +121,7 @@ func getTaskDefArn(context *cli.Context, ecsClient ecsclient.ECSClient, config *
 		return "", errors.Wrap(err, "Failed to Describe Task")
 	}
 	if len(tasks) == 0 {
-		return "", fmt.Errorf("Failed to describe Task: Could Not Find Task %s in cluster %s in region %s. If the task has been stopped, use --%s to specify the Task Definition.", taskID, config.Cluster, aws.StringValue(config.Session.Config.Region), flags.TaskDefinitionFlag)
+		return "", fmt.Errorf("Failed to describe Task: Could Not Find Task %s in cluster %s in region %s. If the task has been stopped, use --%s to specify the Task Definition.", taskID, config.Cluster, config.Region(), flags.TaskDefinitionFlag)
 	}
 
 	return aws.StringValue(tasks[0].TaskDefinitionArn), nil

--- a/ecs-cli/modules/clients/aws/ecr/client.go
+++ b/ecs-cli/modules/clients/aws/ecr/client.go
@@ -68,7 +68,7 @@ func NewClient(config *config.CommandConfig) Client {
 
 // NewFipsClient Creates a new ECR client that will communicate with a FIPS endpoint.
 func NewFipsClient(config *config.CommandConfig) (Client, error) {
-	region := aws.StringValue(config.Session.Config.Region)
+	region := config.Region()
 	resolver := endpoints.DefaultResolver()
 
 	// The convention for FIPS endpoints is to add "-fips" to the official

--- a/ecs-cli/modules/clients/aws/ecs/client.go
+++ b/ecs-cli/modules/clients/aws/ecs/client.go
@@ -104,7 +104,7 @@ func (c *ecsClient) CreateCluster(clusterName string, tags []*ecs.Tag) (string, 
 	}
 	log.WithFields(log.Fields{
 		"cluster": aws.StringValue(resp.Cluster.ClusterName),
-		"region":  aws.StringValue(c.config.Session.Config.Region),
+		"region":  c.config.Region(),
 	}).Info("Created cluster")
 
 	return *resp.Cluster.ClusterName, nil
@@ -248,7 +248,7 @@ func cachedTaskDefinitionRevisionIsActive(cachedTaskDefinition *ecs.TaskDefiniti
 
 func (c *ecsClient) constructTaskDefinitionCacheHash(taskDefinition *ecs.TaskDefinition, request *ecs.RegisterTaskDefinitionInput) string {
 	// Get the region from the ecsClient configuration
-	region := aws.StringValue(c.config.Session.Config.Region)
+	region := c.config.Region()
 	awsUserAccountId := utils.GetAwsAccountIdFromArn(aws.StringValue(taskDefinition.TaskDefinitionArn))
 	sortedRequestString, err := adapter.SortedGoString(adapter.SortedContainerDefinitionsByName(request))
 	if err != nil {

--- a/ecs-cli/modules/clients/aws/route53/servicediscovery_client.go
+++ b/ecs-cli/modules/clients/aws/route53/servicediscovery_client.go
@@ -47,7 +47,7 @@ type WaitUntilSDSDeletableFunc func(id string, config *config.CommandConfig) err
 func FindPrivateNamespace(name, vpc string, config *config.CommandConfig) (*string, error) {
 	r53Client := newRoute53Client(config)
 	sdClient := newSDClient(config)
-	return findPrivateNamespace(name, vpc, aws.StringValue(config.Session.Config.Region), r53Client, sdClient)
+	return findPrivateNamespace(name, vpc, config.Region(), r53Client, sdClient)
 }
 
 // private function findPrivateNamespace can accept mock client objects, allowing it to be unit tested

--- a/ecs-cli/modules/config/command_config.go
+++ b/ecs-cli/modules/config/command_config.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/commands/flags"
 	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/pkg/errors"
 	"github.com/urfave/cli"
 )
@@ -38,6 +39,10 @@ type CommandConfig struct {
 	ComposeProjectNamePrefix string // Deprecated; remains for backwards compatibility
 	CFNStackName             string
 	LaunchType               string
+}
+
+func (c *CommandConfig) Region() string {
+	return aws.StringValue(c.Session.Config.Region)
 }
 
 // Searches as far up the context as necessary. This function works no matter

--- a/ecs-cli/modules/config/command_config_test.go
+++ b/ecs-cli/modules/config/command_config_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 
 	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/commands/flags"
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/stretchr/testify/assert"
 	"github.com/urfave/cli"
 )
@@ -99,7 +98,7 @@ func TestNewCommandConfigFromEnvVarsWithRegionSpecifiedAsEnvVariable(t *testing.
 	config, err := NewCommandConfig(context, rdwr)
 	assert.NoError(t, err, "Unexpected error when region is specified using environment variable AWS_REGION")
 
-	configRegion := aws.StringValue(config.Session.Config.Region)
+	configRegion := config.Region()
 	assert.Equal(t, region, configRegion, "Region should match")
 }
 
@@ -115,7 +114,7 @@ func TestNewCommandConfigFromEnvVarsWithRegionSpecifiedinAwsDefaultEnvVariable(t
 	config, err := NewCommandConfig(context, rdwr)
 	assert.NoError(t, err, "Unexpected error when region is specified using environment variable AWS_DEFAULT_REGION")
 
-	configRegion := aws.StringValue(config.Session.Config.Region)
+	configRegion := config.Region()
 	assert.Equal(t, region, configRegion, "Region should match")
 }
 
@@ -136,7 +135,7 @@ func TestNewCommandConfigFromConfig(t *testing.T) {
 	config, err := NewCommandConfig(context, rdwr)
 	assert.NoError(t, err, "Unexpected error when region is specified")
 
-	configRegion := aws.StringValue(config.Session.Config.Region)
+	configRegion := config.Region()
 	assert.Equal(t, region, configRegion, "Region should match")
 }
 


### PR DESCRIPTION
Previously, passing a full task definition ARN to `local up` would not account for the region specified in the ARN and would default to the region configuration of the ECS client. This change enables local up to fetch and run a task definition from the correct region specified in its ARN.

Fixes #821 

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**  
- [x] Unit tests passed
- [x] Integration tests passed
- [ ] Unit tests added for new functionality
- [x] Listed manual checks and their outputs in the comments ([example](https://github.com/aws/amazon-ecs-cli/pull/750#issuecomment-472623042))
- [ ] Link to issue or PR for the integration tests: 

**Documentation**  
- [ ] Contacted our doc writer
- [ ] Updated our README
----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
