### PR TITLE
fix(service): Replace errors from invalid compose service up flags with warnings

### DIFF
--- a/ecs-cli/modules/cli/compose/entity/service/service.go
+++ b/ecs-cli/modules/cli/compose/entity/service/service.go
@@ -347,7 +347,7 @@ func (s *Service) buildUpdateServiceInput(count *int64, serviceName, taskDefinit
 
 func (s *Service) updateService(ecsService *ecs.Service, newTaskDefinition *ecs.TaskDefinition) error {
 	if s.Context().CLIContext.Bool(flags.EnableServiceDiscoveryFlag) {
-		return fmt.Errorf("Service Discovery can not be enabled on an existing ECS Service")
+		log.Warningln("Service Discovery can not be enabled on an existing ECS Service. Skipping this flag...")
 	}
 
 	schedulingStrategy := strings.ToUpper(s.Context().CLIContext.String(flags.SchedulingStrategyFlag))

--- a/ecs-cli/modules/cli/compose/entity/service/service_test.go
+++ b/ecs-cli/modules/cli/compose/entity/service/service_test.go
@@ -1609,8 +1609,10 @@ func TestUpdateExistingServiceWithServiceDiscoveryFlag(t *testing.T) {
 		ServiceName:    aws.String(serviceName),
 	}
 
+	expectedInput := getDefaultUpdateInput()
+	expectedInput.serviceName = serviceName
 	// call tests
-	updateServiceExceptionTest(t, flagSet, &config.CommandConfig{}, &utils.ECSParams{}, existingService)
+	updateServiceTest(t, flagSet, &config.CommandConfig{}, &utils.ECSParams{}, expectedInput, existingService, true)
 }
 
 ///////////////////////////////////////


### PR DESCRIPTION
Previously, running `ecs-cli compose service up` on an already existing service and specifying the flags --enable-service-discovery would result in errors. 

This was bad behavior, as commands are sometimes scripted without respect to the status of the service and we should offer idempotency in this case when possible.

This PR adjusts the behavior when the service already exists to display warning messages and continue, ignoring those flags, instead of failing. 

Addresses #1069 

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
- [x] Unit tests passed
- [x] Integration tests passed
- [x] Unit tests added for new functionality
- [n/a] Listed manual checks and their outputs in the comments ([example](https://github.com/aws/amazon-ecs-cli/pull/750#issuecomment-472623042))
- [n/a ] Link to issue or PR for the integration tests:

----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
