### PR TITLE
set go dep version to actual; paramiz go version

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@
 - Clone your forked repository into your `$GOPATH`
   - `git clone git@github.com:<user>/aws/amazon-ecs-cli $GOPATH/src/github.com/aws/amazon-ecs-cli`
   - **NOTE:** replace `<user>` with your Github username.
-- We use [dep](https://github.com/golang/dep) to manage dependencies. Make sure you have version 0.4.1 of [dep](https://github.com/golang/dep/releases/tag/v0.4.1) (installation instructions [here](https://golang.github.io/dep/docs/installation.html)). You can also run `make generate-deps` to install the latest version of dep as well as other tools.
+- We use [dep](https://github.com/golang/dep) to manage dependencies. Make sure you have version 0.5.4 of [dep](https://github.com/golang/dep/releases/tag/v0.5.4) (installation instructions [here](https://golang.github.io/dep/docs/installation.html)). You can also run `make generate-deps` to install the latest version of dep as well as other tools.
 
 #### Set upstream
 
@@ -40,7 +40,7 @@ From `$GOPATH/src/github.com/aws/amazon-ecs-cli/ecs-cli`:
 * **NOTE:** `dep ensure` puts the dependencies in a detached HEAD state. It also deletes any unused vendor files (includes running `dep prune`, as of dep 0.4.0)
 
 ### Adding/updating new dependencies
-* We use [dep](https://github.com/golang/dep) to manage dependencies. Make sure you have version 0.4.1 of [dep](https://github.com/golang/dep/releases/tag/v0.4.1) (installation instructions [here](https://golang.github.io/dep/docs/installation.html)).
+* We use [dep](https://github.com/golang/dep) to manage dependencies. Make sure you have version 0.5.4 of [dep](https://github.com/golang/dep/releases/tag/v0.5.4) (installation instructions [here](https://golang.github.io/dep/docs/installation.html)).
 * To [add a dependency](https://golang.github.io/dep/docs/daily-dep.html#adding-a-new-dependency), run `dep ensure -add <your_package>`.
 * To [update a dependency](https://golang.github.io/dep/docs/daily-dep.html#updating-dependencies), run `dep ensure -update<your_package>`.
 

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,8 @@ LINUX_BINARY := bin/linux-amd64/ecs-cli
 DARWIN_BINARY := bin/darwin-amd64/ecs-cli
 WINDOWS_BINARY := bin/windows-amd64/ecs-cli.exe
 LOCAL_PATH := $(ROOT)/scripts:${PATH}
-DEP_RELEASE_TAG := v0.4.1
+DEP_RELEASE_TAG := v0.5.4
+GO_RELEASE_TAG := 1.13
 
 .PHONY: build
 build: $(LOCAL_BINARY)
@@ -83,17 +84,17 @@ docker-build:
 		--workdir=/usr/src/app/src/github.com/aws/amazon-ecs-cli \
 		--env GOPATH=/usr/src/app \
 		--env ECS_RELEASE=$(ECS_RELEASE) \
-		golang:1.13 make $(LINUX_BINARY)
+		golang:$(GO_RELEASE_TAG) make $(LINUX_BINARY)
 	docker run -v $(shell pwd):/usr/src/app/src/github.com/aws/amazon-ecs-cli \
 		--workdir=/usr/src/app/src/github.com/aws/amazon-ecs-cli \
 		--env GOPATH=/usr/src/app \
 		--env ECS_RELEASE=$(ECS_RELEASE) \
-		golang:1.13 make $(DARWIN_BINARY)
+		golang:$(GO_RELEASE_TAG) make $(DARWIN_BINARY)
 	docker run -v $(shell pwd):/usr/src/app/src/github.com/aws/amazon-ecs-cli \
 		--workdir=/usr/src/app/src/github.com/aws/amazon-ecs-cli \
 		--env GOPATH=/usr/src/app \
 		--env ECS_RELEASE=$(ECS_RELEASE) \
-		golang:1.13 make $(WINDOWS_BINARY)
+		golang:$(GO_RELEASE_TAG) make $(WINDOWS_BINARY)
 
 .PHONY: docker-test
 docker-test:
@@ -101,7 +102,7 @@ docker-test:
 		--workdir=/usr/src/app/src/github.com/aws/amazon-ecs-cli \
 		--env GOPATH=/usr/src/app \
 		--env ECS_RELEASE=$(ECS_RELEASE) \
-		golang:1.13 make test
+		golang:$(GO_RELEASE_TAG) make test
 
 .PHONY: supported-platforms
 supported-platforms: $(LINUX_BINARY) $(DARWIN_BINARY) $(WINDOWS_BINARY)


### PR DESCRIPTION
fixes https://github.com/aws/amazon-ecs-cli/issues/977

* sets `go dep` version to 0.5.4, which is the version actually being used (see issue for details)
* parameterized the `go` version in the Makefile, saw oft churn on it, and brings in alignment with how dep's version is already managed

### Checklist

**Testing**
- [X] Unit tests passed
- [N/A] Integration tests passed
- [N/A] Unit tests added for new functionality
- [X] Listed manual checks and their outputs in the comments
- [X] Link to issue or PR for the integration tests:

**Documentation**
- [N/A] Contacted our doc writer
- [N/A] Updated our README
- [X] Updated CONTRIBUTING


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

### Comments

Manual testing also done to verify both the two changes listed at the top.

`make generate-deps` generated the following output. Demonstrating the updated dep version 0.5.4 was successfully used and installed.

```yaml
make generate-deps
DEP_RELEASE_TAG=EP_RELEASE_TAG
curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  5230  100  5230    0     0  19442      0 --:--:-- --:--:-- --:--:-- 19370
ARCH = amd64
OS = linux
Will install into /usr/src/app/bin
Fetching https://github.com/golang/dep/releases/latest..
Release Tag = v0.5.4
Fetching https://github.com/golang/dep/releases/tag/v0.5.4..
Fetching https://github.com/golang/dep/releases/download/v0.5.4/dep-linux-amd64..
Setting executable permissions.
Moving executable to /usr/src/app/bin/dep
go get github.com/golang/mock/mockgen
go get golang.org/x/tools/cmd/goimports
```


`make docker-build` generated the following output and made a successfully running `ecs-cli` binary. This demonstrates the parameterization of the go version worked successfully.

```bash
make docker-build
docker run -v **redacted**/amazon-ecs-cli:/usr/src/app/src/github.com/aws/amazon-ecs-cli \
        --workdir=/usr/src/app/src/github.com/aws/amazon-ecs-cli \
        --env GOPATH=/usr/src/app \
        --env ECS_RELEASE= \
        golang:1.13 make bin/linux-amd64/ecs-cli
Unable to find image 'golang:1.13' locally
1.13: Pulling from library/golang
8f0fdd3eaac0: Pull complete 
d918eaefd9de: Pull complete 
43bf3e3107f5: Pull complete 
27622921edb2: Pull complete 
f862a94ee651: Pull complete 
410143ccff32: Pull complete 
4e820fb4177f: Pull complete 
Digest: sha256:2df96417dca0561bf1027742dcc5b446a18957cd28eba6aa79269f23f1846d3f
Status: Downloaded newer image for golang:1.13
TARGET_GOOS=linux GOARCH=amd64 ./scripts/build_binary.sh ./bin/linux-amd64
Built ecs-cli for linux
docker run -v **redacted**/amazon-ecs-cli:/usr/src/app/src/github.com/aws/amazon-ecs-cli \
        --workdir=/usr/src/app/src/github.com/aws/amazon-ecs-cli \
        --env GOPATH=/usr/src/app \
        --env ECS_RELEASE= \
        golang:1.13 make bin/darwin-amd64/ecs-cli
TARGET_GOOS=darwin GOARCH=amd64 ./scripts/build_binary.sh ./bin/darwin-amd64
Built ecs-cli for darwin
docker run -v **redacted**/amazon-ecs-cli:/usr/src/app/src/github.com/aws/amazon-ecs-cli \
        --workdir=/usr/src/app/src/github.com/aws/amazon-ecs-cli \
        --env GOPATH=/usr/src/app \
        --env ECS_RELEASE= \
        golang:1.13 make bin/windows-amd64/ecs-cli.exe
TARGET_GOOS=windows GOARCH=amd64 ./scripts/build_binary.sh ./bin/windows-amd64
mv ./bin/windows-amd64/ecs-cli ./bin/windows-amd64/ecs-cli.exe
Built ecs-cli.exe for windows
```