### PR TITLE
Add ECS CLI V2 link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,12 @@
+__✨ The [ECS CLI v2](https://github.com/aws/amazon-ecs-cli-v2) is now in preview: a new way to develop, release and operate your container apps on ECS__
+
+<details>
+<summary>Learn more about the ECS CLI V2</summary>
+
+The [ECS CLI v2](https://github.com/aws/amazon-ecs-cli-v2) is a brand new CLI focused on the full developer experience of building, deploying and operating your containerized apps. From helping manage all of your infrastructure, to setting up CD Pipelines, the V2 is here to help. The [ECS CLI v2](https://github.com/aws/amazon-ecs-cli-v2) is still in preview and quite different from V1, but we'd love your feedback! For more info on V2, V1 and how these projects are being developed [check out our V2 proposal](https://github.com/aws/containers-roadmap/issues/513).
+</details>
+
+
 # Amazon ECS CLI
 
 The Amazon ECS Command Line Interface (CLI) is a command line tool for Amazon Elastic Container


### PR DESCRIPTION
Adds a little blurb about the ECS CLI v2 in the Readme. 

Feel free to poke around here: https://github.com/kohidave/amazon-ecs-cli

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
- [N/A] Unit tests passed
- [N/A] Integration tests passed
- [N/A] Unit tests added for new functionality
- [N/A] Listed manual checks and their outputs in the comments ([example](https://github.com/aws/amazon-ecs-cli/pull/750#issuecomment-472623042))
- [N/A] Link to issue or PR for the integration tests:

**Documentation**
- [N/A] Contacted our doc writer
- [x] Updated our README
----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
