### PR TITLE
using AWS_PROFILE if set for local endpoints container

### DIFF
--- a/ecs-cli/modules/cli/local/network/setup.go
+++ b/ecs-cli/modules/cli/local/network/setup.go
@@ -76,6 +76,8 @@ const (
 
 	// Name of the container, we need to give it a name so that we don't re-create a container every time we setup.
 	localEndpointsContainerName = "amazon-ecs-local-container-endpoints"
+
+
 )
 
 // Setup creates a user-defined bridge network with a running Local Container Endpoints container. It will pull
@@ -190,13 +192,18 @@ func createLocalEndpointsContainer(dockerClient containerStarter) string {
 	ctx, cancel := context.WithTimeout(context.Background(), docker.TimeoutInS)
 	defer cancel()
 
+	profile, profile_set := os.LookupEnv("AWS_PROFILE")
+	if !profile_set {
+		profile = "default"
+	}
+
 	// See First Scenario in https://aws.amazon.com/blogs/compute/a-guide-to-locally-testing-containers-with-amazon-ecs-local-endpoints-and-docker-compose/
 	// for an explanation of these fields.
 	resp, err := dockerClient.ContainerCreate(ctx,
 		&container.Config{
 			Image: localEndpointsImageName,
 			Env: []string{
-				"AWS_PROFILE=default",
+				fmt.Sprintf("AWS_PROFILE=%s", profile),
 				"HOME=/home",
 			},
 		},


### PR DESCRIPTION
The local endpoints container always uses default credentials. This PR takes the AWS_PROFILE environment variable, if set and uses that otherwise uses `default` as the AWS_PROFILE used by the local endpoints container. This is needed as when we run locally, our users assume a role for virtually every task and default creds are typically the users keys which do not have the permissions to make any calls that the local endpoints container needs.


Addresses #962 

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
- [X] Unit tests passed
- [N/A] Integration tests passed
- [N/A] Unit tests added for new functionality
- [N/A] Listed manual checks and their outputs in the comments ([example](https://github.com/aws/amazon-ecs-cli/pull/750#issuecomment-472623042))
- [X] Link to issue or PR for the integration tests:

**Documentation**
- [N/A] Contacted our doc writer
- [N/A] Updated our README
----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
