### PR TITLE
Added env to suppress the orphaned checking

### DIFF
--- a/ecs-cli/modules/cli/local/up_app.go
+++ b/ecs-cli/modules/cli/local/up_app.go
@@ -201,6 +201,9 @@ func upCompose(envVars map[string]string, basePath string, overridePaths []strin
 	// Need to add $PATH because of --build, see https://stackoverflow.com/a/55371721/1201381
 	envs = append(envs, fmt.Sprintf("PATH=%s", os.Getenv("PATH")))
 
+	// Disable orphaned containers checking
+	envs = append(envs, fmt.Sprint("COMPOSE_IGNORE_ORPHANS=true"))
+
 	// Gather command arguments
 	var b bytes.Buffer
 	b.WriteString(filepath.Base(basePath))


### PR DESCRIPTION
Set environment variable COMPOSE_IGNORE_ORPHANS so that the orphaned container checking is disabled.

Fixes #852

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**  
- [x] Unit tests passed
- [x] Integration tests passed
- [ ] Unit tests added for new functionality
- [ ] Listed manual checks and their outputs in the comments ([example](https://github.com/aws/amazon-ecs-cli/pull/750#issuecomment-472623042))
- [ ] Link to issue or PR for the integration tests: 

**Documentation**  
- [ ] Contacted our doc writer
- [ ] Updated our README
----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
