### PR TITLE
update docker/cli dependency constraint

### DIFF
--- a/ecs-cli/Gopkg.lock
+++ b/ecs-cli/Gopkg.lock
@@ -124,7 +124,7 @@
   version = "v1.1.0"
 
 [[projects]]
-  digest = "1:a5ca15953ec7d39eced701d326903a1ffed0a7f1339a9b02156f6bc6b2a7cefd"
+  digest = "1:ae25b86119af299d4f1c95a91180580e3ab5a4fd0293ec423dac1c304050a944"
   name = "github.com/docker/cli"
   packages = [
     "cli/compose/interpolation",
@@ -135,8 +135,8 @@
     "opts",
   ]
   pruneopts = "UT"
-  revision = "c89750f836c57ce10386e71669e1b08a54c3caeb"
-  version = "v18.09.5"
+  revision = "1752eb3626e3a17b0881135a9402e57728208fed"
+  version = "v18.09.9"
 
 [[projects]]
   digest = "1:4ddc17aeaa82cb18c5f0a25d7c253a10682f518f4b2558a82869506eec223d76"

--- a/ecs-cli/Gopkg.toml
+++ b/ecs-cli/Gopkg.toml
@@ -78,7 +78,7 @@
 
 [[constraint]]
   name = "github.com/docker/cli"
-  version = "18.06.0-ce"
+  version = "~18.09.5"
 
 [[override]]
   name = "github.com/docker/docker"

--- a/ecs-cli/vendor/github.com/docker/cli/cli/compose/loader/interpolate.go
+++ b/ecs-cli/vendor/github.com/docker/cli/cli/compose/loader/interpolate.go
@@ -16,6 +16,8 @@ var interpolateTypeCastMapping = map[interp.Path]interp.Cast{
 	servicePath("deploy", "replicas"):                                toInt,
 	servicePath("deploy", "update_config", "parallelism"):            toInt,
 	servicePath("deploy", "update_config", "max_failure_ratio"):      toFloat,
+	servicePath("deploy", "rollback_config", "parallelism"):          toInt,
+	servicePath("deploy", "rollback_config", "max_failure_ratio"):    toFloat,
 	servicePath("deploy", "restart_policy", "max_attempts"):          toInt,
 	servicePath("ports", interp.PathMatchList, "target"):             toInt,
 	servicePath("ports", interp.PathMatchList, "published"):          toInt,

--- a/ecs-cli/vendor/github.com/docker/cli/cli/compose/loader/loader.go
+++ b/ecs-cli/vendor/github.com/docker/cli/cli/compose/loader/loader.go
@@ -476,12 +476,13 @@ func resolveVolumePaths(volumes []types.ServiceVolumeConfig, workingDir string, 
 		}
 
 		filePath := expandUser(volume.Source, lookupEnv)
-		// Check for a Unix absolute path first, to handle a Windows client
-		// with a Unix daemon. This handles a Windows client connecting to a
-		// Unix daemon. Note that this is not required for Docker for Windows
-		// when specifying a local Windows path, because Docker for Windows
-		// translates the Windows path into a valid path within the VM.
-		if !path.IsAbs(filePath) {
+		// Check if source is an absolute path (either Unix or Windows), to
+		// handle a Windows client with a Unix daemon or vice-versa.
+		//
+		// Note that this is not required for Docker for Windows when specifying
+		// a local Windows path, because Docker for Windows translates the Windows
+		// path into a valid path within the VM.
+		if !path.IsAbs(filePath) && !isAbs(filePath) {
 			filePath = absPath(workingDir, filePath)
 		}
 		volume.Source = filePath

--- a/ecs-cli/vendor/github.com/docker/cli/cli/compose/loader/windows_path.go
+++ b/ecs-cli/vendor/github.com/docker/cli/cli/compose/loader/windows_path.go
@@ -1,0 +1,66 @@
+package loader
+
+// Copyright 2010 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+// https://github.com/golang/go/blob/master/LICENSE
+
+// This file contains utilities to check for Windows absolute paths on Linux.
+// The code in this file was largely copied from the Golang filepath package
+// https://github.com/golang/go/blob/1d0e94b1e13d5e8a323a63cd1cc1ef95290c9c36/src/path/filepath/path_windows.go#L12-L65
+
+func isSlash(c uint8) bool {
+	return c == '\\' || c == '/'
+}
+
+// isAbs reports whether the path is a Windows absolute path.
+func isAbs(path string) (b bool) {
+	l := volumeNameLen(path)
+	if l == 0 {
+		return false
+	}
+	path = path[l:]
+	if path == "" {
+		return false
+	}
+	return isSlash(path[0])
+}
+
+// volumeNameLen returns length of the leading volume name on Windows.
+// It returns 0 elsewhere.
+// nolint: gocyclo
+func volumeNameLen(path string) int {
+	if len(path) < 2 {
+		return 0
+	}
+	// with drive letter
+	c := path[0]
+	if path[1] == ':' && ('a' <= c && c <= 'z' || 'A' <= c && c <= 'Z') {
+		return 2
+	}
+	// is it UNC? https://msdn.microsoft.com/en-us/library/windows/desktop/aa365247(v=vs.85).aspx
+	if l := len(path); l >= 5 && isSlash(path[0]) && isSlash(path[1]) &&
+		!isSlash(path[2]) && path[2] != '.' {
+		// first, leading `\\` and next shouldn't be `\`. its server name.
+		for n := 3; n < l-1; n++ {
+			// second, next '\' shouldn't be repeated.
+			if isSlash(path[n]) {
+				n++
+				// third, following something characters. its share name.
+				if !isSlash(path[n]) {
+					if path[n] == '.' {
+						break
+					}
+					for ; n < l; n++ {
+						if isSlash(path[n]) {
+							break
+						}
+					}
+					return n
+				}
+				break
+			}
+		}
+	}
+	return 0
+}


### PR DESCRIPTION
Fixes #978 to more clearly specify the `docker/cli` dependency constraint
This change specifies to use any patch from `18.09.x` and includes the `Gopkg.*` and `vendor/` files to match.
My thoughts on this below. 🧐

### Investigation

The Docker projects often do **not** use SemVer. Instead, they use a `YY.MM.patch` approach as documented https://www.docker.com/blog/docker-enterprise-edition/. This is true for this `docker/cli` dependency and others like `docker/docker`

Refer to issue #978 for diagnostic details. In addition to those diagnostics...

The `vendor/` files for this `docker/cli` dependency that were commited months ago to this repo are from `18.09.5`. This was verified with two methods: 1) `Gopkg.lock` declares the specific version and commit it locked; 2) `git diff` showed no changed files when I updated the `Gopkg.toml` constraint from `18.06.0-ce` to `=18.09.5` and ran `dep ensure -update github.com/docker/cli`

### Questions

I have a cautious query, in the `Gopkg.toml` is an override for the `docker/docker` dependency and it is specifically pinned to a commit that is not any full release. Instead, it appears to be a intermediate commit chain before the `18.06.0` release. While this obviously doesn't cause problems today, it is suspicious to use a pre-18.06.0 codebase with elsewhere post-18.06.0 code.


### Recommendations

To keep within a grouping of engine/api compatibility, I recommend to lock on a specific `YY.MM` like `18.09` and then allow the most recent patch. This follows somewhat the approach of @PettitWesley when he wrote "personally prefer to use the latest version of dependencies, unless backwards breaking changes force us to stick with an older version".

I recommend that you do allow patch/bugfixes. Therefore instead of using a `^` constraint, I recommend using a `~` constraint at the patch level. We already know `18.09.5` works because `ecs-cli` has been using/released with that for many months. There have been some minor patches to the `18.09` release and it is currently up to `18.09.9`. You can see those changes in this PR as instructed by CONTRIBUTING.md.

It is also probably desired to support the release e.g. `18.09` that the ECS infrastructure also supports. Currently, the ECS optimized AMIs use docker `18.09`

This also prepares the `ecs-cli` project for a forthcoming patch to the `docker/cli` dependency which I already have in queue on that project. That patch will correct one function that isn't following the compose schema correctly and will enable a new ecs-cli feature that I've completed coding. That work is documented in 607 which I don't want github to autolink that issue.

----

### Checklist

Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
- [X] Unit tests passed
- [N/A] Integration tests passed
- [N/A] Unit tests added for new functionality
- [X] Listed manual checks and their outputs in the comments
- [X] Link to issue or PR for the integration tests:

**Documentation**
- [N/A] Contacted our doc writer
- [N/A] Updated our README
----

### Comments

I `make docker-build` with no errors. It generated an `ecs-cli` which successfully ran some random commands I tested.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
