### PR TITLE
Taskdef constraints

### DIFF
--- a/README.md
+++ b/README.md
@@ -490,6 +490,9 @@ task_definition:
         string: string
       labels:
         string: string
+  placement_constraints:
+    - type: string                      // Valid values: "memberOf"
+      expression: string
 
 run_params:
   network_configuration:
@@ -557,6 +560,8 @@ Fields listed under `task_definition` correspond to fields that will be included
 * `task_execution_role` should be the ARN of an IAM role. **NOTE**: This field is required to enable ECS Tasks to be configured with Cloudwatch Logs, or to pull images from ECR for your tasks.
 
 * `task_size` Contains two fields, CPU and Memory. These fields are required for launching tasks with Fargate launch type. See [the documentation on ECS Task Definition Parameters](http://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html) for more information.
+
+* `placement_constraints` allows you to specify a list of constraints on task placement within the task definition. Not supported with the `FARGATE` launch type.
 
 * `pid_mode` allows you to control the process namespace in which your containers run. Valid values are `task` or `host`. See the [ECS documentation](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html#task_definition_pidmode) for more information.
 

--- a/ecs-cli/modules/cli/compose/project/project.go
+++ b/ecs-cli/modules/cli/compose/project/project.go
@@ -21,7 +21,6 @@ import (
 	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/cli/compose/entity"
 	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/cli/compose/entity/service"
 	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/cli/compose/entity/task"
-	"github.com/aws/aws-sdk-go/service/ecs"
 	"github.com/sirupsen/logrus"
 
 	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/commands/flags"
@@ -219,22 +218,6 @@ func (p *ecsProject) transformTaskDefinition() error {
 	taskDefinition, err := composeutils.ConvertToTaskDefinition(convertParams)
 	if err != nil {
 		return err
-	}
-
-	placementConstraints, err := composeutils.ConvertToECSPlacementConstraints(ecsContext.ECSParams)
-	if err != nil {
-		return err
-	}
-
-	if len(placementConstraints) > 0 {
-		tdPcs := make([]*ecs.TaskDefinitionPlacementConstraint, len(placementConstraints))
-		for i, pc := range placementConstraints {
-			tdPcs[i] = &ecs.TaskDefinitionPlacementConstraint{
-				Type:       pc.Type,
-				Expression: pc.Expression,
-			}
-		}
-		taskDefinition.SetPlacementConstraints(tdPcs)
 	}
 
 	p.entity.SetTaskDefinition(taskDefinition)

--- a/ecs-cli/modules/cli/compose/project/project_test.go
+++ b/ecs-cli/modules/cli/compose/project/project_test.go
@@ -411,7 +411,7 @@ func TestParseECSRegistryCreds_NoFile(t *testing.T) {
 	}
 }
 
-func TestParseCompose_V2_WithPlacementConstraint(t *testing.T) {
+func TestParseCompose_V2_WithTaskDefinitionPlacementConstraint(t *testing.T) {
 	// Setup docker-compose file
 	composeFileString := `version: '2'
 services:
@@ -430,11 +430,10 @@ services:
 	assert.NoError(t, err, "Unexpected error closing file")
 
 	ecsParamsString := `version: 1
-run_params:
-  task_placement:
-    constraints:
-      - type: memberOf
-        expression: "attribute:name == value"`
+task_definition:
+  placement_constraints:
+    - type: memberOf
+      expression: "attribute:name == value"`
 
 	content := []byte(ecsParamsString)
 

--- a/ecs-cli/modules/utils/compose/ecs_params_reader.go
+++ b/ecs-cli/modules/utils/compose/ecs_params_reader.go
@@ -51,6 +51,7 @@ type EcsTaskDef struct {
 	ExecutionRole        string         `yaml:"task_execution_role"`
 	TaskSize             TaskSize       `yaml:"task_size"` // Needed to run FARGATE tasks
 	DockerVolumes        []DockerVolume `yaml:"docker_volumes"`
+	PlacementConstraints []Constraint   `yaml:"placement_constraints"`
 }
 
 // ContainerDefs is a map of ContainerDefs within a task definition

--- a/ecs-cli/modules/utils/compose/ecs_params_reader_test.go
+++ b/ecs-cli/modules/utils/compose/ecs_params_reader_test.go
@@ -241,6 +241,10 @@ run_params:
 
 func TestReadECSParams_WithTaskPlacement(t *testing.T) {
 	ecsParamsString := `version: 1
+task_definition:
+  placement_constraints:
+    - type: memberOf
+      expression: attribute:ecs.os-type == linux
 run_params:
   task_placement:
     strategy:
@@ -288,6 +292,13 @@ run_params:
 		},
 	}
 
+	expectedTaskDefConstraints := []Constraint{
+		{
+			Expression: "attribute:ecs.os-type == linux",
+			Type:       ecs.PlacementConstraintTypeMemberOf,
+		},
+	}
+
 	ecsParams, err := ReadECSParams(ecsParamsFileName)
 
 	if assert.NoError(t, err) {
@@ -298,6 +309,9 @@ run_params:
 		assert.Len(t, constraints, 2)
 		assert.ElementsMatch(t, expectedStrategies, strategies)
 		assert.ElementsMatch(t, expectedConstraints, constraints)
+
+		taskDefConstraints := ecsParams.TaskDefinition.PlacementConstraints
+		assert.ElementsMatch(t, expectedTaskDefConstraints, taskDefConstraints)
 	}
 }
 


### PR DESCRIPTION
Fixes issue described in [this comment](https://github.com/aws/amazon-ecs-cli/pull/909#issuecomment-525497445). 

## test output

docker-compose.yml
```
version: '2'
services:
  database:
    image: httpd:2.4
    ports:
      - "80:80"
    environment:
      - ENV1=test
```

ecs-params.yml
```
version: 1
task_definition:
  placement_constraints:
    - type: memberOf
      expression: "attribute:ecs.os-type == linux"
    - type: memberOf
      expression: "attribute:ecs.instance-type == t2.micro"
run_params:
  task_placement:
    constraints:
      - type: memberOf
        expression: "attribute:ecs.os-type == linux"
```

cmd output:
```
> ecs-cli.exe compose service up
[36mINFO[0m[0000] Using ECS task definition                     [36mTaskDefinition[0m="placement:5"
[36mINFO[0m[0000] Updated the ECS service with a new task definition. Old containers will be stopped automatically, and replaced with new ones  [36mdesiredCount[0m=1 [36mforce-deployment[0m=false [36mservice[0m=placement
[36mINFO[0m[0015] Service status                                [36mdesiredCount[0m=1 [36mrunningCount[0m=1 [36mserviceName[0m=placement
[36mINFO[0m[0015] (service placement) has started 1 tasks: (task 97e72ca4-bf1b-47dc-a7b0-77287f945cfc).  [36mtimestamp[0m="2019-08-28 21:16:25 +0000 UTC"
[36mINFO[0m[0015] (service placement) has reached a steady state.  [36mtimestamp[0m="2019-08-28 21:16:35 +0000 UTC"
[36mINFO[0m[0015] ECS Service has reached a stable state        [36mdesiredCount[0m=1 [36mrunningCount[0m=1 [36mserviceName[0m=placement
```

resulting task definition with constraints:
```
{
    "taskDefinition": {
        "taskDefinitionArn": "arn:aws:ecs:us-west-2:##########:task-definition/placement:7",
        "containerDefinitions": [
            {
                "name": "database",
                "image": "httpd:2.4",
                "portMappings": [
                    {
                        "containerPort": 80,
                        "hostPort": 80,
                        "protocol": "tcp"
                    }
                ],
                "essential": true,
                "environment": [
                    {
                        "name": "ENV1",
                        "value": "test"
                    }
                ]
            }
        ],
        "family": "placement",
        "revision": 7,
        "status": "ACTIVE",
        "requiresAttributes": [
            {
                "name": "com.amazonaws.ecs.capability.docker-remote-api.1.17"
            },
            {
                "name": "com.amazonaws.ecs.capability.docker-remote-api.1.18"
            }
        ],
        "placementConstraints": [
            {
                "type": "memberOf",
                "expression": "attribute:ecs.os-type == linux"
            },
            {
                "type": "memberOf",
                "expression": "attribute:ecs.instance-type == t2.micro"
            }
        ],
        "compatibilities": [
            "EC2"
        ],
        "cpu": "512",
        "memory": "2048"
    }
}
```
----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
- [x] Unit tests passed
- [TBD] Integration tests passed
- [x] Unit tests added for new functionality
- [x] Listed manual checks and their outputs in the comments ([example](https://github.com/aws/amazon-ecs-cli/pull/750#issuecomment-472623042))
- [n/a] Link to issue or PR for the integration tests:

**Documentation**
- [x] Contacted our doc writer
- [x] Updated our README
----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
