### PR TITLE
specified var/run/docker.sock directly to mount it

### DIFF
--- a/ecs-cli/modules/cli/local/network/setup.go
+++ b/ecs-cli/modules/cli/local/network/setup.go
@@ -76,8 +76,6 @@ const (
 
 	// Name of the container, we need to give it a name so that we don't re-create a container every time we setup.
 	localEndpointsContainerName = "amazon-ecs-local-container-endpoints"
-
-
 )
 
 // Setup creates a user-defined bridge network with a running Local Container Endpoints container. It will pull
@@ -209,7 +207,7 @@ func createLocalEndpointsContainer(dockerClient containerStarter) string {
 		},
 		&container.HostConfig{
 			Binds: []string{
-				"/var/run:/var/run",
+				"/var/run/docker.sock:/var/run/docker.sock",
 				fmt.Sprintf("%s/.aws/:/home/.aws/", os.Getenv("HOME")),
 			},
 		},


### PR DESCRIPTION
<!-- Provide summary of changes -->
Specified the `var/run/docker.sock` file clearly instead of the `var/run` folder for the host mount configurations.
- This file is created as a symbolic link with `/Users/${username}/.docker/run/docker.sock` in Mac environment.
- With the folder mount configurations, `/var/run/docker.sock` is also created in a container as a symbolic link with the same path. Users or programs can not access the host's file path from inside a container, they cannot also access the socket file.
- On the other hand, with the file mount configurations, `/var/run/docker.sock` is created as a genuine file, not a symbolic link. So they can access the socket file.

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->
Fixed https://github.com/aws/amazon-ecs-cli/issues/1144

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
- [N/A] Unit tests passed
- [N/A] Integration tests passed
- [N/A] Unit tests added for new functionality
- [N/A] Listed manual checks and their outputs in the comments ([example](https://github.com/aws/amazon-ecs-cli/pull/750#issuecomment-472623042))
- [N/A] Link to issue or PR for the integration tests:

**Documentation**
- [N/A] Contacted our doc writer
- [N/A] Updated our README
----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
