### PR TITLE
Validate instance type before CloudFormation

### DIFF
--- a/ecs-cli/modules/cli/cluster/cluster_app.go
+++ b/ecs-cli/modules/cli/cluster/cluster_app.go
@@ -319,7 +319,7 @@ func createCluster(context *cli.Context, awsClients *AWSClients, commandConfig *
 	}
 
 	if launchType == config.LaunchTypeEC2 {
-		instanceType, err := populateInstanceTypeParameter(cfnParams)
+		instanceType, err := getInstanceType(cfnParams)
 		if err != nil {
 			return err
 		}
@@ -406,19 +406,7 @@ func canEnableContainerInstanceTagging(client ecsclient.ECSClient) (bool, error)
 	return false, nil
 }
 
-func retrieveInstanceType(cfnParams *cloudformation.CfnStackParams) (string, error) {
-	param, err := cfnParams.GetParameter(ParameterKeyInstanceType)
-
-	if err == cloudformation.ParameterNotFoundError {
-		return cloudformation.DefaultECSInstanceType, nil
-	}
-	if err != nil {
-		return "", err
-	}
-	return aws.StringValue(param.ParameterValue), nil
-}
-
-func populateInstanceTypeParameter(cfnParams *cloudformation.CfnStackParams) (string, error) {
+func getInstanceType(cfnParams *cloudformation.CfnStackParams) (string, error) {
 	param, err := cfnParams.GetParameter(ParameterKeyInstanceType)
 	if err == cloudformation.ParameterNotFoundError {
 		logrus.Infof("Defaulting instance type to %s", cloudformation.DefaultECSInstanceType)
@@ -430,7 +418,7 @@ func populateInstanceTypeParameter(cfnParams *cloudformation.CfnStackParams) (st
 		return "", err
 	}
 
-	return aws.StringValue(param.ParameterValue), err
+	return aws.StringValue(param.ParameterValue), nil
 }
 
 func validateInstanceType(instanceType string, supportedInstanceTypes []string) error {
@@ -449,7 +437,7 @@ func validateInstanceType(instanceType string, supportedInstanceTypes []string) 
 }
 
 func populateAMIID(cfnParams *cloudformation.CfnStackParams, client amimetadata.Client) error {
-	instanceType, err := retrieveInstanceType(cfnParams)
+	instanceType, err := getInstanceType(cfnParams)
 	if err != nil {
 		return err
 	}

--- a/ecs-cli/modules/cli/cluster/cluster_app.go
+++ b/ecs-cli/modules/cli/cluster/cluster_app.go
@@ -325,7 +325,7 @@ func createCluster(context *cli.Context, awsClients *AWSClients, commandConfig *
 		}
 		supportedInstanceTypes, err := awsClients.EC2Client.DescribeInstanceTypeOfferings(commandConfig.Region())
 		if err != nil {
-			return errors.Wrapf(err, "No instance type found in region %s", commandConfig.Region())
+			return fmt.Errorf("describe instance type offerings: %w", err)
 		}
 
 		if err = validateInstanceType(instanceType, supportedInstanceTypes); err != nil {

--- a/ecs-cli/modules/clients/aws/cloudformation/cluster_template.go
+++ b/ecs-cli/modules/clients/aws/cloudformation/cluster_template.go
@@ -109,7 +109,7 @@ var clusterTemplate = `
     },
     "EcsInstanceType": {
       "Type": "String",
-      "Description": "ECS EC2 instance type",
+      "Description": "ECS EC2 instance type"
     },
     "SpotPrice": {
       "Type": "Number",

--- a/ecs-cli/modules/clients/aws/cloudformation/cluster_template.go
+++ b/ecs-cli/modules/clients/aws/cloudformation/cluster_template.go
@@ -21,7 +21,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/ecs"
 )
 
-func GetClusterTemplate(tags []*ecs.Tag, stackName string, instanceTypes []string) (string, error) {
+func GetClusterTemplate(tags []*ecs.Tag, stackName string) (string, error) {
 	tagJSON, err := json.Marshal(tags)
 	if err != nil {
 		return "", err
@@ -33,12 +33,7 @@ func GetClusterTemplate(tags []*ecs.Tag, stackName string, instanceTypes []strin
 		return "", err
 	}
 
-	instanceTypesJSON, err := json.Marshal(instanceTypes)
-	if err != nil {
-		return "", err
-	}
-
-	return fmt.Sprintf(clusterTemplate, string(tagJSON), string(asgTagJSON), string(instanceTypesJSON)), nil
+	return fmt.Sprintf(clusterTemplate, string(tagJSON), string(asgTagJSON)), nil
 }
 
 // Autoscaling CFN tags have an additional field that determines if they are
@@ -115,9 +110,6 @@ var clusterTemplate = `
     "EcsInstanceType": {
       "Type": "String",
       "Description": "ECS EC2 instance type",
-      "Default": "` + DefaultECSInstanceType + `",
-      "AllowedValues": %[3]s,
-      "ConstraintDescription": "must be a valid EC2 instance type."
     },
     "SpotPrice": {
       "Type": "Number",

--- a/ecs-cli/modules/clients/aws/cloudformation/cluster_template.go
+++ b/ecs-cli/modules/clients/aws/cloudformation/cluster_template.go
@@ -109,7 +109,8 @@ var clusterTemplate = `
     },
     "EcsInstanceType": {
       "Type": "String",
-      "Description": "ECS EC2 instance type"
+      "Description": "ECS EC2 instance type",
+      "Default": ""
     },
     "SpotPrice": {
       "Type": "Number",


### PR DESCRIPTION
CloudFormation will try to validate the Default ECSInstanceType parameter
based on the AllowedValues field which is problematic in regions that do
not support our default t2.micro instance type such as eu-north-1.

Resolves #1006

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
- [X] Unit tests passed
- [x] Integration tests passed
- [X] Unit tests added for new functionality
- [X] Listed manual checks and their outputs in the comments ([example](https://github.com/aws/amazon-ecs-cli/pull/750#issuecomment-472623042))
- [ ] Link to issue or PR for the integration tests:

**Documentation**
- [ ] Contacted our doc writer
- [ ] Updated our README
----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
