### PR TITLE
Add extra validation to ecs-cli local integ tests

### DIFF
--- a/ecs-cli/integ/e2e/local_test.go
+++ b/ecs-cli/integ/e2e/local_test.go
@@ -16,11 +16,16 @@
 package e2e
 
 import (
+	"context"
+	"fmt"
 	"io/ioutil"
 	"os"
+	"path"
 	"testing"
 
 	"github.com/aws/amazon-ecs-cli/ecs-cli/integ"
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/client"
 	"github.com/stretchr/testify/require"
 )
 
@@ -116,53 +121,109 @@ func TestECSLocal(t *testing.T) {
 					args: []string{"local", "create", "-f", ""},
 					execute: func(t *testing.T, args []string) {
 						tempFileName := createLocalTaskDefFile(t)
-						defer os.Remove(tempFileName)
-						defer os.Remove("docker-compose.ecs-local.yml")
-						defer os.Remove("docker-compose.ecs-local.override.yml")
+						defer cleanUp(tempFileName)
 						args[3] = tempFileName
 						stdout, err := integ.RunCmd(t, args)
 						require.NoError(t, err)
 						stdout.TestHasAllSubstrings(t, []string{
 							"Successfully wrote docker-compose",
 						})
+						checkDockerComposeContents(
+							t,
+							"docker-compose.ecs-local.yml",
+							"docker-compose.ecs-local.override.yml",
+							tempFileName,
+						)
+
 					},
 				},
 				{
 					args: []string{"local", "up", "-f", ""},
 					execute: func(t *testing.T, args []string) {
 						tempFileName := createLocalTaskDefFile(t)
-						defer os.Remove(tempFileName)
-						defer os.Remove("docker-compose.ecs-local.yml")
-						defer os.Remove("docker-compose.ecs-local.override.yml")
-
+						defer cleanUp(tempFileName)
 						args[3] = tempFileName
 						stdout, err := integ.RunCmd(t, args)
 						require.NoError(t, err)
 						stdout.TestHasAllSubstrings(t, []string{
 							"Started container with ID",
 						})
+
+						checkDockerComposeContents(t,
+							"docker-compose.ecs-local.yml",
+							"docker-compose.ecs-local.override.yml",
+							tempFileName,
+						)
+
+						dockerCli := getDockerClient(t)
+						containers := checkNumberRunningContainers(t, dockerCli, 2)
+						containerNames := getContainerNames(t, containers)
+						require.Contains(t, containerNames, "httpd:2.4")
+
 						downArgs := []string{"local", "down", "-f", tempFileName}
 						stdout, err = integ.RunCmd(t, downArgs)
 
+						checkNumberRunningContainers(t, dockerCli, 0)
 					},
 				},
 				{
 					args: []string{"local", "up", "-c", "docker-compose.ecs-local.yml"},
 					execute: func(t *testing.T, args []string) {
 						tempFileName := createLocalTaskDefFile(t)
-						defer os.Remove(tempFileName)
-						defer os.Remove("docker-compose.ecs-local.yml")
-						defer os.Remove("docker-compose.ecs-local.override.yml")
-
+						defer cleanUp(tempFileName)
 						createArgs := []string{"local", "create", "-f", tempFileName}
 						stdout, err := integ.RunCmd(t, createArgs)
 						stdout, err = integ.RunCmd(t, args)
 						require.NoError(t, err)
+						checkDockerComposeContents(t,
+							"docker-compose.ecs-local.yml",
+							"docker-compose.ecs-local.override.yml",
+							tempFileName,
+						)
 						stdout.TestHasAllSubstrings(t, []string{
 							"Created the amazon-ecs-local-container-endpoints container",
 						})
+						dockerCli := getDockerClient(t)
+						containers := checkNumberRunningContainers(t, dockerCli, 2)
+
+						containerNames := getContainerNames(t, containers)
+						require.Contains(t, containerNames, "httpd:2.4")
+
 						downArgs := []string{"local", "down", "-f", tempFileName}
 						stdout, err = integ.RunCmd(t, downArgs)
+					},
+				},
+				{
+					args: []string{"local", "up"},
+					execute: func(t *testing.T, args []string) {
+						tempFileName := createLocalTaskDefFile(t)
+						os.Rename(tempFileName, "task-definition.json")
+						defer cleanUp("task-definition.json")
+						stdout, err := integ.RunCmd(t, args)
+						stdout.TestHasAllSubstrings(t, []string{
+							"Successfully wrote docker-compose.ecs-local.yml",
+							"Started container with ID",
+						})
+						checkDockerComposeContents(
+							t,
+							"docker-compose.ecs-local.yml",
+							"docker-compose.ecs-local.override.yml",
+							"task-definition.json",
+						)
+						dockerCli := getDockerClient(t)
+						containers := checkNumberRunningContainers(t, dockerCli, 2)
+						containerNames := getContainerNames(t, containers)
+						require.Contains(t, containerNames, "httpd:2.4")
+
+						downArgs := []string{"local", "down", "--all"}
+						stdout, err = integ.RunCmd(t, downArgs)
+						stdout.TestHasAllSubstrings(t, []string{
+							"Stopped container with name",
+							"Removed container with name",
+							"Removed network with name",
+						})
+						require.NoError(t, err)
+						checkNumberRunningContainers(t, dockerCli, 0)
 					},
 				},
 			},
@@ -175,6 +236,15 @@ func TestECSLocal(t *testing.T) {
 				cmd.execute(t, cmd.args)
 			}
 		})
+	}
+}
+
+func cleanUp(taskDefFile string) {
+	err := os.Remove(taskDefFile)
+	err = os.Remove("docker-compose.ecs-local.yml")
+	err = os.Remove("docker-compose.ecs-local.override.yml")
+	if err != nil {
+		panic(fmt.Sprintf("error %v removing files!", err))
 	}
 }
 
@@ -203,8 +273,9 @@ func createLocalTaskDefFile(t *testing.T) string {
 	"memory": "512",
 	"networkMode": "bridge"
 	}`
+
 	tmpfile, err := ioutil.TempFile(".", "task-definition-*.json")
-	require.NoError(t, err, "Failed to create task-definition.json")
+	require.NoError(t, err, "Failed to create task-definition-*.json")
 
 	_, err = tmpfile.Write([]byte(content))
 	require.NoError(t, err, "Failed to write to %s", tmpfile.Name())
@@ -213,4 +284,96 @@ func createLocalTaskDefFile(t *testing.T) string {
 	require.NoError(t, err, "Failed to close %s", tmpfile.Name())
 
 	return tmpfile.Name()
+}
+
+func getFullTaskDefPath(t *testing.T, taskDefinitionFilename string) string {
+	workingDirectory, err := os.Getwd()
+	require.NoError(t, err, "error getting working directory")
+	fullPath := path.Join(workingDirectory, taskDefinitionFilename)
+	_, err = os.Stat(fullPath)
+	require.NoError(t, err, "Could not resolve full task definition path. File does not exist at the provided location")
+	return fullPath
+}
+
+func checkDockerComposeContents(t *testing.T, composeFileName string, overrideFileName string, taskDefinitionFile string) {
+	taskDefinitionFullPath := getFullTaskDefPath(t, taskDefinitionFile)
+	contentsCompose := fmt.Sprintf(
+		`version: "3.4"
+services:
+  simple-test-app:
+    entrypoint:
+    - sh
+    - -c
+    environment:
+      AWS_CONTAINER_CREDENTIALS_RELATIVE_URI: /creds
+      ECS_CONTAINER_METADATA_URI: http://169.254.170.2/v3
+    image: httpd:2.4
+    labels:
+      ecs-local.task-definition-input.type: local
+      ecs-local.task-definition-input.value: %s
+    networks:
+      ecs-local-network: null
+    ports:
+    - target: 80
+      published: 80
+      protocol: tcp
+networks:
+  ecs-local-network:
+    external: true
+`, taskDefinitionFullPath)
+	contentsComposeOverride := `version: "3.4"
+services:
+  simple-test-app:
+    environment:
+      AWS_CONTAINER_CREDENTIALS_RELATIVE_URI: /creds
+    logging:
+      driver: json-file
+`
+	checkFileContents(t, composeFileName, contentsCompose)
+	checkFileContents(t, overrideFileName, contentsComposeOverride)
+}
+
+func checkFileContents(t *testing.T, fileName string, testData string) {
+	t.Helper()
+	file, err := os.Open(fileName)
+	require.NoError(t, err, "could not open file to check its contents")
+	defer file.Close()
+	data, err := ioutil.ReadAll(file)
+
+	require.Equal(t, string(data), testData, "Docker compose contents do not match desired test data!")
+}
+
+func getContainerNames(t *testing.T, containers []types.Container) []string {
+	t.Helper()
+	var names []string
+	for _, ctr := range containers {
+		names = append(names, ctr.Image)
+	}
+	return names
+}
+
+func getDockerClient(t *testing.T) *client.Client {
+	t.Helper()
+	dockerCli, err := client.NewClientWithOpts(
+		client.WithVersion("1.40"),
+	)
+	require.NoError(t, err)
+	return dockerCli
+}
+
+func checkNumberRunningContainers(t *testing.T, cli *client.Client, expectedContainers int) []types.Container {
+	t.Helper()
+	containers, err := cli.ContainerList(
+		context.Background(),
+		types.ContainerListOptions{All: true},
+	)
+	require.NoError(t, err)
+	require.Equal(
+		t,
+		len(containers),
+		expectedContainers,
+		"Expected %d containers to be found by Docker SDK.",
+		expectedContainers,
+	)
+	return containers
 }


### PR DESCRIPTION
This commit adds functionality using the Docker SDK to verify that the
correct container images were started by local integration tests. 

It also adds line-by-line comparison of docker compose files generated by
ecs-cli local subcommands to a known valid template.

Finally, one new integration test is added to cover the default behavior of 
"ecs-cli local up" wherein a task definition is not specified.

Related to #772 (Integration tests for ecs-cli local)

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
- [✅] Unit tests passed
- [✅] Integration tests passed
- [N/A] Unit tests added for new functionality
- [N/A] Listed manual checks and their outputs in the comments ([example](https://github.com/aws/amazon-ecs-cli/pull/750#issuecomment-472623042))
- [✅] Link to issue or PR for the integration tests:

**Documentation**
- [N/A ] Contacted our doc writer
- [N/A] Updated our README
----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
