### PR TITLE
fix(pipeline): Add verification step and integ tests to pipeline

### DIFF
--- a/buildspec_canary.yml
+++ b/buildspec_canary.yml
@@ -6,7 +6,6 @@ phases:
       golang: 1.13
   build:
     commands:
-      - GOPROXY=direct
       - latestTag=$(git describe --tags `git rev-list --tags --max-count=1`)
       - echo "checking out $latestTag"
       - git checkout $latestTag

--- a/buildspec_canary.yml
+++ b/buildspec_canary.yml
@@ -1,0 +1,14 @@
+version: 0.2
+
+phases:
+  install:
+    runtime-versions:
+      golang: 1.13
+  build:
+    commands:
+      - GOPROXY=direct
+      - latestTag=$(git describe --tags `git rev-list --tags --max-count=1`)
+      - echo "checking out $latestTag"
+      - git checkout $latestTag
+      - make integ-test
+      - ./bin/local/ecs-cli.test

--- a/buildspec_integ.yml
+++ b/buildspec_integ.yml
@@ -12,7 +12,9 @@ phases:
       - cd /go/src/github.com/aws/amazon-ecs-cli/
   build:
     commands:
-      - $TMPDIR=/tmp make integ-test
+      - mkdir ./test_data
+      - export TMPDIR=./test_data 
+      - make integ-test
       - ./bin/local/ecs-cli.test
 artifacts:
   files:

--- a/buildspec_integ.yml
+++ b/buildspec_integ.yml
@@ -11,8 +11,6 @@ phases:
       - cd /go/src/github.com/aws/amazon-ecs-cli/
   build:
     commands:
-      - mkdir tmp
-      - export TMPDIR=tmp
       - make integ-test
       - ./bin/local/ecs-cli.test
 artifacts:

--- a/buildspec_integ.yml
+++ b/buildspec_integ.yml
@@ -4,11 +4,12 @@ phases:
   install:
     runtime-versions:
       golang: 1.13
-  build:
+  pre_build:
     commands:
       - GOPROXY=direct
-      - latestTag=$(git describe --tags `git rev-list --tags --max-count=1`)
-      - echo "checking out $latestTag"
-      - git checkout $latestTag
+      - mkdir -p /go/src/github.com/aws/amazon-ecs-cli
+      - cp -R . /go/src/github.com/aws/amazon-ecs-cli/
+      - cd /go/src/github.com/aws/amazon-ecs-cli/
+  build:
+    commands:
       - make integ-test
-      - ./bin/local/ecs-cli.test

--- a/buildspec_integ.yml
+++ b/buildspec_integ.yml
@@ -13,6 +13,3 @@ phases:
     commands:
       - make integ-test
       - ./bin/local/ecs-cli.test
-artifacts:
-  files:
-    - '**/*'

--- a/buildspec_integ.yml
+++ b/buildspec_integ.yml
@@ -6,14 +6,13 @@ phases:
       golang: 1.13
   pre_build:
     commands:
-      - GOPROXY=direct
       - mkdir -p /go/src/github.com/aws/amazon-ecs-cli
       - cp -R . /go/src/github.com/aws/amazon-ecs-cli/
       - cd /go/src/github.com/aws/amazon-ecs-cli/
   build:
     commands:
-      - mkdir ./test_data
-      - export TMPDIR=./test_data 
+      - mkdir tmp
+      - export TMPDIR=tmp
       - make integ-test
       - ./bin/local/ecs-cli.test
 artifacts:

--- a/buildspec_integ.yml
+++ b/buildspec_integ.yml
@@ -1,8 +1,12 @@
 version: 0.2
 
 phases:
+  install:
+    runtime-versions:
+      golang: 1.13
   build:
     commands:
+      - GOPROXY=direct
       - latestTag=$(git describe --tags `git rev-list --tags --max-count=1`)
       - echo "checking out $latestTag"
       - git checkout $latestTag

--- a/buildspec_integ.yml
+++ b/buildspec_integ.yml
@@ -12,4 +12,8 @@ phases:
       - cd /go/src/github.com/aws/amazon-ecs-cli/
   build:
     commands:
-      - make integ-test
+      - $TMPDIR=/tmp make integ-test
+      - ./bin/local/ecs-cli.test
+artifacts:
+  files:
+    - '**/*'

--- a/buildspec_verify.yml
+++ b/buildspec_verify.yml
@@ -3,6 +3,7 @@ phases:
   build:
     commands:
       - export S3_ENDPOINT=s3.cn-north-1.amazonaws.com.cn
+      - export S3_ENDPOINT_SIGNATURES=s3.amazonaws.com
       - export BUCKET=amazon-ecs-cli
       - GIT_COMMIT_ID=`git rev-parse HEAD`
       - ./scripts/verify.sh $GIT_COMMIT_ID.manifest

--- a/buildspec_verify.yml
+++ b/buildspec_verify.yml
@@ -1,0 +1,10 @@
+version: 0.2
+phases:
+  install:
+    commands:
+      source ./scripts/verify.sh
+      S3_ENDPOINT=s3.cn-north-1.amazonaws.com.cn
+      BUCKET=amazon-ecs-cli
+  build:
+    GIT_COMMIT_ID=`git rev-parse HEAD`
+    retry verifyAll $GIT_COMMIT_ID.manifest

--- a/buildspec_verify.yml
+++ b/buildspec_verify.yml
@@ -1,10 +1,8 @@
 version: 0.2
 phases:
-  install:
-    commands:
-      source ./scripts/verify.sh
-      S3_ENDPOINT=s3.cn-north-1.amazonaws.com.cn
-      BUCKET=amazon-ecs-cli
   build:
-    GIT_COMMIT_ID=`git rev-parse HEAD`
-    retry verifyAll $GIT_COMMIT_ID.manifest
+    commands:
+      - export S3_ENDPOINT=s3.cn-north-1.amazonaws.com.cn
+      - export BUCKET=amazon-ecs-cli
+      - GIT_COMMIT_ID=`git rev-parse HEAD`
+      - ./scripts/verify.sh $GIT_COMMIT_ID.manifest

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -16,11 +16,12 @@ function verifyAll {
     for artifact in `cat $1`
     do
         bn="$(basename $artifact)"
-        echo "Downloading artifact and verifying signature for $bn"
+        echo "Downloading artifact $bn from endpoint $S3_ENDPOINT"
         wget -q -T 300 https://$S3_ENDPOINT/$BUCKET/$bn
-        echo "Downloading artifact "
-        wget -q -T 300 https://$S3_ENDPOINT/$BUCKET/$bn.asc
-        gpg --verify $bn.asc $bn
+        echo "Downloading artifact signature from $S3_ENDPOINT_SIGNATURES"
+        wget -q -T 300 https://$S3_ENDPOINT_SIGNATURES/$BUCKET/$bn.asc
+        echo "verifying signature..."
+        gpg --verify $bn.asc $bn || return 1
     done
 }
 
@@ -28,7 +29,7 @@ function setupGPG {
     gpg --version
     mkdir ~/.gnupg
     echo "disable-ipv6" >> ~/.gnupg/dirmngr.conf
-    gpg --keyserver hkp://pool.sks-keyservers.net --recv BCE9D9A42D51784F || return 1
+    gpg --keyserver hkp://pool.sks-keyservers.net --recv BCE9D9A42D51784F || exit 1
 }
 
 setupGPG

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -18,6 +18,7 @@ function verifyAll {
         bn="$(basename $artifact)"
         echo "Downloading artifact and verifying signature for $bn"
         wget -q -T 300 https://$S3_ENDPOINT/$BUCKET/$bn
+        echo "Downloading artifact "
         wget -q -T 300 https://$S3_ENDPOINT/$BUCKET/$bn.asc
         gpg --verify $bn.asc $bn
     done
@@ -27,5 +28,8 @@ function setupGPG {
     gpg --version
     mkdir ~/.gnupg
     echo "disable-ipv6" >> ~/.gnupg/dirmngr.conf
-    gpg --keyserver hkp://keys.gnupg.net --recv BCE9D9A42D51784F
+    gpg --keyserver hkp://pool.sks-keyservers.net --recv BCE9D9A42D51784F || return 1
 }
+
+setupGPG
+retry verifyAll $1

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# usage: source these functions and set the s3 endpoint to
+# either s3.<region>.amazonaws.com or s3.<region>.amazonaws.com.cn
+
+# usage: retry <command>
+function retry {
+    local delay=900 # 60 * 15 = 15 minutes
+    while true; do
+        "$@" && break
+        sleep $delay
+    done
+}
+
+#usage: verifyAll <manifestFile>
+function verifyAll {
+    for artifact in `cat $1`
+    do
+        bn="$(basename $artifact)"
+        echo "Downloading artifact and verifying signature for $bn"
+        wget -q -T 300 https://$S3_ENDPOINT/$BUCKET/$bn
+        wget -q -T 300 https://$S3_ENDPOINT/$BUCKET/$bn.asc
+        gpg --verify $bn.asc $bn
+    done
+}
+
+function setupGPG {
+    gpg --version
+    mkdir ~/.gnupg
+    echo "disable-ipv6" >> ~/.gnupg/dirmngr.conf
+    gpg --keyserver hkp://keys.gnupg.net --recv BCE9D9A42D51784F
+}


### PR DESCRIPTION
Adds integ test stage in parallel with build stage which runs "make integ"
Adds verification stage after release which uses the following logic: 
* Download artifacts from cn-north-1 endpoint 
* Download signatures from US endpoint
* If signature mismatch, or unable to download artifact, retry in 15 minutes
* Repeat until 8 hour codebuild project timeout.  

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
- [x ] Unit tests passed
- [x ] Integration tests passed

----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
