### PR TITLE
Remove go 1.9 from travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ env:
   - GOCACHE=$HOME/.cache/go-build
 go_import_path: github.com/aws/amazon-ecs-cli
 go:
-    - 1.9.x
     - 1.10.x
     - 1.11.x
     - 1.12.x


### PR DESCRIPTION
Because we live in the future

----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
