### PR TITLE
Add launchtype check before setting platform version

### DIFF
--- a/ecs-cli/modules/cli/compose/entity/service/service.go
+++ b/ecs-cli/modules/cli/compose/entity/service/service.go
@@ -527,7 +527,6 @@ func (s *Service) buildCreateServiceInput(serviceName, taskDefName string, desir
 	// TODO: revert to "LATEST" when latest refers to 1.4.0
 	var platformVersion *string
 	if launchType == "FARGATE" {
-		platformVersion = aws.String("LATEST")
 		if len(ecsParams.TaskDefinition.EFSVolumes) != 0 {
 			log.Warnf("Detected an EFS Volume in task definition %s", taskDefName)
 			log.Warn("Using Fargate platform version 1.4.0, which includes changes to the networking flows for VPC endpoint customers.")

--- a/ecs-cli/modules/cli/compose/entity/service/service.go
+++ b/ecs-cli/modules/cli/compose/entity/service/service.go
@@ -26,6 +26,7 @@ import (
 	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/clients/aws/route53"
 	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/clients/aws/tagging"
 	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/commands/flags"
+	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/config"
 	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/utils"
 	"github.com/aws/amazon-ecs-cli/ecs-cli/modules/utils/cache"
 	composeutils "github.com/aws/amazon-ecs-cli/ecs-cli/modules/utils/compose"
@@ -524,17 +525,6 @@ func (s *Service) buildCreateServiceInput(serviceName, taskDefName string, desir
 		return nil, fmt.Errorf("--%v is only valid for services configured to use load balancers", flags.HealthCheckGracePeriodFlag)
 	}
 
-	// TODO: revert to "LATEST" when latest refers to 1.4.0
-	var platformVersion *string
-	if launchType == "FARGATE" {
-		if len(ecsParams.TaskDefinition.EFSVolumes) != 0 {
-			log.Warnf("Detected an EFS Volume in task definition %s", taskDefName)
-			log.Warn("Using Fargate platform version 1.4.0, which includes changes to the networking flows for VPC endpoint customers.")
-			log.Warn("Learn more: https://aws.amazon.com/blogs/containers/aws-fargate-launches-platform-version-1-4/")
-			platformVersion = aws.String("1.4.0")
-		}
-	}
-
 	createServiceInput := &ecs.CreateServiceInput{
 		DesiredCount:            aws.Int64(int64(desiredCount)), // Required unless DAEMON schedulingStrategy
 		ServiceName:             aws.String(serviceName),        // Required
@@ -543,7 +533,13 @@ func (s *Service) buildCreateServiceInput(serviceName, taskDefName string, desir
 		DeploymentConfiguration: s.deploymentConfig,
 		LoadBalancers:           s.loadBalancers,
 		Role:                    aws.String(s.role),
-		PlatformVersion:         platformVersion,
+	}
+	// TODO: revert to "LATEST" when latest refers to 1.4.0
+	if launchType == config.LaunchTypeFargate && len(ecsParams.TaskDefinition.EFSVolumes) > 0 {
+		log.Warnf("Detected an EFS Volume in task definition %s", taskDefName)
+		log.Warn("Using Fargate platform version 1.4.0, which includes changes to the networking flows for VPC endpoint customers.")
+		log.Warn("Learn more: https://aws.amazon.com/blogs/containers/aws-fargate-launches-platform-version-1-4/")
+		createServiceInput.PlatformVersion = aws.String("1.4.0")
 	}
 
 	if schedulingStrategy != "" {

--- a/ecs-cli/modules/cli/compose/entity/service/service.go
+++ b/ecs-cli/modules/cli/compose/entity/service/service.go
@@ -523,13 +523,17 @@ func (s *Service) buildCreateServiceInput(serviceName, taskDefName string, desir
 	if s.healthCheckGP != nil && s.loadBalancers == nil {
 		return nil, fmt.Errorf("--%v is only valid for services configured to use load balancers", flags.HealthCheckGracePeriodFlag)
 	}
+
 	// TODO: revert to "LATEST" when latest refers to 1.4.0
-	platformVersion := aws.String("LATEST")
-	if len(ecsParams.TaskDefinition.EFSVolumes) != 0 {
-		log.Warnf("Detected an EFS Volume in task definition %s", taskDefName)
-		log.Warn("Using Fargate platform version 1.4.0, which includes changes to the networking flows for VPC endpoint customers.")
-		log.Warn("Learn more: https://aws.amazon.com/blogs/containers/aws-fargate-launches-platform-version-1-4/")
-		platformVersion = aws.String("1.4.0")
+	var platformVersion *string
+	if launchType == "FARGATE" {
+		platformVersion = aws.String("LATEST")
+		if len(ecsParams.TaskDefinition.EFSVolumes) != 0 {
+			log.Warnf("Detected an EFS Volume in task definition %s", taskDefName)
+			log.Warn("Using Fargate platform version 1.4.0, which includes changes to the networking flows for VPC endpoint customers.")
+			log.Warn("Learn more: https://aws.amazon.com/blogs/containers/aws-fargate-launches-platform-version-1-4/")
+			platformVersion = aws.String("1.4.0")
+		}
 	}
 
 	createServiceInput := &ecs.CreateServiceInput{

--- a/ecs-cli/modules/cli/compose/entity/service/service_test.go
+++ b/ecs-cli/modules/cli/compose/entity/service/service_test.go
@@ -146,6 +146,25 @@ func ecsParamsWithFargateNetworkConfig() *utils.ECSParams {
 	}
 }
 
+func TestCreateWithEFS_EC2(t *testing.T) {
+	flagSet := flag.NewFlagSet("ecs-cli-up", 0)
+
+	createServiceTest(
+		t,
+		flagSet,
+		&config.CommandConfig{LaunchType: config.LaunchTypeEC2},
+		ecsParamsWithFargateEFSVolume(),
+		func(input *ecs.CreateServiceInput) {
+			launchType := input.LaunchType
+			assert.Equal(t, config.LaunchTypeEC2, aws.StringValue(launchType), "launch type is not ec2")
+			platformVersion := input.PlatformVersion
+
+			assert.Nil(t, platformVersion)
+		},
+		ecsSettingDisabled,
+	)
+}
+
 func TestCreateWithEFSFargate(t *testing.T) {
 	flagSet := flag.NewFlagSet("ecs-cli-up", 0)
 

--- a/ecs-cli/modules/cli/compose/entity/service/service_test.go
+++ b/ecs-cli/modules/cli/compose/entity/service/service_test.go
@@ -302,6 +302,7 @@ func TestCreateWithTaskPlacement(t *testing.T) {
 				},
 			}
 			assert.Nil(t, input.PlatformVersion, "platform version should be nil for ec2")
+			assert.Nil(t, input.LaunchType, "Launch type should be nil for default case")
 			assert.Len(t, placementConstraints, 2)
 			assert.Equal(t, expectedConstraints, placementConstraints, "Expected Placement Constraints to match")
 			assert.Len(t, placementStrategy, 2)

--- a/ecs-cli/modules/cli/compose/entity/service/service_test.go
+++ b/ecs-cli/modules/cli/compose/entity/service/service_test.go
@@ -301,7 +301,7 @@ func TestCreateWithTaskPlacement(t *testing.T) {
 					Type:  aws.String("binpack"),
 				},
 			}
-			assert.Nil(t, input.LaunchType, "launch type should be nil")
+			assert.Nil(t, input.PlatformVersion, "platform version should be nil for ec2")
 			assert.Len(t, placementConstraints, 2)
 			assert.Equal(t, expectedConstraints, placementConstraints, "Expected Placement Constraints to match")
 			assert.Len(t, placementStrategy, 2)

--- a/ecs-cli/modules/cli/compose/entity/service/service_test.go
+++ b/ecs-cli/modules/cli/compose/entity/service/service_test.go
@@ -301,7 +301,7 @@ func TestCreateWithTaskPlacement(t *testing.T) {
 					Type:  aws.String("binpack"),
 				},
 			}
-
+			assert.Nil(t, input.LaunchType, "launch type should be nil")
 			assert.Len(t, placementConstraints, 2)
 			assert.Equal(t, expectedConstraints, placementConstraints, "Expected Placement Constraints to match")
 			assert.Len(t, placementStrategy, 2)

--- a/ecs-cli/modules/cli/compose/entity/service/service_test.go
+++ b/ecs-cli/modules/cli/compose/entity/service/service_test.go
@@ -146,6 +146,51 @@ func ecsParamsWithFargateNetworkConfig() *utils.ECSParams {
 	}
 }
 
+func TestCreateWithEFSFargate(t *testing.T) {
+	flagSet := flag.NewFlagSet("ecs-cli-up", 0)
+
+	createServiceTest(
+		t,
+		flagSet,
+		&config.CommandConfig{LaunchType: config.LaunchTypeFargate},
+		ecsParamsWithFargateEFSVolume(),
+		func(input *ecs.CreateServiceInput) {
+			launchType := input.LaunchType
+			assert.Equal(t, config.LaunchTypeFargate, aws.StringValue(launchType), "launch type is not fargate")
+			platformVersion := input.PlatformVersion
+			assert.Equal(t, aws.String("1.4.0"), platformVersion)
+		},
+		ecsSettingDisabled,
+	)
+}
+
+func ecsParamsWithFargateEFSVolume() *utils.ECSParams {
+	return &utils.ECSParams{
+		TaskDefinition: utils.EcsTaskDef{
+			ExecutionRole: "arn:aws:iam::123456789012:role/fargate_role",
+			NetworkMode:   "awsvpc",
+			TaskSize: utils.TaskSize{
+				Cpu:    "512",
+				Memory: "1GB",
+			},
+			EFSVolumes: []utils.EFSVolume{
+				{
+					Name:         "myVolume",
+					FileSystemID: aws.String("fs-1234"),
+				},
+			},
+		},
+		RunParams: utils.RunParams{
+			NetworkConfiguration: utils.NetworkConfiguration{
+				AwsVpcConfiguration: utils.AwsVpcConfiguration{
+					Subnets:        []string{"sg-bafff1ed", "sg-c0ffeefe"},
+					AssignPublicIp: utils.Enabled,
+				},
+			},
+		},
+	}
+}
+
 func TestCreateFargate(t *testing.T) {
 	flagSet := flag.NewFlagSet("ecs-cli-up", 0)
 
@@ -221,7 +266,7 @@ func TestCreateEC2Explicitly(t *testing.T) {
 		func(input *ecs.CreateServiceInput) {
 			launchType := input.LaunchType
 			assert.Equal(t, "EC2", aws.StringValue(launchType))
-
+			assert.Nil(t, input.PlatformVersion, "platform version is not nil")
 			networkConfig := input.NetworkConfiguration
 			assert.Nil(t, networkConfig, "NetworkConfiguration should be nil")
 		},


### PR DESCRIPTION
<!-- Provide summary of changes -->
Checks the launchtype before setting platform version. This reverts a breaking change in compose service up introduced in 1.19.0. 

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->
Addresses issue #1040 

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
- [ x] Unit tests passed
- [... ] Integration tests passed
- [ ] Listed manual checks and their outputs in the comments ([example](https://github.com/aws/amazon-ecs-cli/pull/750#issuecomment-472623042))
- [ ] Link to issue or PR for the integration tests:

**Documentation**
- [ ] Contacted our doc writer
- [ ] Updated our README
----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
