### PR TITLE
fix: "compose service up" sets desired count to 1

### DIFF
--- a/ecs-cli/modules/cli/compose/entity/service/service_helper.go
+++ b/ecs-cli/modules/cli/compose/entity/service/service_helper.go
@@ -72,38 +72,6 @@ func logNewServiceEvents(loggedEvents map[string]bool, events []*ecs.ServiceEven
 
 }
 
-func waitForServiceDescribable(service *Service) error {
-	eventsLogged := make(map[string]bool)
-	timeOut := float64(DefaultUpdateServiceTimeout)
-	actionInvokedAt := time.Now()
-
-	if val := service.Context().CLIContext.Float64(flags.ComposeServiceTimeOutFlag); val > 0 {
-		timeOut = val
-	} else if val < 0 {
-		return fmt.Errorf("Error with timeout flag: %f is not a valid timeout value", val)
-	} else {
-		log.Warn("Timeout was specified as zero. Service creation may not have completed yet.")
-		return nil
-	}
-
-	return waiters.ServiceWaitUntilComplete(func(retryCount int) (bool, error) {
-		if ecsService, err := service.describeService(); err == nil {
-			// log new service events
-			if len(ecsService.Events) > 0 {
-				logNewServiceEvents(eventsLogged, ecsService.Events, actionInvokedAt)
-			}
-			return true, nil
-		}
-
-		if time.Since(actionInvokedAt).Minutes() > timeOut {
-			return false, fmt.Errorf("Deployment has not completed: Service can't be described after %.2f minutes", timeOut)
-		}
-
-		return false, nil
-
-	}, service)
-}
-
 // waitForServiceTasks continuously polls ECS (by calling describeService) and waits for service to get stable
 // with desiredCount == runningCount
 func waitForServiceTasks(service *Service, ecsServiceName string) error {

--- a/ecs-cli/modules/cli/compose/entity/service/service_test.go
+++ b/ecs-cli/modules/cli/compose/entity/service/service_test.go
@@ -431,18 +431,6 @@ func TestCreateWithHealthCheckGracePeriodAndELB(t *testing.T) {
 	)
 }
 
-func TestDelayedServiceCreate(t *testing.T) {
-	// define test flag set
-	timeoutFlagValue := 1
-
-	flagSet := flag.NewFlagSet("ecs-cli-up", 0)
-	flagSet.String(flags.ComposeServiceTimeOutFlag, strconv.Itoa(timeoutFlagValue), "")
-	cliContext := cli.NewContext(nil, flagSet, nil)
-
-	// call tests
-	createNewServiceWithDelay(t, cliContext, &config.CommandConfig{}, &utils.ECSParams{})
-}
-
 func TestCreateWithServiceDiscovery(t *testing.T) {
 	sdsARN := "arn:aws:servicediscovery:eu-west-1:11111111111:service/srv-clydelovespudding"
 
@@ -751,95 +739,6 @@ func createServiceTest(t *testing.T,
 	service.SetTaskDefinition(&taskDefinition)
 	err = service.Create()
 	assert.NoError(t, err, "Unexpected error while create")
-
-	// task definition should be set
-	assert.Equal(t, taskDefArn, aws.StringValue(service.TaskDefinition().TaskDefinitionArn), "TaskDefArn should match")
-}
-
-// helper for createNewServiceWithDelay
-func getCreateServiceWithDelayMockClient(t *testing.T,
-	ctrl *gomock.Controller,
-	taskDefinition ecs.TaskDefinition,
-	taskDefID string,
-	registerTaskDefResponse ecs.TaskDefinition) *mock_ecs.MockECSClient {
-
-	mockEcs := mock_ecs.NewMockECSClient(ctrl)
-
-	createdService := &ecs.Service{
-		TaskDefinition: aws.String("arn/" + taskDefID),
-		Status:         aws.String("ACTIVE"),
-		DesiredCount:   aws.Int64(0),
-		RunningCount:   aws.Int64(0),
-		ServiceName:    aws.String("test-created"),
-	}
-	updatedService := *createdService
-	gomock.InOrder(
-		mockEcs.EXPECT().DescribeService(gomock.Any()).Return(getDescribeServiceTestResponse(nil), nil),
-
-		mockEcs.EXPECT().RegisterTaskDefinitionIfNeeded(
-			gomock.Any(), // RegisterTaskDefinitionInput
-			gomock.Any(), // taskDefinitionCache
-		).Do(func(input, cache interface{}) {
-			verifyTaskDefinitionInput(t, taskDefinition, input.(*ecs.RegisterTaskDefinitionInput))
-		}).Return(&registerTaskDefResponse, nil),
-
-		mockEcs.EXPECT().ListAccountSettings(gomock.Any()).Do(func(input interface{}) {
-			req := input.(*ecs.ListAccountSettingsInput)
-			assert.True(t, aws.BoolValue(req.EffectiveSettings), "Expected Effective settings to be true")
-			assert.Equal(t, ecs.SettingNameTaskLongArnFormat, aws.StringValue(req.Name), "Expected setting name to be service long ARN")
-		}).Return(&ecs.ListAccountSettingsOutput{
-			Settings: []*ecs.Setting{
-				&ecs.Setting{
-					Value: aws.String(ecsSettingDisabled),
-				},
-			},
-		}, nil),
-
-		mockEcs.EXPECT().CreateService(
-			gomock.Any(), // createServiceInput
-		).Do(func(input interface{}) {
-			req := input.(*ecs.CreateServiceInput)
-			observedTaskDefID := req.TaskDefinition
-			assert.Equal(t, taskDefID, aws.StringValue(observedTaskDefID), "Task Definition name should match")
-		}).Return(nil),
-
-		mockEcs.EXPECT().DescribeService(gomock.Any()).Return(getDescribeServiceTestResponse(nil), nil),
-		mockEcs.EXPECT().DescribeService(gomock.Any()).Return(getDescribeServiceTestResponse(createdService), nil).MaxTimes(2),
-		mockEcs.EXPECT().UpdateService(
-			gomock.Any(), // updateServiceInput
-		).Return(nil),
-		mockEcs.EXPECT().DescribeService(gomock.Any()).Return(getDescribeServiceTestResponse(updatedService.SetDeployments([]*ecs.Deployment{&ecs.Deployment{}}).SetDesiredCount(1).SetRunningCount(1)), nil),
-	)
-	return mockEcs
-}
-
-func createNewServiceWithDelay(t *testing.T,
-	cliContext *cli.Context,
-	commandConfig *config.CommandConfig,
-	ecsParams *utils.ECSParams) {
-
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	taskDefID := "newTaskDefinitionId"
-	taskDefArn, taskDefinition, registerTaskDefResponse := getTestTaskDef(taskDefID)
-
-	mockEcs := getCreateServiceWithDelayMockClient(t, ctrl, taskDefinition, taskDefID, registerTaskDefResponse)
-
-	ecsContext := &context.ECSContext{
-		ECSClient:     mockEcs,
-		CommandConfig: commandConfig,
-		CLIContext:    cliContext,
-		ECSParams:     ecsParams,
-	}
-	ecsContext.SetProjectName()
-	service := NewService(ecsContext)
-	err := service.LoadContext()
-	assert.NoError(t, err, "Unexpected error while loading context in update service with new task def test")
-
-	service.SetTaskDefinition(&taskDefinition)
-	err = service.Up()
-	assert.NoError(t, err, "Unexpected error on service up with new task def")
 
 	// task definition should be set
 	assert.Equal(t, taskDefArn, aws.StringValue(service.TaskDefinition().TaskDefinitionArn), "TaskDefArn should match")


### PR DESCRIPTION
Previously, we would first call CreateService with desired count 0 then
call UpdateService to set the desired count to 1. This eliminates extra
API calls, as well as the need to wait until the service is describable
before "starting" it.

Note: This effectively reverts 264fe13

Related: #79

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
- [x] Unit tests passed
- [x] Integration tests passed
- [x] Unit tests added for new functionality
- [x] Listed manual checks and their outputs in the comments ([example](https://github.com/aws/amazon-ecs-cli/pull/750#issuecomment-472623042))
- [x] Link to issue or PR for the integration tests:

**Documentation**
- [N/A] Contacted our doc writer
- [N/A] Updated our README
----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
