### PR TITLE
Add new profile language to --instance-role help text

### DIFF
--- a/ecs-cli/modules/commands/cluster/cluster_command.go
+++ b/ecs-cli/modules/commands/cluster/cluster_command.go
@@ -75,7 +75,7 @@ func clusterUpFlags() []cli.Flag {
 		},
 		cli.StringFlag{
 			Name:  flags.InstanceRoleFlag,
-			Usage: "[Optional] Specifies a custom IAM Role for instances in your cluster. Required if --capability-iam is not specified. NOTE: Not applicable for launch type FARGATE.",
+			Usage: "[Optional] Specifies a custom IAM Role for instances in your cluster. A new instance profile will be created and attached to this role. Required if --capability-iam is not specified. NOTE: Not applicable for launch type FARGATE.",
 		},
 		cli.StringFlag{
 			Name:  flags.KeypairNameFlag,


### PR DESCRIPTION
Change help text for `--instance-role` flag in `up` cmd to reflect the fact we create a new instance profile.

### example output
```
PS ~\amazon-ecs-cli> ./bin/local/ecs-cli.exe up --help
NAME:
   ecs-cli.exe up - Creates the ECS cluster (if it does not already exist) and the AWS resources required to set up the cluster.

USAGE:
   ecs-cli.exe up [command options] [arguments...]

OPTIONS:
   --capability-iam                  Acknowledges that this command may create IAM resources. Required if --instance-role is not specified. NOTE: Not applicable for launch type FARGATE or when creating an empty cluster.
   --empty, -e                       [Optional] Specifies that an ECS cluster will be created with no resources.
   --instance-role value             [Optional] Specifies a custom IAM Role for instances in your cluster. A new instance profile will be created and attached to this role. Required if --capability-iam is not specified. NOTE: Not applicable for launch type FARGATE.
...
```


----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
- [n/a] Unit tests passed
- [n/a] Integration tests passed
- [n/a] Unit tests added for new functionality
- [x] Listed manual checks and their outputs in the comments (see above)
- [n/a] Link to issue or PR for the integration tests:

**Documentation**
- [x] Contacted our doc writer
- [n/a] Updated our README
----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
