### PR TITLE
Convert task definition to default Compose override config

### DIFF
--- a/ecs-cli/modules/cli/local/converter/converter.go
+++ b/ecs-cli/modules/cli/local/converter/converter.go
@@ -89,8 +89,8 @@ const composeVersion = "3.2"
 // See https://github.com/aws/amazon-ecs-cli/issues/797
 const SecretLabelPrefix = "ecs-local.secret"
 
-// ConvertToCompose creates the payload from an ECS Task Definition to be written as a docker compose file
-func ConvertToCompose(taskDefinition *ecs.TaskDefinition, metadata *LocalCreateMetadata) (*composeV3.Config, error) {
+// ConvertToComposeConfig translates an ECS Task Definition to a the Docker Compose config and returns it.
+func ConvertToComposeConfig(taskDefinition *ecs.TaskDefinition, metadata *LocalCreateMetadata) (*composeV3.Config, error) {
 	services, err := createComposeServices(taskDefinition, metadata)
 	if err != nil {
 		return nil, err

--- a/ecs-cli/modules/cli/local/converter/marshal.go
+++ b/ecs-cli/modules/cli/local/converter/marshal.go
@@ -1,0 +1,25 @@
+// Copyright 2015-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package converter
+
+import (
+	composeV3 "github.com/docker/cli/cli/compose/types"
+	"gopkg.in/yaml.v2"
+)
+
+// MarshalComposeConfig serializes a Docker Compose object into a YAML document.
+func MarshalComposeConfig(conf composeV3.Config, filename string) ([]byte, error) {
+	conf.Filename = filename
+	return yaml.Marshal(conf)
+}

--- a/ecs-cli/modules/cli/local/converter/marshal.go
+++ b/ecs-cli/modules/cli/local/converter/marshal.go
@@ -19,7 +19,7 @@ import (
 )
 
 // MarshalComposeConfig serializes a Docker Compose object into a YAML document.
-func MarshalComposeConfig(conf composeV3.Config, filename string) ([]byte, error) {
-	conf.Filename = filename
-	return yaml.Marshal(conf)
+func MarshalComposeConfig(config composeV3.Config, filename string) ([]byte, error) {
+	config.Filename = filename
+	return yaml.Marshal(config)
 }

--- a/ecs-cli/modules/cli/local/converter/override.go
+++ b/ecs-cli/modules/cli/local/converter/override.go
@@ -40,7 +40,7 @@ func ConvertToComposeOverride(taskDefinition *ecs.TaskDefinition) (*composeV3.Co
 
 	var services []composeV3.ServiceConfig
 	for _, container := range taskDefinition.ContainerDefinitions {
-		conf := composeV3.ServiceConfig{
+		config := composeV3.ServiceConfig{
 			Name: aws.StringValue(container.Name),
 			Environment: composeV3.MappingWithEquals{
 				ecsCredsProviderEnvName: aws.String(endpointsTempCredsPath),
@@ -49,7 +49,7 @@ func ConvertToComposeOverride(taskDefinition *ecs.TaskDefinition) (*composeV3.Co
 				Driver: jsonFileLogDriver,
 			},
 		}
-		services = append(services, conf)
+		services = append(services, config)
 	}
 
 	return &composeV3.Config{

--- a/ecs-cli/modules/cli/local/converter/override.go
+++ b/ecs-cli/modules/cli/local/converter/override.go
@@ -1,0 +1,59 @@
+// Copyright 2015-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package converter
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ecs"
+	composeV3 "github.com/docker/cli/cli/compose/types"
+	"github.com/pkg/errors"
+)
+
+const (
+	// jsonFileLogDriver is the default Docker logger.
+	jsonFileLogDriver = "json-file"
+)
+
+// ConvertToComposeOverride returns a Docker Compose object to be used to override containers defined
+// in the task definition.
+//
+// Overrides the AWS_CONTAINER_CREDENTIALS_RELATIVE_URI environment variable to "/creds" for every service.
+// Overrides the logging driver to "json-file" for every service.
+func ConvertToComposeOverride(taskDefinition *ecs.TaskDefinition) (*composeV3.Config, error) {
+	if taskDefinition == nil {
+		return nil, errors.New("task definition cannot be nil")
+	}
+	if len(taskDefinition.ContainerDefinitions) == 0 {
+		return nil, errors.New("task definition needs to have container definitions")
+	}
+
+	var services []composeV3.ServiceConfig
+	for _, container := range taskDefinition.ContainerDefinitions {
+		conf := composeV3.ServiceConfig{
+			Name: aws.StringValue(container.Name),
+			Environment: composeV3.MappingWithEquals{
+				ecsCredsProviderEnvName: aws.String(endpointsTempCredsPath),
+			},
+			Logging: &composeV3.LoggingConfig{
+				Driver: jsonFileLogDriver,
+			},
+		}
+		services = append(services, conf)
+	}
+
+	return &composeV3.Config{
+		Version:  composeVersion,
+		Services: services,
+	}, nil
+}

--- a/ecs-cli/modules/cli/local/converter/override_test.go
+++ b/ecs-cli/modules/cli/local/converter/override_test.go
@@ -72,7 +72,7 @@ func TestConvertToCompose(t *testing.T) {
 						Name: aws.String("app"),
 					},
 					{
-						Name: aws.String("db"),
+						Name: aws.String("envoyproxy"),
 					},
 				},
 			},
@@ -89,7 +89,7 @@ func TestConvertToCompose(t *testing.T) {
 						},
 					},
 					{
-						Name: "db",
+						Name: "envoyproxy",
 						Environment: composeV3.MappingWithEquals{
 							ecsCredsProviderEnvName: aws.String(endpointsTempCredsPath),
 						},

--- a/ecs-cli/modules/cli/local/converter/override_test.go
+++ b/ecs-cli/modules/cli/local/converter/override_test.go
@@ -1,0 +1,117 @@
+// Copyright 2015-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package converter
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ecs"
+	composeV3 "github.com/docker/cli/cli/compose/types"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConvertToCompose(t *testing.T) {
+	testCases := map[string]struct {
+		input         *ecs.TaskDefinition
+		wantedCompose *composeV3.Config
+		wantedError   error
+	}{
+		"nil task definition": {
+			input:         nil,
+			wantedCompose: nil,
+			wantedError:   errors.New("task definition cannot be nil"),
+		},
+		"no containers": {
+			input: &ecs.TaskDefinition{
+				ContainerDefinitions: []*ecs.ContainerDefinition{},
+			},
+			wantedCompose: nil,
+			wantedError:   errors.New("task definition needs to have container definitions"),
+		},
+		"single container definition": {
+			input: &ecs.TaskDefinition{
+				ContainerDefinitions: []*ecs.ContainerDefinition{
+					{
+						Name: aws.String("app"),
+					},
+				},
+			},
+			wantedCompose: &composeV3.Config{
+				Version: composeVersion,
+				Services: composeV3.Services{
+					{
+						Name: "app",
+						Environment: composeV3.MappingWithEquals{
+							ecsCredsProviderEnvName: aws.String(endpointsTempCredsPath),
+						},
+						Logging: &composeV3.LoggingConfig{
+							Driver: jsonFileLogDriver,
+						},
+					},
+				},
+			},
+			wantedError: nil,
+		},
+		"multiple container definitions": {
+			input: &ecs.TaskDefinition{
+				ContainerDefinitions: []*ecs.ContainerDefinition{
+					{
+						Name: aws.String("app"),
+					},
+					{
+						Name: aws.String("db"),
+					},
+				},
+			},
+			wantedCompose: &composeV3.Config{
+				Version: composeVersion,
+				Services: composeV3.Services{
+					{
+						Name: "app",
+						Environment: composeV3.MappingWithEquals{
+							ecsCredsProviderEnvName: aws.String(endpointsTempCredsPath),
+						},
+						Logging: &composeV3.LoggingConfig{
+							Driver: jsonFileLogDriver,
+						},
+					},
+					{
+						Name: "db",
+						Environment: composeV3.MappingWithEquals{
+							ecsCredsProviderEnvName: aws.String(endpointsTempCredsPath),
+						},
+						Logging: &composeV3.LoggingConfig{
+							Driver: jsonFileLogDriver,
+						},
+					},
+				},
+			},
+			wantedError: nil,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			actualCompose, actualErr := ConvertToComposeOverride(tc.input)
+
+			if tc.wantedError != nil {
+				require.EqualError(t, actualErr, tc.wantedError.Error())
+			} else {
+				require.Equal(t, tc.wantedCompose, actualCompose)
+			}
+		})
+	}
+}

--- a/ecs-cli/modules/cli/local/localproject/project.go
+++ b/ecs-cli/modules/cli/local/localproject/project.go
@@ -201,14 +201,16 @@ var readTaskDefFromRemote = func(remote string, p *localProject) (*ecs.TaskDefin
 // Convert translates an ECS Task Definition into a Compose V3 schema and
 // stores the data on the project
 func (p *localProject) Convert() error {
-	data, err := converter.ConvertToDockerCompose(p.taskDefinition, p.inputMetadata)
-
+	conf, err := converter.ConvertToCompose(p.taskDefinition, p.inputMetadata)
+	if err != nil {
+		return err
+	}
+	data, err := converter.MarshalComposeConfig(*conf, LocalOutDefaultFileName)
 	if err != nil {
 		return err
 	}
 
 	p.localBytes = data
-
 	return nil
 }
 

--- a/ecs-cli/modules/cli/local/localproject/project.go
+++ b/ecs-cli/modules/cli/local/localproject/project.go
@@ -201,7 +201,7 @@ var readTaskDefFromRemote = func(remote string, p *localProject) (*ecs.TaskDefin
 // Convert translates an ECS Task Definition into a Compose V3 schema and
 // stores the data on the project
 func (p *localProject) Convert() error {
-	conf, err := converter.ConvertToCompose(p.taskDefinition, p.inputMetadata)
+	conf, err := converter.ConvertToComposeConfig(p.taskDefinition, p.inputMetadata)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
**Issue #, if available**: Related to https://github.com/aws/amazon-ecs-cli/issues/831

**Description of changes**: Override the `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI` environment variable and `logging.driver` field for every service in the Compose file.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**  
- [x] Unit tests passed
- [x] Integration tests passed
- [x] Unit tests added for new functionality
- [x] Listed manual checks and their outputs in the comments ([example](https://github.com/aws/amazon-ecs-cli/pull/750#issuecomment-472623042))
- [ ] Link to issue or PR for the integration tests: 

**Documentation**  
- [ ] Contacted our doc writer
- [ ] Updated our README
----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
