### PR TITLE
Support container dependency in ecs-params.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -471,6 +471,9 @@ task_definition:
   services:
     <service_name>:
       essential: boolean
+      depends_on:
+        - container_name: string         // <service_name> of any other service in services
+          condition: string              // Valid values: START | COMPLETE | SUCCESS | HEALTHY
       repository_credentials:
         credentials_parameter: string
       cpu_shares: integer
@@ -564,6 +567,7 @@ Fields listed under `task_definition` correspond to fields that will be included
 
 * `services` correspond to the services listed in your docker compose file, with `service_name` matching the name of the container you wish to run. Its fields will be merged into an [ECS Container Definition](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ecs-taskdefinition-containerdefinitions.html).
   * If the [`essential`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ecs-taskdefinition-containerdefinitions.html#cfn-ecs-taskdefinition-containerdefinition-essential) field is not specified, the value defaults to true.
+  * `depends_on` field maps to [`dependsOn`](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html#container_definition_dependson) parameter in task definition. It allows you to specify a list of [`ContainerDependency`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ecs-taskdefinition-containerdependency.html), which can be used for conditional startup of dependent containers or ensuring order of startup between containers. Refer [example](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/example_task_definitions.html#example_task_definition-containerdependency).
   * If you are using Docker compose version 3, the `cpu_shares`, `mem_limit`, and `mem_reservation` fields are optional and must be specified in the ECS params file rather than the compose file.
   * In Docker compose version 2, the `cpu_shares`, `mem_limit`, and `mem_reservation` fields can be specified in either the compose or ECS params file. If they are specified in the ECS params file, the values will override values present in the compose file.
   * If you are using a private repository for pulling images, `repository_credentials` allows you to specify an AWS Secrets Manager secret ARN for the name of the secret containing your private repository credentials as a `credential_parameter`.

--- a/ecs-cli/modules/utils/compose/convert_task_definition.go
+++ b/ecs-cli/modules/utils/compose/convert_task_definition.go
@@ -261,6 +261,18 @@ func convertToECSSecrets(secrets []Secret) []*ecs.Secret {
 	return ecsSecrets
 }
 
+func convertToECSContainerDependency(dependencies []ContainerDependency) []*ecs.ContainerDependency {
+	var ecsContainerDependencies []*ecs.ContainerDependency
+	for _, dependency := range dependencies {
+		d := &ecs.ContainerDependency{
+			Condition:     aws.String(dependency.Condition),
+			ContainerName: aws.String(dependency.ContainerName),
+		}
+		ecsContainerDependencies = append(ecsContainerDependencies, d)
+	}
+	return ecsContainerDependencies
+}
+
 func mergeVolumesWithoutHost(composeVolumes []string, ecsParams *ECSParams) ([]*ecs.Volume, error) {
 	volumesWithoutHost := make(map[string]Volume)
 	output := []*ecs.Volume{}

--- a/ecs-cli/modules/utils/compose/ecs_params_reader.go
+++ b/ecs-cli/modules/utils/compose/ecs_params_reader.go
@@ -72,6 +72,7 @@ type ContainerDef struct {
 	FirelensConfiguration FirelensConfiguration  `yaml:"firelens_configuration"`
 	Secrets               []Secret               `yaml:"secrets"`
 	GPU                   string                 `yaml:"gpu"`
+	ContainerDependencies []ContainerDependency  `yaml:"depends_on"`
 }
 
 type Volume struct {
@@ -119,6 +120,12 @@ type HealthCheck struct {
 // RepositoryCredentials holds CredentialParameters for a ContainerDef
 type RepositoryCredentials struct {
 	CredentialsParameter string `yaml:"credentials_parameter"`
+}
+
+// ContainerDependency holds a dependency container
+type ContainerDependency struct {
+	ContainerName string `yaml:"container_name"`
+	Condition     string `yaml:"condition"`
 }
 
 // Logging holds a list of Secrets within SecretOptions. They are essentially

--- a/ecs-cli/modules/utils/compose/ecs_params_reader_test.go
+++ b/ecs-cli/modules/utils/compose/ecs_params_reader_test.go
@@ -89,6 +89,11 @@ task_definition:
       mem_reservation: 500mb
     wordpress:
       essential: true
+      depends_on:
+        - container_name: mysql
+          condition: STARTED
+        - container_name: log_router
+          condition: STARTED
       repository_credentials:
         credentials_parameter: arn:aws:secretsmanager:1234567890:secret:test-RT4iv
       logging:
@@ -151,6 +156,19 @@ task_definition:
 
 		assert.ElementsMatch(t, expectedSecrets, wordpress.Secrets, "Expected secrets to match")
 		assert.ElementsMatch(t, expectedSecrets, wordpress.Logging.SecretOptions, "Expected secrets to match")
+
+		expectedContainerDependencies := []ContainerDependency {
+			ContainerDependency {
+				ContainerName: "mysql",
+				Condition: "STARTED",
+			},
+			ContainerDependency {
+				ContainerName: "log_router",
+				Condition: "STARTED",
+			},
+		}
+
+		assert.ElementsMatch(t, expectedContainerDependencies, wordpress.ContainerDependencies, "Expected container dependiencies to match")
 
 		assert.Equal(t, "fluentbit", log_router.FirelensConfiguration.Type, "Except firelens_configuration type to be fluentbit")
 		assert.Equal(t, "true", log_router.FirelensConfiguration.Options["enable-ecs-log-metadata"], "Expected Firelens 'enable-ecs-log-metadata' to be 'true'")

--- a/ecs-cli/modules/utils/compose/reconcile_container_def.go
+++ b/ecs-cli/modules/utils/compose/reconcile_container_def.go
@@ -130,6 +130,10 @@ func reconcileContainerDef(inputCfg *adapter.ContainerConfig, ecsConDef *Contain
 			outputContDef.SetSecrets(convertToECSSecrets(ecsConDef.Secrets))
 		}
 
+		if len(ecsConDef.ContainerDependencies) > 0 {
+			outputContDef.SetDependsOn(convertToECSContainerDependency(ecsConDef.ContainerDependencies))
+		}
+
 		if len(ecsConDef.Logging.SecretOptions) > 0 {
 			convertedSecrets := convertToECSSecrets(ecsConDef.Logging.SecretOptions)
 			outputContDef.LogConfiguration.SetSecretOptions(convertedSecrets)


### PR DESCRIPTION
Added support for a `depends_on` field for services in ecs-params.yml
This field maps to [`dependsOn`](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html#container_definition_dependson) field in task definition.

Tries to address #897 . Not supporting via docker-compose.yml's `depends_on` because there is no 1:1 mapping between ECS and docker-compose concepts. Also it makes more sense to leverage ECS healthchecks condition. 
<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

----

**Testing**
- [ ] All unit tests passed locally except for "github.com/aws/amazon-ecs-cli/ecs-cli/modules/cli/regcreds", but it's failing on mainline as well. Travis CI tests are passing including regcreds.
- [ ] Integration tests passed
- [x] Unit tests added for new functionality
- [x] Manual testing steps
- [ ] Link to issue or PR for the integration tests:

**Documentation**
- [ ] Contacted our doc writer
- [x] Updated our README
----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
