### PR TITLE
Pass in environment when running 'local up'

### DIFF
--- a/ecs-cli/modules/cli/local/up_app.go
+++ b/ecs-cli/modules/cli/local/up_app.go
@@ -196,12 +196,13 @@ func decryptSecrets(containerSecrets []*secrets.ContainerSecret) (envVars map[st
 // upCompose starts the containers in the Compose files with the environment variables defined in envVars.
 func upCompose(envVars map[string]string, basePath string, overridePaths []string) {
 	// Gather environment variables
-	var envs []string
+
+	// Pass in $PATH and other env vars needed by docker-compose.
+	// See https://stackoverflow.com/a/55371721/1201381, https://github.com/aws/amazon-ecs-cli/issues/892
+	envs := os.Environ()
 	for env, val := range envVars {
 		envs = append(envs, fmt.Sprintf("%s=%s", env, val))
 	}
-	// Need to add $PATH because of --build, see https://stackoverflow.com/a/55371721/1201381
-	envs = append(envs, fmt.Sprintf("PATH=%s", os.Getenv("PATH")))
 
 	// Disable orphaned containers checking
 	envs = append(envs, "COMPOSE_IGNORE_ORPHANS=true")


### PR DESCRIPTION
* Fixes #892

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
- [x] Unit tests passed
- [N/A] Integration tests passed
- [N/A] Unit tests added for new functionality
- [x] Listed manual checks and their outputs in the comments (see below)
- [N/A ] Link to issue or PR for the integration tests:

**Documentation**
- [N/A ] Contacted our doc writer
- [N/A ] Updated our README


## Test output
```
PS ~\go\src\github.com\aws\amazon-ecs-cli> ./bin/local/ecs-cli.exe local up -f ..\local_test\my-task-definition.json
?[36mINFO?[0m[0000] Task Definition network mode is ignored when running containers locally. Tasks will be run in the ecs-local-network.  ?[36mnetworkMode?[0m=awsvpc
docker-compose.ecs-local.yml file already exists. Do you want to write over this file? [y/N]
y
?[36mINFO?[0m[0002] docker-compose.ecs-local.override.yml already exists, skipping write.
?[36mINFO?[0m[0002] The network ecs-local-network already exists
?[36mINFO?[0m[0002] The amazon-ecs-local-container-endpoints container already exists with ID d64862974635b39b8b673d5a8058c5a66624b7af8e21254806452f43f4811129
?[36mINFO?[0m[0002] Started container with ID d64862974635b39b8b673d5a8058c5a66624b7af8e21254806452f43f4811129
?[36mINFO?[0m[0002] Using docker-compose.ecs-local.yml, docker-compose.ecs-local.override.yml files to start containers
Recreating amazon-ecs-cli_httpd_1 ... done
```
----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
