### PR TITLE
chore: don't merge when the do-not-merge or WIP labels are applied

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -9,6 +9,7 @@ pull_request_rules:
       - -title~=(WIP|wip)
       - -merged
       - -closed
+      - label!=(WIP|do-not-merge)
     actions:
       merge:
         method: squash

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -9,7 +9,7 @@ pull_request_rules:
       - -title~=(WIP|wip)
       - -merged
       - -closed
-      - label!=(WIP|do-not-merge)
+      - -label~=(WIP|do-not-merge)
     actions:
       merge:
         method: squash


### PR DESCRIPTION
Allow a quick way of stopping mergify from auto-merging PRs that need to wait for some reason

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
