### PR TITLE
fixing local create to use taskRole

### DIFF
--- a/ecs-cli/modules/cli/local/converter/converter.go
+++ b/ecs-cli/modules/cli/local/converter/converter.go
@@ -26,7 +26,7 @@ import (
 	composeV3 "github.com/docker/cli/cli/compose/types"
 	"github.com/docker/go-units"
 	log "github.com/sirupsen/logrus"
-	arnParser "github.com/aws/aws-sdk-go/aws/arn"
+	arnparser "github.com/aws/aws-sdk-go/aws/arn"
 )
 
 // LinuxParams is a shim between members of ecs.LinuxParamters and their
@@ -410,8 +410,8 @@ func convertEnvironment(def *ecs.ContainerDefinition, taskRoleARN string) map[st
 	}
 
     credsName := endpointsTempCredsPath
-    if parsedRoleARN, err := arnParser.Parse(taskRoleARN); taskRoleARN != "" && err == nil {
-        credsName = "/" + parsedRoleARN.Resource
+    if parsedRoleARN, err := arnparser.Parse(taskRoleARN); taskRoleARN != "" && err == nil {
+        credsName = "/" + parsedRoleARN.Resource // The parsed resource is formatted as "role/{roleName}"
     }
 
 	out[ecsCredsProviderEnvName] = aws.String(credsName)

--- a/ecs-cli/modules/cli/local/converter/converter.go
+++ b/ecs-cli/modules/cli/local/converter/converter.go
@@ -180,11 +180,14 @@ func createComposeServices(taskDefinition *ecs.TaskDefinition, metadata *LocalCr
 }
 
 func resolveCredentials(taskRoleARN string, useRole bool) string {
-    credsName := endpointsTempCredsPath
-    if parsedRoleARN, err := arnparser.Parse(taskRoleARN); useRole && taskRoleARN != "" && err == nil {
-        credsName = "/" + parsedRoleARN.Resource // The parsed resource is formatted as "role/{roleName}"
+    if !useRole {
+      return endpointsTempCredsPath
     }
-    return credsName
+    parsedARN, err := arnparser.Parse(taskRoleARN)
+    if err != nil {
+      return endpointsTempCredsPath
+    }
+    return "/" + parsedARN.Resource // The parsed resource is formatted as "role/{roleName}"
 }
 
 func convertToComposeService(containerDefinition *ecs.ContainerDefinition, commonValues *CommonContainerValues) (composeV3.ServiceConfig, error) {

--- a/ecs-cli/modules/cli/local/converter/override.go
+++ b/ecs-cli/modules/cli/local/converter/override.go
@@ -28,7 +28,6 @@ const (
 // ConvertToComposeOverride returns a Docker Compose object to be used to override containers defined
 // in the task definition.
 //
-// Overrides the AWS_CONTAINER_CREDENTIALS_RELATIVE_URI environment variable to "/creds" for every service.
 // Overrides the logging driver to "json-file" for every service.
 func ConvertToComposeOverride(taskDefinition *ecs.TaskDefinition) (*composeV3.Config, error) {
 	if taskDefinition == nil {
@@ -42,9 +41,6 @@ func ConvertToComposeOverride(taskDefinition *ecs.TaskDefinition) (*composeV3.Co
 	for _, container := range taskDefinition.ContainerDefinitions {
 		config := composeV3.ServiceConfig{
 			Name: aws.StringValue(container.Name),
-			Environment: composeV3.MappingWithEquals{
-				ecsCredsProviderEnvName: aws.String(endpointsTempCredsPath),
-			},
 			Logging: &composeV3.LoggingConfig{
 				Driver: jsonFileLogDriver,
 			},

--- a/ecs-cli/modules/cli/local/converter/override_test.go
+++ b/ecs-cli/modules/cli/local/converter/override_test.go
@@ -54,9 +54,6 @@ func TestConvertToCompose(t *testing.T) {
 				Services: composeV3.Services{
 					{
 						Name: "app",
-						Environment: composeV3.MappingWithEquals{
-							ecsCredsProviderEnvName: aws.String(endpointsTempCredsPath),
-						},
 						Logging: &composeV3.LoggingConfig{
 							Driver: jsonFileLogDriver,
 						},
@@ -81,18 +78,12 @@ func TestConvertToCompose(t *testing.T) {
 				Services: composeV3.Services{
 					{
 						Name: "app",
-						Environment: composeV3.MappingWithEquals{
-							ecsCredsProviderEnvName: aws.String(endpointsTempCredsPath),
-						},
 						Logging: &composeV3.LoggingConfig{
 							Driver: jsonFileLogDriver,
 						},
 					},
 					{
 						Name: "envoyproxy",
-						Environment: composeV3.MappingWithEquals{
-							ecsCredsProviderEnvName: aws.String(endpointsTempCredsPath),
-						},
 						Logging: &composeV3.LoggingConfig{
 							Driver: jsonFileLogDriver,
 						},

--- a/ecs-cli/modules/cli/local/localproject/project.go
+++ b/ecs-cli/modules/cli/local/localproject/project.go
@@ -170,6 +170,7 @@ func (p *LocalProject) readTaskDefinitionFromFile(filename string) (*ecs.TaskDef
 	p.inputMetadata = &converter.LocalCreateMetadata{
 		InputType: LocalTaskDefType,
 		Value:     filename,
+		UseRole:   p.context.Bool(flags.UseRole),
 	}
 	return readTaskDefFromLocal(filename)
 }
@@ -201,6 +202,7 @@ func (p *LocalProject) readTaskDefinitionFromRemote(remote string) (*ecs.TaskDef
 	p.inputMetadata = &converter.LocalCreateMetadata{
 		InputType: RemoteTaskDefType,
 		Value:     remote,
+		UseRole:   p.context.Bool(flags.UseRole),
 	}
 	return readTaskDefFromRemote(remote, p)
 }

--- a/ecs-cli/modules/commands/flags/flags.go
+++ b/ecs-cli/modules/commands/flags/flags.go
@@ -155,6 +155,7 @@ const (
 	Output                = "output"
 	JSON                  = "json"
 	All                   = "all"
+	UseRole               = "use-role"
 )
 
 func OptRegionFlag() []cli.Flag {

--- a/ecs-cli/modules/commands/local/local_command.go
+++ b/ecs-cli/modules/commands/local/local_command.go
@@ -72,6 +72,10 @@ func createCommand() cli.Command {
 				Name:  flagName(flags.ForceFlag),
 				Usage: flagDescription(flags.ForceFlag, createCmdName),
 			},
+			cli.BoolFlag{
+				Name:  flagName(flags.UseRole),
+				Usage: flagDescription(flags.UseRole, createCmdName),
+			},
 		},
 	}
 }
@@ -168,6 +172,7 @@ func flagName(longName string) string {
 		flags.JSON:                  flags.JSON,
 		flags.All:                   flags.All,
 		flags.ForceFlag:             flags.ForceFlag,
+		flags.UseRole:               flags.UseRole,
 	}
 	return m[longName]
 }
@@ -206,6 +211,9 @@ func flagDescription(longName, cmdName string) string {
 		flags.ForceFlag: {
 			createCmdName: fmt.Sprintf("Overwrite output docker compose file if it exists. Default compose file is %s.", project.LocalOutDefaultFileName),
 			upCmdName:     fmt.Sprintf("Overwrite output docker compose file if it exists. Default compose file is %s.", project.LocalOutDefaultFileName),
+		},
+		flags.UseRole: {
+		    createCmdName: "Uses the task role ARN instead of temporary credentials.",
 		},
 	}
 	return m[longName][cmdName]


### PR DESCRIPTION
<!-- Provide summary of changes -->
Looks for a TaskRole and sets that as the `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI` environment variable. Also deletes the `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI` from the `docker-compose.ecs-local.override.yml` as this is not necessary and will always override this setting

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->
Fixes #969

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
- [X] Unit tests passed
- [ ] Integration tests passed
- [X] Unit tests added for new functionality
- [ ] Listed manual checks and their outputs in the comments ([example](https://github.com/aws/amazon-ecs-cli/pull/750#issuecomment-472623042))
- [X] Link to issue or PR for the integration tests:

**Documentation**
- [ ] Contacted our doc writer
- [ ] Updated our README
----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
