### PR TITLE
Send optional fields as nil instead of "" to ECS

### DIFF
--- a/ecs-cli/modules/utils/compose/convert_task_definition.go
+++ b/ecs-cli/modules/utils/compose/convert_task_definition.go
@@ -286,8 +286,12 @@ func mergeVolumesWithoutHost(composeVolumes []string, ecsParams *ECSParams) ([]*
 		if dVol.Name != "" {
 			ecsVolume.DockerVolumeConfiguration = &ecs.DockerVolumeConfiguration{
 				Autoprovision: dVol.Autoprovision,
-				Driver:        aws.String(dVol.Driver),
-				Scope:         aws.String(dVol.Scope),
+			}
+			if dVol.Driver != nil {
+				ecsVolume.DockerVolumeConfiguration.Driver = dVol.Driver
+			}
+			if dVol.Scope != nil {
+				ecsVolume.DockerVolumeConfiguration.Scope = dVol.Scope
 			}
 			if dVol.DriverOptions != nil {
 				ecsVolume.DockerVolumeConfiguration.DriverOpts = aws.StringMap(dVol.DriverOptions)

--- a/ecs-cli/modules/utils/compose/convert_task_definition_test.go
+++ b/ecs-cli/modules/utils/compose/convert_task_definition_test.go
@@ -1383,8 +1383,8 @@ func TestConvertToTaskDefinitionWithECSParamsVolumeWithoutNameError(t *testing.T
 			DockerVolumes: []DockerVolume{
 				DockerVolume{
 					Autoprovision: aws.Bool(true),
-					Scope:         "shared",
-					Driver:        "local",
+					Scope:         aws.String("shared"),
+					Driver:        nil,
 					DriverOptions: options,
 					Labels:        labels,
 				},

--- a/ecs-cli/modules/utils/compose/ecs_params_reader.go
+++ b/ecs-cli/modules/utils/compose/ecs_params_reader.go
@@ -75,9 +75,9 @@ type ContainerDef struct {
 
 type DockerVolume struct {
 	Name          string            `yaml:"name"`
-	Scope         string            `yaml:"scope"`
+	Scope         *string           `yaml:"scope"`
 	Autoprovision *bool             `yaml:"autoprovision"`
-	Driver        string            `yaml:"driver"`
+	Driver        *string           `yaml:"driver"`
 	DriverOptions map[string]string `yaml:"driver_opts"`
 	Labels        map[string]string `yaml:"labels"`
 }

--- a/ecs-cli/modules/utils/compose/ecs_params_reader_test.go
+++ b/ecs-cli/modules/utils/compose/ecs_params_reader_test.go
@@ -647,9 +647,9 @@ task_definition:
 	expectedVolumes := []DockerVolume{
 		DockerVolume{
 			Name:          "my_volume",
-			Scope:         "shared",
+			Scope:         aws.String("shared"),
 			Autoprovision: aws.Bool(true),
-			Driver:        "doggyromcom",
+			Driver:        aws.String("doggyromcom"),
 			DriverOptions: map[string]string{
 				"pudding": "is-engaged-to-marry-Tum-Tum",
 				"clyde":   "professes-his-love-at-the-ceremony",


### PR DESCRIPTION
<!-- Provide summary of changes -->
Previously when sending certain requests that contain optional fields to ECS through the Go AWS SDK, we always send empty strings instead of nil for those optional fields that are not set. The service treats such an action as an explicit intent and hence fails to plug in the default values from the service side.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->
This PR closes #927. Specifically, the repo 3.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
- [X] Unit tests passed
- [X] Integration tests passed
- [N/A] Unit tests added for new functionality
- [X] Listed manual checks and their outputs in the comments ([example](https://github.com/aws/amazon-ecs-cli/pull/750#issuecomment-472623042))
I was able to run `ecs-cli compose service up` instead of getting the `named volume [backup-laptop] is used but no declaration was found in the volumes section` error message described in the issue. Also verified the default, "local" driver, was correctly set on the service side in task def:
```
"volumes": [
    {
      "name": "backup-laptop",
      "host": null,
      "dockerVolumeConfiguration": {
        "autoprovision": false,
        "labels": null,
        "scope": "shared",
        "driver": "local",
        "driverOpts": null
      }
    }
  ]
```
- [N/A] Link to issue or PR for the integration tests:

**Documentation**
- [N/A] Contacted our doc writer
- [N/A] Updated our README
----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
