### PR TITLE
fix: add force flag to ECSClient#DeleteService

### DIFF
--- a/ecs-cli/integ/e2e/fargate_service_test.go
+++ b/ecs-cli/integ/e2e/fargate_service_test.go
@@ -47,7 +47,7 @@ func TestCreateClusterWithFargateService(t *testing.T) {
 	defer os.Remove(project.ECSParamsFileName)
 
 	// Ensure cleanup of service
-	defer cmd.TestServiceDown(t, project)
+	defer cmd.TestServiceDown(t, project) // Add waiter here to make sure this succeeds?
 
 	// Create a new service
 	cmd.TestServiceUp(t, project)

--- a/ecs-cli/modules/cli/compose/entity/service/service.go
+++ b/ecs-cli/modules/cli/compose/entity/service/service.go
@@ -425,14 +425,8 @@ func (s *Service) Down() error {
 		return nil
 	}
 
-	// stop any running tasks
-	if aws.Int64Value(ecsService.DesiredCount) != 0 && aws.StringValue(ecsService.SchedulingStrategy) != ecs.SchedulingStrategyDaemon {
-		if err = s.Stop(); err != nil {
-			return err
-		}
-	}
-
-	// deleteService
+	// DeleteService will ignore desiredCount being non-zero by making use
+	// of the force flag
 	if err = s.Context().ECSClient.DeleteService(ecsServiceName); err != nil {
 		return err
 	}

--- a/ecs-cli/modules/cli/compose/entity/service/service_helper.go
+++ b/ecs-cli/modules/cli/compose/entity/service/service_helper.go
@@ -86,7 +86,7 @@ func waitForServiceDescribable(service *Service) error {
 		return nil
 	}
 
-	return waiters.ServiceWaitUntilComplete(func(retryCount int) (bool, error) {
+	return waiters.ServiceWaitUntilComplete(func() (bool, error) {
 		if ecsService, err := service.describeService(); err == nil {
 			// log new service events
 			if len(ecsService.Events) > 0 {
@@ -122,7 +122,7 @@ func waitForServiceTasks(service *Service, ecsServiceName string) error {
 		return nil
 	}
 
-	return waiters.ServiceWaitUntilComplete(func(retryCount int) (bool, error) {
+	return waiters.ServiceWaitUntilComplete(func() (bool, error) {
 		ecsService, err := service.describeService()
 		if err != nil {
 			return false, err
@@ -131,6 +131,7 @@ func waitForServiceTasks(service *Service, ecsServiceName string) error {
 		desiredCount := aws.Int64Value(ecsService.DesiredCount)
 		runningCount := aws.Int64Value(ecsService.RunningCount)
 
+		// log current state of service
 		logFields := log.Fields{
 			"serviceName":  ecsServiceName,
 			"desiredCount": desiredCount,

--- a/ecs-cli/modules/clients/aws/ecs/client.go
+++ b/ecs-cli/modules/clients/aws/ecs/client.go
@@ -129,6 +129,7 @@ func (c *ecsClient) DeleteService(serviceName string) error {
 	_, err := c.client.DeleteService(&ecs.DeleteServiceInput{
 		Service: aws.String(serviceName),
 		Cluster: aws.String(c.config.Cluster),
+		Force: aws.Bool(true),
 	})
 	if err != nil {
 		log.WithFields(log.Fields{

--- a/ecs-cli/modules/utils/sleeper.go
+++ b/ecs-cli/modules/utils/sleeper.go
@@ -15,12 +15,12 @@ package utils
 
 import "time"
 
-// Sleeper interface implements the sleep() method. Useful for testing Wait* methods.
+// Sleeper interface implements the Sleep() method. Useful for testing Wait* methods.
 type Sleeper interface {
 	Sleep(time.Duration)
 }
 
-// timeSleeper implements sleeper interface by calling the time.Sleep method for sleeping.
+// timeSleeper implements Sleeper interface by calling the time.Sleep method for sleeping.
 type TimeSleeper struct{}
 
 func (t *TimeSleeper) Sleep(d time.Duration) {

--- a/ecs-cli/modules/utils/waiters/waiters.go
+++ b/ecs-cli/modules/utils/waiters/waiters.go
@@ -34,7 +34,7 @@ const (
 	// servicesWaitDelay is the delay between successive ECS DescribeServices API calls
 	// while determining if the service is stable or inactive. This value
 	// reflects the values set in the ecs waiters json file in the aws-go-sdk.
-	servicesWaitDelay = 15 * time.Second
+	servicesWaitDelay = 5 * time.Second
 )
 
 // waiterAction defines an action performed on the project entity
@@ -61,7 +61,6 @@ func ServiceWaitUntilComplete(action waiterAction, entity entity.ProjectEntity) 
 
 // WaitUntilTimeout executes the waiterAction for maxRetries number of times, waiting for delayWait time between execution
 func TaskWaitUntilTimeout(action waiterAction, entity entity.ProjectEntity, timeoutMessage string) error {
-
 	for retryCount := 0; retryCount < tasksMaxRetries; retryCount++ {
 		done, err := action(retryCount)
 		if err != nil {

--- a/ecs-cli/modules/utils/waiters/waiters.go
+++ b/ecs-cli/modules/utils/waiters/waiters.go
@@ -37,15 +37,19 @@ const (
 	servicesWaitDelay = 5 * time.Second
 )
 
-// waiterAction defines an action performed on the project entity
-// and returns a bool to stop the wait or error if something unexpected happens
-type waiterAction func(retryCount int) (bool, error)
+// taskWaiterAction defines an action performed on a task and returns a bool to
+// stop the wait or error if something unexpected happens
+type taskWaiterAction func(retryCount int) (bool, error)
+
+// serviceWaiterAction defines an action performed on a service and returns a bool to
+// stop the wait or error if something unexpected happens
+type serviceWaiterAction func() (bool, error)
 
 // ServiceWaitUntilComplete runs the action in a for true loop, until the action returns true or an error
-func ServiceWaitUntilComplete(action waiterAction, entity entity.ProjectEntity) error {
+func ServiceWaitUntilComplete(action serviceWaiterAction, entity entity.ProjectEntity) error {
 	// run the loop until done or error thrown
-	for retryCount := 0; true; retryCount++ {
-		done, err := action(retryCount)
+	for {
+		done, err := action()
 		if err != nil {
 			return err
 		}
@@ -56,11 +60,10 @@ func ServiceWaitUntilComplete(action waiterAction, entity entity.ProjectEntity) 
 	}
 
 	return nil
-
 }
 
 // WaitUntilTimeout executes the waiterAction for maxRetries number of times, waiting for delayWait time between execution
-func TaskWaitUntilTimeout(action waiterAction, entity entity.ProjectEntity, timeoutMessage string) error {
+func TaskWaitUntilTimeout(action taskWaiterAction, entity entity.ProjectEntity, timeoutMessage string) error {
 	for retryCount := 0; retryCount < tasksMaxRetries; retryCount++ {
 		done, err := action(retryCount)
 		if err != nil {

--- a/ecs-cli/modules/utils/waiters/waiters.go
+++ b/ecs-cli/modules/utils/waiters/waiters.go
@@ -35,11 +35,6 @@ const (
 	// while determining if the service is stable or inactive. This value
 	// reflects the values set in the ecs waiters json file in the aws-go-sdk.
 	servicesWaitDelay = 15 * time.Second
-
-	// servicesMaxRetries is the maximum number of ECS DescribeServices API will be invoked by the WaitUntilComplete method
-	// to determine if the task is running or stopped before giving up. This value reflects the values set in the
-	// ecs waiters json file in the aws-go-sdk.
-	servicesMaxRetries = 40
 )
 
 // waiterAction defines an action performed on the project entity


### PR DESCRIPTION
This eliminates the extra UpdateService call we currently make to scale a service down to 0 before deleting, and should therefore mitigate eventual read consistency errors that occur on updates during describe calls.

Also includes refactor of service waiter to get rid of unused argument.

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
- [x] Unit tests passed
- [x] Integration tests passed
- [x] Unit tests added for new functionality
- [x] Listed manual checks and their outputs in the comments ([example](https://github.com/aws/amazon-ecs-cli/pull/750#issuecomment-472623042))
- [N/A] Link to issue or PR for the integration tests:

----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
