### PR TITLE
Remove parallelization of e2e tests to resolve config race condition

### DIFF
--- a/ecs-cli/integ/e2e/ec2_task_test.go
+++ b/ecs-cli/integ/e2e/ec2_task_test.go
@@ -30,7 +30,6 @@ import (
 // TestCreateClusterWithEC2Task runs the sequence of ecs-cli commands from
 // the EC2 tutorial: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-cli-tutorial-ec2.html
 func TestCreateClusterWithEC2Task(t *testing.T) {
-	t.Parallel()
 
 	// Create the cluster
 	conf := cmd.TestEC2TutorialConfig(t)

--- a/ecs-cli/integ/e2e/fargate_service_test.go
+++ b/ecs-cli/integ/e2e/fargate_service_test.go
@@ -29,7 +29,6 @@ import (
 // TestCreateClusterWithFargateService runs the sequence of ecs-cli commands from
 // the Fargate tutorial: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-cli-tutorial-fargate.html
 func TestCreateClusterWithFargateService(t *testing.T) {
-	t.Parallel()
 
 	// Create the cluster
 	conf := cmd.TestFargateTutorialConfig(t)


### PR DESCRIPTION
This commit removes the t.Parallel() call which marks tests as
parallelizable from ec2_task_test and fargate_service_test. This change
resolves an ABA which resulted from conflicting calls to testConfig in 
integ/cmd/configure.go

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
- [✅] Unit tests passed
- [✅ ] Integration tests passed
- [ n/a] Unit tests added for new functionality
- [n/a ] Listed manual checks and their outputs in the comments ([example](https://github.com/aws/amazon-ecs-cli/pull/750#issuecomment-472623042))
- [✅ ] Link to issue or PR for the integration tests:

**Documentation**
- [ n/a] Contacted our doc writer
- [n/a ] Updated our README
----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
