### PR TITLE
Output progress of docker-compose --build

### DIFF
--- a/ecs-cli/modules/cli/local/up_app.go
+++ b/ecs-cli/modules/cli/local/up_app.go
@@ -222,9 +222,9 @@ func upCompose(envVars map[string]string, basePath string, overridePaths []strin
 	cmd.Stderr = os.Stderr
 
 	if err := cmd.Start(); err != nil {
-		logrus.Fatalf("Failed to start docker-compose due to:\n%v", err)
+		logrus.Fatalf("docker-compose up failed to start due to:\n%v", err)
 	}
 	if err := cmd.Wait(); err != nil {
-		logrus.Fatalf("Failed to exit docker-compose up successfully due to \n%v", err)
+		logrus.Fatalf("docker-compose up failed to exit successfully due to:\n%v", err)
 	}
 }

--- a/ecs-cli/modules/cli/local/up_app.go
+++ b/ecs-cli/modules/cli/local/up_app.go
@@ -218,10 +218,13 @@ func upCompose(envVars map[string]string, basePath string, overridePaths []strin
 	logrus.Infof("Using %s files to start containers", b.String())
 	cmd := exec.Command("docker-compose", args...)
 	cmd.Env = envs
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
 
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		logrus.Fatalf("Failed to run docker-compose up due to \n%v: %s", err, string(out))
+	if err := cmd.Start(); err != nil {
+		logrus.Fatalf("Failed to start docker-compose due to:\n%v", err)
 	}
-	fmt.Printf("Compose out: %s\n", string(out))
+	if err := cmd.Wait(); err != nil {
+		logrus.Fatalf("Failed to exit docker-compose up successfully due to \n%v", err)
+	}
 }


### PR DESCRIPTION
Fixes #864

**Description of changes**: The progress of downloading an image is streamed to stdout whereas previously we would only spit the results at the end once the command finishes.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**  
- [x] Unit tests passed
- [x] Integration tests passed
- [N/A] Unit tests added for new functionality
- [N/A] Listed manual checks and their outputs in the comments ([example](https://github.com/aws/amazon-ecs-cli/pull/750#issuecomment-472623042))
- [N/A] Link to issue or PR for the integration tests: 

**Documentation**  
- [N/A] Contacted our doc writer
- [N/A] Updated our README
----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
