### PR TITLE
Fix user-data shebang newline issue

### DIFF
--- a/ecs-cli/modules/cli/cluster/userdata/user_data.go
+++ b/ecs-cli/modules/cli/cluster/userdata/user_data.go
@@ -150,8 +150,7 @@ func isMultipart(data string) (bool, map[string]string, io.Reader) {
 }
 
 func (b *Builder) getClusterUserData() (string, error) {
-	joinClusterUserData := `
-#!/bin/bash
+	joinClusterUserData := `#!/bin/bash
 echo ECS_CLUSTER=%s >> /etc/ecs/ecs.config
 `
 	if len(b.tags) > 0 {


### PR DESCRIPTION
User-data scripts has a newline before the shebang, causing the resulting script to be invalid. 

Golang MIME multipart writer already puts a newline:
https://github.com/golang/go/blob/beaf7f3282c2548267d3c894417cc4ecacc5d575/src/mime/multipart/writer.go#L120

Removed said newline.

Fixes #1164 

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
- [ ] Unit tests passed
- [ ] Integration tests passed
- [ ] Unit tests added for new functionality
- [ ] Listed manual checks and their outputs in the comments ([example](https://github.com/aws/amazon-ecs-cli/pull/750#issuecomment-472623042))
- [ ] Link to issue or PR for the integration tests:

**Documentation**
- [ N/A] Contacted our doc writer
- [ N/A] Updated our README
----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
