### PR TITLE
Remove --task-def-compose from local ps and down

### DIFF
--- a/ecs-cli/integ/e2e/local_test.go
+++ b/ecs-cli/integ/e2e/local_test.go
@@ -16,11 +16,9 @@
 package e2e
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/aws/amazon-ecs-cli/ecs-cli/integ"
-	project "github.com/aws/amazon-ecs-cli/ecs-cli/modules/cli/local/localproject"
 	"github.com/stretchr/testify/require"
 )
 
@@ -41,9 +39,14 @@ func TestECSLocal(t *testing.T) {
 					args: []string{"local", "ps"},
 					execute: func(t *testing.T, args []string) {
 						stdout, err := integ.RunCmd(t, args)
-						require.Error(t, err, "expected args=%v to fail", args)
+						require.NoError(t, err)
 						stdout.TestHasAllSubstrings(t, []string{
-							fmt.Sprintf("%s does not exist", project.LocalOutDefaultFileName),
+							"CONTAINER ID",
+							"IMAGE",
+							"STATUS",
+							"PORTS",
+							"NAMES",
+							"TASKDEFINITION",
 						})
 					},
 				},
@@ -76,9 +79,9 @@ func TestECSLocal(t *testing.T) {
 					args: []string{"local", "down"},
 					execute: func(t *testing.T, args []string) {
 						stdout, err := integ.RunCmd(t, args)
-						require.Error(t, err, "expected args=%v to fail", args)
+						require.NoError(t, err)
 						stdout.TestHasAllSubstrings(t, []string{
-							fmt.Sprintf("%s does not exist", project.LocalOutDefaultFileName),
+							"No running ECS local tasks found",
 						})
 					},
 				},

--- a/ecs-cli/modules/commands/local/local_command.go
+++ b/ecs-cli/modules/commands/local/local_command.go
@@ -103,10 +103,6 @@ func psCommand() cli.Command {
 		Action: local.Ps,
 		Flags: []cli.Flag{
 			cli.StringFlag{
-				Name:  flagName(flags.TaskDefinitionCompose),
-				Usage: flagDescription(flags.TaskDefinitionCompose, psCmdName),
-			},
-			cli.StringFlag{
 				Name:  flagName(flags.TaskDefinitionFile),
 				Usage: flagDescription(flags.TaskDefinitionFile, psCmdName),
 			},
@@ -132,10 +128,6 @@ func downCommand() cli.Command {
 		Usage:  "Stop and remove a running ECS task.",
 		Action: local.Down,
 		Flags: []cli.Flag{
-			cli.StringFlag{
-				Name:  flagName(flags.TaskDefinitionCompose),
-				Usage: flagDescription(flags.TaskDefinitionCompose, downCmdName),
-			},
 			cli.StringFlag{
 				Name:  flagName(flags.TaskDefinitionFile),
 				Usage: flagDescription(flags.TaskDefinitionFile, downCmdName),
@@ -167,9 +159,7 @@ func flagName(longName string) string {
 func flagDescription(longName, cmdName string) string {
 	m := map[string]map[string]string{
 		flags.TaskDefinitionCompose: {
-			upCmdName:   "The Compose file `name` of a task definition to run.",
-			psCmdName:   "List containers created from the Compose file `name`.",
-			downCmdName: "Stop and remove containers from the Compose file `name`.",
+			upCmdName: "The Compose file `name` of a task definition to run.",
 		},
 		flags.TaskDefinitionFile: {
 			createCmdName: fmt.Sprintf("The file `name` of a task definition json to convert. If not specified, defaults to %s", project.LocalInFileName),


### PR DESCRIPTION
**Description of changes**: The custom named Compose files already contain our labels `ecs-local.*` so there is no need to take `-c` as a flag.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**  
- [x] Unit tests passed
- [x] Integration tests passed
- [ ] Unit tests added for new functionality
- [x] Listed manual checks and their outputs in the comments ([example](https://github.com/aws/amazon-ecs-cli/pull/750#issuecomment-472623042))
- [ ] Link to issue or PR for the integration tests: 

**Documentation**  
- [ ] Contacted our doc writer
- [ ] Updated our README
----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
