### PR TITLE
update MAKE target integ-test-run-with-coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ integ-test-run:
 .PHONY: integ-test-run-with-coverage
 integ-test-run-with-coverage: integ-test-run
 	@echo "Code coverage"
-	$$GOPATH/bin/gocovmerge $$TMPDIR/coverage* > $$TMPDIR/all.out
+	gocovmerge $$TMPDIR/coverage* > $$TMPDIR/all.out
 	go tool cover -func=$$TMPDIR/all.out
 	rm $$TMPDIR/coverage* $$TMPDIR/all.out
 


### PR DESCRIPTION
Updated `make` target to correct reference to coverage tool.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
- [X] Unit tests passed
- [X] Integration tests passed
- [N/A] Unit tests added for new functionality
- [x] Listed manual checks and their outputs in the comments ()
- [N/A ] Link to issue or PR for the integration tests:

**Documentation**
- [N/A] Contacted our doc writer
- [N/A] Updated our README



### Integ test results (trucated):
```
...
total:                                                      (statements)                    38.6% 
rm $TMPDIR/coverage* $TMPDIR/all.out 
 
[Container] 2019/06/05 21:28:36 Running command ./bin/local/ecs-cli.test 
...
 
PASS 
coverage: 2.3% of statements in ./ecs-cli/modules/... 
 
[Container] 2019/06/05 21:28:36 Phase complete: BUILD State: SUCCEEDED 
[Container] 2019/06/05 21:28:36 Phase context status code:  Message:  
[Container] 2019/06/05 21:28:36 Entering phase POST_BUILD 
[Container] 2019/06/05 21:28:36 Phase complete: POST_BUILD State: SUCCEEDED 
[Container] 2019/06/05 21:28:36 Phase context status code:  Message:  
```
----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
