### PR TITLE
fix(cli): Fix incorrect parsing of ARNs w/ nested param names

### DIFF
--- a/ecs-cli/modules/cli/local/secrets/clients/clients_test.go
+++ b/ecs-cli/modules/cli/local/secrets/clients/clients_test.go
@@ -45,7 +45,7 @@ func TestSSMDecrypter_DecryptSecret(t *testing.T) {
 
 				gomock.InOrder(
 					defaultClient.EXPECT().GetParameter(&ssm.GetParameterInput{
-						Name:           aws.String("TEST_DB_PASSWORD"),
+						Name:           aws.String("/TEST_DB_PASSWORD"),
 						WithDecryption: aws.Bool(true),
 					}).Return(&ssm.GetParameterOutput{
 						Parameter: &ssm.Parameter{
@@ -74,7 +74,7 @@ func TestSSMDecrypter_DecryptSecret(t *testing.T) {
 
 				gomock.InOrder(
 					pdxClient.EXPECT().GetParameter(&ssm.GetParameterInput{
-						Name:           aws.String("TEST_DB_PASSWORD"),
+						Name:           aws.String("/TEST_DB_PASSWORD"),
 						WithDecryption: aws.Bool(true),
 					}).Return(&ssm.GetParameterOutput{
 						Parameter: &ssm.Parameter{

--- a/ecs-cli/modules/cli/local/secrets/clients/clients_test.go
+++ b/ecs-cli/modules/cli/local/secrets/clients/clients_test.go
@@ -91,6 +91,37 @@ func TestSSMDecrypter_DecryptSecret(t *testing.T) {
 				}
 			},
 		},
+		"with ARN and forward slashes": {
+			input:        "arn:aws:ssm:us-west-2:11111111111:parameter/TEST/DB/PASSWORD",
+			wantedSecret: "ponies",
+			setupDecrypter: func(ctrl *gomock.Controller) *SSMDecrypter {
+				iadClient := mock_ssmiface.NewMockSSMAPI(ctrl)
+				pdxClient := mock_ssmiface.NewMockSSMAPI(ctrl)
+
+				m := make(map[region]ssmiface.SSMAPI)
+				m["default"] = iadClient
+				m["us-east-1"] = iadClient
+				m["us-west-2"] = pdxClient
+
+				gomock.InOrder(
+					pdxClient.EXPECT().GetParameter(&ssm.GetParameterInput{
+						Name:           aws.String("/TEST/DB/PASSWORD"),
+						WithDecryption: aws.Bool(true),
+					}).Return(&ssm.GetParameterOutput{
+						Parameter: &ssm.Parameter{
+							Value: aws.String("what??"),
+						},
+					}, nil),
+
+					iadClient.EXPECT().GetParameter(gomock.Any()).Times(0), // Should not have called IAD
+				)
+
+				return &SSMDecrypter{
+					SSMAPI:  iadClient,
+					clients: m,
+				}
+			},
+		},
 		"without ARN": {
 			input:        "TEST_DB_PASSWORD",
 			wantedSecret: "hello",

--- a/ecs-cli/modules/cli/local/secrets/clients/clients_test.go
+++ b/ecs-cli/modules/cli/local/secrets/clients/clients_test.go
@@ -109,7 +109,7 @@ func TestSSMDecrypter_DecryptSecret(t *testing.T) {
 						WithDecryption: aws.Bool(true),
 					}).Return(&ssm.GetParameterOutput{
 						Parameter: &ssm.Parameter{
-							Value: aws.String("what??"),
+							Value: aws.String("ponies"),
 						},
 					}, nil),
 

--- a/ecs-cli/modules/cli/local/secrets/secrets_test.go
+++ b/ecs-cli/modules/cli/local/secrets/secrets_test.go
@@ -31,6 +31,10 @@ func TestName(t *testing.T) {
 			input:  NewContainerSecret("mongodb", "DB_PASSWORD", "arn:aws:secretsmanager:us-east-1:11111111111:secret:alpha/efe/local"),
 			wanted: "mongodb_DB_PASSWORD",
 		},
+		"complex": {
+			input:  NewContainerSecret("mongodb", "DB_PASSWORD", "arn:aws:secretsmanager:us-east-1:11111111111:secret:alpha/efe/local/mongo/aws"),
+			wanted: "mongodb_DB_PASSWORD",
+		},
 	}
 
 	for name, tc := range testCases {


### PR DESCRIPTION
Addresses #1010 and #1011. 

This change solves an error where we did not extract
fully qualified paths (/path/to/param) from SSM parameter ARNS
containing nested hierarchical param names. We would instead grab
"path/to/param" (excluding the leading "/") and attempt to call GetParameter via the AWS SDK,
which would result in a failure and an incorrect error message.

More information on SSM parameter name constraints [here].(https://docs.aws.amazon.com/systems-manager/latest/userguide/sysman-parameter-name-constraints.html)

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
- [x] Unit tests passed
- [ in progress] Integration tests passed
- [x] Unit tests added for new functionality

----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
