### PR TITLE
Support override Compose files for "local up"

### DIFF
--- a/ecs-cli/modules/cli/local/up_app.go
+++ b/ecs-cli/modules/cli/local/up_app.go
@@ -51,7 +51,7 @@ func Up(c *cli.Context) {
 	if err != nil {
 		logrus.Fatalf("Failed to create Compose files due to:\n%v", err)
 	}
-	overridePaths, err := composeOverridePaths(basePath, c.StringSlice(flags.AddOverrides))
+	overridePaths, err := composeOverridePaths(basePath, c.StringSlice(flags.ComposeOverride))
 	if err != nil {
 		logrus.Fatalf("Failed to get the path of override Compose files due to:\n%v", err)
 	}

--- a/ecs-cli/modules/cli/local/up_app.go
+++ b/ecs-cli/modules/cli/local/up_app.go
@@ -50,7 +50,7 @@ func Up(c *cli.Context) {
 	if err != nil {
 		logrus.Fatalf("Failed to create Compose files due to:\n%v", err)
 	}
-	overridePaths, err := composeOverridePaths(basePath, c)
+	overridePaths, err := composeOverridePaths(basePath, c.StringSlice(flags.AddOverrides))
 	if err != nil {
 		logrus.Fatalf("Failed to get the path of override Compose files due to:\n%v", err)
 	}
@@ -97,9 +97,18 @@ func createNewComposeProject(c *cli.Context) (string, error) {
 	return filepath.Abs(project.LocalOutFileName())
 }
 
-func composeOverridePaths(basePath string, c *cli.Context) ([]string, error) {
+func composeOverridePaths(basePath string, additionalRelPaths []string) ([]string, error) {
 	defaultPath := basePath[:len(basePath)-len(filepath.Ext(basePath))] + ".override.yml"
 	paths := []string{defaultPath}
+	if len(additionalRelPaths) > 0 {
+		for _, relPath := range additionalRelPaths {
+			p, err := filepath.Abs(relPath)
+			if err != nil {
+				return nil, errors.Wrapf(err, "cannot get absolute path of %s", relPath)
+			}
+			paths = append(paths, p)
+		}
+	}
 
 	// Prune paths that don't exist
 	var overridePaths []string

--- a/ecs-cli/modules/cli/local/up_app.go
+++ b/ecs-cli/modules/cli/local/up_app.go
@@ -14,6 +14,7 @@
 package local
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"os/exec"
@@ -198,7 +199,7 @@ func upCompose(envVars map[string]string, basePath string, overridePaths []strin
 	envs = append(envs, fmt.Sprintf("PATH=%s", os.Getenv("PATH")))
 
 	// Gather command arguments
-	var b strings.Builder
+	var b bytes.Buffer
 	b.WriteString(filepath.Base(basePath))
 	args := []string{"-f", basePath}
 	for _, p := range overridePaths {

--- a/ecs-cli/modules/commands/flags/flags.go
+++ b/ecs-cli/modules/commands/flags/flags.go
@@ -151,7 +151,7 @@ const (
 	TaskDefinitionFile    = "task-def-file"
 	TaskDefinitionRemote  = "task-def-remote"
 	TaskDefinitionCompose = "task-def-compose"
-	AddOverrides          = "add-overrides"
+	ComposeOverride       = "override"
 	Output                = "output"
 	JSON                  = "json"
 	All                   = "all"

--- a/ecs-cli/modules/commands/flags/flags.go
+++ b/ecs-cli/modules/commands/flags/flags.go
@@ -151,6 +151,7 @@ const (
 	TaskDefinitionFile    = "task-def-file"
 	TaskDefinitionRemote  = "task-def-remote"
 	TaskDefinitionCompose = "task-def-compose"
+	AddOverrides          = "add-overrides"
 	Output                = "output"
 	JSON                  = "json"
 	All                   = "all"

--- a/ecs-cli/modules/commands/local/local_command.go
+++ b/ecs-cli/modules/commands/local/local_command.go
@@ -88,6 +88,10 @@ func upCommand() cli.Command {
 				Name:  flagName(flags.TaskDefinitionRemote),
 				Usage: flagDescription(flags.TaskDefinitionRemote, upCmdName),
 			},
+			cli.StringSliceFlag{
+				Name:  flagName(flags.AddOverrides),
+				Usage: flagDescription(flags.AddOverrides, upCmdName),
+			},
 			cli.StringFlag{
 				Name:  flagName(flags.Output),
 				Usage: flagDescription(flags.Output, upCmdName),
@@ -149,6 +153,7 @@ func flagName(longName string) string {
 		flags.TaskDefinitionCompose: flags.TaskDefinitionCompose + ",c",
 		flags.TaskDefinitionFile:    flags.TaskDefinitionFile + ",f",
 		flags.TaskDefinitionRemote:  flags.TaskDefinitionRemote + ",r",
+		flags.AddOverrides:          flags.AddOverrides + ", a",
 		flags.Output:                flags.Output + ",o",
 		flags.JSON:                  flags.JSON,
 		flags.All:                   flags.All,
@@ -172,6 +177,9 @@ func flagDescription(longName, cmdName string) string {
 			upCmdName:     "The `arnOrFamily` of a task definition to convert and run.",
 			psCmdName:     "List all running containers matching the task definition `arnOrFamily`.",
 			downCmdName:   "Stop and remove all running containers matching the task definition `arnOrFamily`.",
+		},
+		flags.AddOverrides: {
+			upCmdName: "The file `name` of an additional Compose override file.",
 		},
 		flags.Output: {
 			createCmdName: fmt.Sprintf("The Compose file `name` to write to. If not specified, defaults to %s", project.LocalOutDefaultFileName),

--- a/ecs-cli/modules/commands/local/local_command.go
+++ b/ecs-cli/modules/commands/local/local_command.go
@@ -88,13 +88,13 @@ func upCommand() cli.Command {
 				Name:  flagName(flags.TaskDefinitionRemote),
 				Usage: flagDescription(flags.TaskDefinitionRemote, upCmdName),
 			},
-			cli.StringSliceFlag{
-				Name:  flagName(flags.AddOverrides),
-				Usage: flagDescription(flags.AddOverrides, upCmdName),
-			},
 			cli.StringFlag{
 				Name:  flagName(flags.Output),
 				Usage: flagDescription(flags.Output, upCmdName),
+			},
+			cli.StringSliceFlag{
+				Name:  flagName(flags.ComposeOverride),
+				Usage: flagDescription(flags.ComposeOverride, upCmdName),
 			},
 		},
 	}
@@ -153,8 +153,8 @@ func flagName(longName string) string {
 		flags.TaskDefinitionCompose: flags.TaskDefinitionCompose + ",c",
 		flags.TaskDefinitionFile:    flags.TaskDefinitionFile + ",f",
 		flags.TaskDefinitionRemote:  flags.TaskDefinitionRemote + ",r",
-		flags.AddOverrides:          flags.AddOverrides + ", a",
 		flags.Output:                flags.Output + ",o",
+		flags.ComposeOverride:       flags.ComposeOverride,
 		flags.JSON:                  flags.JSON,
 		flags.All:                   flags.All,
 	}
@@ -178,7 +178,7 @@ func flagDescription(longName, cmdName string) string {
 			psCmdName:     "List all running containers matching the task definition `arnOrFamily`.",
 			downCmdName:   "Stop and remove all running containers matching the task definition `arnOrFamily`.",
 		},
-		flags.AddOverrides: {
+		flags.ComposeOverride: {
 			upCmdName: "The file `name` of an additional Compose override file.",
 		},
 		flags.Output: {


### PR DESCRIPTION
**Description of changes**: Added a `--add-overrides` flag that's passed down to docker-compose. This way users can specify additional override files besides the default one that we generate.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**  
- [x] Unit tests passed
- [x] Integration tests passed
- [ ] Unit tests added for new functionality
- [x] Listed manual checks and their outputs in the comments ([example](https://github.com/aws/amazon-ecs-cli/pull/750#issuecomment-472623042))
- [ ] Link to issue or PR for the integration tests: 

**Documentation**  
- [ ] Contacted our doc writer
- [ ] Updated our README
----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
