### PR TITLE
fix: ensure cleanup of service

### DIFF
--- a/ecs-cli/integ/e2e/fargate_service_test.go
+++ b/ecs-cli/integ/e2e/fargate_service_test.go
@@ -46,12 +46,11 @@ func TestCreateClusterWithFargateService(t *testing.T) {
 	defer os.Remove(project.ComposeFileName)
 	defer os.Remove(project.ECSParamsFileName)
 
-	// Create a new service
-	cmd.TestServiceUp(t, project)
-
 	// Ensure cleanup of service
 	defer cmd.TestServiceDown(t, project)
 
+	// Create a new service
+	cmd.TestServiceUp(t, project)
 	cmd.TestServicePs(t, project, 1)
 
 	// Increase the number of running tasks


### PR DESCRIPTION
Previous fix in 26c7177e did not ensure cleanup of the service if the
TestServiceUp call failed. This would lead to situations in which
cluster deletion would fail in the TestCreateClusterWithFargateService
integration test because the cluster still contained an "active" service.

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
- [x] Unit tests passed
- [ ] Integration tests passed
- [x] Unit tests added for new functionality
- [x] Listed manual checks and their outputs in the comments ([example](https://github.com/aws/amazon-ecs-cli/pull/750#issuecomment-472623042))
- [N/A] Link to issue or PR for the integration tests:

----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
