### PR TITLE
fix: add waiters to create task

### DIFF
--- a/ecs-cli/integ/cmd/up.go
+++ b/ecs-cli/integ/cmd/up.go
@@ -64,6 +64,7 @@ func TestUp(t *testing.T, conf *CLIConfig, options ...func([]string) []string) *
 	})
 	cfn.TestStackNameExists(t, stackName(conf.ClusterName))
 
+	// TODO fix: Cluster not technically part of the stack
 	t.Logf("Created cluster %s in stack %s", conf.ClusterName, stackName(conf.ClusterName))
 	return parseVPC(out)
 }

--- a/ecs-cli/integ/e2e/fargate_service_test.go
+++ b/ecs-cli/integ/e2e/fargate_service_test.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/aws/amazon-ecs-cli/ecs-cli/integ"
 	"github.com/aws/amazon-ecs-cli/ecs-cli/integ/cmd"
 
 	"github.com/stretchr/testify/require"
@@ -38,12 +39,12 @@ func TestCreateClusterWithFargateService(t *testing.T) {
 	defer cmd.TestDown(t, conf)
 
 	// Create the files for a task definition
-	project := cmd.NewProject("e2e-fargate-test-service", conf.ConfigName)
+	projectName := integ.SuggestedResourceName("e2e-fargate-test-service")
+	project := cmd.NewProject(projectName, conf.ConfigName)
 	project.ComposeFileName = createFargateTutorialComposeFile(t)
 	project.ECSParamsFileName = createFargateTutorialECSParamsFile(t, vpc.Subnets)
 	defer os.Remove(project.ComposeFileName)
 	defer os.Remove(project.ECSParamsFileName)
-
 
 	// Create a new service
 	cmd.TestServiceUp(t, project)

--- a/ecs-cli/modules/cli/compose/entity/entity_helper.go
+++ b/ecs-cli/modules/cli/compose/entity/entity_helper.go
@@ -213,6 +213,8 @@ func collectTasks(entity ProjectEntity, filterLocal bool, desiredStatus string) 
 
 // CollectTasksWithStatus gets all the tasks of specified desired status
 // If filterLocal is true, it filters out with Group or StartedBy as this project
+
+// NOTE: desired status is misleading, we should probably filter on last status.
 func CollectTasksWithStatus(entity ProjectEntity, status string, filterLocal bool) ([]*ecs.Task, error) {
 	request := constructListPagesRequest(entity, status, filterLocal)
 	result := []*ecs.Task{}

--- a/ecs-cli/modules/cli/compose/entity/service/service.go
+++ b/ecs-cli/modules/cli/compose/entity/service/service.go
@@ -663,7 +663,12 @@ func (s *Service) createService(desiredCount int) error {
 		return err
 	}
 
-	return nil
+	err = waitForServiceDescribable(s)
+	if err != nil {
+		return err
+	}
+
+	return waitForServiceTasks(s, serviceName)
 }
 
 // describeService calls underlying ECS.DescribeService and expects the service to be present,

--- a/ecs-cli/modules/cli/compose/entity/service/service_helper.go
+++ b/ecs-cli/modules/cli/compose/entity/service/service_helper.go
@@ -72,8 +72,40 @@ func logNewServiceEvents(loggedEvents map[string]bool, events []*ecs.ServiceEven
 
 }
 
-// waitForServiceTasks continuously polls ECS (by calling describeService) and waits for service to get stable
-// with desiredCount == runningCount
+func waitForServiceDescribable(service *Service) error {
+	eventsLogged := make(map[string]bool)
+	timeOut := float64(DefaultUpdateServiceTimeout)
+	actionInvokedAt := time.Now()
+
+	if val := service.Context().CLIContext.Float64(flags.ComposeServiceTimeOutFlag); val > 0 {
+		timeOut = val
+	} else if val < 0 {
+		return fmt.Errorf("Error with timeout flag: %f is not a valid timeout value", val)
+	} else {
+		log.Warn("Timeout was specified as zero. Service creation may not have completed yet.")
+		return nil
+	}
+
+	return waiters.ServiceWaitUntilComplete(func(retryCount int) (bool, error) {
+		if ecsService, err := service.describeService(); err == nil {
+			// log new service events
+			if len(ecsService.Events) > 0 {
+				logNewServiceEvents(eventsLogged, ecsService.Events, actionInvokedAt)
+			}
+			return true, nil
+		}
+
+		if time.Since(actionInvokedAt).Minutes() > timeOut {
+			return false, fmt.Errorf("Deployment has not completed: Service can't be described after %.2f minutes", timeOut)
+		}
+
+		return false, nil
+
+	}, service)
+}
+
+// waitForServiceTasks continuously polls ECS (by calling describeService) and
+// waits for service to get stable with desiredCount == runningCount
 func waitForServiceTasks(service *Service, ecsServiceName string) error {
 	eventsLogged := make(map[string]bool)
 	var lastRunningCount int64


### PR DESCRIPTION
Previously, calling createTask without any waiters would cause the
integration tests to fail since we depend on eventual consistency to
make assertions on the state of the service. There were issues with the
DescribeService calls being made hitting different DB replicas, causing
the integration tests to be brittle. This keeps the change that combines
the API calls on `compose service up` for a new service, while also
ensuring that the service gets to a stable state before further action.

This also adds an identifier prefix on the name of the service being
launched by the TestCreateClusterWithFargateService integ test.

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
- [x] Unit tests passed
- [x] Integration tests passed
- [x] Unit tests added for new functionality
- [x] Listed manual checks and their outputs in the comments ([example](https://github.com/aws/amazon-ecs-cli/pull/750#issuecomment-472623042))
- [x] Link to issue or PR for the integration tests:

**Documentation**
- [N/A] Contacted our doc writer
- [ N/A] Updated our README
----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
