### PR TITLE
update Makefile to use docker Go 1.12

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,17 +83,17 @@ docker-build:
 		--workdir=/usr/src/app/src/github.com/aws/amazon-ecs-cli \
 		--env GOPATH=/usr/src/app \
 		--env ECS_RELEASE=$(ECS_RELEASE) \
-		golang:1.11 make $(LINUX_BINARY)
+		golang:1.12 make $(LINUX_BINARY)
 	docker run -v $(shell pwd):/usr/src/app/src/github.com/aws/amazon-ecs-cli \
 		--workdir=/usr/src/app/src/github.com/aws/amazon-ecs-cli \
 		--env GOPATH=/usr/src/app \
 		--env ECS_RELEASE=$(ECS_RELEASE) \
-		golang:1.11 make $(DARWIN_BINARY)
+		golang:1.12 make $(DARWIN_BINARY)
 	docker run -v $(shell pwd):/usr/src/app/src/github.com/aws/amazon-ecs-cli \
 		--workdir=/usr/src/app/src/github.com/aws/amazon-ecs-cli \
 		--env GOPATH=/usr/src/app \
 		--env ECS_RELEASE=$(ECS_RELEASE) \
-		golang:1.11 make $(WINDOWS_BINARY)
+		golang:1.12 make $(WINDOWS_BINARY)
 
 .PHONY: docker-test
 docker-test:
@@ -101,7 +101,7 @@ docker-test:
 		--workdir=/usr/src/app/src/github.com/aws/amazon-ecs-cli \
 		--env GOPATH=/usr/src/app \
 		--env ECS_RELEASE=$(ECS_RELEASE) \
-		golang:1.11 make test
+		golang:1.12 make test
 
 .PHONY: supported-platforms
 supported-platforms: $(LINUX_BINARY) $(DARWIN_BINARY) $(WINDOWS_BINARY)


### PR DESCRIPTION
Updated Makefile to use docker Go 1.12 as per CONTRIBUTING instructions

Fixes https://github.com/aws/amazon-ecs-cli/issues/956

## Testing


- [N/A] Unit tests passed
- [N/A] Integration tests passed
- [N/A] Unit tests added for new functionality
- [X] Listed manual checks and their outputs in the comments
- [X] Link to issue or PR

----
## Manual Testing

```sh
$ make docker-build
docker run -v **redacted**/amazon-ecs-cli:/usr/src/app/src/github.com/aws/amazon-ecs-cli \
        --workdir=/usr/src/app/src/github.com/aws/amazon-ecs-cli \
        --env GOPATH=/usr/src/app \
        --env ECS_RELEASE= \
        golang:1.12 make bin/linux-amd64/ecs-cli
Unable to find image 'golang:1.12' locally
1.12: Pulling from library/golang
16ea0e8c8879: Pull complete 
50024b0106d5: Pull complete 
ff95660c6937: Pull complete 
9c7d0e5c0bc2: Pull complete 
2a19d2e6789c: Pull complete 
1b21789f9965: Pull complete 
a5831c4ee599: Pull complete 
Digest: sha256:d31d32445c55b3e136f3b5ce299a2d4208eea9188fe946465aae93926cade425
Status: Downloaded newer image for golang:1.12
TARGET_GOOS=linux GOARCH=amd64 ./scripts/build_binary.sh ./bin/linux-amd64
Built ecs-cli for linux
docker run -v **redacted**/amazon-ecs-cli:/usr/src/app/src/github.com/aws/amazon-ecs-cli \
        --workdir=/usr/src/app/src/github.com/aws/amazon-ecs-cli \
        --env GOPATH=/usr/src/app \
        --env ECS_RELEASE= \
        golang:1.12 make bin/darwin-amd64/ecs-cli
TARGET_GOOS=darwin GOARCH=amd64 ./scripts/build_binary.sh ./bin/darwin-amd64
Built ecs-cli for darwin
docker run -v **redacted**/amazon-ecs-cli:/usr/src/app/src/github.com/aws/amazon-ecs-cli \
        --workdir=/usr/src/app/src/github.com/aws/amazon-ecs-cli \
        --env GOPATH=/usr/src/app \
        --env ECS_RELEASE= \
        golang:1.12 make bin/windows-amd64/ecs-cli.exe
TARGET_GOOS=windows GOARCH=amd64 ./scripts/build_binary.sh ./bin/windows-amd64
mv ./bin/windows-amd64/ecs-cli ./bin/windows-amd64/ecs-cli.exe
Built ecs-cli.exe for windows
$ cd bin/linux-amd64/
$ ./ecs-cli --version
ecs-cli version 1.18.0 (*3970a6c)
$ 
```

----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
