### PR TITLE
Skip overwriting .override file if it already exists

### DIFF
--- a/ecs-cli/modules/cli/local/localproject/project.go
+++ b/ecs-cli/modules/cli/local/localproject/project.go
@@ -269,13 +269,14 @@ func (p *LocalProject) Write() error {
 		return err
 	}
 
-	if err := writeFileIfNotExist(p.OverrideFileName(), p.composeBytes[overrideComposeIndex]); err != nil {
+	if err := writeNewFile(p.OverrideFileName(), p.composeBytes[overrideComposeIndex]); err != nil {
 		return err
 	}
 
 	return nil
 }
 
+// writeFile writes the content to a filename. If the file already exists, then prompts the user for overwrite.
 func writeFile(filename string, content []byte) error {
 	f, err := openFile(filename)
 	defer f.Close()
@@ -290,7 +291,8 @@ func writeFile(filename string, content []byte) error {
 	return err
 }
 
-func writeFileIfNotExist(filename string, content []byte) error {
+// writeNewFile writes the content to a filename only if the file does not already exist.
+func writeNewFile(filename string, content []byte) error {
 	f, err := openFile(filename)
 	defer f.Close()
 

--- a/ecs-cli/modules/cli/local/localproject/project.go
+++ b/ecs-cli/modules/cli/local/localproject/project.go
@@ -268,27 +268,39 @@ func (p *LocalProject) Write() error {
 	if err := writeFile(p.LocalOutFileName(), p.composeBytes[baseComposeIndex]); err != nil {
 		return err
 	}
-	logrus.Infof("Successfully wrote %s", p.LocalOutFileName())
 
-	if err := writeFile(p.OverrideFileName(), p.composeBytes[overrideComposeIndex]); err != nil {
+	if err := writeFileIfNotExist(p.OverrideFileName(), p.composeBytes[overrideComposeIndex]); err != nil {
 		return err
 	}
-	logrus.Infof("Successfully wrote %s", p.OverrideFileName())
 
 	return nil
 }
 
 func writeFile(filename string, content []byte) error {
-	out, err := openFile(filename)
-	defer out.Close()
+	f, err := openFile(filename)
+	defer f.Close()
 
 	// File already exists
 	if err != nil {
 		return overwriteFile(filename, content)
 	}
 
-	_, err = out.Write(content)
+	_, err = f.Write(content)
+	logrus.Infof("Successfully wrote %s", filename)
+	return err
+}
 
+func writeFileIfNotExist(filename string, content []byte) error {
+	f, err := openFile(filename)
+	defer f.Close()
+
+	if err != nil {
+		// File already exists, skip writing it.
+		logrus.Infof("%s already exists, skipping write.", filename)
+		return nil
+	}
+	_, err = f.Write(content)
+	logrus.Infof("Successfully wrote %s", filename)
 	return err
 }
 


### PR DESCRIPTION
If the Compose override file already exists then we log it to the user and don't overwrite it.

Fixes #863


----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**  
- [x] Unit tests passed
- [x] Integration tests passed
- [ ] Unit tests added for new functionality
- [x] Listed manual checks and their outputs in the comments ([example](https://github.com/aws/amazon-ecs-cli/pull/750#issuecomment-472623042))
- [ ] Link to issue or PR for the integration tests: 

**Documentation**  
- [ ] Contacted our doc writer
- [ ] Updated our README
----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
