### PR TITLE
Only compare with the checked in version string if the commit is tagged

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -42,7 +42,7 @@ phases:
       - |
         # $CHECKED_IN_VERSION is not prefixed with "v", only the semantic version number,
         # such as 1.17.0 instead of v1.17.0, which is what normal version tags look like.
-        if [ "$VERSION" != "v$CHECKED_IN_VERSION" ]; then
+        if [ -n "$VERSION" ] && [ "$VERSION" != "v$CHECKED_IN_VERSION" ]; then
           echo "the VERSION file contains a version number that is different from the git tag. file: $CHECKED_IN_VERSION, tag: $VERSION"  
           exit 1
         fi


### PR DESCRIPTION
<!-- Provide summary of changes -->
Our internal cli release pipeline has been failing due to:
```
# such as 1.17.0 instead of v1.17.0, which is what normal version tags look like. 
if [ "$VERSION" != "v$CHECKED_IN_VERSION" ]; then 
  echo "the VERSION file contains a version number that is different from the git tag. file: $CHECKED_IN_VERSION, tag: $VERSION"   
  exit 1 
fi 
 
the VERSION file contains a version number that is different from the git tag. file: 1.18.0, tag:  
 
[Container] 2019/12/19 23:45:15 Command did not exit successfully
```
The culprit is it tries to compare the checked in version file with the git tag of the current commit when it's actually not being tagged at all. This is the case for all non-release commits. This PR changes the it to only validate against the checked-in version string when the current commit is indeed tagged.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->
N/A
----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
- [N/A] Unit tests passed
- [N/A] Integration tests passed
- [N/A] Unit tests added for new functionality
- [N/A] Listed manual checks and their outputs in the comments ([example](https://github.com/aws/amazon-ecs-cli/pull/750#issuecomment-472623042))
- [N/A] Link to issue or PR for the integration tests:

**Documentation**
- [N/A] Contacted our doc writer
- [N/A] Updated our README
----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
