### PR TITLE
Cleanup log messages for log driver conversions

### DIFF
--- a/ecs-cli/modules/cli/local/converter/converter.go
+++ b/ecs-cli/modules/cli/local/converter/converter.go
@@ -281,7 +281,7 @@ func convertLogging(logConfig *ecs.LogConfiguration) *composeV3.LoggingConfig {
 	driver := aws.StringValue(logConfig.LogDriver)
 	for _, unsupported := range unsupportedDrivers {
 		if driver == unsupported {
-			log.Warningf("%s will not be supported", unsupported)
+			log.Infof("%s log driver is ignored when running locally. Tasks will default to %s instead. This can be changed in your compose override file.", unsupported, jsonFileLogDriver)
 		}
 	}
 	opts := make(map[string]string)


### PR DESCRIPTION
When we convert a task def, if the log driver is set to
"awslogs", we convert that to use json-file localy (so customers
aren't surprised when their local testing logs don't end up in
CloudWatch).

This change updates the messaging when we do that.

New output:
```
INFO[0000] Task Definition network mode is ignored when running containers locally. Tasks will be run in the ecs-local-network.  networkMode=awsvpc
INFO[0000] awslogs log driver is ignored when running locally. Tasks will default to json-file instead. This can be changed in your compose override file.
INFO[0000] Successfully wrote docker-compose.ecs-local.yml
INFO[0000] Successfully wrote docker-compose.ecs-local.override.yml
```

Fixes #862 


----
**Testing**  
- [x] Unit tests passed
- [x] Integration tests passed
- [ ] (N/A) Unit tests added for new functionality
- [x] Listed manual checks and their outputs in the comments ([example](https://github.com/aws/amazon-ecs-cli/pull/750#issuecomment-472623042))
- [ ]  (N/A) Link to issue or PR for the integration tests: 

**Documentation**  
- [ ] (N/A) Contacted our doc writer
- [ ] (N/A) Updated our README
----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
