### PR TITLE
Support using relative path when specifying task def file

### DIFF
--- a/ecs-cli/modules/cli/local/localproject/project.go
+++ b/ecs-cli/modules/cli/local/localproject/project.go
@@ -92,6 +92,10 @@ func (p *LocalProject) LocalOutFileName() string {
 	return LocalOutDefaultFileName
 }
 
+func (p *LocalProject) LocalOutFileFullPath() (string, error) {
+	return filepath.Abs(p.LocalOutFileName())
+}
+
 // OverrideFileName returns the name of the override Compose file.
 func (p *LocalProject) OverrideFileName() string {
 	baseName := p.LocalOutFileName()

--- a/ecs-cli/modules/cli/local/localproject/project.go
+++ b/ecs-cli/modules/cli/local/localproject/project.go
@@ -128,13 +128,23 @@ func (p *LocalProject) ReadTaskDefinition() error {
 			return err
 		}
 	} else if filename != "" {
+		filename, err = filepath.Abs(filename)
+		if err != nil {
+			return err
+		}
+
 		taskDefinition, err = p.readTaskDefinitionFromFile(filename)
 		if err != nil {
 			return err
 		}
 
 	} else if defaultInputExists() {
-		taskDefinition, err = p.readTaskDefinitionFromFile(LocalInFileName)
+		filename, err = filepath.Abs(LocalInFileName)
+		if err != nil {
+			return err
+		}
+
+		taskDefinition, err = p.readTaskDefinitionFromFile(filename)
 		if err != nil {
 			return err
 		}

--- a/ecs-cli/modules/cli/local/localproject/project_test.go
+++ b/ecs-cli/modules/cli/local/localproject/project_test.go
@@ -19,6 +19,7 @@ import (
 	"flag"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/cli/local/converter"
@@ -158,9 +159,10 @@ func TestReadTaskDefinition_FromLocal(t *testing.T) {
 	project := New(context)
 
 	expectedTaskDef := mockTaskDef()
+	expectedLabelValue, _ := filepath.Abs(taskDefFile)
 	expectedMetadata := &converter.LocalCreateMetadata{
 		InputType: LocalTaskDefType,
-		Value:     taskDefFile,
+		Value:     expectedLabelValue,
 	}
 
 	oldRead := readTaskDefFromLocal
@@ -191,9 +193,10 @@ func TestReadTaskDefinition_FromLocalDefault(t *testing.T) {
 	defer func() { defaultInputExists = oldDefaultInputExists }()
 
 	expectedTaskDef := mockTaskDef()
+	expectedLabelValue, _ := filepath.Abs(LocalInFileName)
 	expectedMetadata := &converter.LocalCreateMetadata{
 		InputType: LocalTaskDefType,
-		Value:     LocalInFileName,
+		Value:     expectedLabelValue,
 	}
 
 	oldRead := readTaskDefFromLocal

--- a/ecs-cli/modules/cli/local/ps_app.go
+++ b/ecs-cli/modules/cli/local/ps_app.go
@@ -15,6 +15,7 @@ package local
 
 import (
 	"encoding/json"
+	"path/filepath"
 	"fmt"
 	"os"
 	"strings"
@@ -70,9 +71,12 @@ func Ps(c *cli.Context) {
 
 func listContainers(c *cli.Context) ([]types.Container, error) {
 	if c.IsSet(flags.TaskDefinitionFile) {
+		file, err := filepath.Abs(c.String(flags.TaskDefinitionFile))
+		if err != nil {
+			return nil, err
+		}
 		return listContainersWithFilters(filters.NewArgs(
-			filters.Arg("label", fmt.Sprintf("%s=%s", converter.TaskDefinitionLabelValue,
-				c.String(flags.TaskDefinitionFile))),
+			filters.Arg("label", fmt.Sprintf("%s=%s", converter.TaskDefinitionLabelValue, file)),
 			filters.Arg("label", fmt.Sprintf("%s=%s", converter.TaskDefinitionLabelType, localproject.LocalTaskDefType)),
 		))
 	}

--- a/ecs-cli/modules/cli/local/ps_app.go
+++ b/ecs-cli/modules/cli/local/ps_app.go
@@ -92,8 +92,14 @@ func listContainers(c *cli.Context) ([]types.Container, error) {
 			filters.Arg("label", converter.TaskDefinitionLabelValue),
 		))
 	}
+
+	defaultFile, err := filepath.Abs(localproject.LocalInFileName)
+	if err != nil {
+		return nil, err
+	}
+
 	return listContainersWithFilters(filters.NewArgs(
-		filters.Arg("label", fmt.Sprintf("%s=%s", converter.TaskDefinitionLabelValue, localproject.LocalInFileName)),
+		filters.Arg("label", fmt.Sprintf("%s=%s", converter.TaskDefinitionLabelValue, defaultFile)),
 		filters.Arg("label", fmt.Sprintf("%s=%s", converter.TaskDefinitionLabelType, localproject.LocalTaskDefType)),
 	))
 }

--- a/ecs-cli/modules/cli/local/up_app.go
+++ b/ecs-cli/modules/cli/local/up_app.go
@@ -39,10 +39,12 @@ import (
 
 // Up creates a Compose file from an ECS task definition and runs it locally.
 //
-// The Amazon ECS Local Endpoints container needs to be running already for any local ECS task to work
-// (see https://github.com/awslabs/amazon-ecs-local-container-endpoints).
-// If the container is not running, this command creates a new network for all local ECS tasks to join
-// and communicate with the Amazon ECS Local Endpoints container.
+// The Amazon ECS Local Endpoints container needs to be running already for any
+// local ECS task to work (see
+// https://github.com/awslabs/amazon-ecs-local-container-endpoints). If the
+// container is not running, this command creates a new network for all local
+// ECS tasks to join and communicate with the Amazon ECS Local Endpoints
+// container.
 func Up(c *cli.Context) {
 	if err := options.ValidateFlagPairs(c); err != nil {
 		logrus.Fatalf(err.Error())
@@ -61,10 +63,11 @@ func Up(c *cli.Context) {
 
 // composeProjectPath creates Compose files if necessary and returns the path of the base Compose file.
 //
-// If the user set the TaskDefinitionCompose flag, then return that Compose file path.
-// If the user doesn't have any flags set, and doesn't have LocalInFileName but has a LocalOutDefaultFileName,
-// then we use the LocalOutDefaultFileName file.
-// Otherwise, we create a new Compose file from the user's flags and return its path.
+// If the user set the TaskDefinitionCompose flag, then return that Compose
+// file path.  If the user doesn't have any flags set, and doesn't have
+// LocalInFileName but has a LocalOutDefaultFileName, then we use the
+// LocalOutDefaultFileName file.  Otherwise, we create a new Compose file from
+// the user's flags and return its path.
 func composeProjectPath(c *cli.Context) (string, error) {
 	if c.IsSet(flags.TaskDefinitionFile) {
 		return createNewComposeProject(c)
@@ -95,7 +98,7 @@ func createNewComposeProject(c *cli.Context) (string, error) {
 	if err := createLocal(project); err != nil {
 		return "", err
 	}
-	return filepath.Abs(project.LocalOutFileName())
+	return project.LocalOutFileFullPath()
 }
 
 func composeOverridePaths(basePath string, additionalRelPaths []string) ([]string, error) {


### PR DESCRIPTION
Previously, specifying the `--file` flag on `local up`, `local ps` and `local down` would assume the file was only in the current directory the command was being run from. This would cause unexpected behavior when task definition files with the same name existed in different directories.

With this change, Local up, ps, and down will correctly recognize the file used to run containers by looking at the absolute path, which is stored in the metadata labels on the local project.

Fixes #834 

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**  
- [x] Unit tests passed
- [x] Integration tests passed
- [x] Unit tests added for new functionality
- [x] Listed manual checks and their outputs in the comments ([example](https://github.com/aws/amazon-ecs-cli/pull/750#issuecomment-472623042))
- [x] Link to issue or PR for the integration tests: 

**Documentation**  
- [ ] Contacted our doc writer
- [ ] Updated our README
----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
