### PR TITLE
Add capacity provider strategy support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ ecs-cli/vendor/pkg
 ecs-cli/.vscode/*
 ecs-cli/.idea
 .idea/*
+.DS_Store

--- a/ecs-cli/modules/cli/compose/entity/service/service.go
+++ b/ecs-cli/modules/cli/compose/entity/service/service.go
@@ -510,8 +510,6 @@ func (s *Service) GetTags() ([]*ecs.Tag, error) {
 
 // ----------- Commands' helper functions --------
 
-// i think this is what needs to be modified so that instead of just a launchType it could also take a capacity provider (strategy)
-
 func (s *Service) buildCreateServiceInput(serviceName, taskDefName string, desiredCount int) (*ecs.CreateServiceInput, error) {
 	launchType := s.Context().CommandConfig.LaunchType
 	cluster := s.Context().CommandConfig.Cluster
@@ -622,8 +620,6 @@ func (s *Service) buildCreateServiceInput(serviceName, taskDefName string, desir
 			createServiceInput.EnableECSManagedTags = aws.Bool(true)
 		}
 	}
-
-	// fmt.Println(createServiceInput)
 
 	return createServiceInput, nil
 }

--- a/ecs-cli/modules/cli/compose/project/project.go
+++ b/ecs-cli/modules/cli/compose/project/project.go
@@ -222,10 +222,6 @@ func (p *ecsProject) transformTaskDefinition() error {
 
 	p.entity.SetTaskDefinition(taskDefinition)
 
-	// i think this is where we can get the task definition out of here
-	// fmt.Println(taskDefinition)
-	// i can but really what i want is the create-service call
-
 	return nil
 }
 

--- a/ecs-cli/modules/cli/compose/project/project.go
+++ b/ecs-cli/modules/cli/compose/project/project.go
@@ -221,6 +221,11 @@ func (p *ecsProject) transformTaskDefinition() error {
 	}
 
 	p.entity.SetTaskDefinition(taskDefinition)
+
+	// i think this is where we can get the task definition out of here
+	// fmt.Println(taskDefinition)
+	// i can but really what i want is the create-service call
+
 	return nil
 }
 

--- a/ecs-cli/modules/cli/compose/project/project.go
+++ b/ecs-cli/modules/cli/compose/project/project.go
@@ -221,7 +221,6 @@ func (p *ecsProject) transformTaskDefinition() error {
 	}
 
 	p.entity.SetTaskDefinition(taskDefinition)
-
 	return nil
 }
 

--- a/ecs-cli/modules/commands/compose/service/compose_service_command.go
+++ b/ecs-cli/modules/commands/compose/service/compose_service_command.go
@@ -68,7 +68,7 @@ func createServiceCommand(factory composeFactory.ProjectFactory) cli.Command {
 		Name:         "create",
 		Usage:        usage.ServiceCreate,
 		Action:       compose.WithProject(factory, compose.ProjectCreate, true),
-		Flags:        flags.AppendFlags(deploymentConfigFlags(true), loadBalancerFlags(), flags.OptionalConfigFlags(), flags.OptionalLaunchTypeFlag(), flags.OptionalCreateLogsFlag(), serviceDiscoveryFlags(), flags.OptionalSchedulingStrategyFlag(), taggingFlags()),
+		Flags:        flags.AppendFlags(deploymentConfigFlags(true), loadBalancerFlags(), capacityProviderStrategyFlags(), flags.OptionalConfigFlags(), flags.OptionalLaunchTypeFlag(), flags.OptionalCreateLogsFlag(), serviceDiscoveryFlags(), flags.OptionalSchedulingStrategyFlag(), taggingFlags()),
 		OnUsageError: flags.UsageErrorFactory("create"),
 	}
 }
@@ -88,7 +88,7 @@ func upServiceCommand(factory composeFactory.ProjectFactory) cli.Command {
 		Name:         "up",
 		Usage:        usage.ServiceUp,
 		Action:       compose.WithProject(factory, compose.ProjectUp, true),
-		Flags:        flags.AppendFlags(deploymentConfigFlags(true), loadBalancerFlags(), flags.OptionalConfigFlags(), ComposeServiceTimeoutFlag(), flags.OptionalLaunchTypeFlag(), flags.OptionalCreateLogsFlag(), ForceNewDeploymentFlag(), serviceDiscoveryFlags(), updateServiceDiscoveryFlags(), flags.OptionalSchedulingStrategyFlag(), taggingFlags()),
+		Flags:        flags.AppendFlags(deploymentConfigFlags(true), loadBalancerFlags(), capacityProviderStrategyFlags(), flags.OptionalConfigFlags(), ComposeServiceTimeoutFlag(), flags.OptionalLaunchTypeFlag(), flags.OptionalCreateLogsFlag(), ForceNewDeploymentFlag(), serviceDiscoveryFlags(), updateServiceDiscoveryFlags(), flags.OptionalSchedulingStrategyFlag(), taggingFlags()),
 		OnUsageError: flags.UsageErrorFactory("up"),
 	}
 }
@@ -226,7 +226,7 @@ func loadBalancerFlags() []cli.Flag {
 	containerNameUsageString := fmt.Sprintf("[Deprecated] Specifies the container name (as it appears in a container definition). This parameter is required if --%s or --%s is specified.", flags.LoadBalancerNameFlag, flags.TargetGroupArnFlag)
 	containerPortUsageString := fmt.Sprintf("[Deprecated] Specifies the port on the container to associate with the load balancer. This port must correspond to a containerPort in the service's task definition. This parameter is required if --%s or --%s is specified.", flags.LoadBalancerNameFlag, flags.TargetGroupArnFlag)
 	loadBalancerNameUsageString := fmt.Sprintf("[Deprecated] Specifies the name of a previously configured Classic Elastic Load Balancing load balancer to associate with your service. NOTE: For Application Load Balancers or Network Load Balancers, use the --%s flag.", flags.TargetGroupArnFlag)
-	targetGroupsUsageString := fmt.Sprintf("[Optional] Specifies multiple target groups to register with a service. Can't be used with --%s flag or --%s at the same time. To specify multiple target groups, add multiple seperate --%s flags Example: ecs-cli compose service create --target-groups targetGroupArn=arn,containerName=nginx,containerPort=80 --target-groups targetGroupArn=arn,containerName=database,containerPort=3306", flags.LoadBalancerNameFlag, flags.TargetGroupArnFlag, flags.TargetGroupsFlag)
+	targetGroupsUsageString := fmt.Sprintf("[Optional] Specifies multiple target groups to register with a service. Can't be used with --%s flag or --%s at the same time. To specify multiple target groups, add multiple separate --%s flags Example: ecs-cli compose service create --target-groups targetGroupArn=arn,containerName=nginx,containerPort=80 --target-groups targetGroupArn=arn,containerName=database,containerPort=3306", flags.LoadBalancerNameFlag, flags.TargetGroupArnFlag, flags.TargetGroupsFlag)
 	roleUsageString := fmt.Sprintf("[Optional] Specifies the name or full Amazon Resource Name (ARN) of the IAM role that allows Amazon ECS to make calls to your load balancer or target group on your behalf. This parameter requires either --%s or --%s to be specified.", flags.LoadBalancerNameFlag, flags.TargetGroupArnFlag)
 	healthCheckGracePeriodString := "[Optional] Specifies the period of time, in seconds, that the Amazon ECS service scheduler should ignore unhealthy Elastic Load Balancing target health checks after a task has first started."
 
@@ -258,6 +258,18 @@ func loadBalancerFlags() []cli.Flag {
 		cli.StringSliceFlag{
 			Name:  flags.TargetGroupsFlag,
 			Usage: targetGroupsUsageString,
+			Value: &cli.StringSlice{},
+		},
+	}
+}
+
+func capacityProviderStrategyFlags() []cli.Flag {
+	capacityProviderStrategyUsageString := fmt.Sprintf("[Optional] Specifies multiple capacity providers to register with a service. Can't be used with --%s flag at the same time. To specify multiple capacity providers, add multiple separate --%s flags Example: ecs-cli compose service create --capacity-provider capacityProviderName=t3-large-capacity-provider,base=1,weight=1 --capacity-provider capacityProviderName=t3-nano-capacity-provider,weight=5", flags.LaunchTypeFlag, flags.CapacityProviderStrategyFlag)
+
+	return []cli.Flag{
+		cli.StringSliceFlag{
+			Name:  flags.CapacityProviderStrategyFlag,
+			Usage: capacityProviderStrategyUsageString,
 			Value: &cli.StringSlice{},
 		},
 	}

--- a/ecs-cli/modules/commands/compose/service/compose_service_command.go
+++ b/ecs-cli/modules/commands/compose/service/compose_service_command.go
@@ -264,7 +264,7 @@ func loadBalancerFlags() []cli.Flag {
 }
 
 func capacityProviderStrategyFlags() []cli.Flag {
-	capacityProviderStrategyUsageString := fmt.Sprintf("[Optional] Specifies multiple capacity providers to register with a service. Can't be used with --%s flag at the same time. To specify multiple capacity providers, add multiple separate --%s flags Example: ecs-cli compose service create --capacity-provider capacityProviderName=t3-large-capacity-provider,base=1,weight=1 --capacity-provider capacityProviderName=t3-nano-capacity-provider,weight=5", flags.LaunchTypeFlag, flags.CapacityProviderStrategyFlag)
+	capacityProviderStrategyUsageString := fmt.Sprintf("[Optional] Specifies multiple capacity providers to register with a service. Can't be used with --%s flag at the same time. To specify multiple capacity providers, add multiple separate --%s flags.  Only one capacity provider can have a base > 0, set the base of all others to zero.  Example: ecs-cli compose service create --capacity-provider capacityProviderName=t3-large-capacity-provider,base=1,weight=1 --capacity-provider capacityProviderName=t3-nano-capacity-provider,base=0,weight=5", flags.LaunchTypeFlag, flags.CapacityProviderStrategyFlag)
 
 	return []cli.Flag{
 		cli.StringSliceFlag{

--- a/ecs-cli/modules/commands/flags/flags.go
+++ b/ecs-cli/modules/commands/flags/flags.go
@@ -135,6 +135,7 @@ const (
 	ComposeServiceTimeOutFlag               = "timeout"
 	ForceDeploymentFlag                     = "force-deployment"
 	TargetGroupsFlag                        = "target-groups"
+	CapacityProviderStrategyFlag            = "capacity-provider"
 
 	// Registry Creds
 	UpdateExistingSecretsFlag = "update-existing-secrets"

--- a/ecs-cli/modules/utils/utils.go
+++ b/ecs-cli/modules/utils/utils.go
@@ -115,17 +115,8 @@ func GetPartition(region string) string {
 	}
 }
 
-// I think i need to create a new ParseCapacityProviders to parse the StringSlice array into an array of capacity providers struct, just like the target groups below
-
-// capacityProviderName=t3-large-capacity-provider,base=1,weight=1
-
-// ParseCapacityProviders parses a StringSlice array into an array of capacity provider strategy item struct
+// ParseCapacityProviders parses a StringSlice array into an array of CapacityProviderItem
 // When you specify a capacity provider strategy, the number of capacity providers that can be specified is limited to six.
-// A CapacityProviderItem is (https://docs.aws.amazon.com/sdk-for-go/v2/api/service/ecs/#CapacityProviderStrategyItem):
-// need a string capacity provider name
-// optionally, need an integer Base (but only one capacity provider in a capacity provider strategy can have a base defined)
-// optionally, need an integer Weight
-
 // Input: ["capacityProviderName="...",base="...",weight=80","capacityProviderName="...",base="...",weight=40"]
 func ParseCapacityProviders(flagValues []string) ([]*ecs.CapacityProviderStrategyItem, error) {
 	var list []*ecs.CapacityProviderStrategyItem
@@ -140,8 +131,6 @@ func ParseCapacityProviders(flagValues []string) ([]*ecs.CapacityProviderStrateg
 		validFlags := []string{capacityProviderNameParamKey, capacityProviderBaseParamKey, capacityProviderWeightParamKey}
 		currentFlags := map[string]bool{
 			"capacityProviderName": false,
-			"base":                 false,
-			"weight":               false,
 		}
 
 		keyValPairs := strings.Split(flagValue, ",")
@@ -171,11 +160,11 @@ func ParseCapacityProviders(flagValues []string) ([]*ecs.CapacityProviderStrateg
 
 		base, err := strconv.ParseInt(m["base"], 10, 64)
 		if err != nil {
-			return nil, fmt.Errorf("Fail to capacity provider base %s for capacity provider %s", m["base"], m["capacityProviderName"])
+			return nil, fmt.Errorf("Failed to parse capacity provider base for capacity provider %s; set base to zero on all providers except one", m["capacityProviderName"])
 		}
 		weight, err := strconv.ParseInt(m["weight"], 10, 64)
 		if err != nil {
-			return nil, fmt.Errorf("Fail to parse capacity provider weight %s for capacity provider %s", m["weight"], m["capacityProviderName"])
+			return nil, fmt.Errorf("Failed to parse capacity provider weight for capacity provider %s", m["capacityProviderName"])
 		}
 
 		list = append(list, &ecs.CapacityProviderStrategyItem{


### PR DESCRIPTION
Add capacity provider support via command line flags, in the same vein as the existing `target-groups` support.

Addresses #1089 

Hi everyone, I have not made an open source contribution before, but we want to use capacity providers with our `ecs-cli` implementation, so I wrote it in.  I have not added any tests: I have not written golang tests before.

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
- [ ] Unit tests passed
- [ ] Integration tests passed
- [ ] Unit tests added for new functionality
- [ ] Listed manual checks and their outputs in the comments ([example](https://github.com/aws/amazon-ecs-cli/pull/750#issuecomment-472623042))
- [ ] Link to issue or PR for the integration tests:

**Documentation**
- [ ] Contacted our doc writer
- [ ] Updated our README
----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
