### PR TITLE
chore: merge dependabot PRs into mainline

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -18,7 +18,7 @@ pull_request_rules:
 
   - name: Automatically approve Dependabot PRs
     conditions:
-      - base=master
+      - base=mainline
       - status-success=continuous-integration/travis-ci/pr
       - author~=^dependabot(|-preview)\[bot\]$
       - -title~=(WIP|wip)


### PR DESCRIPTION
<!-- Provide summary of changes -->
Between the time we opened #1062 and the time we merged it, we added another mergify rule which automerges dependabot PRs into master. This was not reflected in the changes in 1062.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
