### PR TITLE
List all containers matching the ecs-local labels

### DIFF
--- a/ecs-cli/modules/cli/local/ps_app.go
+++ b/ecs-cli/modules/cli/local/ps_app.go
@@ -15,9 +15,9 @@ package local
 
 import (
 	"encoding/json"
-	"path/filepath"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"text/tabwriter"
 
@@ -110,6 +110,7 @@ func listContainersWithFilters(args filters.Args) ([]types.Container, error) {
 
 	cl := docker.NewClient()
 	containers, err := cl.ContainerList(ctx, types.ContainerListOptions{
+		All:     true, // Include containers that are not running so that they can be removed with local down.
 		Filters: args,
 	})
 	if err != nil {


### PR DESCRIPTION
Fixes #869 

**Description of changes**: If we don't set `All: true` then containers that were stopped would not be listed and hence not removed when running `local down --all`.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**  
- [x] Unit tests passed
- [x] Integration tests passed
- [ ] Unit tests added for new functionality
- [x] Listed manual checks and their outputs in the comments ([example](https://github.com/aws/amazon-ecs-cli/pull/750#issuecomment-472623042))
- [ ] Link to issue or PR for the integration tests: 

**Documentation**  
- [ ] Contacted our doc writer
- [ ] Updated our README
----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
