### PR TITLE
Pin docker client for integ tests to 1.39

### DIFF
--- a/ecs-cli/integ/e2e/local_test.go
+++ b/ecs-cli/integ/e2e/local_test.go
@@ -355,7 +355,7 @@ func getContainerNames(t *testing.T, containers []types.Container) []string {
 func getDockerClient(t *testing.T) *client.Client {
 	t.Helper()
 	dockerCli, err := client.NewClientWithOpts(
-		client.WithVersion("1.40"),
+		client.WithVersion("1.39"),
 	)
 	require.NoError(t, err)
 	return dockerCli


### PR DESCRIPTION
See title. Fixes build failures in CodeBuild standard image 1.8.0 where latest client is too new.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
- [x] Unit tests passed
- [x] Integration tests passed
- [N/A] Unit tests added for new functionality
- [N/A] Listed manual checks and their outputs in the comments ([example](https://github.com/aws/amazon-ecs-cli/pull/750#issuecomment-472623042))
- [N/A] Link to issue or PR for the integration tests:

**Documentation**
- [N/A] Contacted our doc writer
- [N/A] Updated our README
----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
