### PR TITLE
Write an override compose file with local create

### DIFF
--- a/ecs-cli/modules/cli/local/create_app.go
+++ b/ecs-cli/modules/cli/local/create_app.go
@@ -23,6 +23,13 @@ import (
 	"github.com/urfave/cli"
 )
 
+// TaskReadConvertWriter is the interface that groups the ReadTaskDefinition, Convert, and Write methods.
+type TaskReadConvertWriter interface {
+	ReadTaskDefinition() error
+	Convert() error
+	Write() error
+}
+
 // Create reads in an ECS task definition, converts and writes it to a local
 // Docker Compose file
 func Create(c *cli.Context) {
@@ -36,7 +43,7 @@ func Create(c *cli.Context) {
 	fmt.Printf("Successfully wrote %s\n", project.LocalOutFileName())
 }
 
-func createLocal(project localproject.LocalProject) error {
+func createLocal(project TaskReadConvertWriter) error {
 	// Reads task definition and loads it onto project
 	err := project.ReadTaskDefinition()
 	if err != nil {

--- a/ecs-cli/modules/cli/local/create_app.go
+++ b/ecs-cli/modules/cli/local/create_app.go
@@ -33,8 +33,7 @@ type TaskReadConvertWriter interface {
 func Create(c *cli.Context) {
 	project := localproject.New(c)
 
-	err := createLocal(project)
-	if err != nil {
+	if err := createLocal(project); err != nil {
 		log.Fatalf("Error with local create: %s", err.Error())
 	}
 }

--- a/ecs-cli/modules/cli/local/create_app.go
+++ b/ecs-cli/modules/cli/local/create_app.go
@@ -16,8 +16,6 @@
 package local
 
 import (
-	"fmt"
-
 	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/cli/local/localproject"
 	log "github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
@@ -39,8 +37,6 @@ func Create(c *cli.Context) {
 	if err != nil {
 		log.Fatalf("Error with local create: %s", err.Error())
 	}
-
-	fmt.Printf("Successfully wrote %s\n", project.LocalOutFileName())
 }
 
 func createLocal(project TaskReadConvertWriter) error {

--- a/ecs-cli/modules/cli/local/localproject/project.go
+++ b/ecs-cli/modules/cli/local/localproject/project.go
@@ -11,7 +11,7 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-// Package localproject defines LocalProject interface and implements them on LocalProject
+// Package localproject provides functionality to retrieve a task definition, convert it to a Docker Compose config, and write it to a file.
 package localproject
 
 import (
@@ -54,7 +54,7 @@ const (
 	LocalInFileName = "task-definition.json"
 )
 
-// LocalProject holds data needed to convert an ECS Task Definition to a Docker Compose file.
+// LocalProject holds data needed to convert an ECS Task Definition to Docker Compose files.
 type LocalProject struct {
 	context         *cli.Context
 	taskDefinition  *ecs.TaskDefinition

--- a/ecs-cli/modules/cli/local/localproject/project_test.go
+++ b/ecs-cli/modules/cli/local/localproject/project_test.go
@@ -11,7 +11,7 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-// Package localproject defines LocalProject interface and implements them on localProject
+// Package localproject defines LocalProject interface and implements them on LocalProject
 
 package localproject
 
@@ -54,7 +54,7 @@ func TestReadTaskDefinition_FromRemote(t *testing.T) {
 	}
 
 	oldRead := readTaskDefFromRemote
-	readTaskDefFromRemote = func(remote string, p *localProject) (*ecs.TaskDefinition, error) {
+	readTaskDefFromRemote = func(remote string, p *LocalProject) (*ecs.TaskDefinition, error) {
 		return mockTaskDef(), nil
 	}
 	defer func() { readTaskDefFromRemote = oldRead }()


### PR DESCRIPTION
**Description of changes**: Writes a default `docker-compose.ecs-local.override.yml` if no `-o` flag is provided. Otherwise, creates a `{customName}.override.yml` file.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**  
- [x] Unit tests passed
- [x] Integration tests passed
- [ ] Unit tests added for new functionality
- [x] Listed manual checks and their outputs in the comments ([example](https://github.com/aws/amazon-ecs-cli/pull/750#issuecomment-472623042))
- [ ] Link to issue or PR for the integration tests: 

**Documentation**  
- [ ] Contacted our doc writer
- [ ] Updated our README
----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
