### PR TITLE
Updated the canary buildspec to check out the latest release

### DIFF
--- a/buildspec_integ.yml
+++ b/buildspec_integ.yml
@@ -3,5 +3,8 @@ version: 0.2
 phases:
   build:
     commands:
+      - latestTag=$(git describe --tags `git rev-list --tags --max-count=1`)
+      - echo "checking out $latestTag"
+      - git checkout $latestTag
       - make integ-test
       - ./bin/local/ecs-cli.test


### PR DESCRIPTION
<!-- Provide summary of changes -->
The default behavior for CodeBuild is to check out the master branch and run the canary from there. However, for canary we would like it to run based of the latest release.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
- [N/A] Unit tests passed
- [X] Integration tests passed
- [N/A] Unit tests added for new functionality
- [X] Listed manual checks and their outputs in the comments ([example]
- [N/A] Link to issue or PR for the integration tests:

**Documentation**
- [N/A] Contacted our doc writer
- [N/A] Updated our README
----

##Manual testing
Modified the buildspec_integ.yml and use the ecs-cli-on-demand-integ-test CodeBuild project to test run the integ tests just like what our canary does. And it started successfully with the right tagged commit:
![Screen Shot 2020-01-13 at 2 04 58 PM](https://user-images.githubusercontent.com/3822365/72296105-b9543600-360d-11ea-82dc-cdc50f482a64.png)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
