### PR TITLE
Bump compose file version to v3.4

### DIFF
--- a/ecs-cli/modules/cli/local/converter/converter.go
+++ b/ecs-cli/modules/cli/local/converter/converter.go
@@ -371,8 +371,7 @@ func convertHealthCheck(healthCheck *ecs.HealthCheck) *composeV3.HealthCheckConf
 		out.Retries = &retries
 	}
 	if healthCheck.StartPeriod != nil {
-		startPeriod := time.Duration(aws.Int64Value(healthCheck.StartPeriod)) * time.Second
-		out.StartPeriod = &startPeriod
+		log.Warn("startPeriod will be ignored and not be supported in the initial release.")
 	}
 
 	return out

--- a/ecs-cli/modules/cli/local/converter/converter.go
+++ b/ecs-cli/modules/cli/local/converter/converter.go
@@ -83,7 +83,7 @@ const (
 )
 
 // composeVersion is the minimum Compose file version supporting task definition fields.
-const composeVersion = "3.2"
+const composeVersion = "3.4"
 
 // SecretLabelPrefix is the prefix of Docker label keys
 // whose value is an ARN of a secret to expose to the container.
@@ -371,7 +371,8 @@ func convertHealthCheck(healthCheck *ecs.HealthCheck) *composeV3.HealthCheckConf
 		out.Retries = &retries
 	}
 	if healthCheck.StartPeriod != nil {
-		log.Warn("startPeriod will be ignored and not be supported in the initial release.")
+		startPeriod := time.Duration(aws.Int64Value(healthCheck.StartPeriod)) * time.Second
+		out.StartPeriod = &startPeriod
 	}
 
 	return out

--- a/ecs-cli/modules/cli/local/converter/converter_test.go
+++ b/ecs-cli/modules/cli/local/converter/converter_test.go
@@ -471,7 +471,6 @@ func TestConvertHealthCheck(t *testing.T) {
 
 	interval := time.Duration(90) * time.Second
 	timeout := time.Duration(10) * time.Second
-	startPeriod := time.Duration(40) * time.Second
 	retries := uint64(3)
 
 	expected := &composeV3.HealthCheckConfig{
@@ -479,7 +478,7 @@ func TestConvertHealthCheck(t *testing.T) {
 		Retries:     &retries,
 		Interval:    &interval,
 		Timeout:     &timeout,
-		StartPeriod: &startPeriod,
+		StartPeriod: nil,
 	}
 	actual := convertHealthCheck(input)
 

--- a/ecs-cli/modules/cli/local/converter/converter_test.go
+++ b/ecs-cli/modules/cli/local/converter/converter_test.go
@@ -471,6 +471,7 @@ func TestConvertHealthCheck(t *testing.T) {
 
 	interval := time.Duration(90) * time.Second
 	timeout := time.Duration(10) * time.Second
+	startPeriod := time.Duration(40) * time.Second
 	retries := uint64(3)
 
 	expected := &composeV3.HealthCheckConfig{
@@ -478,7 +479,7 @@ func TestConvertHealthCheck(t *testing.T) {
 		Retries:     &retries,
 		Interval:    &interval,
 		Timeout:     &timeout,
-		StartPeriod: nil,
+		StartPeriod: &startPeriod,
 	}
 	actual := convertHealthCheck(input)
 


### PR DESCRIPTION
Compose file version is bumped to v3.4 and container with `startPeriod` set now can be started without erroring.

Fixes #868 

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**  
- [x] Unit tests passed
- [x] Integration tests passed
- [ ] Unit tests added for new functionality
- [x] Listed manual checks and their outputs in the comments ([example](https://github.com/aws/amazon-ecs-cli/pull/750#issuecomment-472623042))
- [ ] Link to issue or PR for the integration tests: 

**Documentation**  
- [ ] Contacted our doc writer
- [ ] Updated our README
----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
