### PR TITLE
Detect Graviton 2 instance as arm64 Fix #1113

### DIFF
--- a/ecs-cli/modules/clients/aws/amimetadata/client.go
+++ b/ecs-cli/modules/clients/aws/amimetadata/client.go
@@ -103,8 +103,13 @@ func (c *metadataClient) parameterValueFor(ssmParamName string) (*AMIMetadata, e
 	return metadata, err
 }
 
+// See: https://aws.amazon.com/ec2/instance-types/
+// a1 is the first generation of graviton processors.
+// t4g, m6g, c6g, r6g are using graviton 2.
+// The d suffix is for disk optimized and applies to all except a1 and t4g, e.g. m6gd.medium.
+// Invalid instance type like t4gd.nano will trigger validation error in API so we don't do validation here.
 func isARM64Instance(instanceType string) bool {
-	r := regexp.MustCompile("a1\\.(medium|\\d*x?large)")
+	r := regexp.MustCompile("(a1|.\\dgd?)\\.(medium|\\d*x?large|metal)")
 	if r.MatchString(instanceType) {
 		return true
 	}

--- a/ecs-cli/modules/clients/aws/amimetadata/client_test.go
+++ b/ecs-cli/modules/clients/aws/amimetadata/client_test.go
@@ -43,7 +43,7 @@ func TestMetadataClient_GetRecommendedECSLinuxAMI(t *testing.T) {
 		},
 		{
 			// validate that we use the generic AMI for other instances
-			[]string{"t2.micro"},
+			[]string{"t2.micro", "m5ad.large", "c4.large", "i3.2xlarge"},
 			func(ssmClient *mock_ssmiface.MockSSMAPI) *mock_ssmiface.MockSSMAPI {
 				ssmClient.EXPECT().GetParameter(gomock.Any()).Do(func(input *ssm.GetParameterInput) {
 					assert.Equal(t, amazonLinux2X86RecommendedParameterName, *input.Name)


### PR DESCRIPTION
<!-- Provide summary of changes -->

Detect Graviton 2 arm instances as arm64 when choosing AMI.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

Fix #1113 

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
- [x] Unit tests passed
- [ ] Integration tests passed
- [x] Unit tests added for new functionality
- [x] Listed manual checks and their outputs in the comments ([example](https://github.com/aws/amazon-ecs-cli/pull/750#issuecomment-472623042))
- [ ] Link to issue or PR for the integration tests:

**Documentation**
- [N/A] Contacted our doc writer
- [N/A] Updated our README
----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
