### PR TITLE
Defer resource cleanup in integ test

### DIFF
--- a/ecs-cli/integ/cmd/down.go
+++ b/ecs-cli/integ/cmd/down.go
@@ -45,6 +45,9 @@ func TestDown(t *testing.T, conf *CLIConfig) {
 		"Deleted cluster",
 		fmt.Sprintf("cluster=%s", conf.ClusterName),
 	})
+
+	t.Logf("Deleted cluster %s", conf.ClusterName)
+
 	cfn.TestNoStackName(t, stackName(conf.ClusterName))
 	t.Logf("Deleted stack %s", stackName(conf.ClusterName))
 }

--- a/ecs-cli/integ/e2e/fargate_service_test.go
+++ b/ecs-cli/integ/e2e/fargate_service_test.go
@@ -34,6 +34,9 @@ func TestCreateClusterWithFargateService(t *testing.T) {
 	conf := cmd.TestFargateTutorialConfig(t)
 	vpc := cmd.TestUp(t, conf)
 
+	// Ensure cleanup of cluster
+	defer cmd.TestDown(t, conf)
+
 	// Create the files for a task definition
 	project := cmd.NewProject("e2e-fargate-test-service", conf.ConfigName)
 	project.ComposeFileName = createFargateTutorialComposeFile(t)
@@ -41,19 +44,18 @@ func TestCreateClusterWithFargateService(t *testing.T) {
 	defer os.Remove(project.ComposeFileName)
 	defer os.Remove(project.ECSParamsFileName)
 
+
 	// Create a new service
 	cmd.TestServiceUp(t, project)
+
+	// Ensure cleanup of service
+	defer cmd.TestServiceDown(t, project)
+
 	cmd.TestServicePs(t, project, 1)
 
 	// Increase the number of running tasks
 	cmd.TestServiceScale(t, project, 2)
 	cmd.TestServicePs(t, project, 2)
-
-	// Delete the service
-	cmd.TestServiceDown(t, project)
-
-	// Delete the cluster
-	cmd.TestDown(t, conf)
 }
 
 func createFargateTutorialComposeFile(t *testing.T) string {


### PR DESCRIPTION
We were seeing services and empty clusters being left over when UpdateService was being called immediately after CreateService, due to eventual read consistency issues in ECS, mostly on the `TestCreateClusterWithFargateService` integration test.. This would cause the UpdateService call to fail, which meant the cleanup actions (DeleteService, DeleteCluster) were not getting called. This ensures they will be even if intermediate calls inside the test function fail.

----
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
